### PR TITLE
EZP-29462: Improve docblock and return type hint for ContentView::getLocation method

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/ContentView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ContentView.php
@@ -76,7 +76,7 @@ class ContentView extends BaseView implements View, ContentValueView, LocationVa
     }
 
     /**
-     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     * @return \eZ\Publish\API\Repository\Values\Content\Location|null
      */
     public function getLocation()
     {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29462](https://jira.ez.no/browse/EZP-29462)
| **Improvement**| yes
| **New feature**    |no
| **Target version** | `master`
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     |no

Improve docblock and return type hint for `\eZ\Publish\Core\MVC\Symfony\View\ContentView::getLocation` method. Because we did not set `$this->location` in the constructor, it is a possibility to have `$this->location` as null, ex https://jira.ez.no/browse/EZP-29342


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
