### PR TITLE
Prioritized fallback URL Alias translation by its language mask

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\API\Repository\Tests;
 
 use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
 use eZ\Publish\API\Repository\Tests\PHPUnitConstraint\ValidationErrorOccurs as PHPUnitConstraintValidationErrorOccurs;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\API\Repository\Repository;
@@ -621,5 +622,44 @@ abstract class BaseTest extends TestCase
         $constraint = new PHPUnitConstraintValidationErrorOccurs($expectedValidationErrorMessage);
 
         self::assertThat($exception, $constraint);
+    }
+
+    /**
+     * Create 'folder' Content.
+     *
+     * @param array $names Folder names in the form of <code>['&lt;language_code&gt;' => '&lt;name&gt;']</code>
+     * @param int $parentLocationId
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content published Content
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    protected function createFolder(array $names, $parentLocationId): Content
+    {
+        $repository = $this->getRepository(false);
+        $contentService = $repository->getContentService();
+        $contentTypeService = $repository->getContentTypeService();
+        $locationService = $repository->getLocationService();
+
+        if (empty($names)) {
+            throw new \RuntimeException(sprintf('%s expects non-empty names list', __METHOD__));
+        }
+        $mainLanguageCode = array_keys($names)[0];
+
+        $struct = $contentService->newContentCreateStruct(
+            $contentTypeService->loadContentTypeByIdentifier('folder'),
+            $mainLanguageCode
+        );
+        foreach ($names as $languageCode => $translatedName) {
+            $struct->setField('name', $translatedName, $languageCode);
+        }
+        $contentDraft = $contentService->createContent(
+            $struct,
+            [$locationService->newLocationCreateStruct($parentLocationId)]
+        );
+
+        return $contentService->publishVersion($contentDraft->versionInfo);
     }
 }

--- a/eZ/Publish/Core/Repository/URLAliasService.php
+++ b/eZ/Publish/Core/Repository/URLAliasService.php
@@ -285,10 +285,25 @@ class URLAliasService implements URLAliasServiceInterface
             }
         }
 
-        if ($spiUrlAlias->alwaysAvailable || $showAllTranslations) {
-            $lastLevelData = end($spiUrlAlias->pathData);
-            reset($lastLevelData['translations']);
+        $lastLevelData = end($spiUrlAlias->pathData);
+        reset($lastLevelData['translations']);
 
+        // keep BC for showAllTranslations service setting
+        if ($showAllTranslations) {
+            return key($lastLevelData['translations']);
+        } elseif ($spiUrlAlias->alwaysAvailable) {
+            // use forced languageCode if it exists in the available translations
+            if (!empty($languageCode) && isset($lastLevelData['translations'][$languageCode])) {
+                return $languageCode;
+            }
+            // use language code of URL alias first found in available translations
+            foreach ($spiUrlAlias->languageCodes as $_languageCode) {
+                if (isset($lastLevelData['translations'][$_languageCode])) {
+                    return $_languageCode;
+                }
+            }
+
+            // fallback to use language code of first available translation
             return key($lastLevelData['translations']);
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | TBD
| **Related JIRA issue** | [EZP-29335](https://jira.ez.no/browse/EZP-29335) (indirectly)
| **Discovered when working on** | #2388
| **Bug/Improvement**| yes
| **New feature**    | changed behavior
| **Target version** | `master`
| **BC breaks**      | TBD
| **Tests pass**     | yes
| **Doc needed**     | no

### Summary

It seems that the `path` returned in `URLAlias` ValueObject for Location with multilingual Content name is incorrect, but only on MySQL and SQLite.

For nested Content that exists in `eng-GB` translation and some other translation, e.g. `ger-DE`, when calling `URLAliasService::lookup('/<ger-DE_name1>/<ger-DE_name2>')` we should get that exact path, however we get `'/<ger-DE_name1>/<eng-GB_name2>'`. Seems like PostgreSQL is not affected by this.

### Alternative approach

As a workaround list of prioritized languages should include all languages.

TBH this doesn't make much sense, because Repository has all the information needed to build proper URLAlias Value Object. It is possible to return first language of SPI URL alias (from language mask) as a fallback in the case when prioritized languages list doesn't contain that language, as done in c4d3885.

### Issues with proper solution

There are tests like [`UrlAliasTest::testListLocationAliasesWithShowAllTranslations`](https://github.com/ezsystems/ezpublish-kernel/blob/v6.7.8/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlAliasTest.php#L789) which assume that in case of `showAllTranslations` service setting set to `true`, the first available translation in `pathData` is used.

Why this is IMHO wrong? There is no sort order applied on list of translation for `pathData` elements, which means the order of translations could potentially be random - depending on DBMS. We had in the past known issues when PostgreSQL returned unordered rows differently than MySQL.

Nevertheless to keep BC I [changed the behavior based on `showAllTranslations` setting](https://github.com/ezsystems/ezpublish-kernel/pull/2391/files/be6f1e2e4a28c7f2bbd451e3939da46b3b91fd7e..417c728ca34be981fb5471c68ff78b4384003dd1).

### Open questions

1. Should we change for the next major the behavior for `showAllTranslation = true` to also take into the account language mask first?
2. The other way around - is `alwaysAvailable` on URL Alias expected to behave in the same way as `showAllTranslations` now? In that case this solution is a BC break anyway.


**TODO**:
- [x] Fix the bug.
- [x] Implement tests.
- [x] Retarget for `master`.
- [ ] Answer open questions.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
