### PR TITLE
[TRAVIS] EZEE-2236: Retry installation after Composer failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ branches:
     - /^\d.\d+$/
 
 # setup requirements for running unit/integration/behat tests
-before_script:
+before_install:
   # Disable memory_limit for composer in PHP 5.6
   - echo "memory_limit=-1" >> ~/.phpenv/versions/5.6/etc/conf.d/travis.ini
   # Install igbinary & lzf PHP extensions if necessary
@@ -73,6 +73,12 @@ before_script:
   # Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
+
+install:
+  -  if [ "$TEST_CONFIG" != "" ] ; then travis_retry composer install --no-progress --no-interaction --prefer-dist ; fi
+  # Setup Solr / Elastic search if asked for
+  - if [ "$TEST_CONFIG" = "phpunit-integration-legacy-elasticsearch.xml" ] ; then ./bin/.travis/init_elasticsearch.sh ; fi
+  - if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then ./vendor/ezsystems/ezplatform-solr-search-engine/bin/.travis/init_solr.sh; fi
 
 # execute phpunit or behat as the script command
 script:

--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -35,16 +35,10 @@ if [ "$DB" = "postgresql" ] ; then psql -c "CREATE DATABASE testdb;" -U postgres
 # Setup GitHub key to avoid api rate limit (pure auth read only key, no rights, for use by ezsystems repos only!)
 composer config -g github-oauth.github.com "d0285ed5c8644f30547572ead2ed897431c1fc09"
 
-COMPOSER_UPDATE=""
-
 # solr package search API integration tests
 if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then
     echo "> Require ezsystems/ezplatform-solr-search-engine:^1.3.0@dev"
     composer require --no-update ezsystems/ezplatform-solr-search-engine:^1.3.0@dev
-    COMPOSER_UPDATE="true"
-
-    # Because of either some changes in travis, composer or git, composer is not able to pick version for "self" on inclusion of solr anymore, so we force it:
-    export COMPOSER_ROOT_VERSION=`php -r 'echo json_decode(file_get_contents("./composer.json"), true)["extra"]["branch-alias"]["dev-tmp_ci_branch"];'`
 fi
 
 # Switch to another Symfony version if asked for
@@ -54,18 +48,4 @@ if [ "$SYMFONY_VERSION" != "" ] ; then
     # Remove php-cs-fixer as it is not needed for these tests and tends to cause Symfony version conflicts
     echo "> Remove php-cs-fixer"
     composer remove --dev --no-update friendsofphp/php-cs-fixer
-    COMPOSER_UPDATE="true"
 fi
-
-# Install packages with composer update if asked for to make sure not use composer.lock if present
-if [ "$COMPOSER_UPDATE" = "true" ] ; then
-    echo "> Install dependencies through Composer (using update as other packages was requested)"
-    composer update --no-progress --no-interaction --prefer-dist
-else
-    echo "> Install dependencies through Composer"
-    composer install --no-progress --no-interaction --prefer-dist
-fi
-
-# Setup Solr / Elastic search if asked for
-if [ "$TEST_CONFIG" = "phpunit-integration-legacy-elasticsearch.xml" ] ; then ./bin/.travis/init_elasticsearch.sh ; fi
-if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then ./vendor/ezsystems/ezplatform-solr-search-engine/bin/.travis/init_solr.sh; fi


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Done as part of https://jira.ez.no/browse/EZEE-2236
| **Bug/Improvement**| CI improvment
| **New feature**    | no
| **Target version** | 6.7, 6.13, 7.2, master
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | no

Sometimes `composer install` fails because of network connection problems, for example:
```
```[37;41m                                                                               [39;49m
[37;41m  [Composer\Downloader\TransportException]                                     [39;49m
[37;41m  The "http://packagist.org/p/ezsystems/ezpublish%24668516c3c81fe7235019645bb  [39;49m
[37;41m  ea5df277a1823a31351e9a2b6dd701bbfbb404e.json" file could not be downloaded   [39;49m
[37;41m  (HTTP/1.1 404 Not Found)                                                     [39;49m
[37;41m                                                                               [39;49m```
```

Adding `travis_retry` should help avoid this (and improve stability).

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
