### PR TITLE
EZP-29386: Added FQCN-named Repository services to simplify autowiring

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -296,6 +296,7 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
         $coreLoader->load('repository/inner.yml');
         $coreLoader->load('repository/event.yml');
         $coreLoader->load('repository/siteaccessaware.yml');
+        $coreLoader->load('repository/autowire.yml');
         $coreLoader->load('fieldtype_external_storages.yml');
         $coreLoader->load('fieldtypes.yml');
         $coreLoader->load('indexable_fieldtypes.yml');

--- a/eZ/Publish/Core/settings/containerBuilder.php
+++ b/eZ/Publish/Core/settings/containerBuilder.php
@@ -39,6 +39,7 @@ $loader->load('repository.yml');
 $loader->load('repository/inner.yml');
 $loader->load('repository/event.yml');
 $loader->load('repository/siteaccessaware.yml');
+$loader->load('repository/autowire.yml');
 $loader->load('roles.yml');
 $loader->load('storage_engines/common.yml');
 $loader->load('storage_engines/cache.yml');

--- a/eZ/Publish/Core/settings/repository/autowire.yml
+++ b/eZ/Publish/Core/settings/repository/autowire.yml
@@ -1,0 +1,23 @@
+services:
+    eZ\Publish\API\Repository\Repository: '@ezpublish.api.repository'
+
+    eZ\Publish\API\Repository\BookmarkService: '@ezpublish.api.service.bookmark'
+    eZ\Publish\API\Repository\ContentService: '@ezpublish.api.service.content'
+    eZ\Publish\API\Repository\ContentTypeService: '@ezpublish.api.service.content_type'
+    eZ\Publish\API\Repository\FieldTypeService: '@ezpublish.api.service.field_type'
+    eZ\Publish\API\Repository\LanguageService: '@ezpublish.api.service.language'
+    eZ\Publish\API\Repository\LocationService: '@ezpublish.api.service.location'
+    eZ\Publish\API\Repository\NotificationService: '@ezpublish.api.service.notification'
+    eZ\Publish\API\Repository\ObjectStateService: '@ezpublish.api.service.object_state'
+    eZ\Publish\API\Repository\RoleService: '@ezpublish.api.service.role'
+    eZ\Publish\API\Repository\SearchService: '@ezpublish.api.service.search'
+    eZ\Publish\API\Repository\SectionService: '@ezpublish.api.service.section'
+    eZ\Publish\API\Repository\UserPreferenceService: '@ezpublish.api.service.user_preference'
+    eZ\Publish\API\Repository\UserService: '@ezpublish.api.service.user'
+    eZ\Publish\API\Repository\URLService: '@ezpublish.api.service.url'
+    eZ\Publish\API\Repository\URLWildcardService: '@ezpublish.api.service.url_wildcard'
+    eZ\Publish\API\Repository\URLAliasService: '@ezpublish.api.service.url_alias'
+    eZ\Publish\API\Repository\TrashService: '@ezpublish.api.service.trash'
+
+    eZ\Publish\API\Repository\PermissionResolver:
+        factory: 'eZ\Publish\API\Repository\Repository:getPermissionResolver'

--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -573,6 +573,7 @@ abstract class BaseIntegrationTest extends TestCase
         $loader->load('repository/inner.yml');
         $loader->load('repository/event.yml');
         $loader->load('repository/siteaccessaware.yml');
+        $loader->load('repository/autowire.yml');
         $loader->load('fieldtype_external_storages.yml');
         $loader->load('storage_engines/common.yml');
         $loader->load('storage_engines/shortcuts.yml');

--- a/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
@@ -139,6 +139,7 @@ abstract class FileBaseIntegrationTest extends BaseIntegrationTest
         $loader->load('repository/inner.yml');
         $loader->load('repository/event.yml');
         $loader->load('repository/siteaccessaware.yml');
+        $loader->load('repository/autowire.yml');
         $loader->load('fieldtype_external_storages.yml');
         $loader->load('storage_engines/common.yml');
         $loader->load('storage_engines/shortcuts.yml');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29386](https://jira.ez.no/browse/EZP-29386)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | could improve DX

This PR adds Repository API service aliases to simplify autowiring.
We already use this feature in at least two `EzPublishCoreBundle` commands, thus it is considered to be a bug. It works because these aliases are defined in AdminUI which is a flaw in the architecture.

**TODO**:
- [x] Ask for Code Review.