### PR TITLE
EZP-29474: Fix for the hasAccess method when a policy has no limitations

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -62,18 +62,27 @@ class RepositoryFactory implements ContainerAwareInterface
      */
     private $policyMap;
 
+    /**
+     * Role Limitation map.
+     *
+     * @var array
+     */
+    protected $roleLimitationMap = array();
+
     public function __construct(
         ConfigResolverInterface $configResolver,
         FieldTypeCollectionFactory $fieldTypeCollectionFactory,
         FieldTypeNameableCollectionFactory $fieldTypeNameableCollectionFactory,
         $repositoryClass,
-        array $policyMap
+        array $policyMap,
+        array $roleLimitationMap
     ) {
         $this->configResolver = $configResolver;
         $this->fieldTypeCollectionFactory = $fieldTypeCollectionFactory;
         $this->fieldTypeNameableCollectionFactory = $fieldTypeNameableCollectionFactory;
         $this->repositoryClass = $repositoryClass;
         $this->policyMap = $policyMap;
+        $this->roleLimitationMap = $roleLimitationMap;
     }
 
     /**
@@ -108,6 +117,7 @@ class RepositoryFactory implements ContainerAwareInterface
                 'role' => array(
                     'limitationTypes' => $this->roleLimitations,
                     'policyMap' => $this->policyMap,
+                    'roleLimitationMap' => $this->roleLimitationMap,
                 ),
                 'languages' => $this->configResolver->getParameter('languages'),
                 'content' => ['default_version_archive_limit' => $config['options']['default_version_archive_limit']],

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -31,6 +31,7 @@ services:
             - "@ezpublish.field_type_nameable_collection.factory"
             - "%ezpublish.api.inner_repository.class%"
             - "%ezpublish.api.role.policy_map%"
+            - "%ezpublish.api.role.role_limitation_map%"
         calls:
             - [setContainer, ["@service_container"]]
 

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -56,16 +56,25 @@ class RepositoryFactory implements ContainerAwareInterface
      */
     protected $policyMap = array();
 
+    /**
+     * Role Limitation map.
+     *
+     * @var array
+     */
+    protected $roleLimitationMap = array();
+
     public function __construct(
         $repositoryClass,
         FieldTypeCollectionFactory $fieldTypeCollectionFactory,
         FieldTypeNameableCollectionFactory $fieldTypeNameableCollectionFactory,
-        array $policyMap
+        array $policyMap,
+        array $roleLimitationMap
     ) {
         $this->repositoryClass = $repositoryClass;
         $this->fieldTypeCollectionFactory = $fieldTypeCollectionFactory;
         $this->fieldTypeNameableCollectionFactory = $fieldTypeNameableCollectionFactory;
         $this->policyMap = $policyMap;
+        $this->roleLimitationMap = $roleLimitationMap;
     }
 
     /**
@@ -97,6 +106,7 @@ class RepositoryFactory implements ContainerAwareInterface
                 'role' => array(
                     'limitationTypes' => $this->roleLimitations,
                     'policyMap' => $this->policyMap,
+                    'roleLimitationMap' => $this->roleLimitationMap,
                 ),
                 'languages' => $this->container->getParameter('languages'),
             ),

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -61,24 +61,34 @@ class PermissionResolver implements PermissionResolverInterface
     private $policyMap;
 
     /**
+     * Map of modules adhering to role limitations.
+     *
+     * @var array
+     */
+    private $roleLimitationMap;
+
+    /**
      * @param \eZ\Publish\Core\Repository\Helper\RoleDomainMapper $roleDomainMapper
      * @param \eZ\Publish\Core\Repository\Helper\LimitationService $limitationService
      * @param \eZ\Publish\SPI\Persistence\User\Handler $userHandler
      * @param \eZ\Publish\API\Repository\Values\User\UserReference $userReference
      * @param array $policyMap Map of system configured policies, for validation usage.
+     * @param array $roleLimitationMap Map of modules adhering to role limitations.
      */
     public function __construct(
         RoleDomainMapper $roleDomainMapper,
         LimitationService $limitationService,
         UserHandler $userHandler,
         APIUserReference $userReference,
-        array $policyMap = []
+        array $policyMap = [],
+        array $roleLimitationMap = []
     ) {
         $this->roleDomainMapper = $roleDomainMapper;
         $this->limitationService = $limitationService;
         $this->userHandler = $userHandler;
         $this->currentUserRef = $userReference;
         $this->policyMap = $policyMap;
+        $this->roleLimitationMap = $roleLimitationMap;
     }
 
     public function getCurrentUserReference()
@@ -138,6 +148,10 @@ class PermissionResolver implements PermissionResolverInterface
                 }
 
                 if ($spiPolicy->limitations === '*' && $spiRoleAssignment->limitationIdentifier === null) {
+                    return true;
+                }
+
+                if (empty($this->policyMap[$module][$function]) && !isset($this->roleLimitationMap[$module])) {
                     return true;
                 }
 

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -964,7 +964,8 @@ class Repository implements RepositoryInterface
                     $this->getLimitationService(),
                     $this->persistenceHandler->userHandler(),
                     $this->currentUserRef,
-                    $this->serviceSettings['role']['policyMap']
+                    $this->serviceSettings['role']['policyMap'],
+                    $this->serviceSettings['role']['roleLimitationMap']
                 ),
                 new PermissionCriterionResolver(
                     $permissionResolver,

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -1318,8 +1318,10 @@ class RoleService implements RoleServiceInterface
 
         $types = array();
         try {
-            foreach (array_keys($this->settings['policyMap'][$module][$function]) as $identifier) {
-                $types[$identifier] = $this->limitationService->getLimitationType($identifier);
+            foreach ($this->settings['policyMap'][$module][$function] as $identifier => $included) {
+                if (true === $included) {
+                    $types[$identifier] = $this->limitationService->getLimitationType($identifier);
+                }
             }
         } catch (LimitationNotFoundException $e) {
             throw new BadStateException(

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -32,6 +32,7 @@ services:
             - "@ezpublish.field_type_collection.factory"
             - "@ezpublish.field_type_nameable_collection.factory"
             - "%ezpublish.api.role.policy_map%"
+            - "%ezpublish.api.role.role_limitation_map%"
         calls:
             - [setContainer, ["@service_container"]]
 

--- a/eZ/Publish/Core/settings/roles.yml
+++ b/eZ/Publish/Core/settings/roles.yml
@@ -19,6 +19,9 @@ parameters:
 
     ezpublish.api.role.policy_map: {}
 
+    ezpublish.api.role.role_limitation_map:
+        content: true
+
 services:
     ## Implemented Limitations
     ezpublish.api.role.limitation_type.content_type:

--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -586,6 +586,7 @@ abstract class BaseIntegrationTest extends TestCase
         $loader->load('utils.yml');
         $loader->load('tests/common.yml');
         $loader->load('policies.yml');
+        $loader->load('roles.yml');
 
         $containerBuilder->setParameter('ezpublish.kernel.root_dir', $installDir);
 

--- a/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
@@ -149,6 +149,7 @@ abstract class FileBaseIntegrationTest extends BaseIntegrationTest
         $loader->load('utils.yml');
         $loader->load('tests/common.yml');
         $loader->load('policies.yml');
+        $loader->load('roles.yml');
 
         $containerBuilder->setParameter('ezpublish.kernel.root_dir', $installDir);
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29474](https://jira.ez.no/browse/EZP-29474)
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.2`
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     |no

When Role is assigned to a user or a user group with limitations, all policies have these limitations. Even if by design they should have no limitation. This PR fixed hasAccess method to grant access when user has policy without limitations.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
