### PR TITLE
[TESTS] Support usage of port in host name for local testing

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TestCase.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TestCase.php
@@ -164,7 +164,7 @@ class TestCase extends BaseTestCase
 
         return new HttpRequest(
             $method,
-            $this->httpHost . $uri,
+            $this->getBaseURI() . $uri,
             array_merge($headers, $extraHeaders),
             $body
         );


### PR DESCRIPTION
To verify this works on Travis to, this adapts REST functional tests so it will support port in host name which is useful for local development.