### PR TITLE
Fix duplicated siteaccesses in generated URLs.

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Routing/DefaultRouter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/DefaultRouter.php
@@ -76,7 +76,7 @@ class DefaultRouter extends Router implements RequestMatcherInterface, SiteAcces
         return $this->match($request->attributes->get('semanticPathinfo', $request->getPathInfo()));
     }
 
-    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
+    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH, $ignoreSiteAccess = false)
     {
         $siteAccess = $this->siteAccess;
         $originalContext = $context = $this->getContext();
@@ -100,7 +100,7 @@ class DefaultRouter extends Router implements RequestMatcherInterface, SiteAcces
         $url = parent::generate($name, $parameters, $referenceType);
 
         // Now putting back SiteAccess URI if needed.
-        if ($isSiteAccessAware && $siteAccess && $siteAccess->matcher instanceof URILexer) {
+        if ($isSiteAccessAware && $siteAccess && $siteAccess->matcher instanceof URILexer && false === $ignoreSiteAccess) {
             if ($referenceType === self::ABSOLUTE_URL || $referenceType === self::NETWORK_PATH) {
                 $scheme = $context->getScheme();
                 $port = '';

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/DefaultRouterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/DefaultRouterTest.php
@@ -147,7 +147,7 @@ class DefaultRouterTest extends \PHPUnit_Framework_TestCase
      * @param int $referenceType The type of reference to be generated (one of the constants)
      * @param string $routeName
      */
-    public function testGenerateWithSiteAccess($urlGenerated, $relevantUri, $expectedUrl, $saName, $isMatcherLexer, $referenceType, $routeName)
+    public function testGenerateWithSiteAccess($urlGenerated, $relevantUri, $expectedUrl, $saName, $isMatcherLexer, $referenceType, $routeName, $parameters = [], $ignoreSiteAccess = false)
     {
         $routeName = $routeName ?: __METHOD__;
         $nonSiteAccessAwareRoutes = array('_dontwantsiteaccess');
@@ -169,7 +169,7 @@ class DefaultRouterTest extends \PHPUnit_Framework_TestCase
         if ($isMatcherLexer) {
             $matcher = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\URILexer');
             // Route is siteaccess aware, we're expecting analyseLink() to be called
-            if (!in_array($routeName, $nonSiteAccessAwareRoutes)) {
+            if (!in_array($routeName, $nonSiteAccessAwareRoutes) && false === $ignoreSiteAccess) {
                 $matcher
                     ->expects($this->once())
                     ->method('analyseLink')
@@ -205,7 +205,7 @@ class DefaultRouterTest extends \PHPUnit_Framework_TestCase
         $router->setContext($requestContext);
         $router->setNonSiteAccessAwareRoutes($nonSiteAccessAwareRoutes);
 
-        $this->assertSame($expectedUrl, $router->generate($routeName, array(), $referenceType));
+        $this->assertSame($expectedUrl, $router->generate($routeName, $parameters, $referenceType, $ignoreSiteAccess));
     }
 
     public function providerGenerateWithSiteAccess()
@@ -223,6 +223,9 @@ class DefaultRouterTest extends \PHPUnit_Framework_TestCase
             array('/foo/bar/baz', '/foo/bar/baz', '/test_siteaccess/foo/bar/baz', 'test_siteaccess', true, UrlGeneratorInterface::ABSOLUTE_PATH, null),
             array('/foo/root_folder/bar/baz', '/bar/baz', '/foo/root_folder/test_siteaccess/bar/baz', 'test_siteaccess', true, UrlGeneratorInterface::ABSOLUTE_PATH, null),
             array('/foo/bar/baz', '/foo/bar/baz', '/foo/bar/baz', 'test_siteaccess', true, UrlGeneratorInterface::ABSOLUTE_PATH, '_dontwantsiteaccess'),
+            array('/view/content/154/full/1/153', '/view/content/154/full/1/153', '/eng/view/content/154/full/1/153', 'eng', true, UrlGeneratorInterface::ABSOLUTE_PATH, '_ez_content_view'),
+            array('/view/content/154/full/1/153', '/view/content/154/full/1/153', '/eng/view/content/154/full/1/153', 'eng', true, UrlGeneratorInterface::ABSOLUTE_PATH, '_ez_content_view', [], false),
+            array('/view/content/154/full/1/153', '/view/content/154/full/1/153', '/view/content/154/full/1/153', 'eng', true, UrlGeneratorInterface::ABSOLUTE_PATH, '_ez_content_view', [], true),
         );
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -127,7 +127,9 @@ class UrlAliasGenerator extends Generator
         } else {
             $path = $this->defaultRouter->generate(
                 self::INTERNAL_CONTENT_VIEW_ROUTE,
-                array('contentId' => $location->contentId, 'locationId' => $location->id)
+                array('contentId' => $location->contentId, 'locationId' => $location->id),
+                $this->defaultRouter::ABSOLUTE_PATH,
+                true
             );
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -444,4 +444,41 @@ class UrlAliasGeneratorTest extends PHPUnit_Framework_TestCase
             )
             ->getMock();
     }
+
+    public function testDoGenerateNoUrlAliasNorSiteAccess()
+    {
+        $location = new Location(array('id' => 153, 'contentInfo' => new ContentInfo(array('id' => 154))));
+        $uri = "/view/content/154/full/1/153";
+
+        $this->configResolver
+            ->expects($this->at(0))
+            ->method('getParameter')
+            ->with('languages', null, 'eng')
+            ->will($this->returnValue(['eng-US']));
+
+        $this->configResolver
+            ->expects($this->at(1))
+            ->method('getParameter')
+            ->with('content.tree_root.location_id', null, 'eng')
+            ->will($this->returnValue(2));
+
+        $this->urlAliasService
+            ->expects($this->once())
+            ->method('listLocationAliases')
+            ->with($location, false, null, null, ['eng-US'])
+            ->will($this->returnValue(array()));
+
+        $this->router
+            ->expects($this->once())
+            ->method('generate')
+            ->with(
+                UrlAliasGenerator::INTERNAL_CONTENT_VIEW_ROUTE,
+                array('contentId' => $location->contentId, 'locationId' => $location->id),
+                $this->router::ABSOLUTE_PATH,
+                true
+            )
+            ->will($this->returnValue($uri));
+
+        $this->assertSame($uri, $this->urlAliasGenerator->doGenerate($location, array('contentId' => 154, 'siteaccess' => 'eng')));
+    }
 }


### PR DESCRIPTION
Assume two siteaccesses, `eng` and `chi`, have been configured to support
`eng-US` and `chi-CN` locales respectively. If an article at
`/chi/news/article_1` only has `chi-CN` translation available, calling
`path(ez_route(null, {language: 'eng-US'}))` in the template would
output something like `/eng/chi/view/content/...`, which is incorrect
because the `/chi` part should not be there.

This issue occurs when `UrlAliasGenerator` has failed to generate the
URL alias for the specific article in the target language, as the
translation in the target language does not exist, so as the fallback
generator, the `DefaultRouter` will be used to generate the internal URL
for the article. However, by default, the `DefaultRouter` always
prepends the siteaccess, which is `chi` in this case, to the genreated
URL, and finally the `UrlAliasGenerator` will also prepend the target
siteaccess 'eng' to the URL.

To fix this issue, a new argument `$ignoreSiteAccess` has been
introducted in `DefaultRouter::generate()`, which indicates if the `DefaultRouter` should ignore the siteeaccess from the start of the URL it generates.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29364](https://jira.ez.no/browse/EZP-29364)
| **Bug**            | yes
| **New feature**    | yes
| **Target version** | `6.x`/`7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.