### PR TITLE
Add ezsystems/ezpublish-legacy < 2018.06 to conflict section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
     },
     "conflict": {
         "symfony/symfony": "3.4.7",
-        "doctrine/dbal": "2.7.0"
+        "doctrine/dbal": "2.7.0",
+        "ezsystems/ezpublish-legacy": "<2018.06"
     },
     "replace": {
         "ezsystems/ezpublish": "*",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28950](https://jira.ez.no/browse/EZP-28950)
| **Bug/Improvement**| no
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Due to utf8mb4 changes, only ezsystems/ezpublish-legacy version compatible is 2018.06, to be released soon. All other versions will fail with the error described in https://github.com/ezsystems/ezpublish-legacy/pull/1361

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
