### PR TITLE
Use getenv() to retrieve test testup factory

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -160,17 +160,18 @@ abstract class BaseTest extends TestCase
     protected function getSetupFactory()
     {
         if (null === $this->setupFactory) {
-            if (false === isset($_ENV['setupFactory'])) {
+            $setupClass = getenv('setupFactory');
+
+            if (false === $setupClass) {
                 throw new \ErrorException(
-                    'Missing mandatory setting $_ENV["setupFactory"], this should normally be set in the relevant phpunit-integration-*.xml file and refer to a setupFactory for the given StorageEngine/SearchEngine in use'
+                    'Missing mandatory environment variable "setupFactory", this should normally be set in the relevant phpunit-integration-*.xml file and refer to a setupFactory for the given StorageEngine/SearchEngine in use'
                 );
             }
 
-            $setupClass = $_ENV['setupFactory'];
             if (false === class_exists($setupClass)) {
                 throw new \ErrorException(
                     sprintf(
-                        '$_ENV["setupFactory"] does not reference an existing class: %s. Did you forget to install an package dependency?',
+                        'Environment variable "setupFactory" does not reference an existing class: %s. Did you forget to install an package dependency?',
                         $setupClass
                     )
                 );


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Not needed
| **Bug/Improvement**| no
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This changes fetching of test `SetupFactory` class from `$_ENV` to `getenv()`, which will also check system's environment variables. It will enable overriding of `<env name="setupFactory" ... />` directive in PHPUnit configuration from command line, which is useful for example for running kernel integration tests from external repo to test for regressions.

Several other `<env ... />` configurations already use `getenv()`, for example `CORES_SETUP` and `fixtureDir`:

- https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php#L1396
- https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/API/Repository/Tests/SearchServiceTest.php#L4477