### PR TITLE
EZP-29387: Variation cache should be SiteAccess and domain aware

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
@@ -8,8 +8,10 @@ namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Cache;
 
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\SPI\Variation\VariationHandler;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Routing\RequestContext;
 
 /**
  * Persistence Cache layer for AliasGenerator.
@@ -27,13 +29,27 @@ class AliasGeneratorDecorator implements VariationHandler
     private $cache;
 
     /**
+     * @var \eZ\Publish\Core\MVC\Symfony\SiteAccess
+     */
+    private $siteAccess;
+
+    /**
+     * @var \Symfony\Component\Routing\RequestContext
+     */
+    private $requestContext;
+
+    /**
      * @param \eZ\Publish\SPI\Variation\VariationHandler $aliasGenerator
      * @param \Psr\Cache\CacheItemPoolInterface $cache
+     * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteAccess
+     * @param \Symfony\Component\Routing\RequestContext $requestContext
      */
-    public function __construct(VariationHandler $aliasGenerator, CacheItemPoolInterface $cache)
+    public function __construct(VariationHandler $aliasGenerator, CacheItemPoolInterface $cache, SiteAccess $siteAccess, RequestContext $requestContext)
     {
         $this->aliasGenerator = $aliasGenerator;
         $this->cache = $cache;
+        $this->siteAccess = $siteAccess;
+        $this->requestContext = $requestContext;
     }
 
     /**
@@ -68,7 +84,11 @@ class AliasGeneratorDecorator implements VariationHandler
     private function getCacheKey(Field $field, VersionInfo $versionInfo, $variationName)
     {
         return sprintf(
-            'ez-image-variation-%d-%d-%s-%s',
+            'ez-image-variation-%s-%s-%s-%d-%d-%d-%s-%s',
+            $this->siteAccess->name,
+            $this->requestContext->getScheme(),
+            $this->requestContext->getHost(),
+            $this->requestContext->getScheme() === 'https' ? $this->requestContext->getHttpsPort() : $this->requestContext->getHttpPort(),
             $versionInfo->getContentInfo()->id,
             $versionInfo->id,
             $field->id,

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -88,6 +88,8 @@ services:
         arguments:
             - '@ezpublish.image_alias.imagine.variation.imagine_alias_generator'
             - '@ezpublish.cache_pool'
+            - '@ezpublish.siteaccess'
+            - '@router.request_context'
 
     ezpublish.image_alias.imagine.variation.imagine_alias_generator:
         class: '%ezpublish.image_alias.imagine.variation.imagine_alias_generator.class%'


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29387](https://jira.ez.no/browse/EZP-29387)
| **Bug** | yes
| **New feature**    | no
| **Target version** | `6.7`/`6.13` / `7.2`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

As stated in the JIRA issue, variation cache should be SiteAccess aware. 


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
