### PR TITLE
EZP-29326: Fix OwnerLimitationType check ContentCreateStruct

### DIFF
--- a/eZ/Publish/Core/Limitation/OwnerLimitationType.php
+++ b/eZ/Publish/Core/Limitation/OwnerLimitationType.php
@@ -142,7 +142,7 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
          * @var $object ContentInfo
          */
         $isOwner = $object->ownerId === $userId;
-        $isSelf = !$object instanceof ContentCreateStruct && $object->id === $userId;
+        $isSelf = $object instanceof ContentInfo && $object->id === $userId;
 
         return $isOwner || $isSelf;
     }

--- a/eZ/Publish/Core/Limitation/OwnerLimitationType.php
+++ b/eZ/Publish/Core/Limitation/OwnerLimitationType.php
@@ -142,7 +142,7 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
          * @var $object ContentInfo
          */
         $isOwner = $object->ownerId === $userId;
-        $isSelf = $object->id === $userId;
+        $isSelf = !$object instanceof ContentCreateStruct && $object->id === $userId;
 
         return $isOwner || $isSelf;
     }


### PR DESCRIPTION
Can't test for self if content does not yet have an id.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29326](https://jira.ez.no/browse/EZP-29326)
| **Bug*| yes
| **New feature**    | no
| **Target version** | `6.x`/`7.x` `master` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

OwnerLimitationType can't check for self if id does not exist yet, also as user needs to have been created already we now this is not "self".


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
