### PR TITLE
Changed usage of deprecated ezpublish.connection alias

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/TestInitDbCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/TestInitDbCommand.php
@@ -32,7 +32,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $database = $this->getContainer()->get('ezpublish.connection')->getConnection()->getParams();
+        $database = $this->getContainer()->get('ezpublish.persistence.connection')->getConnection()->getParams();
         if (is_array($database)) {
             $driverMap = array(
                 'pdo_mysql' => 'mysql',

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
@@ -26,9 +26,9 @@ services:
 
     # Alias for backend connection used by eZ Publish storage engine
     # Useful if you need to reuse it in order to access resources not related to eZ Publish, but stored in your backend (e.g. foreign DB tables)
+    # Using this service name is deprecated, and will be removed in a future major release
     ezpublish.connection:
         alias: ezpublish.api.storage_engine.legacy.dbhandler
-        deprecated: 'The "%service_id%" service is deprecated. Use "ezpublish.persistence.connection" instead'
 
     ezpublish.api.storage_engine.legacy:
         alias: ezpublish.spi.persistence.legacy

--- a/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/CleanUpRelationTypeEqZeroCommand.php
+++ b/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/CleanUpRelationTypeEqZeroCommand.php
@@ -105,7 +105,7 @@ EOT
     protected function executeFix()
     {
         /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler $conn */
-        $conn = $this->getContainer()->get('ezpublish.connection');
+        $conn = $this->getContainer()->get('ezpublish.persistence.connection');
         $conn->exec('DELETE FROM ezcontentobject_link WHERE relation_type = 0');
     }
 
@@ -129,7 +129,7 @@ EOT
                     . 'relation_type FROM ezcontentobject_link WHERE relation_type = 0';
 
         /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler $conn */
-        $conn = $this->getContainer()->get('ezpublish.connection');
+        $conn = $this->getContainer()->get('ezpublish.persistence.connection');
 
         $stmt = $conn->prepare($sql);
         $stmt->execute();
@@ -140,7 +140,7 @@ EOT
     protected function getTotalCount()
     {
         /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler $conn */
-        $conn = $this->getContainer()->get('ezpublish.connection');
+        $conn = $this->getContainer()->get('ezpublish.persistence.connection');
 
         $stmt = $conn->prepare('SELECT COUNT(id) FROM ezcontentobject_link WHERE relation_type = 0');
         $stmt->execute();

--- a/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/RegenerateUrlAliasesCommand.php
+++ b/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/RegenerateUrlAliasesCommand.php
@@ -158,7 +158,7 @@ EOT
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler $databaseHandler */
-        $databaseHandler = $this->getContainer()->get('ezpublish.connection');
+        $databaseHandler = $this->getContainer()->get('ezpublish.persistence.connection');
         /** @var \eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway $gateway */
         $gateway = $this->getContainer()->get('ezpublish.persistence.legacy.url_alias.gateway');
         /** @var \eZ\Publish\SPI\Persistence\Handler $persistenceHandler */

--- a/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/UpdateFieldAlwaysAvailableFlagCommand.php
+++ b/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/UpdateFieldAlwaysAvailableFlagCommand.php
@@ -65,7 +65,7 @@ EOT
         $dryRun = $input->getOption('dry-run');
 
         /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler $databaseHandler */
-        $databaseHandler = $this->getContainer()->get('ezpublish.connection');
+        $databaseHandler = $this->getContainer()->get('ezpublish.persistence.connection');
 
         $warningStyle = new OutputFormatterStyle('red');
         $output->getFormatter()->setStyle('warning', $warningStyle);
@@ -168,7 +168,7 @@ EOT
     protected function initSelectQuery(SelectQuery $query)
     {
         /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler $databaseHandler */
-        $databaseHandler = $this->getContainer()->get('ezpublish.connection');
+        $databaseHandler = $this->getContainer()->get('ezpublish.persistence.connection');
 
         $query
             ->select(
@@ -270,7 +270,7 @@ EOT
         }
 
         /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler $databaseHandler */
-        $databaseHandler = $this->getContainer()->get('ezpublish.connection');
+        $databaseHandler = $this->getContainer()->get('ezpublish.persistence.connection');
 
         // Remove always available flag from all fields not in main language
         /** @var $query \eZ\Publish\Core\Persistence\Database\UpdateQuery */

--- a/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/UpdateSortKeysCommand.php
+++ b/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/UpdateSortKeysCommand.php
@@ -57,7 +57,7 @@ EOT
         $dryRun = $input->getOption('dry-run');
 
         /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler $databaseHandler */
-        $databaseHandler = $this->getContainer()->get('ezpublish.connection');
+        $databaseHandler = $this->getContainer()->get('ezpublish.persistence.connection');
 
         /** @var \eZ\Publish\API\Repository\Repository $repository */
         $repository = $this->getContainer()->get('ezpublish.api.repository');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29422](https://jira.ez.no/browse/EZP-29422) for the deprecation log fix
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Removes the `deprecated` key from the definition, as it is not supported for aliases (will error out with Symfony 4.x).

Also changes usages of `ezpublish.connection` to `ezpublish.persistence.connection`.

### TODO
- [x] Wait for tests results.
- [ ] Ask for Code Review.
