### PR TITLE
EZEE-2145: [Router] Fixed generating Req. Context to include URI scheme

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Routing/DefaultRouter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/DefaultRouter.php
@@ -164,7 +164,14 @@ class DefaultRouter extends Router implements RequestMatcherInterface, SiteAcces
         }
 
         if ($simplifiedRequest->port) {
-            $context->setHttpPort($simplifiedRequest->port);
+            switch ($simplifiedRequest->scheme) {
+                case 'https':
+                    $context->setHttpsPort($simplifiedRequest->port);
+                    break;
+                default:
+                    $context->setHttpPort($simplifiedRequest->port);
+                    break;
+            }
         }
 
         if ($simplifiedRequest->host) {

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator.php
@@ -161,7 +161,14 @@ abstract class Generator implements SiteAccessAware
         }
 
         if ($simplifiedRequest->port) {
-            $context->setHttpPort($simplifiedRequest->port);
+            switch ($simplifiedRequest->scheme) {
+                case 'https':
+                    $context->setHttpsPort($simplifiedRequest->port);
+                    break;
+                default:
+                    $context->setHttpPort($simplifiedRequest->port);
+                    break;
+            }
         }
 
         if ($simplifiedRequest->host) {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-2145](https://jira.ez.no/browse/EZEE-2145)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR changes DefaultRouter and Generator to use proper method of `\Symfony\Component\Routing\RequestContext` to set HTTP port depending on used URI scheme.

Symfony's `RequestContext` distinguishes between HTTP and HTTPS ports by the means of two different methods, therefore we also should take that into the account.

This fixes the root cause of [EZEE-2145](https://jira.ez.no/browse/EZEE-2145).

**TODO**:
- [x] Set proper type of port based on URI scheme.
- [x] Improve tests to cover missing code paths use cases.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
