### PR TITLE
EZP-29376: New SiteAccess aware repo not handling languages with sudo()

### DIFF
--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -378,7 +378,7 @@ class Repository implements RepositoryInterface
      *
      *
      * @param \Closure $callback
-     * @param \eZ\Publish\API\Repository\Repository $outerRepository
+     * @param \eZ\Publish\API\Repository\Repository|null $outerRepository
      *
      * @throws \RuntimeException Thrown on recursive sudo() use.
      * @throws \Exception Re throws exceptions thrown inside $callback
@@ -387,10 +387,7 @@ class Repository implements RepositoryInterface
      */
     public function sudo(Closure $callback, RepositoryInterface $outerRepository = null)
     {
-        return $this->getPermissionResolver()->sudo(
-            $callback,
-            $outerRepository !== null ? $outerRepository : $this
-        );
+        return $this->getPermissionResolver()->sudo($callback, $outerRepository ?? $this);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Repository.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Repository.php
@@ -100,9 +100,9 @@ class Repository implements RepositoryInterface
         return $this->repository->setCurrentUser($user);
     }
 
-    public function sudo(Closure $callback)
+    public function sudo(Closure $callback, RepositoryInterface $outerRepository = null)
     {
-        return $this->repository->sudo($callback, $this);
+        return $this->repository->sudo($callback, $outerRepository ?? $this);
     }
 
     public function hasAccess($module, $function, UserReference $user = null)

--- a/eZ/Publish/Core/SignalSlot/Repository.php
+++ b/eZ/Publish/Core/SignalSlot/Repository.php
@@ -261,15 +261,16 @@ class Repository implements RepositoryInterface
      *
      *
      * @param \Closure $callback
+     * @param \eZ\Publish\API\Repository\Repository|null $outerRepository
      *
      * @throws \RuntimeException Thrown on recursive sudo() use.
      * @throws \Exception Re throws exceptions thrown inside $callback
      *
      * @return mixed
      */
-    public function sudo(Closure $callback)
+    public function sudo(Closure $callback, RepositoryInterface $outerRepository = null)
     {
-        return $this->repository->sudo($callback, $this);
+        return $this->repository->sudo($callback, $outerRepository ?? $this);
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29376](https://jira.ez.no/browse/EZP-29376)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 7.2
| **BC breaks**      | no
| **Tests pass**     | yes _(but we should find a way to add more functional testing around this)_
| **Doc needed**     | no _(well yes, but for the feature itself, not this bug fix)_

Another issue [found and fixed late in the review of SiteAccess Aware repo:
- https://github.com/ezsystems/ezpublish-kernel/pull/2064#discussion_r197780401

Broke usage in some cases out of the box with ContentView as it is using sudo() which was no longer
passing right repository by SignalSlot repo.

PR here is cleaning up the signature for sudo() on all Repo implementations
so this is not an issue anymore.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] ~Implement tests.~
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
