### PR TITLE
EZP-29335: In back office only last part of content URL uses translated name

### DIFF
--- a/eZ/Publish/Core/Repository/URLAliasService.php
+++ b/eZ/Publish/Core/Repository/URLAliasService.php
@@ -302,26 +302,25 @@ class URLAliasService implements URLAliasServiceInterface
         $prioritizedLanguageList
     ) {
         $pathData = array();
-        $pathLevels = count($spiUrlAlias->pathData);
 
         foreach ($spiUrlAlias->pathData as $level => $levelEntries) {
-            if ($level === $pathLevels - 1) {
-                $prioritizedLanguageCode = $this->selectAliasLanguageCode(
-                    $spiUrlAlias,
-                    $languageCode,
-                    $showAllTranslations,
-                    $prioritizedLanguageList
-                );
-            } else {
+            $prioritizedLanguageCode = $this->selectAliasLanguageCode(
+                $spiUrlAlias,
+                $languageCode,
+                $showAllTranslations,
+                $prioritizedLanguageList
+            );
+
+            if ($prioritizedLanguageCode === false) {
+                return false;
+            }
+
+            if (!isset($levelEntries['translations'][$prioritizedLanguageCode])) {
                 $prioritizedLanguageCode = $this->choosePrioritizedLanguageCode(
                     $levelEntries,
                     $showAllTranslations,
                     $prioritizedLanguageList
                 );
-            }
-
-            if ($prioritizedLanguageCode === false) {
-                return false;
             }
 
             $pathData[$level] = $levelEntries['translations'][$prioritizedLanguageCode];


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29335](https://jira.ez.no/browse/EZP-29335)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.2`+
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
