### PR TITLE
EZP-28881: Add a field to support "date object was trashed

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -726,6 +726,7 @@ CREATE TABLE `ezcontentobject_trash` (
   `remote_id` varchar(100) NOT NULL DEFAULT '',
   `sort_field` int(11) DEFAULT '1',
   `sort_order` int(11) DEFAULT '1',
+  `trashed` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`node_id`),
   KEY `ezcobj_trash_co_id` (`contentobject_id`),
   KEY `ezcobj_trash_depth` (`depth`),

--- a/data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql
+++ b/data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql
@@ -118,3 +118,10 @@ COMMIT;
 
 CREATE INDEX `ezcontentobject_tree_contentobject_id_path_string` ON `ezcontentobject_tree` (`path_string`, `contentobject_id`);
 CREATE INDEX `ezcontentobject_section` ON `ezcontentobject` (`section_id`);
+
+--
+-- EZP-28881: Add a field to support "date object was trashed"
+--
+
+ALTER TABLE ezcontentobject_trash add  trashed int(11) NOT NULL DEFAULT '0';
+

--- a/data/update/postgres/dbupdate-7.1.0-to-7.2.0.sql
+++ b/data/update/postgres/dbupdate-7.1.0-to-7.2.0.sql
@@ -241,3 +241,10 @@ WHERE def.adsrc LIKE 'nextval(%';
 
 CREATE INDEX ezcontentobject_tree_contentobject_id_path_string ON ezcontentobject_tree (path_string, contentobject_id);
 CREATE INDEX ezcontentobject_section ON ezcontentobject (section_id);
+
+--
+-- EZP-28881: Add a field to support "date object was trashed"
+--
+
+ALTER TABLE ezcontentobject_trash add  trashed integer DEFAULT 0 NOT NULL;
+

--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -20,6 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\Trash\SearchResult;
 use eZ\Publish\API\Repository\Values\Content\TrashItem as APITrashItem;
 use eZ\Publish\Core\Repository\Values\Content\TrashItem;
 use eZ\Publish\Core\Repository\Values\Content\Location;
+use DateTime;
 
 /**
  * Test case for operations in the TrashService using in memory storage.
@@ -254,6 +255,21 @@ class TrashServiceTest extends BaseTrashServiceTest
         $this->assertEquals(
             $trashItem,
             $trashItemReloaded
+        );
+
+        $this->assertInstanceOf(
+            DateTime::class,
+            $trashItemReloaded->trashed
+        );
+
+        $this->assertEquals(
+            $trashItem->trashed->getTimestamp(),
+            $trashItemReloaded->trashed->getTimestamp()
+        );
+
+        $this->assertGreaterThan(
+            0,
+            $trashItemReloaded->trashed->getTimestamp()
         );
 
         $this->assertInstanceOf(

--- a/eZ/Publish/API/Repository/Values/Content/TrashItem.php
+++ b/eZ/Publish/API/Repository/Values/Content/TrashItem.php
@@ -13,4 +13,10 @@ namespace eZ\Publish\API\Repository\Values\Content;
  */
 abstract class TrashItem extends Location
 {
+    /**
+     * Trashed timestamp.
+     *
+     * @var \DateTime
+     */
+    protected $trashed;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1143,6 +1143,7 @@ class DoctrineDatabase extends Gateway
         $query->insertInto($this->handler->quoteTable('ezcontentobject_trash'));
 
         unset($locationRow['contentobject_is_published']);
+        $locationRow['trashed'] = time();
         foreach ($locationRow as $key => $value) {
             $query->set($key, $query->bindValue($value));
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Mapper.php
@@ -45,6 +45,9 @@ class Mapper
         $location->depth = (int)$data[$prefix . 'depth'];
         $location->sortField = (int)$data[$prefix . 'sort_field'];
         $location->sortOrder = (int)$data[$prefix . 'sort_order'];
+        if (isset($data[$prefix . 'trashed'])) {
+            $location->trashed = (int)$data[$prefix . 'trashed'];
+        }
 
         return $location;
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -290,6 +290,7 @@ CREATE TABLE ezcontentobject_trash (
   remote_id varchar(100) NOT NULL DEFAULT '',
   sort_field int(11) DEFAULT 1,
   sort_order int(11) DEFAULT 1,
+  trashed int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (node_id),
   KEY ezcobj_trash_co_id (contentobject_id),
   KEY ezcobj_trash_depth (depth),

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
@@ -248,7 +248,8 @@ CREATE TABLE ezcontentobject_trash (
     priority integer DEFAULT 0 NOT NULL,
     remote_id character varying(100) DEFAULT ''::character varying NOT NULL,
     sort_field integer DEFAULT 1,
-    sort_order integer DEFAULT 1
+    sort_order integer DEFAULT 1,
+    trashed integer DEFAULT 0 NOT NULL
 );
 
 DROP TABLE IF EXISTS ezcontentobject_tree;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -256,6 +256,7 @@ CREATE TABLE ezcontentobject_trash (
   remote_id text(100) NOT NULL,
   sort_field integer DEFAULT 1,
   sort_order integer DEFAULT 1,
+  trashed integer NOT NULL DEFAULT 0,
   PRIMARY KEY (node_id)
 );
 CREATE INDEX ezcobj_trash_co_id ON ezcontentobject_trash (contentobject_id);

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -348,6 +348,7 @@ class TrashService implements TrashServiceInterface
                 'depth' => $spiTrashItem->depth,
                 'sortField' => $spiTrashItem->sortField,
                 'sortOrder' => $spiTrashItem->sortOrder,
+                'trashed' => isset($spiTrashItem->trashed) ? new DateTime('@' . $spiTrashItem->trashed) : new DateTime('@0'),
             )
         );
     }

--- a/eZ/Publish/SPI/Persistence/Content/Location/Trashed.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Trashed.php
@@ -15,4 +15,10 @@ use eZ\Publish\SPI\Persistence\Content\Location;
  */
 class Trashed extends Location
 {
+    /**
+     * Trashed timestamp.
+     *
+     * @var mixed Trashed timestamp.
+     */
+    public $trashed;
 }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-28881

See also https://github.com/ezsystems/ezpublish-legacy/pull/1351

The eZ Publish trash can really fill and make it difficult to find something in the trash. It would be nice to be able to have a script that periodically clears out items that are older than "n days" (for example). In order to do this, we would need a field for objects in the trash that saves the "date object was trashed". It has been often requested by clients.

This pull request makes the changes from the ez publish legacy repository compatible with the ezpublish kernel.

For this pull request we should add the support for the date attribute the object was trashed, so users can implement their own command while there is not an official one.

Todo:

- [ ] **ON MERGE:** Adjust upgrade scripts for release this will be in.