### PR TITLE
[PHPUnit] Fixed configuration files to conform to XSD schema

### DIFF
--- a/phpunit-integration-legacy-elasticsearch.xml
+++ b/phpunit-integration-legacy-elasticsearch.xml
@@ -23,6 +23,8 @@
                @todo: Search service is used all over the place, so we must test
                       all services here.
           -->
+          <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
+          <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
           <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/LanguageServiceTest.php</file>
@@ -53,8 +55,6 @@
           <file>eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/LimitationTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php</file>
-          <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
-          <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/phpunit-integration-legacy-solr.xml
+++ b/phpunit-integration-legacy-solr.xml
@@ -24,6 +24,8 @@
                  @todo: Search service is used all over the place, so we must test
                         all services here.
             -->
+            <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
+            <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceTest.php</file>
@@ -55,8 +57,6 @@
             <file>eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LimitationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php</file>
-            <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
-            <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
         </testsuite>
         <testsuite name="eZ\Publish\API\Repository\Tests\Regression">
             <directory>eZ/Publish/API/Repository/Tests/Regression/</directory>

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -16,6 +16,8 @@
     </php>
     <testsuites>
         <testsuite name="eZ\Publish\API\Repository">
+            <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
+            <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/PermissionServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
@@ -48,8 +50,6 @@
             <file>eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LimitationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php</file>
-            <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
-            <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
         </testsuite>
         <testsuite name="eZ\Publish\API\Repository\Tests\Regression">
             <directory>eZ/Publish/API/Repository/Tests/Regression/</directory>

--- a/phpunit-integration-rest-json.xml
+++ b/phpunit-integration-rest-json.xml
@@ -15,6 +15,8 @@
     </php>
     <testsuites>
         <testsuite name="eZ\Publish\API\Repository">
+            <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
+            <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceTest.php</file>
@@ -39,8 +41,6 @@
             <file>eZ/Publish/API/Repository/Tests/URLWildcardServiceAuthorizationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ObjectStateServiceAuthorizationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LimitationTest.php</file>
-            <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
-            <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/phpunit-integration-rest-xml.xml
+++ b/phpunit-integration-rest-xml.xml
@@ -15,6 +15,8 @@
     </php>
     <testsuites>
         <testsuite name="eZ\Publish\API\Repository">
+            <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
+            <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceTest.php</file>
@@ -39,8 +41,6 @@
             <file>eZ/Publish/API/Repository/Tests/URLWildcardServiceAuthorizationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ObjectStateServiceAuthorizationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LimitationTest.php</file>
-            <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
-            <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`, `6.13`, `7.2`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

According to the [PHPUnit XSD schema for configuration file](https://github.com/sebastianbergmann/phpunit/blob/4.8/phpunit.xsd#L139-L142), the `directory` entries should preceed `file` entries in a configuration file.

This PR fixes our PHPUnit configuration files to conform to that schema.

While [validation error occurs](https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/400907867#L738-L744) when using PHPUnit `^7.2`, I'm fixing it for Kernel `6.7` (using PHPUnit `^4.8`), because it has never been correct. We saw it only now because PHPUnit `7.2` included validating against that schema.

**TODO**:
- [x] Move `directory` section to the top of `testsuite` configuration in every PHPUnit configuration file.
- [x] Ask for Code Review.
