### PR TITLE
EZP-29385: Richtext : blockquote does not allow multiple titles on the same level

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -22,6 +22,15 @@
       </a:documentation>
       <ref name="db.title"/>
     </define>
+    <define name="db.blockquote.info" combine="choice">
+      <a:documentation>
+        Needed by the LIBXML engine to allow for multiple title elements on the same level below blockquote
+      </a:documentation>
+      <optional>
+        <ref name="db.title"/>
+      </optional>
+    </define>
+
     <define name="db.orderedlist">
       <element name="orderedlist">
         <a:documentation>A list in which each entry is marked with a sequentially incremented label</a:documentation>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Validator/DocbookTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Validator/DocbookTest.php
@@ -57,6 +57,25 @@ class DocbookTest extends TestCase
 ',
                 array(),
             ),
+            array(
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <blockquote>
+    <para>Some comments to people\'s comments!</para>
+  </blockquote>
+  <blockquote>
+    <title ezxhtml:level="3">Header level 3</title>
+    <title ezxhtml:level="4">Header level 4</title>
+    <para>foobar quote<link xlink:href="ezurl://1044" xlink:show="none">http://ez.no</link> for more info.</para>
+  </blockquote>
+</section>
+',
+                array(),
+            ),
         );
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29385](https://jira.ez.no/browse/EZP-29385)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`/`6.13`/`7.x` for bug fixes or improvements _(on existing features)_, `master` for features
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This one fixes [EZP-29385](https://jira.ez.no/browse/EZP-29385)
The fix is based on Petar's fix to a [similar issue](https://github.com/ezsystems/ezpublish-kernel/pull/740/commits/8324a9f9c00267b96aa1f11c60fe774324f38dac) with `<section>`.
Honesty, I don't quite understand Petar's fix, but based on his comment it seems to be a workaround for a libxml bug.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
