### PR TITLE
EZP-29391: Richtext : superscript/subscript does not support <emphasis> and  <link> tag

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -22,6 +22,7 @@
       </a:documentation>
       <ref name="db.title"/>
     </define>
+
     <define name="db.blockquote.info" combine="choice">
       <a:documentation>
         Needed by the LIBXML engine to allow for multiple title elements on the same level below blockquote
@@ -29,6 +30,26 @@
       <optional>
         <ref name="db.title"/>
       </optional>
+    </define>
+
+    <define name="db.superscript.attlist" combine="interleave">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="db.emphasis"/>
+          <ref name="db.link"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+
+    <define name="db.subscript.attlist" combine="interleave">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="db.emphasis"/>
+          <ref name="db.link"/>
+        </choice>
+      </zeroOrMore>
     </define>
 
     <define name="db.orderedlist">

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Validator/DocbookTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Validator/DocbookTest.php
@@ -76,6 +76,44 @@ class DocbookTest extends TestCase
 ',
                 array(),
             ),
+            array(
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+    xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>test
+        <superscript>1
+            <emphasis role="strong">bold</emphasis>
+            <emphasis>italic</emphasis>
+            <emphasis role="underlined">underline</emphasis> superscript
+            <link xlink:href="http://ez.no" xlink:show="none" xlink:title="link tile">link</link>
+            <emphasis role="strikedthrough">strikedthrough</emphasis>
+        </superscript>
+    </para>
+</section>',
+                array(),
+            ),
+            array(
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+    xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>test
+        <subscript>1
+            <emphasis role="strong">bold</emphasis>
+            <emphasis>italic</emphasis>
+            <emphasis role="underlined">underline</emphasis> subscript
+            <link xlink:href="http://ez.no" xlink:show="none" xlink:title="link tile">link</link>
+            <emphasis role="strikedthrough">strikedthrough</emphasis>
+        </subscript>
+    </para>
+</section>',
+                array(),
+            ),
         );
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29391](https://jira.ez.no/browse/EZP-29391)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`/`6.13`/`7.x`for features
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This one fixes [EZP-29391](https://jira.ez.no/browse/EZP-29391)

I am a bit fuzzed that Docbook schema can contain such a bug. I locally converted the .rng to [simple syntax](http://www.oasis-open.org/committees/relax-ng/spec-20011203.html#simple-syntax) using [rng2srng](http://kohsuke.org/relaxng/rng2srng/) so that my brain could easier cope whith the insane nesting level in the schema and indeed the validation schema seems wrong

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
