### PR TITLE
EZP-29363: extended to check version remove for unpublished content

### DIFF
--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -967,9 +967,11 @@ class ContentService implements ContentServiceInterface
         $contentInfo = $this->internalLoadContentInfo($contentInfo->id);
         $content = $this->internalLoadContent($contentInfo->id);
 
-        if (!$contentInfo->published && !$this->repository->canUser('content', 'versionremove', $content)) {
+        $canDeleteContent = $this->repository->canUser('content', 'remove', $contentInfo);
+
+        if (!$contentInfo->published && !$this->repository->canUser('content', 'versionremove', $content) && !$canDeleteContent) {
             throw new UnauthorizedException('content', 'versionremove', array('contentId' => $content->id));
-        } elseif (!$this->repository->canUser('content', 'remove', $contentInfo)) {
+        } elseif (!$canDeleteContent) {
             throw new UnauthorizedException('content', 'remove', array('contentId' => $contentInfo->id));
         }
 

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -965,8 +965,11 @@ class ContentService implements ContentServiceInterface
     public function deleteContent(ContentInfo $contentInfo)
     {
         $contentInfo = $this->internalLoadContentInfo($contentInfo->id);
+        $content = $this->internalLoadContent($contentInfo->id);
 
-        if (!$this->repository->canUser('content', 'remove', $contentInfo)) {
+        if (!$contentInfo->published && !$this->repository->canUser('content', 'versionremove', $content)) {
+            throw new UnauthorizedException('content', 'versionremove', array('contentId' => $content->id));
+        } elseif (!$this->repository->canUser('content', 'remove', $contentInfo)) {
             throw new UnauthorizedException('content', 'remove', array('contentId' => $contentInfo->id));
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29363](https://jira.ez.no/browse/EZP-29363)
| **Origin** | https://github.com/ezsystems/ezplatform-admin-ui/pull/552
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.x` and `7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Added check for versionremove if content is not published. Enables a user able to remove his own draft of a new content before it got published without requiring `content/delete`. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
