### PR TITLE
EZP-29104: Impl. ImageAsset field type

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldType/ImageAsset.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldType/ImageAsset.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\FieldType;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\AbstractFieldTypeParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use eZ\Publish\Core\FieldType\ImageAsset\Type as ImageAssetFieldType;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+class ImageAsset extends AbstractFieldTypeParser
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFieldTypeIdentifier(): string
+    {
+        return ImageAssetFieldType::FIELD_TYPE_IDENTIFIER;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFieldTypeSemanticConfig(NodeBuilder $nodeBuilder): void
+    {
+        $nodeBuilder
+            ->scalarNode('content_type_identifier')
+                ->isRequired()
+                ->cannotBeEmpty()
+            ->end()
+            ->scalarNode('content_field_identifier')
+                ->isRequired()
+                ->cannotBeEmpty()
+            ->end()
+            ->scalarNode('name_field_identifier')
+                ->isRequired()
+                ->cannotBeEmpty()
+            ->end()
+            ->scalarNode('parent_location_id')
+                ->isRequired()
+                ->cannotBeEmpty()
+            ->end();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
+    {
+        $fieldTypeIdentifier = $this->getFieldTypeIdentifier();
+
+        if (isset($scopeSettings['fieldtypes'][$fieldTypeIdentifier])) {
+            $contextualizer->setContextualParameter(
+                "fieldtypes.{$fieldTypeIdentifier}.mappings",
+                $currentScope,
+                $scopeSettings['fieldtypes'][$fieldTypeIdentifier]
+            );
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -115,6 +115,7 @@ class EzPublishCoreBundle extends Bundle
                     new ConfigParser\Common(),
                     new ConfigParser\Content(),
                     new ConfigParser\FieldType\RichText(),
+                    new ConfigParser\FieldType\ImageAsset(),
                     new ConfigParser\FieldTemplates(),
                     new ConfigParser\FieldEditTemplates(),
                     new ConfigParser\FieldDefinitionSettingsTemplates(),

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/ImageAsset/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/ImageAsset/AliasGenerator.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\ImageAsset;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\FieldType\ImageAsset\AssetMapper;
+use eZ\Publish\SPI\FieldType\Value;
+use eZ\Publish\SPI\Variation\Values\Variation;
+use eZ\Publish\SPI\Variation\VariationHandler;
+use eZ\Publish\Core\FieldType\ImageAsset\Value as ImageAssetValue;
+
+/**
+ * Alias Generator Decorator allowing generate variations based on passed ImageAsset\Value.
+ */
+class AliasGenerator implements VariationHandler
+{
+    /** @var \eZ\Publish\SPI\Variation\VariationHandler */
+    private $innerAliasGenerator;
+
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper */
+    private $assetMapper;
+
+    /**
+     * @param \eZ\Publish\SPI\Variation\VariationHandler $innerAliasGenerator
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper $assetMapper
+     */
+    public function __construct(
+        VariationHandler $innerAliasGenerator,
+        ContentService $contentService,
+        AssetMapper $assetMapper)
+    {
+        $this->innerAliasGenerator = $innerAliasGenerator;
+        $this->contentService = $contentService;
+        $this->assetMapper = $assetMapper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVariation(Field $field, VersionInfo $versionInfo, $variationName, array $parameters = []): Variation
+    {
+        if ($this->supportsValue($field->value)) {
+            $destinationContent = $this->contentService->loadContent(
+                $field->value->destinationContentId
+            );
+
+            return $this->innerAliasGenerator->getVariation(
+                $this->assetMapper->getAssetField($destinationContent),
+                $destinationContent->versionInfo,
+                $variationName,
+                $parameters
+            );
+        }
+
+        return $this->innerAliasGenerator->getVariation($field, $versionInfo, $variationName, $parameters);
+    }
+
+    /**
+     * Returns TRUE if the value is supported by alias generator.
+     *
+     * @param \eZ\Publish\SPI\FieldType\Value $value
+     *
+     * @return bool
+     */
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof ImageAssetValue;
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/ImageAsset/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/ImageAsset/AliasGenerator.php
@@ -22,13 +22,19 @@ use eZ\Publish\Core\FieldType\ImageAsset\Value as ImageAssetValue;
  */
 class AliasGenerator implements VariationHandler
 {
-    /** @var \eZ\Publish\SPI\Variation\VariationHandler */
+    /**
+     * @var \eZ\Publish\SPI\Variation\VariationHandler
+     */
     private $innerAliasGenerator;
 
-    /** @var \eZ\Publish\API\Repository\ContentService */
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService
+     */
     private $contentService;
 
-    /** @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper */
+    /**
+     * @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper
+     */
     private $assetMapper;
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -18,12 +18,20 @@ parameters:
     ezplatform.default_view_templates.content.text_linked: 'EzPublishCoreBundle:default:content/text_linked.html.twig'
     ezplatform.default_view_templates.content.embed: 'EzPublishCoreBundle:default:content/embed.html.twig'
     ezplatform.default_view_templates.content.embed_image: 'EzPublishCoreBundle:default:content/embed_image.html.twig'
+    ezplatform.default_view_templates.content.asset_image: 'EzPublishCoreBundle:default:content/asset_image.html.twig'
     ezplatform.default_view_templates.block: 'EzPublishCoreBundle:default:block/block.html.twig'
 
     # Rich Text Custom Tags global configuration
     ezplatform.ezrichtext.custom_tags: {}
     # Rich Text Custom Tags default scope (for SiteAccess) configuration
     ezsettings.default.fieldtypes.ezrichtext.custom_tags: []
+
+    # Image Asset mappings
+    ezsettings.default.fieldtypes.ezimageasset.mappings:
+        content_type_identifier: image
+        content_field_identifier: image
+        name_field_identifier: name
+        parent_location_id: 51
 
     ezsettings.default.pagelayout: 'EzPublishCoreBundle::pagelayout.html.twig'
 
@@ -50,6 +58,10 @@ parameters:
                     Identifier\ContentType: '%ezplatform.content_view.image_embed_content_types_identifiers%'
             default:
                 template: "%ezplatform.default_view_templates.content.embed%"
+                match: []
+        asset_image:
+            default:
+                template: '%ezplatform.default_view_templates.content.asset_image%'
                 match: []
 
     ezsettings.default.block_view_defaults:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -91,6 +91,15 @@ services:
         tags:
             - {name: ezpublish.fieldType.parameterProvider, alias: ezobjectrelationlist}
 
+    ezpublish.fieldType.ezimageasset.parameterProvider:
+        class: \eZ\Publish\Core\MVC\Symfony\FieldType\ImageAsset\ParameterProvider
+        arguments:
+            - "@ezpublish.api.service.content"
+            - "@ezpublish.api.service.inner_field_type"
+            - "@eZ\\Publish\\Core\\FieldType\\ImageAsset\\AssetMapper"
+        tags:
+            - {name: ezpublish.fieldType.parameterProvider, alias: ezimageasset}
+
     # Page
     ezpublish.fieldType.ezpage.pageService.factory:
         class: "%ezpublish.fieldType.ezpage.pageService.factory.class%"
@@ -285,3 +294,17 @@ services:
     eZ\Publish\Core\FieldType\RichText\CustomTagsValidator:
         public: false
         arguments: ['%ezplatform.ezrichtext.custom_tags%']
+
+    eZ\Publish\Core\FieldType\ImageAsset\NameableField:
+        arguments:
+            $handler: '@ezpublish.spi.persistence.cache.contentHandler'
+        tags:
+            - {name: ezpublish.fieldType.nameable, alias: ezimageasset}
+
+    eZ\Publish\Core\FieldType\ImageAsset\AssetMapper:
+        arguments:
+            $contentService: '@ezpublish.api.service.content'
+            $locationService: '@ezpublish.api.service.location'
+            $contentTypeService: '@ezpublish.api.service.content_type'
+            $mappings: '$fieldtypes.ezimageasset.mappings$'
+

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -129,6 +129,15 @@ services:
             - '@ezpublish.fieldType.ezimage.io_service'
         public: false
 
+    ezpublish.image_alias.imagine.alias_generator.image_asset:
+        class: 'eZ\Bundle\EzPublishCoreBundle\Imagine\ImageAsset\AliasGenerator'
+        decorates: 'ezpublish.image_alias.imagine.alias_generator'
+        arguments:
+            - '@ezpublish.image_alias.imagine.alias_generator.image_asset.inner'
+            - '@ezpublish.api.service.content'
+            - '@eZ\Publish\Core\FieldType\ImageAsset\AssetMapper'
+        public: false
+
     ezpublish.image_alias.imagine.placeholder_provider.registry:
         class: 'eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProviderRegistry'
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -190,6 +190,7 @@ services:
         class: "%ezpublish.twig.extension.image.class%"
         arguments:
             - '@ezpublish.fieldType.ezimage.variation_service'
+            - '@eZ\Publish\Core\FieldType\ImageAsset\AssetMapper'
         tags:
             - { name: twig.extension }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/translations/fieldtypes.en.xlf
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/translations/fieldtypes.en.xlf
@@ -56,6 +56,11 @@
         <target>Image</target>
         <note>key: ezimage.name</note>
       </trans-unit>
+      <trans-unit id="3afdca17c734ecb3a077bcc4ba7f75a7544e845d" resname="ezimageasset.name">
+        <source>Image Asset</source>
+        <target>Image Asset</target>
+        <note>key: ezimageasset.name</note>
+      </trans-unit>
       <trans-unit id="3b0f44cd332c71e78209a1a4b235bc6a1e6d374b" resname="ezinteger.name">
         <source>Integer</source>
         <target>Integer</target>

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -430,6 +430,24 @@
 {% endspaceless %}
 {% endblock %}
 
+{% block ezimageasset_field %}
+    {% spaceless %}
+        {% if not ez_is_field_empty(content, field) and parameters.available %}
+            {{ fos_httpcache_tag('relation-' ~ field.value.destinationContentId) }}
+            <div {{ block('field_attributes') }}>
+                {{ render(controller('ez_content:viewAction', {
+                    contentId: field.value.destinationContentId,
+                    viewType: 'asset_image',
+                    noLayout: true,
+                    params: {
+                        parameters: parameters|default({'alias': 'original'})
+                    }
+                }))}}
+            </div>
+        {% endif %}
+    {% endspaceless %}
+{% endblock %}
+
 {% block ezobjectrelation_field %}
 {% spaceless %}
 {% if not ez_is_field_empty( content, field ) and parameters.available %}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/asset_image.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/asset_image.html.twig
@@ -1,0 +1,7 @@
+{% set image_field_identifier = ez_image_asset_content_field_identifier() %}
+
+{% if image_field_identifier is not null %}
+    {{ ez_render_field(content, image_field_identifier, {
+        parameters: parameters
+    }) }}
+{% endif %}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -410,3 +410,6 @@
         <div class="ez-fielddefinition-setting-value">{{ isISBN13 ? 'ISBN-13' : 'ISBN-10' }}</div>
     </li>
 {% endblock %}
+
+{% block ezimageasset_settings %}
+{% endblock %}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/FieldType/ImageAssetTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/FieldType/ImageAssetTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser\FieldType;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\FieldType\ImageAsset as ImageAssetConfigParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
+use eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser\AbstractParserTestCase;
+
+class ImageAssetTest extends AbstractParserTestCase
+{
+    /**
+     * @{@inheritdoc}
+     */
+    protected function getContainerExtensions()
+    {
+        return [
+            new EzPublishCoreExtension([new ImageAssetConfigParser()]),
+        ];
+    }
+
+    public function testDefaultImageAssetSettings()
+    {
+        $this->load();
+
+        $this->assertConfigResolverParameterValue(
+            'fieldtypes.ezimageasset.mappings',
+            [
+                'content_type_identifier' => 'image',
+                'content_field_identifier' => 'image',
+                'name_field_identifier' => 'name',
+                'parent_location_id' => 51,
+            ],
+            'ezdemo_site'
+        );
+    }
+
+    /**
+     * @dataProvider imageAssetSettingsProvider
+     */
+    public function testImageAssetSettings(array $config, array $expected)
+    {
+        $this->load(
+            [
+                'system' => [
+                    'ezdemo_site' => $config,
+                ],
+            ]
+        );
+
+        foreach ($expected as $key => $val) {
+            $this->assertConfigResolverParameterValue($key, $val, 'ezdemo_site');
+        }
+    }
+
+    public function imageAssetSettingsProvider(): array
+    {
+        return [
+            [
+                [
+                    'fieldtypes' => [
+                        'ezimageasset' => [
+                            'content_type_identifier' => 'photo',
+                            'content_field_identifier' => 'file',
+                            'name_field_identifier' => 'title',
+                            'parent_location_id' => 68,
+                        ],
+                    ],
+                ],
+                [
+                    'fieldtypes.ezimageasset.mappings' => [
+                        'content_type_identifier' => 'photo',
+                        'content_field_identifier' => 'file',
+                        'name_field_identifier' => 'title',
+                        'parent_location_id' => 68,
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/ImageAsset/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/ImageAsset/AliasGeneratorTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\ImageAsset;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\ImageAsset\AliasGenerator;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\FieldType\ImageAsset;
+use eZ\Publish\Core\FieldType\Image;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\SPI\Variation\Values\Variation;
+use eZ\Publish\SPI\Variation\VariationHandler;
+use PHPUnit\Framework\TestCase;
+
+class AliasGeneratorTest extends TestCase
+{
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\ImageAsset\AliasGenerator */
+    private $aliasGenerator;
+
+    /** @var \eZ\Publish\SPI\Variation\VariationHandler|\PHPUnit_Framework_MockObject_MockObject */
+    private $innerAliasGenerator;
+
+    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit_Framework_MockObject_MockObject */
+    private $contentService;
+
+    /** @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper|\PHPUnit_Framework_MockObject_MockObject */
+    private $assetMapper;
+
+    protected function setUp()
+    {
+        $this->innerAliasGenerator = $this->createMock(VariationHandler::class);
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->assetMapper = $this->createMock(ImageAsset\AssetMapper::class);
+
+        $this->aliasGenerator = new AliasGenerator(
+            $this->innerAliasGenerator,
+            $this->contentService,
+            $this->assetMapper
+        );
+    }
+
+    public function testGetVariationOfImageAsset()
+    {
+        $assetField = new Field([
+            'value' => new ImageAsset\Value([
+                'destinationContentId' => 486,
+            ]),
+        ]);
+        $imageField = new Field([
+            'value' => new Image\Value([
+                'id' => 'images/6/8/4/0/486-10-eng-GB/photo.jpg',
+            ]),
+        ]);
+
+        $assetVersionInfo = new VersionInfo();
+        $imageVersionInfo = new VersionInfo();
+        $imageContent = new Content([
+            'versionInfo' => $imageVersionInfo,
+        ]);
+
+        $variationName = 'thumbnail';
+        $parameters = [];
+
+        $expectedVariation = new Variation();
+
+        $this->contentService
+            ->expects($this->once())
+            ->method('loadContent')
+            ->with($assetField->value->destinationContentId)
+            ->willReturn($imageContent);
+
+        $this->assetMapper
+            ->expects($this->once())
+            ->method('getAssetField')
+            ->with($imageContent)
+            ->willReturn($imageField);
+
+        $this->innerAliasGenerator
+            ->expects($this->once())
+            ->method('getVariation')
+            ->with($imageField, $imageVersionInfo, $variationName, $parameters)
+            ->willReturn($expectedVariation);
+
+        $actualVariation = $this->aliasGenerator->getVariation(
+            $assetField,
+            $assetVersionInfo,
+            $variationName,
+            $parameters
+        );
+
+        $this->assertEquals($expectedVariation, $actualVariation);
+    }
+
+    public function testGetVariationOfNonImageAsset()
+    {
+        $imageField = new Field([
+            'value' => new Image\Value([
+                'id' => 'images/6/8/4/0/486-10-eng-GB/photo.jpg',
+            ]),
+        ]);
+
+        $imageVersionInfo = new VersionInfo();
+        $variationName = 'thumbnail';
+        $parameters = [];
+
+        $expectedVariation = new Variation();
+
+        $this->contentService
+            ->expects($this->never())
+            ->method('loadContent');
+
+        $this->assetMapper
+            ->expects($this->never())
+            ->method('getAssetField');
+
+        $this->innerAliasGenerator
+            ->expects($this->once())
+            ->method('getVariation')
+            ->with($imageField, $imageVersionInfo, $variationName, $parameters)
+            ->willReturn($expectedVariation);
+
+        $actualVariation = $this->aliasGenerator->getVariation(
+            $imageField,
+            $imageVersionInfo,
+            $variationName,
+            $parameters
+        );
+
+        $this->assertEquals($expectedVariation, $actualVariation);
+    }
+
+    public function testSupport()
+    {
+        $this->assertTrue($this->aliasGenerator->supportsValue(new ImageAsset\Value()));
+        $this->assertFalse($this->aliasGenerator->supportsValue(new Image\Value()));
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/ImageAsset/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/ImageAsset/AliasGeneratorTest.php
@@ -21,16 +21,24 @@ use PHPUnit\Framework\TestCase;
 
 class AliasGeneratorTest extends TestCase
 {
-    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\ImageAsset\AliasGenerator */
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Imagine\ImageAsset\AliasGenerator
+     */
     private $aliasGenerator;
 
-    /** @var \eZ\Publish\SPI\Variation\VariationHandler|\PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var \eZ\Publish\SPI\Variation\VariationHandler|\PHPUnit_Framework_MockObject_MockObject
+     */
     private $innerAliasGenerator;
 
-    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService|\PHPUnit_Framework_MockObject_MockObject
+     */
     private $contentService;
 
-    /** @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper|\PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper|\PHPUnit_Framework_MockObject_MockObject
+     */
     private $assetMapper;
 
     protected function setUp()

--- a/eZ/Publish/Core/FieldType/ImageAsset/AssetMapper.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/AssetMapper.php
@@ -19,19 +19,29 @@ use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
 
 class AssetMapper
 {
-    /** @var \eZ\Publish\API\Repository\ContentService */
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService
+     */
     private $contentService;
 
-    /** @var \eZ\Publish\API\Repository\LocationService */
+    /**
+     * @var \eZ\Publish\API\Repository\LocationService
+     */
     private $locationService;
 
-    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService
+     */
     private $contentTypeService;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     private $mappings = [];
 
-    /** @var int */
+    /**
+     * @var int
+     */
     private $contentTypeId = null;
 
     /**
@@ -53,6 +63,8 @@ class AssetMapper
     }
 
     /**
+     * Creates an Image Asset.
+     *
      * @param string $name
      * @param \eZ\Publish\Core\FieldType\Image\Value $image
      * @param string $languageCode
@@ -77,6 +89,8 @@ class AssetMapper
     }
 
     /**
+     * Returns field which is used to store the Image Asset value from specified content.
+     *
      * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Field
@@ -94,6 +108,8 @@ class AssetMapper
     }
 
     /**
+     * Returns definition of the field which is used to store value of the Image Asset.
+     *
      * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition
      */
     public function getAssetFieldDefinition(): FieldDefinition
@@ -108,6 +124,8 @@ class AssetMapper
     }
 
     /**
+     * Returns field value of the Image Asset from specified content.
+     *
      * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      *
      * @return \eZ\Publish\Core\FieldType\Image\Value
@@ -125,6 +143,8 @@ class AssetMapper
     }
 
     /**
+     * Returns TRUE if content is an Image Asset.
+     *
      * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      *
      * @return bool
@@ -145,6 +165,8 @@ class AssetMapper
     }
 
     /**
+     * Return identifier of the field used to store Image Asset value.
+     *
      * @return string
      */
     public function getContentFieldIdentifier(): string
@@ -153,6 +175,8 @@ class AssetMapper
     }
 
     /**
+     * Return ID of the base location for the Image Assets.
+     *
      * @return int
      */
     public function getParentLocationId(): int

--- a/eZ/Publish/Core/FieldType/ImageAsset/AssetMapper.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/AssetMapper.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\FieldType\ImageAsset;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
+
+class AssetMapper
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /** @var array */
+    private $mappings = [];
+
+    /** @var int */
+    private $contentTypeId = null;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \eZ\Publish\API\Repository\LocationService $locationService
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     * @param array $mappings
+     */
+    public function __construct(
+        ContentService $contentService,
+        LocationService $locationService,
+        ContentTypeService $contentTypeService,
+        array $mappings)
+    {
+        $this->contentService = $contentService;
+        $this->locationService = $locationService;
+        $this->contentTypeService = $contentTypeService;
+        $this->mappings = $mappings;
+    }
+
+    /**
+     * @param string $name
+     * @param \eZ\Publish\Core\FieldType\Image\Value $image
+     * @param string $languageCode
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     */
+    public function createAsset(string $name, ImageValue $image, string $languageCode): Content
+    {
+        $contentType = $this->contentTypeService->loadContentTypeByIdentifier(
+            $this->mappings['content_type_identifier']
+        );
+
+        $contentCreateStruct = $this->contentService->newContentCreateStruct($contentType, $languageCode);
+        $contentCreateStruct->setField($this->mappings['name_field_identifier'], $name);
+        $contentCreateStruct->setField($this->mappings['content_field_identifier'], $image);
+
+        $contentDraft = $this->contentService->createContent($contentCreateStruct, [
+            $this->locationService->newLocationCreateStruct($this->mappings['parent_location_id']),
+        ]);
+
+        return $this->contentService->publishVersion($contentDraft->versionInfo);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Field
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function getAssetField(Content $content): Field
+    {
+        if (!$this->isAsset($content)) {
+            throw new InvalidArgumentException('contentId', "Content {$content->id} is not a image asset!");
+        }
+
+        return $content->getField($this->mappings['content_field_identifier']);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition
+     */
+    public function getAssetFieldDefinition(): FieldDefinition
+    {
+        $contentType = $this->contentTypeService->loadContentTypeByIdentifier(
+            $this->mappings['content_type_identifier']
+        );
+
+        return $contentType->getFieldDefinition(
+            $this->mappings['content_field_identifier']
+        );
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @return \eZ\Publish\Core\FieldType\Image\Value
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function getAssetValue(Content $content): ImageValue
+    {
+        if (!$this->isAsset($content)) {
+            throw new InvalidArgumentException('contentId', "Content {$content->id} is not a image asset!");
+        }
+
+        return $content->getFieldValue($this->mappings['content_field_identifier']);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @return bool
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function isAsset(Content $content): bool
+    {
+        if ($this->contentTypeId === null) {
+            $contentType = $this->contentTypeService->loadContentTypeByIdentifier(
+                $this->mappings['content_type_identifier']
+            );
+
+            $this->contentTypeId = $contentType->id;
+        }
+
+        return $content->contentInfo->contentTypeId === $this->contentTypeId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContentFieldIdentifier(): string
+    {
+        return $this->mappings['content_field_identifier'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getParentLocationId(): int
+    {
+        return $this->mappings['parent_location_id'];
+    }
+}

--- a/eZ/Publish/Core/FieldType/ImageAsset/NameableField.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/NameableField.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\ImageAsset;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\SPI\FieldType\Nameable;
+use eZ\Publish\SPI\FieldType\Value as SPIValue;
+use eZ\Publish\SPI\Persistence\Content\Handler as SPIContentHandler;
+
+/**
+ * Class NameableField for ImageAsset FieldType.
+ */
+class NameableField implements Nameable
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Handler
+     */
+    private $handler;
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Handler $handler
+     */
+    public function __construct(SPIContentHandler $handler)
+    {
+        $this->handler = $handler;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\FieldType\ImageAsset\Value $value
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
+     * @param string $languageCode
+     *
+     * @return string
+     */
+    public function getFieldName(SPIValue $value, FieldDefinition $fieldDefinition, $languageCode)
+    {
+        if (empty($value->destinationContentId)) {
+            return '';
+        }
+
+        try {
+            $contentInfo = $this->handler->loadContentInfo($value->destinationContentId);
+            $versionInfo = $this->handler->loadVersionInfo($value->destinationContentId, $contentInfo->currentVersionNo);
+        } catch (NotFoundException $e) {
+            return '';
+        }
+
+        if (isset($versionInfo->names[$languageCode])) {
+            return $versionInfo->names[$languageCode];
+        }
+
+        return $versionInfo->names[$contentInfo->mainLanguageCode];
+    }
+}

--- a/eZ/Publish/Core/FieldType/ImageAsset/SearchField.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/SearchField.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\FieldType\ImageAsset;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+
+/**
+ * Indexable definition for Image Asset field type.
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData(Field $field, FieldDefinition $fieldDefinition): array
+    {
+        return [
+            new Search\Field(
+                'value',
+                reset($field->value->data),
+                new Search\FieldType\StringField()
+            ),
+        ];
+    }
+
+    /**
+     * Get index field types for search backend.
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition(): array
+    {
+        return [
+            'value' => new Search\FieldType\StringField(),
+        ];
+    }
+
+    /**
+     * Get name of the default field to be used for matching.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for matching. Default field is typically used by Field criterion.
+     *
+     * @return string
+     */
+    public function getDefaultMatchField(): string
+    {
+        return 'value';
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField(): string
+    {
+        return $this->getDefaultMatchField();
+    }
+}

--- a/eZ/Publish/Core/FieldType/ImageAsset/Type.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/Type.php
@@ -23,13 +23,19 @@ class Type extends FieldType
 {
     const FIELD_TYPE_IDENTIFIER = 'ezimageasset';
 
-    /** @var \eZ\Publish\API\Repository\ContentService */
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService
+     */
     private $contentService;
 
-    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService
+     */
     private $contentTypeService;
 
-    /** @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper */
+    /**
+     * @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper
+     */
     private $assetMapper;
 
     /**
@@ -45,30 +51,6 @@ class Type extends FieldType
         $this->contentService = $contentService;
         $this->contentTypeService = $contentTypeService;
         $this->assetMapper = $mapper;
-    }
-
-    /**
-     * @see \eZ\Publish\Core\FieldType\FieldType::validateFieldSettings()
-     *
-     * @param mixed $fieldSettings
-     *
-     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
-     */
-    public function validateFieldSettings($fieldSettings): array
-    {
-        return [];
-    }
-
-    /**
-     * Validates the validatorConfiguration of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
-     *
-     * @param mixed $validatorConfiguration
-     *
-     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
-     */
-    public function validateValidatorConfiguration($validatorConfiguration): array
-    {
-        return [];
     }
 
     /**
@@ -160,7 +142,7 @@ class Type extends FieldType
      *
      * @return \eZ\Publish\Core\FieldType\ImageAsset\Value The potentially converted and structurally plausible value.
      */
-    protected function createValueFromInput($inputValue): Value
+    protected function createValueFromInput($inputValue)
     {
         if ($inputValue instanceof ContentInfo) {
             $inputValue = new Value($inputValue->id);

--- a/eZ/Publish/Core/FieldType/ImageAsset/Type.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/Type.php
@@ -1,0 +1,269 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\FieldType\ImageAsset;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\FieldType\FieldType;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\API\Repository\Values\Content\Relation;
+use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\SPI\FieldType\Value as SPIValue;
+use eZ\Publish\Core\FieldType\Value as BaseValue;
+
+class Type extends FieldType
+{
+    const FIELD_TYPE_IDENTIFIER = 'ezimageasset';
+
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /** @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper */
+    private $assetMapper;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     * @param \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper $mapper
+     */
+    public function __construct(
+        ContentService $contentService,
+        ContentTypeService $contentTypeService,
+        AssetMapper $mapper
+    ) {
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+        $this->assetMapper = $mapper;
+    }
+
+    /**
+     * @see \eZ\Publish\Core\FieldType\FieldType::validateFieldSettings()
+     *
+     * @param mixed $fieldSettings
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateFieldSettings($fieldSettings): array
+    {
+        return [];
+    }
+
+    /**
+     * Validates the validatorConfiguration of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
+     *
+     * @param mixed $validatorConfiguration
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateValidatorConfiguration($validatorConfiguration): array
+    {
+        return [];
+    }
+
+    /**
+     * Validates a field based on the validators in the field definition.
+     *
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
+     * @param \eZ\Publish\Core\FieldType\ImageAsset\Value $fieldValue The field value for which an action is performed
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue): array
+    {
+        $errors = [];
+
+        if ($this->isEmptyValue($fieldValue)) {
+            return $errors;
+        }
+
+        $content = $this->contentService->loadContent($fieldValue->destinationContentId);
+
+        if (!$this->assetMapper->isAsset($content)) {
+            $currentContentType = $this->contentTypeService->loadContentType($content->contentInfo->contentTypeId);
+
+            $errors[] = new ValidationError(
+                'Content %type% is not a valid asset target',
+                null,
+                [
+                    '%type%' => $currentContentType->identifier,
+                ],
+                'destinationContentId'
+            );
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns the field type identifier for this field type.
+     *
+     * @return string
+     */
+    public function getFieldTypeIdentifier(): string
+    {
+        return self::FIELD_TYPE_IDENTIFIER;
+    }
+
+    /**
+     * Returns the name of the given field value.
+     *
+     * It will be used to generate content name and url alias if current field is designated
+     * to be used in the content name/urlAlias pattern.
+     *
+     * @param \eZ\Publish\Core\FieldType\ImageAsset\Value $value
+     *
+     * @return string
+     */
+    public function getName(SPIValue $value): string
+    {
+        throw new \RuntimeException('Name generation provided via NameableField set via "ezpublish.fieldType.nameable" service tag');
+    }
+
+    /**
+     * Returns the fallback default value of field type when no such default
+     * value is provided in the field definition in content types.
+     *
+     * @return \eZ\Publish\Core\FieldType\ImageAsset\Value
+     */
+    public function getEmptyValue(): Value
+    {
+        return new Value();
+    }
+
+    /**
+     * Returns if the given $value is considered empty by the field type.
+     *
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function isEmptyValue(SPIValue $value): bool
+    {
+        return null === $value->destinationContentId;
+    }
+
+    /**
+     * Inspects given $inputValue and potentially converts it into a dedicated value object.
+     *
+     * @param int|string|\eZ\Publish\API\Repository\Values\Content\ContentInfo|\eZ\Publish\Core\FieldType\Relation\Value $inputValue
+     *
+     * @return \eZ\Publish\Core\FieldType\ImageAsset\Value The potentially converted and structurally plausible value.
+     */
+    protected function createValueFromInput($inputValue): Value
+    {
+        if ($inputValue instanceof ContentInfo) {
+            $inputValue = new Value($inputValue->id);
+        } elseif (is_int($inputValue) || is_string($inputValue)) {
+            $inputValue = new Value($inputValue);
+        }
+
+        return $inputValue;
+    }
+
+    /**
+     * Throws an exception if value structure is not of expected format.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If the value does not match the expected structure.
+     *
+     * @param \eZ\Publish\Core\FieldType\ImageAsset\Value $value
+     */
+    protected function checkValueStructure(BaseValue $value): void
+    {
+        if (!is_int($value->destinationContentId) && !is_string($value->destinationContentId)) {
+            throw new InvalidArgumentType(
+                '$value->destinationContentId',
+                'string|int',
+                $value->destinationContentId
+            );
+        }
+    }
+
+    /**
+     * Returns information for FieldValue->$sortKey relevant to the field type.
+     * For this FieldType, the related object's name is returned.
+     *
+     * @param \eZ\Publish\Core\FieldType\Relation\Value $value
+     *
+     * @return bool
+     */
+    protected function getSortInfo(BaseValue $value): bool
+    {
+        return false;
+    }
+
+    /**
+     * Converts an $hash to the Value defined by the field type.
+     *
+     * @param mixed $hash
+     *
+     * @return \eZ\Publish\Core\FieldType\ImageAsset\Value $value
+     */
+    public function fromHash($hash): Value
+    {
+        if ($hash) {
+            return new Value($hash['destinationContentId']);
+        }
+
+        return new Value();
+    }
+
+    /**
+     * Converts a $Value to a hash.
+     *
+     * @param \eZ\Publish\Core\FieldType\ImageAsset\Value $value
+     *
+     * @return array
+     */
+    public function toHash(SPIValue $value): array
+    {
+        return [
+            'destinationContentId' => $value->destinationContentId,
+        ];
+    }
+
+    /**
+     * Returns relation data extracted from value.
+     *
+     * Not intended for \eZ\Publish\API\Repository\Values\Content\Relation::COMMON type relations,
+     * there is an API for handling those.
+     *
+     * @param \eZ\Publish\Core\FieldType\ImageAsset\Value $fieldValue
+     *
+     * @return array Hash with relation type as key and array of destination content ids as value.
+     *
+     * Example:
+     * <code>
+     *  array(
+     *      \eZ\Publish\API\Repository\Values\Content\Relation::LINK => array(
+     *          "contentIds" => array( 12, 13, 14 ),
+     *          "locationIds" => array( 24 )
+     *      ),
+     *      \eZ\Publish\API\Repository\Values\Content\Relation::EMBED => array(
+     *          "contentIds" => array( 12 ),
+     *          "locationIds" => array( 24, 45 )
+     *      ),
+     *      \eZ\Publish\API\Repository\Values\Content\Relation::FIELD => array( 12 )
+     *  )
+     * </code>
+     */
+    public function getRelations(SPIValue $fieldValue): array
+    {
+        $relations = [];
+        if ($fieldValue->destinationContentId !== null) {
+            $relations[Relation::FIELD] = [$fieldValue->destinationContentId];
+        }
+
+        return $relations;
+    }
+}

--- a/eZ/Publish/Core/FieldType/ImageAsset/Type.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/Type.php
@@ -248,4 +248,14 @@ class Type extends FieldType
 
         return $relations;
     }
+
+    /**
+     * Returns whether the field type is searchable.
+     *
+     * @return bool
+     */
+    public function isSearchable(): bool
+    {
+        return true;
+    }
 }

--- a/eZ/Publish/Core/FieldType/ImageAsset/Value.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/Value.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\FieldType\ImageAsset;
+
+use eZ\Publish\Core\FieldType\Value as BaseValue;
+
+class Value extends BaseValue
+{
+    /**
+     * Related content id's.
+     *
+     * @var mixed|null
+     */
+    public $destinationContentId;
+
+    /**
+     * @param mixed|null $destinationContentId
+     */
+    public function __construct($destinationContentId = null)
+    {
+        parent::__construct([
+            'destinationContentId' => $destinationContentId,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return (string) $this->destinationContentId;
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/ImageAsset/AssetMapperTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAsset/AssetMapperTest.php
@@ -1,0 +1,311 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\FieldType\Tests\ImageAsset;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\FieldType\ImageAsset\AssetMapper;
+use eZ\Publish\Core\Repository\ContentTypeService;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
+use eZ\Publish\Core\FieldType\Image;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use PHPUnit\Framework\TestCase;
+
+class AssetMapperTest extends TestCase
+{
+    const EXAMPLE_CONTENT_ID = 487;
+
+    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit_Framework_MockObject_MockObject */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit_Framework_MockObject_MockObject */
+    private $locationService;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit_Framework_MockObject_MockObject */
+    private $contentTypeService;
+
+    /** @var array */
+    private $mappings = [
+        'content_type_identifier' => 'image',
+        'content_field_identifier' => 'image',
+        'name_field_identifier' => 'name',
+        'parent_location_id' => 51,
+    ];
+
+    protected function setUp()
+    {
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->locationService = $this->createMock(LocationService::class);
+        $this->contentTypeService = $this->createMock(ContentTypeService::class);
+    }
+
+    public function testCreateAsset()
+    {
+        $name = 'Example asset';
+        $value = new Image\Value();
+        $contentType = new ContentType();
+        $languageCode = 'eng-GB';
+        $contentCreateStruct = $this->createMock(ContentCreateStruct::class);
+        $locationCreateStruct = new LocationCreateStruct();
+        $contentDraft = new Content([
+            'versionInfo' => new VersionInfo(),
+        ]);
+        $content = new Content();
+
+        $this->contentTypeService
+            ->expects($this->once())
+            ->method('loadContentTypeByIdentifier')
+            ->with($this->mappings['content_type_identifier'])
+            ->willReturn($contentType);
+
+        $this->contentService
+            ->expects($this->once())
+            ->method('newContentCreateStruct')
+            ->with($contentType, $languageCode)
+            ->willReturn($contentCreateStruct);
+
+        $contentCreateStruct
+            ->expects($this->at(0))
+            ->method('setField')
+            ->with($this->mappings['name_field_identifier'], $name);
+
+        $contentCreateStruct
+            ->expects($this->at(1))
+            ->method('setField')
+            ->with($this->mappings['content_field_identifier'], $value);
+
+        $this->locationService
+            ->expects($this->once())
+            ->method('newLocationCreateStruct')
+            ->with($this->mappings['parent_location_id'])
+            ->willReturn($locationCreateStruct);
+
+        $this->contentService
+            ->expects($this->once())
+            ->method('createContent')
+            ->with($contentCreateStruct, [$locationCreateStruct])
+            ->willReturn($contentDraft);
+
+        $this->contentService
+            ->expects($this->once())
+            ->method('publishVersion')
+            ->with($contentDraft->versionInfo)
+            ->willReturn($content);
+
+        $mapper = $this->createMapper();
+        $mapper->createAsset($name, $value, $languageCode);
+    }
+
+    public function testGetAssetField()
+    {
+        $expectedValue = new Field();
+        $content = $this->createContentWithId(self::EXAMPLE_CONTENT_ID);
+
+        $mapper = $this->createPartialMapper(['isAsset']);
+        $mapper
+            ->expects($this->once())
+            ->method('isAsset')
+            ->with($content)
+            ->willReturn(true);
+
+        $content
+            ->expects($this->once())
+            ->method('getField')
+            ->with($this->mappings['content_field_identifier'])
+            ->willReturn($expectedValue);
+
+        $this->assertEquals($expectedValue, $mapper->getAssetField($content));
+    }
+
+    /**
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testGetAssetFieldThrowsInvalidArgumentException()
+    {
+        $content = $this->createContentWithId(self::EXAMPLE_CONTENT_ID);
+
+        $mapper = $this->createPartialMapper(['isAsset']);
+        $mapper
+            ->expects($this->once())
+            ->method('isAsset')
+            ->with($content)
+            ->willReturn(false);
+
+        $mapper->getAssetField($content);
+    }
+
+    public function testGetAssetFieldDefinition()
+    {
+        $fieldDefinition = new FieldDefinition();
+
+        $contentType = $this->createMock(ContentType::class);
+        $contentType
+            ->expects($this->once())
+            ->method('getFieldDefinition')
+            ->with($this->mappings['content_field_identifier'])
+            ->willReturn($fieldDefinition);
+
+        $this->contentTypeService
+            ->expects($this->once())
+            ->method('loadContentTypeByIdentifier')
+            ->with($this->mappings['content_type_identifier'])
+            ->willReturn($contentType);
+
+        $this->assertEquals($fieldDefinition, $this->createMapper()->getAssetFieldDefinition());
+    }
+
+    public function testGetAssetValue()
+    {
+        $expectedValue = new Image\Value();
+        $content = $this->createContentWithId(self::EXAMPLE_CONTENT_ID);
+
+        $mapper = $this->createPartialMapper(['isAsset']);
+        $mapper
+            ->expects($this->once())
+            ->method('isAsset')
+            ->with($content)
+            ->willReturn(true);
+
+        $content
+            ->expects($this->once())
+            ->method('getFieldValue')
+            ->with($this->mappings['content_field_identifier'])
+            ->willReturn($expectedValue);
+
+        $this->assertEquals($expectedValue, $mapper->getAssetValue($content));
+    }
+
+    /**
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testGetAssetValueThrowsInvalidArgumentException()
+    {
+        $content = $this->createContentWithId(self::EXAMPLE_CONTENT_ID);
+
+        $mapper = $this->createPartialMapper(['isAsset']);
+        $mapper
+            ->expects($this->once())
+            ->method('isAsset')
+            ->with($content)
+            ->willReturn(false);
+
+        $mapper->getAssetField($content);
+    }
+
+    /**
+     * @dataProvider dataProviderForIsAsset
+     */
+    public function testIsAsset(int $contentContentTypeId, int $assetContentTypeId, bool $expected)
+    {
+        $assetContentType = new ContentType([
+            'id' => $assetContentTypeId,
+        ]);
+
+        $this->contentTypeService
+            ->expects($this->once())
+            ->method('loadContentTypeByIdentifier')
+            ->with($this->mappings['content_type_identifier'])
+            ->willReturn($assetContentType);
+
+        $actual = $this
+            ->createMapper()
+            ->isAsset($this->createContentWithContentType($contentContentTypeId));
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function dataProviderForIsAsset(): array
+    {
+        return [
+            [487, 487, true],
+            [487, 784, false],
+        ];
+    }
+
+    public function testGetContentFieldIdentifier()
+    {
+        $mapper = $this->createMapper();
+
+        $this->assertEquals(
+            $this->mappings['content_field_identifier'],
+            $mapper->getContentFieldIdentifier()
+        );
+    }
+
+    public function testGetParentLocationId()
+    {
+        $mapper = $this->createMapper();
+
+        $this->assertEquals(
+            $this->mappings['parent_location_id'],
+            $mapper->getParentLocationId()
+        );
+    }
+
+    private function createMapper(): AssetMapper
+    {
+        return new AssetMapper(
+            $this->contentService,
+            $this->locationService,
+            $this->contentTypeService,
+            $this->mappings
+        );
+    }
+
+    private function createPartialMapper(array $methods = []): AssetMapper
+    {
+        return $this
+            ->getMockBuilder(AssetMapper::class)
+            ->setConstructorArgs([
+                $this->contentService,
+                $this->locationService,
+                $this->contentTypeService,
+                $this->mappings,
+            ])
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->setMethods($methods)
+            ->getMock();
+    }
+
+    private function createContentWithId(int $id): Content
+    {
+        $content = $this->createMock(Content::class);
+        $content
+            ->expects($this->any())
+            ->method('__get')
+            ->with('id')
+            ->willReturn($id);
+
+        return $content;
+    }
+
+    private function createContentWithContentType(int $contentTypeId): Content
+    {
+        $contentInfo = new ContentInfo([
+            'contentTypeId' => $contentTypeId,
+        ]);
+
+        $content = $this->createMock(Content::class);
+        $content
+            ->expects($this->any())
+            ->method('__get')
+            ->with('contentInfo')
+            ->willReturn($contentInfo);
+
+        return $content;
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/ImageAsset/AssetMapperTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAsset/AssetMapperTest.php
@@ -27,16 +27,24 @@ class AssetMapperTest extends TestCase
 {
     const EXAMPLE_CONTENT_ID = 487;
 
-    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService|\PHPUnit_Framework_MockObject_MockObject
+     */
     private $contentService;
 
-    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var \eZ\Publish\API\Repository\LocationService|\PHPUnit_Framework_MockObject_MockObject
+     */
     private $locationService;
 
-    /** @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit_Framework_MockObject_MockObject
+     */
     private $contentTypeService;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     private $mappings = [
         'content_type_identifier' => 'image',
         'content_field_identifier' => 'image',

--- a/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\FieldType\Tests;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\FieldType\ImageAsset as ImageAsset;
+use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\SPI\FieldType\Value as SPIValue;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+
+/**
+ * @group fieldType
+ * @group ezimageasset
+ */
+class ImageAssetTest extends FieldTypeTest
+{
+    /**
+     * @var \eZ\Publish\API\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $contentServiceMock;
+
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $contentTypeServiceMock;
+
+    /**
+     * @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $assetMapperMock;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->contentServiceMock = $this->createMock(ContentService::class);
+        $this->contentTypeServiceMock = $this->createMock(ContentTypeService::class);
+        $this->assetMapperMock = $this->createMock(ImageAsset\AssetMapper::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function provideFieldTypeIdentifier(): string
+    {
+        return ImageAsset\Type::FIELD_TYPE_IDENTIFIER;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createFieldTypeUnderTest()
+    {
+        return new ImageAsset\Type(
+            $this->contentServiceMock,
+            $this->contentTypeServiceMock,
+            $this->assetMapperMock
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getValidatorConfigurationSchemaExpectation(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getSettingsSchemaExpectation(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getEmptyValueExpectation()
+    {
+        return new ImageAsset\Value();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideInvalidInputForAcceptValue(): array
+    {
+        return [
+            [
+                true,
+                InvalidArgumentException::class,
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideValidInputForAcceptValue(): array
+    {
+        $destinationContentId = 7;
+
+        return [
+            [
+                null,
+                $this->getEmptyValueExpectation(),
+            ],
+            [
+                $destinationContentId,
+                new ImageAsset\Value($destinationContentId),
+            ],
+            [
+                new ContentInfo([
+                    'id' => $destinationContentId,
+                ]),
+                new ImageAsset\Value($destinationContentId),
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideInputForToHash(): array
+    {
+        $destinationContentId = 7;
+
+        return [
+            [
+                new ImageAsset\Value(),
+                [
+                    'destinationContentId' => null,
+                ],
+            ],
+            [
+                new ImageAsset\Value($destinationContentId),
+                [
+                    'destinationContentId' => $destinationContentId,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideInputForFromHash(): array
+    {
+        $destinationContentId = 7;
+
+        return [
+            [
+                null,
+                new ImageAsset\Value(),
+            ],
+            [
+                [
+                    'destinationContentId' => $destinationContentId,
+                ],
+                new ImageAsset\Value($destinationContentId),
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideInvalidDataForValidate(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testValidateNonAsset()
+    {
+        $destinationContentId = 7;
+        $destinationContent = $this->createMock(Content::class);
+        $invalidContentTypeId = 789;
+        $invalidContentTypeIdentifier = 'article';
+        $invalidContentType = $this->createMock(ContentType::class);
+
+        $destinationContentInfo = $this->createMock(ContentInfo::class);
+
+        $destinationContentInfo
+            ->expects($this->once())
+            ->method('__get')
+            ->with('contentTypeId')
+            ->willReturn($invalidContentTypeId);
+
+        $destinationContent
+            ->expects($this->once())
+            ->method('__get')
+            ->with('contentInfo')
+            ->willReturn($destinationContentInfo);
+
+        $this->contentServiceMock
+            ->expects($this->once())
+            ->method('loadContent')
+            ->with($destinationContentId)
+            ->willReturn($destinationContent);
+
+        $this->assetMapperMock
+            ->expects($this->once())
+            ->method('isAsset')
+            ->with($destinationContent)
+            ->willReturn(false);
+
+        $this->contentTypeServiceMock
+            ->expects($this->once())
+            ->method('loadContentType')
+            ->with($invalidContentTypeId)
+            ->willReturn($invalidContentType);
+
+        $invalidContentType
+            ->expects($this->once())
+            ->method('__get')
+            ->with('identifier')
+            ->willReturn($invalidContentTypeIdentifier);
+
+        $validationErrors = $this->doValidate([], new ImageAsset\Value($destinationContentId));
+
+        $this->assertInternalType('array', $validationErrors);
+        $this->assertEquals([
+            new ValidationError(
+                'Content %type% is not a valid asset target',
+                null,
+                [
+                    '%type%' => $invalidContentTypeIdentifier,
+                ],
+                'destinationContentId'
+            ),
+        ], $validationErrors);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideValidDataForValidate(): array
+    {
+        return [
+            [
+                [],
+                $this->getEmptyValueExpectation(),
+            ],
+        ];
+    }
+
+    public function testValidateValidNonEmptyAssetValue()
+    {
+        $destinationContentId = 7;
+        $destinationContent = $this->createMock(Content::class);
+
+        $this->contentServiceMock
+            ->expects($this->once())
+            ->method('loadContent')
+            ->with($destinationContentId)
+            ->willReturn($destinationContent);
+
+        $this->assetMapperMock
+            ->expects($this->once())
+            ->method('isAsset')
+            ->with($destinationContent)
+            ->willReturn(true);
+
+        $validationErrors = $this->doValidate([], new ImageAsset\Value($destinationContentId));
+
+        $this->assertInternalType('array', $validationErrors);
+        $this->assertEmpty($validationErrors, "Got value:\n" . var_export($validationErrors, true));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provideDataForGetName(): array
+    {
+        return [
+            [
+                $this->getEmptyValueExpectation(),
+                '',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDataForGetName
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testGetName(SPIValue $value, $expected)
+    {
+        $this->getFieldTypeUnderTest()->getName($value);
+    }
+
+    public function testIsSearchable()
+    {
+        $this->assertFalse($this->getFieldTypeUnderTest()->isSearchable());
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
@@ -310,6 +310,6 @@ class ImageAssetTest extends FieldTypeTest
 
     public function testIsSearchable()
     {
-        $this->assertFalse($this->getFieldTypeUnderTest()->isSearchable());
+        $this->assertTrue($this->getFieldTypeUnderTest()->isSearchable());
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/ImageAsset/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/ImageAsset/ParameterProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\ImageAsset;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderInterface;
+
+class ParameterProvider implements ParameterProviderInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService
+     */
+    public function __construct(ContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getViewParameters(Field $field): array
+    {
+        try {
+            $contentInfo = $this->contentService->loadContentInfo(
+                $field->value->destinationContentId
+            );
+
+            return [
+                'available' => !$contentInfo->isTrashed(),
+            ];
+        } catch (NotFoundException | UnauthorizedException $exception) {
+            return [
+                'available' => false,
+            ];
+        }
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/ImageAsset/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/ImageAsset/ParameterProviderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\ImageAsset;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\Core\FieldType\ImageAsset\Value as ImageAssetValue;
+use eZ\Publish\Core\MVC\Symfony\FieldType\ImageAsset\ParameterProvider;
+use PHPUnit\Framework\TestCase;
+
+class ParameterProviderTest extends TestCase
+{
+    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
+    private $contentServiceMock;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\FieldType\ImageAsset\ParameterProvider */
+    private $parameterProvider;
+
+    protected function setUp(): void
+    {
+        $this->contentServiceMock = $this->createMock(ContentService::class);
+        $this->parameterProvider = new ParameterProvider(
+            $this->contentServiceMock
+        );
+    }
+
+    public function dataProviderForTestGetViewParameters(): array
+    {
+        return [
+            [ContentInfo::STATUS_PUBLISHED, ['available' => true]],
+            [ContentInfo::STATUS_TRASHED, ['available' => false]],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTestGetViewParameters
+     */
+    public function testGetViewParameters($status, array $expected): void
+    {
+        $destinationContentId = 1;
+
+        $this->contentServiceMock
+            ->method('loadContentInfo')
+            ->with($destinationContentId)
+            ->willReturn(new ContentInfo([
+                'status' => $status,
+            ]));
+
+        $actual = $this->parameterProvider->getViewParameters(new Field([
+            'value' => new ImageAssetValue($destinationContentId),
+        ]));
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetViewParametersHandleNotFoundException(): void
+    {
+        $destinationContentId = 1;
+
+        $this->contentServiceMock
+            ->expects($this->once())
+            ->method('loadContentInfo')
+            ->with($destinationContentId)
+            ->willThrowException($this->createMock(NotFoundException::class));
+
+        $actual = $this->parameterProvider->getViewParameters(new Field([
+            'value' => new ImageAssetValue($destinationContentId),
+        ]));
+
+        $this->assertEquals([
+            'available' => false,
+        ], $actual);
+    }
+
+    public function testGetViewParametersHandleUnauthorizedException(): void
+    {
+        $destinationContentId = 1;
+
+        $this->contentServiceMock
+            ->expects($this->once())
+            ->method('loadContentInfo')
+            ->with($destinationContentId)
+            ->willThrowException($this->createMock(UnauthorizedException::class));
+
+        $actual = $this->parameterProvider->getViewParameters(new Field([
+            'value' => new ImageAssetValue($destinationContentId),
+        ]));
+
+        $this->assertEquals([
+            'available' => false,
+        ], $actual);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ImageExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ImageExtension.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;
 use eZ\Publish\API\Repository\Exceptions\InvalidVariationException;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\FieldType\ImageAsset\AssetMapper;
 use eZ\Publish\Core\MVC\Exception\SourceImageNotFoundException;
 use eZ\Publish\SPI\Variation\VariationHandler;
 use InvalidArgumentException;
@@ -24,9 +25,15 @@ class ImageExtension extends Twig_Extension
      */
     private $imageVariationService;
 
-    public function __construct(VariationHandler $imageVariationService)
+    /**
+     * @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper
+     */
+    protected $assetMapper;
+
+    public function __construct(VariationHandler $imageVariationService, AssetMapper $assetMapper)
     {
         $this->imageVariationService = $imageVariationService;
+        $this->assetMapper = $assetMapper;
     }
 
     public function getName()
@@ -40,6 +47,11 @@ class ImageExtension extends Twig_Extension
             new Twig_SimpleFunction(
                 'ez_image_alias',
                 array($this, 'getImageVariation'),
+                array('is_safe' => array('html'))
+            ),
+            new Twig_SimpleFunction(
+                'ez_image_asset_content_field_identifier',
+                array($this, 'getImageAssetContentFieldIdentifier'),
                 array('is_safe' => array('html'))
             ),
         );
@@ -75,5 +87,13 @@ class ImageExtension extends Twig_Extension
                 );
             }
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function getImageAssetContentFieldIdentifier(): string
+    {
+        return $this->assetMapper->getContentFieldIdentifier();
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ImageExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ImageExtension.php
@@ -90,6 +90,10 @@ class ImageExtension extends Twig_Extension
     }
 
     /**
+     * Return identifier of the field used to store Image Asset value.
+     *
+     * Typically used to create generic view of the Image Asset field.
+     *
      * @return string
      */
     public function getImageAssetContentFieldIdentifier(): string

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageAssetConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageAssetConverter.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
+
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
+use eZ\Publish\SPI\Persistence\Content\FieldValue;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+
+class ImageAssetConverter implements Converter
+{
+    /**
+     * Converts data from $value to $storageFieldValue.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\FieldValue $value
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue $storageFieldValue
+     */
+    public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue)
+    {
+        $storageFieldValue->dataInt = !empty($value->data['destinationContentId'])
+            ? $value->data['destinationContentId']
+            : null;
+        $storageFieldValue->sortKeyInt = (int)$value->sortKey;
+    }
+
+    /**
+     * Converts data from $value to $fieldValue.
+     *
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue $value
+     * @param \eZ\Publish\SPI\Persistence\Content\FieldValue $fieldValue
+     */
+    public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue)
+    {
+        $fieldValue->data = [
+            'destinationContentId' => $value->dataInt ?: null,
+        ];
+        $fieldValue->sortKey = (int)$value->sortKeyInt;
+    }
+
+    /**
+     * Converts field definition data in $fieldDef into $storageFieldDef.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDef
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDef
+     */
+    public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef)
+    {
+    }
+
+    /**
+     * Converts field definition data in $storageDef into $fieldDef.
+     *
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDef
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDef
+     */
+    public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef)
+    {
+    }
+
+    /**
+     * Returns the name of the index column in the attribute table.
+     *
+     * Returns the name of the index column the datatype uses, which is either
+     * "sort_key_int" or "sort_key_string". This column is then used for
+     * filtering and sorting for this type.
+     *
+     * @return string
+     */
+    public function getIndexColumn()
+    {
+        return 'sort_key_string';
+    }
+}

--- a/eZ/Publish/Core/settings/fieldtype_services.yml
+++ b/eZ/Publish/Core/settings/fieldtype_services.yml
@@ -120,3 +120,17 @@ services:
     eZ\Publish\Core\FieldType\RichText\CustomTagsValidator:
         public: false
         arguments: ['%ezplatform.ezrichtext.custom_tags%']
+
+    eZ\Publish\Core\FieldType\ImageAsset\NameableField:
+        public: false
+        arguments:
+            $handler: '@ezpublish.spi.persistence.cache.contentHandler'
+        tags:
+            - {name: ezpublish.fieldType.nameable, alias: ezimageasset}
+
+    eZ\Publish\Core\FieldType\ImageAsset\AssetMapper:
+        arguments:
+            $contentService: '@ezpublish.api.service.content'
+            $locationService: '@ezpublish.api.service.location'
+            $contentTypeService: '@ezpublish.api.service.content_type'
+            $mappings: '$fieldtypes.ezimageasset.mappings$'

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -571,3 +571,15 @@ services:
         arguments: [ "ezrecommendation" ]
         tags:
             - {name: ezpublish.fieldType, alias: ezrecommendation}
+
+    eZ\Publish\Core\FieldType\ImageAsset\Type:
+        parent: ezpublish.fieldType
+        arguments:
+            - '@ezpublish.api.service.content'
+            - '@ezpublish.api.service.content_type'
+            - '@eZ\Publish\Core\FieldType\ImageAsset\AssetMapper'
+        tags:
+            - {name: ezpublish.fieldType, alias: ezimageasset}
+
+    ezpublish.fieldType.ezimageasset:
+        alias: eZ\Publish\Core\FieldType\ImageAsset\Type

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -142,6 +142,12 @@ services:
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezurl}
 
+    ezpublish.fieldType.indexable.ezimageasset:
+        class: 'eZ\Publish\Core\FieldType\ImageAsset\SearchField'
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezimageasset}
+
+
     ezpublish.fieldType.indexable.unindexed:
         class: "%ezpublish.fieldType.indexable.unindexed.class%"
         tags:

--- a/eZ/Publish/Core/settings/storage_engines/legacy/field_value_converters.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/field_value_converters.yml
@@ -256,3 +256,10 @@ services:
         class: "%ezpublish.fieldType.eznull.converter.class%"
         tags:
             - {name: ezpublish.storageEngine.legacy.converter, alias: ezrecommendation}
+
+    eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageAssetConverter:
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezimageasset}
+
+    ezpublish.fieldType.ezimageasset.converter:
+        alias: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageAssetConverter

--- a/eZ/Publish/Core/settings/tests/integration_legacy.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy.yml
@@ -5,3 +5,18 @@ parameters:
     ignored_storage_files:
         -
             var/ezdemo_site/storage/images/design/plain-site/172-2-eng-US/eZ-Publish-Demo-Design-without-demo-content1.png
+    # Image Asset mappings
+    ezsettings.default.fieldtypes.ezimageasset.mappings:
+        content_type_identifier: image
+        content_field_identifier: image
+        name_field_identifier: name
+        parent_location_id: 51
+
+services:
+    eZ\Publish\Core\FieldType\ImageAsset\AssetMapper:
+        arguments:
+            $contentService: '@ezpublish.api.service.content'
+            $locationService: '@ezpublish.api.service.location'
+            $contentTypeService: '@ezpublish.api.service.content_type'
+            # Siteaccess aware configuration is not available in the integration tests
+            $mappings: '%ezsettings.default.fieldtypes.ezimageasset.mappings%'

--- a/eZ/Publish/Core/settings/tests/integration_legacy_elasticsearch.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_elasticsearch.yml
@@ -15,6 +15,13 @@ parameters:
     # SignalDispatcher factory
     ezpublish.signalslot.signal_dispatcher.factory.class: eZ\Publish\Core\Base\Container\ApiLoader\SignalSlot\SignalDispatcherFactory
 
+    # Image Asset mappings
+    ezsettings.default.fieldtypes.ezimageasset.mappings:
+        content_type_identifier: image
+        content_field_identifier: image
+        name_field_identifier: name
+        parent_location_id: 51
+
 services:
     ezpublish.spi.search_engine:
         alias: ezpublish.spi.search.elasticsearch
@@ -24,3 +31,11 @@ services:
         arguments:
             - "%ezpublish.signalslot.signal_dispatcher.class%"
             - "elasticsearch"
+
+    eZ\Publish\Core\FieldType\ImageAsset\AssetMapper:
+        arguments:
+            $contentService: '@ezpublish.api.service.content'
+            $locationService: '@ezpublish.api.service.location'
+            $contentTypeService: '@ezpublish.api.service.content_type'
+            # Siteaccess aware configuration is not available in the integration tests
+            $mappings: '%ezsettings.default.fieldtypes.ezimageasset.mappings%'

--- a/eZ/Publish/SPI/Tests/FieldType/ImageAssetIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageAssetIntegrationTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Tests\FieldType;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\FieldType;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageAssetConverter;
+use eZ\Publish\SPI\Persistence\Content;
+
+class ImageAssetIntegrationTest extends BaseIntegrationTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeName()
+    {
+        return FieldType\ImageAsset\Type::FIELD_TYPE_IDENTIFIER;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomHandler()
+    {
+        $contentService = $this->createMock(ContentService::class);
+        $locationService = $this->createMock(LocationService::class);
+        $contentTypeService = $this->createMock(ContentTypeService::class);
+
+        $config = [];
+
+        $mapper = new FieldType\ImageAsset\AssetMapper(
+            $contentService,
+            $locationService,
+            $contentTypeService,
+            $config
+        );
+
+        $fieldType = new FieldType\ImageAsset\Type(
+            $contentService,
+            $contentTypeService,
+            $mapper
+        );
+
+        $fieldType->setTransformationProcessor($this->getTransformationProcessor());
+
+        return $this->getHandler(
+            'ezimageasset',
+            $fieldType,
+            new ImageAssetConverter(),
+            new FieldType\NullStorage()
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypeConstraints()
+    {
+        return new Content\FieldTypeConstraints();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFieldDefinitionData()
+    {
+        return [
+            ['fieldType', 'ezimageasset'],
+            ['fieldTypeConstraints', new Content\FieldTypeConstraints(['fieldSettings' => null])],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInitialValue()
+    {
+        return new Content\FieldValue(
+            [
+                'data' => [
+                    'destinationContentId' => 1,
+                ],
+                'externalData' => null,
+                'sortKey' => null,
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUpdatedValue()
+    {
+        return new Content\FieldValue(
+            [
+                'data' => [
+                    'destinationContentId' => 2,
+                ],
+                'externalData' => null,
+                'sortKey' => null,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29104](https://jira.ez.no/browse/EZP-29104)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

ImageAsset Field Type allows to store images in independent content items of a generic Image content type, in the media library, instead of storing them within the original content item to make then reusable accross system. 

From the kernel POV its works as same as a `ezobjetrelation` field type.

## ImageAsset Field Type configuration

ImageAsset Field Type allows to configure the following options:

| Name                     | Description                          | Default value                |
|--------------------------|--------------------------------------|------------------------------|
| `content_type_identifier`  | Content type used to store assets    | `image`                      |
| `content_field_identifier` | Field identifier used to asset data  | `image`                      |
| `name_field_identifier`    | Field identifier used to asset name  | `name`                       |
| `parent_location_id`       | Location where the asset are created | `51`  |

Example configuration: 

```yml
ezpublish:
    system:
       default:
            fieldtypes:
                ezimageasset:
                    content_type_identifier: photo
                    content_field_identifier: image
                    name_field_identifier: title
                    parent_location_id: 106
```

## Customizing ImageAsset Field Type rendering 

Internally the Image Asset Type is render via subrequest (similar to other relation types). Rendering customization is possible by configuring view type `asset_image`:

```yml
ezpublish:
    system:
       default:           
            content_view:
                asset_image:
                    default:
                        template: '::custom_image_asset_template.html.twig'
                        match: []
```

## Generating image variation from the Image Asset

Thanks to the `eZ\Bundle\EzPublishCoreBundle\Imagine\ImageAsset\AliasGenerator` decorator it is possible to work with `\eZ\Publish\SPI\Variation\VariationHandler` in same way as with Image Field Type.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
