### PR TITLE
[TEST] EZP-29333: test create + delete content in same transaction

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -5737,6 +5737,18 @@ XML
         $contentService->deleteTranslationFromDraft($draft->versionInfo, $languageCode);
     }
 
+    public function testCreateAndDeleteWithinSameTransaction()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $repository->beginTransaction();
+        $content = $this->createContentDraft('folder', 2, ['name' => __METHOD__]);
+        $contentService->publishVersion($content->versionInfo);
+        $contentService->deleteContent($content->contentInfo);
+        $repository->commit();
+    }
+
     /**
      * Asserts that all aliases defined in $expectedAliasProperties with the
      * given properties are available in $actualAliases and not more.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29333](https://jira.ez.no/browse/EZP-29333)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.x`/`7.x` ?
| **BC breaks**      | no
| **Tests pass**     | no (on purpose)
| **Doc needed**     | no

Tests the case reported by @gggeek on JIRA. Creating and deleting a content item within a unique repository transaction throws an exception in the signal slot layer.

### TODO
- [ ] Integrate into the pull-request fixing the issue
