### PR TITLE
EZP-28774: Marked PAPI services as public

### DIFF
--- a/eZ/Publish/Core/settings/repository.yml
+++ b/eZ/Publish/Core/settings/repository.yml
@@ -2,48 +2,64 @@ services:
     # API Aliases
     ezpublish.api.repository:
         alias: ezpublish.signalslot.repository
+        public: true
 
     ezpublish.api.service.bookmark:
         alias: ezpublish.signalslot.service.bookmark
+        public: true
 
     ezpublish.api.service.content:
         alias: ezpublish.signalslot.service.content
+        public: true
 
     ezpublish.api.service.content_type:
         alias: ezpublish.signalslot.service.content_type
+        public: true
 
     ezpublish.api.service.field_type:
         alias: ezpublish.signalslot.service.field_type
+        public: true
 
     ezpublish.api.service.role:
         alias: ezpublish.signalslot.service.role
+        public: true
 
     ezpublish.api.service.object_state:
         alias: ezpublish.signalslot.service.object_state
+        public: true
 
     ezpublish.api.service.url_wildcard:
         alias: ezpublish.signalslot.service.url_wildcard
+        public: true
 
     ezpublish.api.service.url_alias:
         alias: ezpublish.signalslot.service.url_alias
+        public: true
 
     ezpublish.api.service.user:
         alias: ezpublish.signalslot.service.user
+        public: true
 
     ezpublish.api.service.search:
         alias: ezpublish.signalslot.service.search
+        public: true
 
     ezpublish.api.service.section:
         alias: ezpublish.signalslot.service.section
+        public: true
 
     ezpublish.api.service.trash:
         alias: ezpublish.signalslot.service.trash
+        public: true
 
     ezpublish.api.service.location:
         alias: ezpublish.signalslot.service.location
+        public: true
 
     ezpublish.api.service.language:
         alias: ezpublish.signalslot.service.language
+        public: true
 
     ezpublish.api.service.url:
         alias: ezpublish.signalslot.service.url
+        public: true


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28774](https://jira.ez.no/browse/EZP-28774)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Since the Symfony 3.4, services which do not specify explicit their visibility are private by default (Ref. https://symfony.com/blog/new-in-symfony-3-4-services-are-private-by-default). Trying to access them directly from container (for instance using has or get method) will generate deprecation warning e.g. "User Deprecated: Checking for the initialization of the "ezpublish.api.repository" private service is deprecated since Symfony 3.4 and won't be supported anymore in Symfony 4.0." (Ref. https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/DependencyInjection/Container.php#L224)

_This PR is a very first step to clean up logs from the deprecation warnings_

**TODO**:
- [X] ~Implement feature / fix a bug.~
- [X] ~Implement tests.~
- [X] ~Fix new code according to Coding Standards (`$ composer fix-cs`).~
- [X] Ask for Code Review.
