### PR TITLE
EZEE-2081: NotificationService clean up    

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -2562,7 +2562,7 @@ ADD CONSTRAINT `ezcontentbrowsebookmark_user_fk`
 DROP TABLE IF EXISTS `eznotification`;
 CREATE TABLE `eznotification` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  owner_id int(11) NOT NULL DEFAULT 0,
+  `owner_id` int(11) NOT NULL DEFAULT 0,
   `is_pending` tinyint(1) NOT NULL DEFAULT '1',
   `type` varchar(128) NOT NULL DEFAULT '',
   `created` int(11) NOT NULL DEFAULT 0,

--- a/data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql
+++ b/data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql
@@ -101,7 +101,7 @@ ADD CONSTRAINT `ezcontentbrowsebookmark_user_fk`
 
 CREATE TABLE `eznotification` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  owner_id int(11) NOT NULL DEFAULT 0,
+  `owner_id` int(11) NOT NULL DEFAULT 0,
   `is_pending` tinyint(1) NOT NULL DEFAULT '1',
   `type` varchar(128) NOT NULL DEFAULT '',
   `created` int(11) NOT NULL DEFAULT 0,

--- a/doc/upgrade/7.2.md
+++ b/doc/upgrade/7.2.md
@@ -34,21 +34,8 @@ Charset=utf8mb4
 
 ## Notifications moved to Community edition
 
-Following query should be executed on database in order to add new table
+Database schema needs to be updated. To do this you should execute one of the following scripts:
 
-```sql
--- Table structure for table `eznotification`
- 
-DROP TABLE IF EXISTS `eznotification`;
-CREATE TABLE `eznotification` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `owner_id` int(11) NOT NULL,
-  `is_pending` tinyint(1) NOT NULL DEFAULT '1',
-  `type` varchar(128) NOT NULL,
-  `created` int(11) NOT NULL,
-  `data` blob NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `owner_id` (`owner_id`),
-  KEY `is_pending` (`is_pending`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-```
+* For MySQL: `data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql`
+* For PostgreSQL: `data/update/postgres/dbupdate-7.1.0-to-7.2.0.sql`
+

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/NotificationRendererPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/NotificationRendererPass.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
 
+use LogicException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -16,20 +17,47 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class NotificationRendererPass implements CompilerPassInterface
 {
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     */
+    const TAG_NAME = 'ezpublish.notification.renderer';
+    const REGISTRY_DEFINITION_ID = 'notification.renderer.registry';
+
     public function process(ContainerBuilder $container)
     {
-        if (!$container->has('notification.renderer.registry')) {
+        if (!$container->has(self::REGISTRY_DEFINITION_ID)) {
             return;
         }
 
-        $registry = $container->findDefinition('notification.renderer.registry');
+        $registry = $container->findDefinition(self::REGISTRY_DEFINITION_ID);
 
-        foreach ($container->findTaggedServiceIds('ezstudio.notification.renderer') as $id => $tags) {
-            foreach ($tags as $tag) {
-                $registry->addMethodCall('addRenderer', [$tag['alias'], new Reference($id)]);
+        foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $attributes) {
+            foreach ($attributes as $attribute) {
+                if (!isset($attribute['alias'])) {
+                    throw new LogicException(sprintf(
+                        'Tag %s needs a "alias" attribute to identify the notification type. None given.',
+                        self::TAG_NAME
+                    ));
+                }
+
+                $registry->addMethodCall('addRenderer', [$attribute['alias'], new Reference($id)]);
+            }
+        }
+
+        foreach ($container->findTaggedServiceIds('ezstudio.notification.renderer') as $id => $attributes) {
+            @trigger_error(
+                sprintf(
+                    'Tag ezstudio.notification.renderer is deprecated since 2.2. Please use \'%s\' instead.',
+                    self::TAG_NAME
+                ),
+                E_USER_DEPRECATED
+            );
+
+            foreach ($attributes as $attribute) {
+                if (!isset($attribute['alias'])) {
+                    throw new LogicException(
+                        'Tag ezstudio.notification.renderer needs a "alias" attribute to identify the notification type. None given.'
+                    );
+                }
+
+                $registry->addMethodCall('addRenderer', [$attribute['alias'], new Reference($id)]);
             }
         }
     }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/NotificationRendererPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/NotificationRendererPass.php
@@ -12,9 +12,6 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * Adds all available export methods to registry.
- */
 class NotificationRendererPass implements CompilerPassInterface
 {
     const TAG_NAME = 'ezpublish.notification.renderer';
@@ -35,26 +32,6 @@ class NotificationRendererPass implements CompilerPassInterface
                         'Tag %s needs a "alias" attribute to identify the notification type. None given.',
                         self::TAG_NAME
                     ));
-                }
-
-                $registry->addMethodCall('addRenderer', [$attribute['alias'], new Reference($id)]);
-            }
-        }
-
-        foreach ($container->findTaggedServiceIds('ezstudio.notification.renderer') as $id => $attributes) {
-            @trigger_error(
-                sprintf(
-                    'Tag ezstudio.notification.renderer is deprecated since 2.2. Please use \'%s\' instead.',
-                    self::TAG_NAME
-                ),
-                E_USER_DEPRECATED
-            );
-
-            foreach ($attributes as $attribute) {
-                if (!isset($attribute['alias'])) {
-                    throw new LogicException(
-                        'Tag ezstudio.notification.renderer needs a "alias" attribute to identify the notification type. None given.'
-                    );
                 }
 
                 $registry->addMethodCall('addRenderer', [$attribute['alias'], new Reference($id)]);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/NotificationRendererPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/NotificationRendererPassTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\NotificationRendererPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class NotificationRendererPassTest extends AbstractCompilerPassTestCase
+{
+    const NOTIFICATION_RENDERER_ID = 'notification.renderer.id';
+    const NOTIFICATION_ALIAS = 'example';
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setDefinition(NotificationRendererPass::REGISTRY_DEFINITION_ID, new Definition());
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new NotificationRendererPass());
+    }
+
+    public function testAddRenderer()
+    {
+        $definition = new Definition();
+        $definition->addTag(NotificationRendererPass::TAG_NAME, [
+            'alias' => self::NOTIFICATION_ALIAS,
+        ]);
+
+        $this->setDefinition(self::NOTIFICATION_RENDERER_ID, $definition);
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            NotificationRendererPass::REGISTRY_DEFINITION_ID,
+            'addRenderer',
+            [self::NOTIFICATION_ALIAS, new Reference(self::NOTIFICATION_RENDERER_ID)]
+        );
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testAddRendererWithoutAliasThrowsLogicException()
+    {
+        $definition = new Definition();
+        $definition->addTag(NotificationRendererPass::TAG_NAME);
+
+        $this->setDefinition(self::NOTIFICATION_RENDERER_ID, $definition);
+        $this->compile();
+    }
+}

--- a/eZ/Publish/API/Repository/NotificationService.php
+++ b/eZ/Publish/API/Repository/NotificationService.php
@@ -13,8 +13,6 @@ use eZ\Publish\API\Repository\Values\Notification\Notification;
 use eZ\Publish\API\Repository\Values\Notification\NotificationList;
 
 /**
- * Notification Service.
- *
  * Service to manager user notifications. It works in the context of a current User (obtained from
  * the PermissionResolver).
  */
@@ -77,7 +75,7 @@ interface NotificationService
     public function createNotification(CreateStruct $createStruct): Notification;
 
     /**
-     * Deletes notification.
+     * Deletes a notification.
      *
      * @param \eZ\Publish\API\Repository\Values\Notification\Notification $notification
      */

--- a/eZ/Publish/API/Repository/NotificationService.php
+++ b/eZ/Publish/API/Repository/NotificationService.php
@@ -31,7 +31,7 @@ interface NotificationService
     public function loadNotifications(int $offset, int $limit): NotificationList;
 
     /**
-     * Load single notification (by ID)
+     * Load single notification (by ID).
      *
      * @param int $notificationId Notification ID
      *

--- a/eZ/Publish/API/Repository/NotificationService.php
+++ b/eZ/Publish/API/Repository/NotificationService.php
@@ -12,20 +12,30 @@ use eZ\Publish\API\Repository\Values\Notification\CreateStruct;
 use eZ\Publish\API\Repository\Values\Notification\Notification;
 use eZ\Publish\API\Repository\Values\Notification\NotificationList;
 
+/**
+ * Notification Service.
+ *
+ * Service to manager user notifications. It works in the context of a current User (obtained from
+ * the PermissionResolver).
+ */
 interface NotificationService
 {
     /**
      * Get currently logged user notifications.
-
-     * @param int $offset
-     * @param int $limit
+     *
+     * @param int $offset the start offset for paging
+     * @param int $limit  the number of notifications returned
      *
      * @return \eZ\Publish\API\Repository\Values\Notification\NotificationList
      */
     public function loadNotifications(int $offset, int $limit): NotificationList;
 
     /**
-     * @param int $notificationId
+     * Load single notification (by ID)
+     *
+     * @param int $notificationId Notification ID
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      *
      * @return \eZ\Publish\API\Repository\Values\Notification\Notification
      */
@@ -35,6 +45,9 @@ interface NotificationService
      * Mark notification as read so it no longer bother the user.
      *
      * @param \eZ\Publish\API\Repository\Values\Notification\Notification $notification
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
     public function markNotificationAsRead(Notification $notification): void;
 
@@ -53,14 +66,20 @@ interface NotificationService
     public function getNotificationCount(): int;
 
     /**
-     * @param \eZ\Publish\API\Repository\Values\Notification\Notification $notification
-     */
-    public function deleteNotification(Notification $notification): void;
-
-    /**
+     * Creates a new notification.
+     *
      * @param \eZ\Publish\API\Repository\Values\Notification\CreateStruct $createStruct
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      *
      * @return \eZ\Publish\API\Repository\Values\Notification\Notification
      */
     public function createNotification(CreateStruct $createStruct): Notification;
+
+    /**
+     * Deletes notification.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Notification\Notification $notification
+     */
+    public function deleteNotification(Notification $notification): void;
 }

--- a/eZ/Publish/API/Repository/Tests/NotificationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/NotificationServiceTest.php
@@ -154,4 +154,46 @@ class NotificationServiceTest extends BaseTest
         $this->assertInstanceOf(Notification::class, $notification);
         $this->assertGreaterThan(0, $notification->id);
     }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\NotificationService::createNotification()
+     * @depends testCreateNotification
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testCreateNotificationThrowsInvalidArgumentExceptionOnMissingOwner()
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $notificationService = $repository->getNotificationService();
+
+        $createStruct = new CreateStruct([
+            'type' => 'TEST',
+        ]);
+
+        // This call will fail because notification owner is not specified
+        $notificationService->createNotification($createStruct);
+        /* END: Use Case */
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\NotificationService::createNotification()
+     * @depends testCreateNotification
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testCreateNotificationThrowsInvalidArgumentExceptionOnMissingType()
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $notificationService = $repository->getNotificationService();
+
+        $createStruct = new CreateStruct([
+            'ownerId' => 14,
+        ]);
+
+        // This call will fail because notification type is not specified
+        $notificationService->createNotification($createStruct);
+        /* END: Use Case */
+    }
 }

--- a/eZ/Publish/Core/Notification/Renderer/NotificationRenderer.php
+++ b/eZ/Publish/Core/Notification/Renderer/NotificationRenderer.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace eZ\Publish\SPI\Notification\Renderer;
+namespace eZ\Publish\Core\Notification\Renderer;
 
 use eZ\Publish\API\Repository\Values\Notification\Notification;
 

--- a/eZ/Publish/Core/Notification/Renderer/Registry.php
+++ b/eZ/Publish/Core/Notification/Renderer/Registry.php
@@ -8,16 +8,14 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Notification\Renderer;
 
-use eZ\Publish\SPI\Notification\Renderer\NotificationRenderer;
-
 class Registry
 {
-    /** @var \eZ\Publish\SPI\Notification\Renderer\NotificationRenderer[] */
+    /** @var \eZ\Publish\Core\Notification\Renderer\NotificationRenderer[] */
     protected $registry = [];
 
     /**
      * @param string $alias
-     * @param \eZ\Publish\SPI\Notification\Renderer\NotificationRenderer $notificationRenderer
+     * @param \eZ\Publish\Core\Notification\Renderer\NotificationRenderer $notificationRenderer
      */
     public function addRenderer(string $alias, NotificationRenderer $notificationRenderer): void
     {
@@ -27,7 +25,7 @@ class Registry
     /**
      * @param string $alias
      *
-     * @return \eZ\Publish\SPI\Notification\Renderer\NotificationRenderer
+     * @return \eZ\Publish\Core\Notification\Renderer\NotificationRenderer
      */
     public function getRenderer(string $alias): NotificationRenderer
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -633,7 +633,7 @@ ADD CONSTRAINT `ezcontentbrowsebookmark_user_fk`
 DROP TABLE IF EXISTS `eznotification`;
 CREATE TABLE `eznotification` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  owner_id int(11) NOT NULL DEFAULT 0,
+  `owner_id` int(11) NOT NULL DEFAULT 0,
   `is_pending` tinyint(1) NOT NULL DEFAULT '1',
   `type` varchar(128) NOT NULL DEFAULT '',
   `created` int(11) NOT NULL DEFAULT 0,

--- a/eZ/Publish/Core/Repository/NotificationService.php
+++ b/eZ/Publish/Core/Repository/NotificationService.php
@@ -25,12 +25,12 @@ use eZ\Publish\SPI\Persistence\Notification\UpdateStruct;
 class NotificationService implements NotificationServiceInterface
 {
     /**
-     * @var \eZ\Publish\SPI\Persistence\Notification\Handler $persistenceHandler
+     * @var \eZ\Publish\SPI\Persistence\Notification\Handler
      */
     protected $persistenceHandler;
 
     /**
-     * @var \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
+     * @var \eZ\Publish\API\Repository\PermissionResolver
      */
     protected $permissionResolver;
 

--- a/eZ/Publish/Core/Repository/NotificationService.php
+++ b/eZ/Publish/Core/Repository/NotificationService.php
@@ -24,14 +24,10 @@ use eZ\Publish\SPI\Persistence\Notification\UpdateStruct;
 
 class NotificationService implements NotificationServiceInterface
 {
-    /**
-     * @var \eZ\Publish\SPI\Persistence\Notification\Handler
-     */
+    /** @var \eZ\Publish\SPI\Persistence\Notification\Handler */
     protected $persistenceHandler;
 
-    /**
-     * @var \eZ\Publish\API\Repository\PermissionResolver
-     */
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
     protected $permissionResolver;
 
     /**

--- a/eZ/Publish/Core/Repository/NotificationService.php
+++ b/eZ/Publish/Core/Repository/NotificationService.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Values\Notification\CreateStruct as APICreateStruct;
 use eZ\Publish\API\Repository\Values\Notification\Notification as APINotification;
 use eZ\Publish\API\Repository\Values\Notification\NotificationList;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\SPI\Persistence\Notification\CreateStruct;
@@ -167,8 +168,17 @@ class NotificationService implements NotificationServiceInterface
     public function createNotification(APICreateStruct $createStruct): APINotification
     {
         $spiCreateStruct = new CreateStruct();
+
+        if (empty($createStruct->ownerId)) {
+            throw new InvalidArgumentException('ownerId', $createStruct->ownerId);
+        }
+
         $spiCreateStruct->ownerId = $createStruct->ownerId;
-        $spiCreateStruct->type = $createStruct->type;
+
+        if (empty($createStruct->type)) {
+            throw new InvalidArgumentException('type', $createStruct->type);
+        }
+
         $spiCreateStruct->isPending = $createStruct->isPending;
         $spiCreateStruct->data = $createStruct->data;
         $spiCreateStruct->created = (new DateTime())->getTimestamp();

--- a/eZ/Publish/SPI/Persistence/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Handler.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 
 namespace eZ\Publish\SPI\Persistence;
 
-use eZ\Publish\SPI\Persistence\Notification\Handler as NotificationHandler;
-
 /**
  * The main handler for Storage Engine.
  */


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-2081](https://jira.ez.no/browse/EZEE-2081)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Cleaned things missed in https://github.com/ezsystems/ezpublish-kernel/pull/2356. Most important points:

* Replaced tag `ezstudio.notification.renderer` with `ezpublish.notification.renderer`
* Moved `NotificationRenderer` to `eZ\Publish\Core\Notification\Renderer\`
* Added `\eZ\Publish\API\Repository\Values\Notification\CreateStruct` validation

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [x] Adjust code in `date-based-publisher`/ `flex-workflow` / ... according to this changes
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
