### PR TITLE
[6.13] EZP-29206: Added missing upgrade scripts

### DIFF
--- a/data/update/mysql/dbupdate-6.13.3-to-6.13.4.sql
+++ b/data/update/mysql/dbupdate-6.13.3-to-6.13.4.sql
@@ -1,0 +1,10 @@
+SET default_storage_engine=InnoDB;
+BEGIN;
+-- Set storage engine schema version number
+UPDATE ezsite_data SET value='6.13.4' WHERE name='ezpublish-version';
+COMMIT;
+
+-- If the queries below fail, it means database is already updated
+
+CREATE INDEX `ezcontentobject_tree_contentobject_id_path_string` ON `ezcontentobject_tree` (`path_string`, `contentobject_id`);
+CREATE INDEX `ezcontentobject_section` ON `ezcontentobject` (`section_id`);

--- a/data/update/postgres/dbupdate-6.13.3-to-6.13.4.sql
+++ b/data/update/postgres/dbupdate-6.13.3-to-6.13.4.sql
@@ -1,0 +1,9 @@
+-- Set storage engine schema version number
+BEGIN;
+UPDATE ezsite_data SET value='6.13.4' WHERE name='ezpublish-version';
+COMMIT;
+
+-- If the queries below fail, it means database is already updated
+
+CREATE INDEX ezcontentobject_tree_contentobject_id_path_string ON ezcontentobject_tree (path_string, contentobject_id);
+CREATE INDEX ezcontentobject_section ON ezcontentobject (section_id);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Follow-up for [EZP-29206](https://jira.ez.no/browse/EZP-29206)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This is a `6.13` follow-up for #2339 adding new database table indices to solve [EZP-29206](https://jira.ez.no/browse/EZP-29206).

It is intended for Developers upgrading from the last stable `6.13.3` to the new stable `6.13.4`.

The portion of the script is wrapped in a transaction to update `ezpublish-version` even if the indices already exist (for Developers updating from `6.7.x` to `6.13.4`).

**TODO**:
- [x] Add missing 6.13.4 upgrade script for MySQL.
- [x] Add missing 6.13.4 upgrade script for PostgreSQL.
- [x] Ask for Code Review.
