### PR TITLE
[7.2] EZP-29206: Added missing upgrade scripts

### DIFF
--- a/data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql
+++ b/data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql
@@ -1,4 +1,5 @@
 SET default_storage_engine=InnoDB;
+BEGIN;
 -- Set storage engine schema version number
 UPDATE ezsite_data SET value='7.2.0' WHERE name='ezpublish-version';
 
@@ -110,3 +111,10 @@ CREATE TABLE `eznotification` (
   KEY `eznotification_owner` (`owner_id`),
   KEY `eznotification_owner_is_pending` (`owner_id`, `is_pending`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+COMMIT;
+
+-- If the queries below fail, it means database is already updated
+
+CREATE INDEX `ezcontentobject_tree_contentobject_id_path_string` ON `ezcontentobject_tree` (`path_string`, `contentobject_id`);
+CREATE INDEX `ezcontentobject_section` ON `ezcontentobject` (`section_id`);

--- a/data/update/postgres/dbupdate-7.1.0-to-7.2.0.sql
+++ b/data/update/postgres/dbupdate-7.1.0-to-7.2.0.sql
@@ -1,4 +1,5 @@
 -- Set storage engine schema version number
+BEGIN;
 UPDATE ezsite_data SET value='7.2.0' WHERE name='ezpublish-version';
 
 --
@@ -40,3 +41,9 @@ ALTER TABLE ONLY eznotification
 
 CREATE INDEX eznotification_owner_id ON eznotification USING btree (owner_id);
 CREATE INDEX eznotification_owner_id_is_pending ON eznotification USING btree (owner_id, is_pending);
+COMMIT;
+
+-- If the queries below fail, it means database is already updated
+
+CREATE INDEX ezcontentobject_tree_contentobject_id_path_string ON ezcontentobject_tree (path_string, contentobject_id);
+CREATE INDEX ezcontentobject_section ON ezcontentobject (section_id);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Follow-up for [EZP-29206](https://jira.ez.no/browse/EZP-29206)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This is a `7.2` follow-up for #2339 adding new database table indices to solve [EZP-29206](https://jira.ez.no/browse/EZP-29206).

It is intended for Developers upgrading from the last stable `7.1` to the new stable `7.2.0`.

The portion of the script is wrapped in a transaction to perform unrelated updates even if adding indices fails, because they already exist (for Developers updating from `6.7.x` or `6.13.4` to `7.2.0`).

**TODO**:
- [x] Add missing 7.2.0 upgrade script for MySQL.
- [x] Add missing 7.2.0 upgrade script for PostgreSQL.
- [x] Ask for Code Review.
