### PR TITLE
EZP-29297: 404 error pages for hidden locations should be tagged

### DIFF
--- a/eZ/Publish/Core/MVC/Exception/HiddenLocationException.php
+++ b/eZ/Publish/Core/MVC/Exception/HiddenLocationException.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Exception;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class HiddenLocationException extends NotFoundHttpException
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Location
+     */
+    private $location;
+
+    public function __construct(Location $location, $message = null, \Exception $previous = null, $code = 0)
+    {
+        $this->location = $location;
+        parent::__construct($message, $previous, $code);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     */
+    public function getLocation()
+    {
+        return $this->location;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -13,13 +13,13 @@ use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\Core\Helper\ContentInfoLocationLoader;
+use eZ\Publish\Core\MVC\Exception\HiddenLocationException;
 use eZ\Publish\Core\MVC\Symfony\View\Configurator;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 use eZ\Publish\Core\MVC\Symfony\View\EmbedView;
 use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
@@ -211,7 +211,7 @@ class ContentViewBuilder implements ViewBuilder
             }
         );
         if ($location->invisible) {
-            throw new NotFoundHttpException('Location cannot be displayed as it is flagged as invisible.');
+            throw new HiddenLocationException($location, 'Location cannot be displayed as it is flagged as invisible.');
         }
 
         return $location;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29297](https://jira.ez.no/browse/EZP-29297)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `6.13`/`7.1`/`master`
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | no

Previously, when a user tried to load content location which is invisible `eZ\Publish\Core\MVC\Symfony\View\Builder\ContentViewBuilder` thrown `NotFoundException` which ended up as a Twig's 404 error page. 
The response was tagged only with `ez-all` xkey.  Therefore, after changing location visibility to visible, `PURGE` request was unable to purge that content correctly, so the content was still served from the cache as a 404 page instead of the correct page. Issue appears in both Varnish and Symfony Proxy.

The idea to solve the problem is to tag 404 response with all tags as in case of visible content. Thanks to that, when user change visibility back to visible, cache entry will be correctly invalidated. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [x] Create related PR in `ezplatform-http-cache`: https://github.com/ezsystems/ezplatform-http-cache/pull/69
