### PR TITLE
[RFC][Cache] Limit number of locations we tag to not cripple performance

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -424,6 +424,26 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
 
         if ($contentInfo->mainLocationId) {
             $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($contentInfo->id);
+            $locationCount = count($locations);
+            if ($locationCount > 30) {
+                // As we don't have paging support on loadLocationsByContent(), slice it to avoid overloading tag system
+                $locations = array_slice(
+                    $locations,
+                    0,
+                    25
+                );
+                // TODO: Will this contain main location? if not, somehow make sure of it in SE or here
+                @trigger_error(
+                    sprintf(
+                        '%d locations for content %d, not able to handle that many tags so took the first 25!',
+                        $locationCount,
+                        $contentInfo->id
+                    ),
+                    E_USER_WARNING
+                );
+
+            }
+
             foreach ($locations as $location) {
                 $tags[] = 'location-' . $location->id;
                 foreach (explode('/', trim($location->pathString, '/')) as $pathId) {


### PR DESCRIPTION
Reported on slack on some install with several hundred locations for a given content, as Symfony Cache is not designed for such amount of tags it made the whole system immensely slow. eZ is not really made for this either atm, as we don't really have paging even on listing locations.

Which is why this patch just ignores anything beyond 25 locations.

Todo:
- [ ] check if main location is among the first, as this one is somewhat more important then the others
