### PR TITLE
[WIP][SPI][Cache] Add tag for versions for clearing before preview

### DIFF
--- a/doc/specifications/cache/persistence/Readme.md
+++ b/doc/specifications/cache/persistence/Readme.md
@@ -17,6 +17,9 @@ List of tags and their meaning:
 - `content-<content-id>` :
   _Meta tag used on anything that are affected on changes to content, on content itself as well as location and so on._
 
+- `content-<content-id>-version-<version-number>`
+   _Used for specific versions, usuefull for clearing cache of a specific draft on changes for instance._
+
 - `content-fields-<content-id>` :
   _Used on content/user object itself (with fields), for use when operations affects field values but not content meta info._
 

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -207,7 +207,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
         if ($status === VersionInfo::STATUS_PUBLISHED) {
             $this->cache->invalidateTags(['content-' . $contentId]);
         } else {
-            $this->cache->invalidateTags(["content-$contentId-version-list"]);
+            $this->cache->invalidateTags(["content-$contentId-version-list", "content-$contentId-version-$versionNo"]);
         }
 
         return $return;
@@ -232,7 +232,15 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
     {
         $this->logger->logCall(__METHOD__, array('content' => $contentId, 'version' => $versionNo, 'struct' => $struct));
         $content = $this->persistenceHandler->contentHandler()->updateContent($contentId, $versionNo, $struct);
-        $this->cache->invalidateTags(['content-' . $contentId]);
+        // Not that it's supported by API, but if change was on published version we need to clear all content cache
+        if (
+            $content->versionInfo->contentInfo->status === ContentInfo::STATUS_PUBLISHED &&
+            $content->versionInfo->contentInfo->currentVersionNo == $versionNo
+        ) {
+            $this->cache->invalidateTags(["content-$contentId"]);
+        } else {
+            $this->cache->invalidateTags(["content-$contentId-version-$versionNo"]);
+        }
 
         return $content;
     }
@@ -275,7 +283,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
     {
         $this->logger->logCall(__METHOD__, array('content' => $contentId, 'version' => $versionNo));
         $return = $this->persistenceHandler->contentHandler()->deleteVersion($contentId, $versionNo);
-        $this->cache->invalidateTags(['content-' . $contentId]);
+        $this->cache->invalidateTags(["content-$contentId-version-$versionNo"]);
 
         return $return;
     }
@@ -400,7 +408,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
             $versionNo,
             $languageCode
         );
-        $this->cache->invalidateTags(['content-' . $contentId]);
+        $this->cache->invalidateTags(["content-$contentId-version-$versionNo"]);
 
         return $content;
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-XXXXX](https://jira.ez.no/browse/EZP-XXXXX)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.x`
| **BC breaks**      | no
| **Tests pass**     | we'll see
| **Doc needed**     | no

PRs* opend on legacy made me aware there is currently no way to clear cache for specific version.
And on closer look it seems we can optimize kernel a bit if we have that to reduce amount of cache we invalidate, so this PR adds such a tag and takes advantage of it.

*:
- https://github.com/ezsystems/ezpublish-legacy/pull/1375 _(this PR will not be needed anymore)_
- https://github.com/ezsystems/LegacyBridge/pull/153 _(this PR can be adapted to clear this new tag in  `contentVersion($contentId, $versionNo)`)_

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
