### PR TITLE
EZP-28942: As a REST consumer, I want to sort a view using a Field

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -66,6 +66,7 @@ parameters:
     ezpublish_rest.input.parser.internal.criterion.Visibility.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\Visibility
 
     ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class: eZ\Publish\Core\REST\Server\Input\Parser\SortClause\DataKeyValueObjectClass
+    ezpublish_rest.input.parser.internal.sortclause.field.class: eZ\Publish\Core\REST\Server\Input\Parser\SortClause\Field
 
     ezpublish_rest.input.parser.internal.route_based_limitation.class: eZ\Publish\Core\REST\Server\Input\Parser\Limitation\RouteBasedLimitationParser
     ezpublish_rest.input.parser.internal.path_string_route_based_limitation.class: eZ\Publish\Core\REST\Server\Input\Parser\Limitation\PathStringRouteBasedLimitationParser
@@ -649,6 +650,12 @@ services:
             - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionName'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.SectionName }
+
+    ezpublish_rest.input.parser.internal.sortclause.Field:
+        parent: ezpublish_rest.input.parser
+        class: '%ezpublish_rest.input.parser.internal.sortclause.field.class%'
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.Field }
 
     # role limitation parsers
 

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/SortClauseTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/SortClauseTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishRestBundle\Tests\Functional;
+
+use eZ\Bundle\EzPublishRestBundle\Tests\Functional\TestCase as RESTFunctionalTestCase;
+use SimpleXMLElement;
+
+class SortClauseTest extends RESTFunctionalTestCase
+{
+    public function testFieldSortClause()
+    {
+        $string = $this->addTestSuffix(__FUNCTION__);
+        $mainTestFolderContent = $this->createFolder($string, '/api/ezp/v2/content/locations/1/2');
+
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest('GET', $mainTestFolderContent['_href'], '', 'Content+json')
+        );
+
+        self::assertHttpResponseCodeEquals($response, 200);
+
+        $mainFolderContent = json_decode($response->getContent(), true);
+
+        if (!isset($mainFolderContent['Content']['MainLocation']['_href'])) {
+            self::fail("Incomplete response (no main location):\n" . $response->getContent() . "\n");
+        }
+
+        $mainFolderLocationHref = $mainFolderContent['Content']['MainLocation']['_href'];
+
+        $locationArray = explode('/', $mainFolderLocationHref);
+        $mainFolderLocationId = array_pop($locationArray);
+
+        $foldersForSorting = [
+            'AAA',
+            'BBB',
+            'CCC',
+        ];
+
+        $foldersNames = [];
+
+        foreach ($foldersForSorting as $folder) {
+            $folderContent = $this->createFolder($folder, $mainFolderLocationHref);
+            $foldersNames[$folder] = $folderContent['Name'];
+        }
+
+        $body = <<< XML
+<?xml version="1.0" encoding="UTF-8"?>
+<ViewInput>
+  <identifier>TestView</identifier>
+  <LocationQuery>
+    <Filter>
+      <ParentLocationIdCriterion>{$mainFolderLocationId}</ParentLocationIdCriterion>
+    </Filter>
+    <limit>10</limit>
+    <offset>0</offset>
+    <SortClauses>
+      <Field identifier="folder/name">descending</Field>
+    </SortClauses>
+    <FacetBuilders>
+      <contentTypeFacetBuilder/>
+    </FacetBuilders>
+  </LocationQuery>
+</ViewInput>
+XML;
+        $request = $this->createHttpRequest('POST', '/api/ezp/v2/content/views', 'ViewInput+xml; version=1.1', 'View+xml');
+        $request->setContent($body);
+
+        $response = $this->sendHttpRequest(
+            $request
+        );
+
+        $xml = new SimpleXMLElement($response->getContent());
+
+        $searchHits = [];
+        foreach ($xml->xpath('//Name') as $searchHit) {
+            $searchHits[] = (string) $searchHit[0];
+        }
+
+        self::assertCount(3, $searchHits);
+        self::assertEquals($foldersNames['CCC'], $searchHits[0]);
+        self::assertEquals($foldersNames['BBB'], $searchHits[1]);
+        self::assertEquals($foldersNames['AAA'], $searchHits[2]);
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
@@ -64,11 +64,7 @@ abstract class Query extends CriterionParser
         // SortClauses
         // -- [SortClauseName: direction|data]
         if (array_key_exists('SortClauses', $data)) {
-            $sortClauses = [];
-            foreach ($data['SortClauses'] as $sortClauseName => $sortClauseData) {
-                $sortClauses[] = $this->dispatchSortClause($sortClauseName, $sortClauseData, $parsingDispatcher);
-            }
-            $query->sortClauses = $sortClauses;
+            $query->sortClauses = $this->processSortClauses($data['SortClauses'], $parsingDispatcher);
         }
 
         // FacetBuilders
@@ -103,5 +99,29 @@ abstract class Query extends CriterionParser
         }
 
         return (count($criteria) === 1) ? $criteria[0] : new CriterionValue\LogicalAnd($criteria);
+    }
+
+    /**
+     * Handles SortClause data.
+     *
+     * @param array $sortClausesArray
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @return array
+     */
+    private function processSortClauses(array $sortClausesArray, ParsingDispatcher $parsingDispatcher)
+    {
+        $sortClauses = [];
+        foreach ($sortClausesArray as $sortClauseName => $sortClauseData) {
+            if (!is_array($sortClauseData) || !isset($sortClauseData[0])) {
+                $sortClauseData = [$sortClauseData];
+            }
+
+            foreach ($sortClauseData as $data) {
+                $sortClauses[] = $this->dispatchSortClause($sortClauseName, $data, $parsingDispatcher);
+            }
+        }
+
+        return $sortClauses;
     }
 }

--- a/eZ/Publish/Core/REST/Server/Input/Parser/SortClause/Field.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/SortClause/Field.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Input\Parser\SortClause;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Common\Exceptions;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Field as FieldSortClause;
+
+class Field extends BaseParser
+{
+    /**
+     * Parse input structure for Field sort clause.
+     *
+     * @param array $data
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\SortClause\Field
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+        if (!isset($data['Field'])) {
+            throw new Exceptions\Parser("The <Field> sort clause doesn't exist in the input structure");
+        }
+
+        if (!is_array($data['Field'])) {
+            throw new Exceptions\Parser('The <Field> sort clause has missing arguments: contentTypeIdentifier, fieldDefinitionIdentifier');
+        }
+
+        $data['Field'] = $this->normalizeData($data['Field']);
+
+        $direction = isset($data['Field']['direction']) ? $data['Field']['direction'] : null;
+
+        if (!in_array($direction, [Query::SORT_ASC, Query::SORT_DESC])) {
+            throw new Exceptions\Parser('Invalid direction format in <Field> sort clause');
+        }
+
+        if (isset($data['Field']['identifier'])) {
+            if (false === strpos($data['Field']['identifier'], '/')) {
+                throw new Exceptions\Parser('<Field> sort clause parameter "identifier" value has to be in "contentTypeIdentifier/fieldDefinitionIdentifier" format');
+            }
+
+            list($contentTypeIdentifier, $fieldDefinitionIdentifier) = explode('/', $data['Field']['identifier'], 2);
+        } else {
+            if (!isset($data['Field']['contentTypeIdentifier'])) {
+                throw new Exceptions\Parser('<Field> sort clause have missing parameter "contentTypeIdentifier"');
+            }
+            if (!isset($data['Field']['fieldDefinitionIdentifier'])) {
+                throw new Exceptions\Parser('<Field> sort clause have missing parameter "fieldDefinitionIdentifier"');
+            }
+
+            $contentTypeIdentifier = $data['Field']['contentTypeIdentifier'];
+            $fieldDefinitionIdentifier = $data['Field']['fieldDefinitionIdentifier'];
+        }
+
+        return new FieldSortClause($contentTypeIdentifier, $fieldDefinitionIdentifier, $direction);
+    }
+
+    /**
+     * Normalize passed Field Sort Clause data by making both xml and json parameters to have same names (by dropping
+     * xml "_" prefix and changing "#text" xml attribute to "direction").
+     *
+     * @param array $data
+     *
+     * @return array
+     */
+    private function normalizeData($data)
+    {
+        $normalizedData = [];
+
+        foreach ($data as $key => $value) {
+            if ('#text' === $key) {
+                $key = 'direction';
+            }
+
+            $normalizedData[trim($key, '_')] = $value;
+        }
+
+        return $normalizedData;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/SortClause/FieldTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/SortClause/FieldTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser\SortClause;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Field;
+use eZ\Publish\Core\REST\Server\Input\Parser\SortClause\Field as FieldParser;
+use eZ\Publish\Core\REST\Server\Tests\Input\Parser\BaseTest;
+
+class FieldTest extends BaseTest
+{
+    /**
+     * Tests the Field parser.
+     */
+    public function testParse()
+    {
+        $inputArray = [
+            'Field' => [
+                'identifier' => 'content/field',
+                'direction' => Query::SORT_ASC,
+            ],
+        ];
+
+        $fieldParser = $this->getParser();
+        $result = $fieldParser->parse($inputArray, $this->getParsingDispatcherMock());
+
+        $this->assertEquals(
+            new Field('content', 'field', Query::SORT_ASC),
+            $result,
+            'Field parser not created correctly.'
+        );
+    }
+
+    /**
+     * Test Field parser throwing exception on missing sort clause.
+     *
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     * @expectedExceptionMessage The <Field> sort clause doesn't exist in the input structure
+     */
+    public function testParseExceptionOnMissingSortClause()
+    {
+        $inputArray = [
+            'name' => 'Keep on mocking in the free world',
+        ];
+
+        $fieldParser = $this->getParser();
+        $fieldParser->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * Test Field parser throwing exception on invalid direction format.
+     *
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     * @expectedExceptionMessage Invalid direction format in <Field> sort clause
+     */
+    public function testParseExceptionOnInvalidDirectionFormat()
+    {
+        $inputArray = [
+            'Field' => [
+                'identifier' => 'content/field',
+                'direction' => 'mock',
+            ],
+        ];
+
+        $fieldParser = $this->getParser();
+        $fieldParser->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * Returns the Field parser.
+     *
+     * @return \eZ\Publish\Core\REST\Server\Input\Parser\SortClause\Field
+     */
+    protected function internalGetParser()
+    {
+        return new FieldParser();
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28942](https://jira.ez.no/browse/EZP-28942)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 6.7
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR adds an option to use Field sort clause in REST API requests in `ViewInput`.

XML example:
```xml
    <SortClauses>
      <Field contentTypeIdentifier="content" fieldDefinitionIdentifier="field1">descending</Field>
      <Field identifier="content/field2">ascending</Field>
    </SortClauses>
```

JSON example:
```json
      "SortClauses": {
        "Field": [
          {
            "contentTypeIdentifier": "content",
            "fieldDefinitionIdentifier": "field1",
            "direction": "descending"
          },
          {
            "identifier": "content/field2",
            "direction": "ascending"
          }
        ]
      },
```

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
