### PR TITLE
EZP-29377: Source translation (en) should be always available

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/TranslationCollectorPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/TranslationCollectorPass.php
@@ -25,15 +25,15 @@ class TranslationCollectorPass implements CompilerPassInterface
         'fi_FI' => 'fi',
         'fr_FR' => 'fr',
         'hi_IN' => 'hi',
+        'hr_HR' => 'hr',
         'hu_HU' => 'hu',
+        'it_IT' => 'it',
         'ja_JP' => 'ja',
-        'nb_NO' => 'no',
+        'nb_NO' => 'nb',
+        'no_NO' => 'no',
         'pl_PL' => 'pl',
         'pt_PT' => 'pt',
         'ru_RU' => 'ru',
-        'en_US' => 'en',
-        'it_IT' => 'it',
-        'hr_HR' => 'hr',
     ];
 
     public function process(ContainerBuilder $container)
@@ -45,7 +45,10 @@ class TranslationCollectorPass implements CompilerPassInterface
         $definition = $container->getDefinition('translator.default');
         $collector = new GlobCollector($container->getParameterBag()->get('kernel.root_dir'));
 
-        $availableTranslations = [];
+        $availableTranslations = [
+            'en', /* Source translation should be always available */
+        ];
+
         foreach ($collector->collect() as $file) {
             /* TODO - to remove when translation files will have proper names. */
             if (isset(self::LOCALES_MAP[$file['locale']])) {

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/TranslationCollectorPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/TranslationCollectorPass.php
@@ -30,7 +30,6 @@ class TranslationCollectorPass implements CompilerPassInterface
         'it_IT' => 'it',
         'ja_JP' => 'ja',
         'nb_NO' => 'nb',
-        'no_NO' => 'no',
         'pl_PL' => 'pl',
         'pt_PT' => 'pt',
         'ru_RU' => 'ru',

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/TranslationCollectorPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/TranslationCollectorPass.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class TranslationCollectorPass implements CompilerPassInterface
 {
+    const ORIGINAL_TRANSLATION = 'en';
+
     /** @var array */
     public const LOCALES_MAP = [
         'de_DE' => 'de',
@@ -44,10 +46,7 @@ class TranslationCollectorPass implements CompilerPassInterface
         $definition = $container->getDefinition('translator.default');
         $collector = new GlobCollector($container->getParameterBag()->get('kernel.root_dir'));
 
-        $availableTranslations = [
-            'en', /* Source translation should be always available */
-        ];
-
+        $availableTranslations = [self::ORIGINAL_TRANSLATION];
         foreach ($collector->collect() as $file) {
             /* TODO - to remove when translation files will have proper names. */
             if (isset(self::LOCALES_MAP[$file['locale']])) {

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/TranslationCollectorPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/TranslationCollectorPassTest.php
@@ -44,12 +44,12 @@ class TranslationCollectorPassTest extends AbstractCompilerPassTestCase
             [
                 'xlf',
                 __DIR__ . $this->normalizePath('/../Fixtures/vendor/../vendor/ezplatform-i18n/ezplatform-i18n-nb_no/ezpublish-kernel/messages.nb_NO.xlf'),
-                'no',
+                'nb',
                 'messages',
             ]
         );
 
-        $this->assertContainerBuilderHasParameter('available_translations', ['hi', 'no']);
+        $this->assertContainerBuilderHasParameter('available_translations', ['en', 'hi', 'nb']);
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29377](https://jira.ez.no/browse/EZP-29377)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Source translation (en) should be always available. Otherwise, it won't be properly resolved if: 

1. English is the primary language in the browser 
2. Other i18n package is installed from the list of preferred languages in browser

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
