### PR TITLE
EZP-29470: As a developer I want trace for uncache Persistence calls

### DIFF
--- a/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
@@ -84,6 +84,7 @@ class PersistenceCacheCollector extends DataCollector
                 'arguments' => empty($call['arguments']) ?
                     '' :
                     preg_replace(array('/^array\s\(\s/', '/,\s\)$/'), '', var_export($call['arguments'], true)),
+                'trace' => implode(', ', $call['trace']),
             );
         }
 

--- a/eZ/Bundle/EzPublishDebugBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishDebugBundle/Resources/config/services.yml
@@ -12,6 +12,15 @@ services:
                 template: "EzPublishDebugBundle:Profiler:layout"
                 id: "ezpublish.debug.toolbar"
 
+    ezpublish_debug.siteaccess_collector:
+        class: "%ezpublish_debug.siteaccess_collector.class%"
+        tags:
+            -
+                name: ezpublish_data_collector
+                id: "ezpublish.debug.siteaccess"
+                panelTemplate: "EzPublishDebugBundle:Profiler/siteaccess:panel.html.twig"
+                toolbarTemplate: "EzPublishDebugBundle:Profiler/siteaccess:toolbar.html.twig"
+
     ezpublish_debug.persistence_collector:
         class: "%ezpublish_debug.persistence_collector.class%"
         arguments: ["@ezpublish.spi.persistence.cache.persistenceLogger"]
@@ -21,12 +30,3 @@ services:
                 id: "ezpublish.debug.persistence"
                 panelTemplate: "EzPublishDebugBundle:Profiler/persistence:panel.html.twig"
                 toolbarTemplate: "EzPublishDebugBundle:Profiler/persistence:toolbar.html.twig"
-
-    ezpublish_debug.siteaccess_collector:
-        class: "%ezpublish_debug.siteaccess_collector.class%"
-        tags:
-            -
-                name: ezpublish_data_collector
-                id: "ezpublish.debug.siteaccess"
-                panelTemplate: "EzPublishDebugBundle:Profiler/siteaccess:panel.html.twig"
-                toolbarTemplate: "EzPublishDebugBundle:Profiler/siteaccess:toolbar.html.twig"

--- a/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/persistence/panel.html.twig
+++ b/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/persistence/panel.html.twig
@@ -1,6 +1,12 @@
+<h3 title="Calls made to SPI\Persistence, persistance layer beneath Repository, which where not cached in SPI\Persistence\Cache">
+    Uncached Persistence\Cache calls
+</h3>
+
+<p class="text-small text-muted">TIP: This can represent both cold cache, and calls to methods which has not been made to be cached <em>(yet)</em>. Make sure to reload a few times to warmup cache in order to only see the latter.</p>
+
 <table>
     <tr>
-        <th>Total Uncached SPI calls:</th>
+        <th>Total Uncached calls:</th>
         <td>{{ collector.count }}</td>
     </tr>
     {% if collector.handlerscount %}
@@ -12,7 +18,6 @@
 </table>
 
 {% if collector.callsLoggingEnabled %}
-    <h3>Uncached SPI calls</h3>
     <table>
         <tr>
             <th>Class</th>

--- a/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/persistence/panel.html.twig
+++ b/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/persistence/panel.html.twig
@@ -23,12 +23,14 @@
             <th>Class</th>
             <th>Method</th>
             <th>Arguments</th>
+            <th title="Simplified trace">Trace</th>
         </tr>
         {% for call in collector.calls %}
             <tr>
                 <td>{{ call.class }}</td>
                 <td>{{ call.method }}</td>
                 <td>{{ call.arguments }}</td>
+                <td class="text-small text-muted">{{ call.trace }}</td>
             </tr>
         {% endfor %}
     </table>

--- a/eZ/Publish/Core/Persistence/Cache/PersistenceLogger.php
+++ b/eZ/Publish/Core/Persistence/Cache/PersistenceLogger.php
@@ -58,8 +58,29 @@ class PersistenceLogger
             $this->calls[] = array(
                 'method' => $method,
                 'arguments' => $arguments,
+                'trace' => $this->getSimpleCallTrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 7)),
             );
         }
+    }
+
+    private function getSimpleCallTrace(array $backtrace) :array
+    {
+        $calls = [];
+        foreach (array_slice($backtrace, 2) as $call) {
+            if (strpos($call['class'], '\\') === false) {
+                // skip if class has no namspace (in the slice of call graph here that would be a Symfony lazy proxy)
+                continue;
+            }
+
+            $calls[] = $call['class'] . $call['type'] . $call['function']. '()';
+
+            // Break out as soon as we have listed a class outside of kernel
+            if (strpos($call['class'], 'eZ\\Publish\\Core\\') !== 0) {
+                break;
+            }
+        }
+
+        return $calls;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/Tests/PersistenceLoggerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/PersistenceLoggerTest.php
@@ -99,12 +99,12 @@ class PersistenceLoggerTest extends TestCase
     {
         $method = __CLASS__ . '::testLogCall';
         $this->assertEquals(
-            array(
-                array('method' => $method, 'arguments' => array()),
-                array('method' => $method, 'arguments' => array()),
-                array('method' => $method, 'arguments' => array()),
-                array('method' => $method, 'arguments' => array(33)),
-            ),
+            [
+                ['method' => $method, 'arguments' => [], 'trace' => ['PHPUnit\Framework\TestCase->runTest()']],
+                ['method' => $method, 'arguments' => [], 'trace' => ['PHPUnit\Framework\TestCase->runTest()']],
+                ['method' => $method, 'arguments' => [], 'trace' => ['PHPUnit\Framework\TestCase->runTest()']],
+                ['method' => $method, 'arguments' => [33], 'trace' => ['PHPUnit\Framework\TestCase->runTest()']],
+            ],
             $logger->getCalls()
         );
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29470](https://jira.ez.no/browse/EZP-29470)
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | _maybe update of screenshoots_

#### Main change
Adds a simplified trace on the listing of un-cached `Persistence\Cache` calls in order to simplify identifying where they are called. 

#### Other tweaks
- Changes order so siteaccess info is shown first to not have to scroll down on long un-cached list
- Updated headers to make it more clear what this _(Persistence call info)_ is, and what is part of it

#### Screenshoot

![screen shot 2018-07-28 at 18 27 52](https://user-images.githubusercontent.com/289757/43358537-fdb931a2-9293-11e8-9be1-aeebdf9309b1.png)

Screenshoot of frontpage for clean install, trace immediately identifies two possible improvements:
1. [Bug] Admin UI seems to wrongly load config including backend data, also for frontend
2. [Feature] loadAll() methods for languages and content type groups would be worth caching


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
