### PR TITLE
EZP-29387: Variation cache should be SiteAccess and domain aware

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
@@ -9,6 +9,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Cache;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\SPI\Variation\VariationHandler;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Routing\RequestContext;
@@ -16,7 +17,7 @@ use Symfony\Component\Routing\RequestContext;
 /**
  * Persistence Cache layer for AliasGenerator.
  */
-class AliasGeneratorDecorator implements VariationHandler
+class AliasGeneratorDecorator implements VariationHandler, SiteAccessAware
 {
     /**
      * @var \eZ\Publish\SPI\Variation\VariationHandler
@@ -75,7 +76,7 @@ class AliasGeneratorDecorator implements VariationHandler
     /**
      * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteAccess
      */
-    public function setSiteAccess(SiteAccess $siteAccess)
+    public function setSiteAccess(SiteAccess $siteAccess = null)
     {
         $this->siteAccess = $siteAccess;
     }
@@ -91,7 +92,7 @@ class AliasGeneratorDecorator implements VariationHandler
     {
         return sprintf(
             'ez-image-variation-%s-%s-%s-%d-%d-%d-%s-%s',
-            $this->siteAccess->name,
+            $this->siteAccess ? $this->siteAccess->name : 'default',
             $this->requestContext->getScheme(),
             $this->requestContext->getHost(),
             $this->requestContext->getScheme() === 'https' ? $this->requestContext->getHttpsPort() : $this->requestContext->getHttpPort(),

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
@@ -41,14 +41,12 @@ class AliasGeneratorDecorator implements VariationHandler
     /**
      * @param \eZ\Publish\SPI\Variation\VariationHandler $aliasGenerator
      * @param \Psr\Cache\CacheItemPoolInterface $cache
-     * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteAccess
      * @param \Symfony\Component\Routing\RequestContext $requestContext
      */
-    public function __construct(VariationHandler $aliasGenerator, CacheItemPoolInterface $cache, SiteAccess $siteAccess, RequestContext $requestContext)
+    public function __construct(VariationHandler $aliasGenerator, CacheItemPoolInterface $cache, RequestContext $requestContext)
     {
         $this->aliasGenerator = $aliasGenerator;
         $this->cache = $cache;
-        $this->siteAccess = $siteAccess;
         $this->requestContext = $requestContext;
     }
 
@@ -72,6 +70,14 @@ class AliasGeneratorDecorator implements VariationHandler
         }
 
         return $image;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteAccess
+     */
+    public function setSiteAccess(SiteAccess $siteAccess)
+    {
+        $this->siteAccess = $siteAccess;
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -90,7 +90,7 @@ services:
             - '@ezpublish.cache_pool'
             - '@router.request_context'
         calls:
-            - [setSiteAccess, ["@ezpublish.siteaccess"]]
+            - [setSiteAccess, ['@ezpublish.siteaccess']]
 
     ezpublish.image_alias.imagine.variation.imagine_alias_generator:
         class: '%ezpublish.image_alias.imagine.variation.imagine_alias_generator.class%'

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -88,8 +88,9 @@ services:
         arguments:
             - '@ezpublish.image_alias.imagine.variation.imagine_alias_generator'
             - '@ezpublish.cache_pool'
-            - '@ezpublish.siteaccess'
             - '@router.request_context'
+        calls:
+            - [setSiteAccess, ["@ezpublish.siteaccess"]]
 
     ezpublish.image_alias.imagine.variation.imagine_alias_generator:
         class: '%ezpublish.image_alias.imagine.variation.imagine_alias_generator.class%'


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29387](https://jira.ez.no/browse/EZP-29387)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `6.7`/`6.13`/`7.2`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This is follow-up for changes introduced in https://github.com/ezsystems/ezpublish-kernel/pull/2382 regarding to the @andrerom's comment: https://github.com/ezsystems/ezpublish-kernel/pull/2382#discussion_r200099476


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
