### PR TITLE
[Tests] Fixed incorrect case in expected XML for Custom Tag

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/TemplateTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/TemplateTest.php
@@ -242,7 +242,7 @@ class TemplateTest extends TestCase
  <section xmlns="http://docbook.org/ns/docbook" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
   <eztemplate name="custom_tag" ezxhtml:align="right">
     <ezcontent>
-      <para>param: value</para>
+      <para>Param: value</para>
     </ezcontent>
     <ezconfig>
       <ezvalue key="param">value</ezvalue>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.1`, `master` (`7.2`)
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

We've missed incorrect case used in XML testing Custom Tags. It wasn't discovered until the latest release of [sebastian/comparator](https://packagist.org/packages/sebastian/comparator) ([`v3.0.1`](https://github.com/sebastianbergmann/comparator/releases/tag/3.0.1)) which introduces the sebastianbergmann/comparator#53 fix.

**TODO**:
- [x] Fix incorrect letter case used in XML test for Custom Tag.
