### PR TITLE
EZP-25487: Fixed incorrect variation service passed to Twig Image Ext.

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -189,7 +189,7 @@ services:
     ezpublish.twig.extension.image:
         class: "%ezpublish.twig.extension.image.class%"
         arguments:
-            - '@ezpublish.image_alias.imagine.alias_generator'
+            - '@ezpublish.fieldType.ezimage.variation_service'
         tags:
             - { name: twig.extension }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-25487](https://jira.ez.no/browse/EZP-25487)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master` (`7.2`)
| **BC breaks**      | no
| **Tests pass**     | TBD
| **Doc needed**     | no

As a result of #2311 feature, the `ezpublish.twig.extension.image` Twig Extension service got injected with `@ezpublish.image_alias.imagine.alias_generator`, which is core implementation that right now doesn't include caching.

I believe we still should use `@ezpublish.fieldType.ezimage.variation_service` to ensure proper layers are preserved.

This fixes problem with [EZP-25487](https://jira.ez.no/browse/EZP-25487) not working on `master`.
What needs to be checked is if it doesn't influence generating placeholders for missing images.

**TODO**:
- [x] Fix `ezpublish.twig.extension.image` service definition by injecting proper Field Type service.
- [x] Ask for Code Review.
