### PR TITLE
Fix Duplicated Siteaccesses in Generated URL.

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Routing/DefaultRouter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/DefaultRouter.php
@@ -96,6 +96,10 @@ class DefaultRouter extends Router implements RequestMatcherInterface, SiteAcces
             unset($parameters['siteaccess']);
         }
 
+        $ignoreSiteAccess = isset($parameters['ignoreSiteAccess']) ? $parameters['ignoreSiteAccess'] : false;
+
+        unset($parameters['ignoreSiteAccess']);
+
         try {
             $url = parent::generate($name, $parameters, $referenceType);
         } catch (RouteNotFoundException $e) {
@@ -105,7 +109,7 @@ class DefaultRouter extends Router implements RequestMatcherInterface, SiteAcces
         }
 
         // Now putting back SiteAccess URI if needed.
-        if ($isSiteAccessAware && $siteAccess && $siteAccess->matcher instanceof URILexer) {
+        if ($isSiteAccessAware && $siteAccess && $siteAccess->matcher instanceof URILexer && false === $ignoreSiteAccess) {
             if ($referenceType === self::ABSOLUTE_URL || $referenceType === self::NETWORK_PATH) {
                 $scheme = $context->getScheme();
                 $port = '';

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/DefaultRouterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/DefaultRouterTest.php
@@ -146,7 +146,7 @@ class DefaultRouterTest extends TestCase
      * @param int $referenceType The type of reference to be generated (one of the constants)
      * @param string $routeName
      */
-    public function testGenerateWithSiteAccess($urlGenerated, $relevantUri, $expectedUrl, $saName, $isMatcherLexer, $referenceType, $routeName)
+    public function testGenerateWithSiteAccess($urlGenerated, $relevantUri, $expectedUrl, $saName, $isMatcherLexer, $referenceType, $routeName, $parameters = [], $ignoreSiteAccess = false)
     {
         $routeName = $routeName ?: __METHOD__;
         $nonSiteAccessAwareRoutes = array('_dontwantsiteaccess');
@@ -168,7 +168,7 @@ class DefaultRouterTest extends TestCase
         if ($isMatcherLexer) {
             $matcher = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\URILexer');
             // Route is siteaccess aware, we're expecting analyseLink() to be called
-            if (!in_array($routeName, $nonSiteAccessAwareRoutes)) {
+            if (!in_array($routeName, $nonSiteAccessAwareRoutes) && false === $ignoreSiteAccess) {
                 $matcher
                     ->expects($this->once())
                     ->method('analyseLink')
@@ -204,7 +204,9 @@ class DefaultRouterTest extends TestCase
         $router->setContext($requestContext);
         $router->setNonSiteAccessAwareRoutes($nonSiteAccessAwareRoutes);
 
-        $this->assertSame($expectedUrl, $router->generate($routeName, array(), $referenceType));
+        $parameters['ignoreSiteAccess'] = $ignoreSiteAccess;
+
+        $this->assertSame($expectedUrl, $router->generate($routeName, $parameters, $referenceType));
     }
 
     public function providerGenerateWithSiteAccess()
@@ -222,6 +224,9 @@ class DefaultRouterTest extends TestCase
             array('/foo/bar/baz', '/foo/bar/baz', '/test_siteaccess/foo/bar/baz', 'test_siteaccess', true, UrlGeneratorInterface::ABSOLUTE_PATH, null),
             array('/foo/root_folder/bar/baz', '/bar/baz', '/foo/root_folder/test_siteaccess/bar/baz', 'test_siteaccess', true, UrlGeneratorInterface::ABSOLUTE_PATH, null),
             array('/foo/bar/baz', '/foo/bar/baz', '/foo/bar/baz', 'test_siteaccess', true, UrlGeneratorInterface::ABSOLUTE_PATH, '_dontwantsiteaccess'),
+            array('/view/content/154/full/1/153', '/view/content/154/full/1/153', '/eng/view/content/154/full/1/153', 'eng', true, UrlGeneratorInterface::ABSOLUTE_PATH, '_ez_content_view'),
+            array('/view/content/154/full/1/153', '/view/content/154/full/1/153', '/eng/view/content/154/full/1/153', 'eng', true, UrlGeneratorInterface::ABSOLUTE_PATH, '_ez_content_view', [], false),
+            array('/view/content/154/full/1/153', '/view/content/154/full/1/153', '/view/content/154/full/1/153', 'eng', true, UrlGeneratorInterface::ABSOLUTE_PATH, '_ez_content_view', [], true),
         );
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -125,7 +125,8 @@ class UrlAliasGenerator extends Generator
         } else {
             $path = $this->defaultRouter->generate(
                 self::INTERNAL_CONTENT_VIEW_ROUTE,
-                array('contentId' => $location->contentId, 'locationId' => $location->id)
+                array('contentId' => $location->contentId, 'locationId' => $location->id, 'ignoreSiteAccess' => true),
+                $this->defaultRouter::ABSOLUTE_PATH
             );
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -312,7 +312,7 @@ class UrlAliasGeneratorTest extends TestCase
             ->method('generate')
             ->with(
                 UrlAliasGenerator::INTERNAL_CONTENT_VIEW_ROUTE,
-                array('contentId' => $location->contentId, 'locationId' => $location->id)
+                array('contentId' => $location->contentId, 'locationId' => $location->id, 'ignoreSiteAccess' => true)
             )
             ->will($this->returnValue($uri));
 
@@ -441,5 +441,41 @@ class UrlAliasGeneratorTest extends TestCase
                 ]
             )
             ->getMock();
+    }
+
+    public function testDoGenerateNoUrlAliasNorSiteAccess()
+    {
+        $location = new Location(array('id' => 153, 'contentInfo' => new ContentInfo(array('id' => 154))));
+        $uri = '/view/content/154/full/1/153';
+
+        $this->configResolver
+            ->expects($this->at(0))
+            ->method('getParameter')
+            ->with('languages', null, 'eng')
+            ->will($this->returnValue(['eng-US']));
+
+        $this->configResolver
+            ->expects($this->at(1))
+            ->method('getParameter')
+            ->with('content.tree_root.location_id', null, 'eng')
+            ->will($this->returnValue(2));
+
+        $this->urlAliasService
+            ->expects($this->once())
+            ->method('listLocationAliases')
+            ->with($location, false, null, null, ['eng-US'])
+            ->will($this->returnValue(array()));
+
+        $this->router
+            ->expects($this->once())
+            ->method('generate')
+            ->with(
+                UrlAliasGenerator::INTERNAL_CONTENT_VIEW_ROUTE,
+                array('contentId' => $location->contentId, 'locationId' => $location->id, 'ignoreSiteAccess' => true),
+                $this->router::ABSOLUTE_PATH
+            )
+            ->will($this->returnValue($uri));
+
+        $this->assertSame($uri, $this->urlAliasGenerator->doGenerate($location, array('contentId' => 154, 'siteaccess' => 'eng')));
     }
 }


### PR DESCRIPTION
Assume two siteaccesses, `eng` and `chi`, have been configured to support
`eng-US` and `chi-CN` locales respectively. If an article at
`/chi/news/article_1` only has `chi-CN` translation available, calling
`path(ez_route(null, {language: 'eng-US'}))` in the template would
output something like `/eng/chi/view/content/...`, which is incorrect
because the `/chi` part should not be there.

This issue occurs when `UrlAliasGenerator` has failed to generate the
URL alias for the specific article in the target language, as the
translation in the target language does not exist, so as the fallback
generator, the `DefaultRouter` will be used to generate the internal URL
for the article. However, by default, the `DefaultRouter` always
prepends the siteaccess, which is `chi` in this case, to the genreated
URL, and finally the `UrlAliasGenerator` will also prepend the target
siteaccess 'eng' to the URL.

To fix this issue, a new parameter `$ignoreSiteAccess` has been
introducted in argument `$parameters` of `DefaultRouter::generate()`, which indicates if the `DefaultRouter` should ignore the siteaccess from the start of the URL it generates.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29364](https://jira.ez.no/browse/EZP-29364)
| **Bug**            | yes
| **New feature**    | yes
| **Target version** | `6.x`/`7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
