### PR TITLE
Fix access denied error for legacy content preview

### DIFF
--- a/eZ/Publish/Core/settings/repository.yml
+++ b/eZ/Publish/Core/settings/repository.yml
@@ -62,7 +62,7 @@ services:
             - '@ezpublish.spi.search'
             - '@ezpublish.search.background_indexer'
             - '@ezpublish.repository.relation_processor'
-        lazy: true
+        lazy: false
 
     ezpublish.api.service.content:
         class: "%ezpublish.api.service.content.class%"


### PR DESCRIPTION
Previewing content through the legacy admin interface triggers an
access denied error. This is because the `ezpublish.api.inner_repository`
service, abbreviated as `repository` service hereafter for discussion
purposes, has been configured as a lazy service, so an independent real
instance is initialized for each variable that refers to this service
id, therefore any permission check that depends on the `setCurrentUser()`
and `getCurrentUser()` methods fails.

Take the legacy content preview function as an example, the
`ezpublish_legacy.request_listener` listener stores current user in the
repository instance it holds by calling the `setCurrentUser()` method of
the instance, the `ezpublish_legacy.preview.controller` controller is
then supposed to retrieve the user from the same repository instance and
to perform permission checks on it. However, due to the nature of lazy
service, the request listener and the preview controller each holds an
independent repository instance, therefore the permission checks fail.

To fix this issue, set the `lazy` option of the service definition to
`false`.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug**            | yes
| **New feature**    | no
| **Target version** | `6.x`/`7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
