### PR TITLE
EZEE-2176: Fixed fail of the db schema update script when the eznotification table already exists

### DIFF
--- a/data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql
+++ b/data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql
@@ -100,7 +100,7 @@ ADD CONSTRAINT `ezcontentbrowsebookmark_user_fk`
 -- EZEE-2081: Move NotificationBundle into AdminUI
 --
 
-CREATE TABLE `eznotification` (
+CREATE TABLE IF NOT EXISTS `eznotification` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `owner_id` int(11) NOT NULL DEFAULT 0,
   `is_pending` tinyint(1) NOT NULL DEFAULT '1',

--- a/data/update/postgres/dbupdate-7.1.0-to-7.2.0.sql
+++ b/data/update/postgres/dbupdate-7.1.0-to-7.2.0.sql
@@ -27,19 +27,20 @@ ADD CONSTRAINT ezcontentbrowsebookmark_user_fk
 -- EZEE-2081: Move NotificationBundle into AdminUI
 --
 
-CREATE TABLE eznotification (
+CREATE TABLE IF NOT EXISTS eznotification (
     id SERIAL,
     owner_id integer DEFAULT 0 NOT NULL ,
     is_pending integer DEFAULT 1 NOT NULL,
     type character varying(128) NOT NULL,
     created integer DEFAULT 0 NOT NULL,
-    data text
+    data text,
+    CONSTRAINT eznotification_pkey PRIMARY KEY (id)
 );
 
-ALTER TABLE ONLY eznotification
-    ADD CONSTRAINT eznotification_pkey PRIMARY KEY (id);
-
+DROP INDEX IF EXISTS eznotification_owner_id;
 CREATE INDEX eznotification_owner_id ON eznotification USING btree (owner_id);
+
+DROP INDEX IF EXISTS eznotification_owner_id_is_pending;
 CREATE INDEX eznotification_owner_id_is_pending ON eznotification USING btree (owner_id, is_pending);
 COMMIT;
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-2176](https://jira.ez.no/browse/EZEE-2176)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.x` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

In the EE installations database schema update script is failing because the `eznotification` table already exists. To proper update also the following queries should be executed (needs to be mentioned in documentation // cc @DominikaK @MagdalenaZuba)

```sql
ALTER TABLE `eznotification` 
CHANGE COLUMN `data` `data` BLOB NULL ;

ALTER TABLE `eznotification` 
DROP INDEX `owner_id` ,
ADD INDEX `eznotification_owner` (`owner_id` ASC);

ALTER TABLE `eznotification` 
DROP INDEX `is_pending` ,
ADD INDEX `eznotification_owner_is_pending` (`owner_id` ASC, `is_pending` ASC);
```

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Ask for Code Review.
