### PR TITLE
EZP-29421: Contents of file field are lost if object is saved before publishing

### DIFF
--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
@@ -94,9 +94,12 @@ class BinaryBaseStorage extends GatewayBasedStorage
             $field->value->externalData['mimeType'] = $this->IOService->getMimeType($field->value->externalData['id']);
         }
 
-        $this->removeOldFile($field->id, $versionInfo->versionNo, $context);
+        $referenced = $this->gateway->getReferencedFiles([$field->id], $versionInfo->versionNo);
+        if ($referenced === null || !in_array($field->value->externalData['id'], $referenced)) {
+            $this->removeOldFile($field->id, $versionInfo->versionNo, $context);
 
-        $this->gateway->storeFileReference($versionInfo, $field);
+            $this->gateway->storeFileReference($versionInfo, $field);
+        }
     }
 
     public function copyLegacyField(VersionInfo $versionInfo, Field $field, Field $originalField, array $context)


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29421](https://jira.ez.no/browse/EZP-29421)
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.2`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->

Now we fetch all referenced files. If are any referenced files and the sent file is not in referenced files we remove old file and store file reference.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
