### PR TITLE
"Array to string conversion" exception when UrlAlias has non-existent parent.

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -877,7 +877,13 @@ class DoctrineDatabase extends Gateway
             if (empty($rows)) {
                 // Normally this should never happen
                 // @todo remove throw when tested
-                $path = implode('/', $pathData);
+                $pathDataArray = [];
+
+                foreach ($pathData as $path) {
+                    $pathDataArray[] = $path[0]['text'];
+                }
+
+                $path = implode('/', $pathDataArray);
                 throw new \RuntimeException("Path ({$path}...) is broken, last id is '{$id}': " . __METHOD__);
             }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **Bug**| yes
| **New feature**    | no
| **Target version** | `6.x`,`7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Broken UrlAliast (for example with not-existent parent) will throw "Array to string conversion" exception, which is very misleading. This happens because `$path` for a proper exception is generated via `implode` with an array of arrays as a parameter (not array of strings).

This PR fixes it, so instead `RuntimeException: "Path ({$path}...) is broken, last id is '{$id}'` will be thrown. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
