### PR TITLE
Fix EZP-29375: REST API doesn't support multiple relation types

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RelationTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RelationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishRestBundle\Tests\Functional;
+
+use eZ\Bundle\EzPublishRestBundle\Tests\Functional\TestCase as RESTFunctionalTestCase;
+
+class RelationTest extends RESTFunctionalTestCase
+{
+    public function testRelation()
+    {
+        $xml = <<< XML
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentCreate>
+  <ContentType href="/api/ezp/v2/content/types/2" />
+  <mainLanguageCode>eng-GB</mainLanguageCode>
+  <LocationCreate>
+    <ParentLocation href="/api/ezp/v2/content/locations/1/2" />
+    <priority>0</priority>
+    <hidden>false</hidden>
+    <sortField>PATH</sortField>
+    <sortOrder>ASC</sortOrder>
+  </LocationCreate>
+  <Section href="/api/ezp/v2/content/sections/1" />
+  <alwaysAvailable>true</alwaysAvailable>
+  <User href="/api/ezp/v2/user/users/14" />
+  <modificationDate>2012-09-30T12:30:00</modificationDate>
+  <fields>
+    <field>
+      <fieldDefinitionIdentifier>title</fieldDefinitionIdentifier>
+      <languageCode>eng-GB</languageCode>
+      <fieldValue>testRelation</fieldValue>
+    </field>
+    <field>
+      <fieldDefinitionIdentifier>intro</fieldDefinitionIdentifier>
+      <languageCode>eng-GB</languageCode>
+      <fieldValue>
+        <value key="xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0"&gt;
+&lt;title ezxhtml:level="2"&gt;This is a title.&lt;/title&gt;
+&lt;para&gt;&lt;link xlink:href="ezcontent://1" xml:id="id1" xlink:title="Content title" ezxhtml:class="linkClass5"&gt;Content name&lt;/link&gt;&lt;/para&gt;
+&lt;ezembed xlink:href="ezcontent://1" view="line" xml:id="embed-id-2" ezxhtml:class="embedClass2" ezxhtml:align="right"/&gt;
+&lt;/section&gt;</value>
+      </fieldValue>
+    </field>
+    <field>
+      <fieldDefinitionIdentifier>image</fieldDefinitionIdentifier>
+      <languageCode>eng-GB</languageCode>
+      <fieldValue>
+        <value key="destinationContentId">1</value>
+      </fieldValue>
+    </field>
+  </fields>
+</ContentCreate>
+XML;
+        $testContent = $this->createContent($xml);
+        $relations = $testContent['CurrentVersion']['Version']['Relations']['Relation'];
+
+        self::assertEquals('LINK', $relations[0]['RelationType']);
+        self::assertEquals('EMBED', $relations[1]['RelationType']);
+        self::assertEquals('ATTRIBUTE', $relations[2]['RelationType']);
+    }
+}

--- a/eZ/Publish/Core/REST/Client/Input/Parser/Relation.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/Relation.php
@@ -72,18 +72,30 @@ class Relation extends BaseParser
      */
     protected function convertRelationType($stringType)
     {
-        switch (strtoupper($stringType)) {
-            case 'COMMON':
-                return Values\Content\Relation::COMMON;
-            case 'EMBED':
-                return Values\Content\Relation::EMBED;
-            case 'LINK':
-                return Values\Content\Relation::LINK;
-            case 'FIELD':
-                return Values\Content\Relation::FIELD;
+        $stringTypeList = explode(',', strtoupper($stringType));
+        $relationType = 0;
+
+        foreach ($stringTypeList as $stringTypeValue) {
+            switch ($stringTypeValue) {
+                case 'COMMON':
+                    $relationType |= Values\Content\Relation::COMMON;
+                    break;
+                case 'EMBED':
+                    $relationType |= Values\Content\Relation::EMBED;
+                    break;
+                case 'LINK':
+                    $relationType |= Values\Content\Relation::LINK;
+                    break;
+                case 'FIELD':
+                    $relationType |= Values\Content\Relation::FIELD;
+                    break;
+                default:
+                    throw new \RuntimeException(
+                        sprintf('Unknown Relation type: "%s"', $stringTypeValue)
+                    );
+            }
         }
-        throw new \RuntimeException(
-            sprintf('Unknown Relation type: "%s"', $stringType)
-        );
+
+        return $relationType;
     }
 }

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestRelation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestRelation.php
@@ -85,21 +85,31 @@ class RestRelation extends ValueObjectVisitor
      *
      * @param int $relationType
      *
+     * @throws \Exception
+     *
      * @return string
      */
     protected function getRelationTypeString($relationType)
     {
-        switch ($relationType) {
-            case RelationValue::COMMON:
-                return 'COMMON';
-            case RelationValue::EMBED:
-                return 'EMBED';
-            case RelationValue::LINK:
-                return 'LINK';
-            case RelationValue::FIELD:
-                return 'ATTRIBUTE';
+        $relationTypeList = [];
+
+        if (RelationValue::COMMON & $relationType) {
+            $relationTypeList[] = 'COMMON';
+        }
+        if (RelationValue::EMBED & $relationType) {
+            $relationTypeList[] = 'EMBED';
+        }
+        if (RelationValue::LINK & $relationType) {
+            $relationTypeList[] = 'LINK';
+        }
+        if (RelationValue::FIELD & $relationType) {
+            $relationTypeList[] = 'ATTRIBUTE';
         }
 
-        throw new \Exception('Unknown relation type ' . $relationType . '.');
+        if (empty($relationTypeList)) {
+            throw new \Exception('Unknown relation type ' . $relationType . '.');
+        }
+
+        return implode(',', $relationTypeList);
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29375](https://jira.ez.no/browse/EZP-29375)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

If a content has a relation with e. g. COMMON and EMBED relation type, the REST API can't load it.

Following exception is thrown:
```
Unknown relation type 3
```

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
