### PR TITLE
EZP-29408: Implemented Asset Relation type

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Relation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Relation.php
@@ -51,6 +51,13 @@ abstract class Relation extends ValueObject
     const FIELD = 8;
 
     /**
+     * the relation type ASSET is set for a relation to asset in an attribute value.
+     *
+     * @var int
+     */
+    const ASSET = 16;
+
+    /**
      * Id of the relation.
      *
      * @var mixed
@@ -83,7 +90,7 @@ abstract class Relation extends ValueObject
     /**
      * The relation type bitmask.
      *
-     * @see Relation::COMMON, Relation::EMBED, Relation::LINK, Relation::FIELD
+     * @see Relation::COMMON, Relation::EMBED, Relation::LINK, Relation::FIELD, Relation::ASSET
      *
      * @var int
      */

--- a/eZ/Publish/Core/FieldType/ImageAsset/Type.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/Type.php
@@ -252,7 +252,7 @@ class Type extends FieldType
     {
         $relations = [];
         if ($fieldValue->destinationContentId !== null) {
-            $relations[Relation::FIELD] = [$fieldValue->destinationContentId];
+            $relations[Relation::ASSET] = [$fieldValue->destinationContentId];
         }
 
         return $relations;

--- a/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Relation;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\FieldType\ImageAsset as ImageAsset;
 use eZ\Publish\Core\FieldType\ValidationError;
@@ -330,5 +331,21 @@ class ImageAssetTest extends FieldTypeTest
     public function testIsSearchable()
     {
         $this->assertTrue($this->getFieldTypeUnderTest()->isSearchable());
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\FieldType\Relation\Type::getRelations
+     */
+    public function testGetRelations()
+    {
+        $destinationContentId = 7;
+        $fieldType = $this->createFieldTypeUnderTest();
+
+        $this->assertEquals(
+            array(
+                Relation::ASSET => [$destinationContentId],
+            ),
+            $fieldType->getRelations($fieldType->acceptValue($destinationContentId))
+        );
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -237,7 +237,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
         // Load reverse field relations first
         $reverseRelations = $this->persistenceHandler->contentHandler()->loadReverseRelations(
             $contentId,
-            APIRelation::FIELD
+            APIRelation::FIELD | APIRelation::ASSET
         );
 
         $return = $this->persistenceHandler->contentHandler()->deleteContent($contentId);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -100,7 +100,7 @@ class ContentHandlerTest extends AbstractCacheHandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('loadReverseRelations')
-            ->with(2, APIRelation::FIELD)
+            ->with(2, APIRelation::FIELD | APIRelation::ASSET)
             ->will(
                 $this->returnValue(
                     array(

--- a/eZ/Publish/Core/REST/Client/Input/Parser/Relation.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/Relation.php
@@ -81,6 +81,8 @@ class Relation extends BaseParser
                 return Values\Content\Relation::LINK;
             case 'FIELD':
                 return Values\Content\Relation::FIELD;
+            case 'ASSET':
+                return Values\Content\Relation::ASSET;
         }
         throw new \RuntimeException(
             sprintf('Unknown Relation type: "%s"', $stringType)

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestRelation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestRelation.php
@@ -98,6 +98,8 @@ class RestRelation extends ValueObjectVisitor
                 return 'LINK';
             case RelationValue::FIELD:
                 return 'ATTRIBUTE';
+            case RelationValue::ASSET:
+                return 'ASSET';
         }
 
         throw new \Exception('Unknown relation type ' . $relationType . '.');

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
@@ -59,6 +59,10 @@ class RelationProcessorTest extends BaseServiceMockTest
                 array(Relation::EMBED => array(100 => 0)),
             ),
             array(
+                array(Relation::ASSET => array(100)),
+                array(Relation::ASSET => array(42 => array(100 => 0))),
+            ),
+            array(
                 array(
                     Relation::FIELD => array(100),
                     Relation::LINK => array('contentIds' => array(100)),
@@ -126,6 +130,44 @@ class RelationProcessorTest extends BaseServiceMockTest
                 ),
                 array(
                     Relation::FIELD => array(42 => array(100 => 0)),
+                    Relation::LINK => array(100 => 0, 200 => true),
+                    Relation::EMBED => array(100 => 0, 201 => true),
+                ),
+            ),
+            array(
+                array(
+                    Relation::ASSET => array(100),
+                    Relation::LINK => array(
+                        'locationIds' => array(100),
+                        'contentIds' => array(100),
+                    ),
+                    Relation::EMBED => array(
+                        'locationIds' => array(101),
+                        'contentIds' => array(100),
+                    ),
+                ),
+                array(
+                    Relation::ASSET => array(42 => array(100 => 0)),
+                    Relation::LINK => array(100 => 0, 200 => true),
+                    Relation::EMBED => array(100 => 0, 201 => true),
+                ),
+            ),
+            array(
+                array(
+                    Relation::FIELD => array(100),
+                    Relation::ASSET => array(100),
+                    Relation::LINK => array(
+                        'locationIds' => array(100),
+                        'contentIds' => array(100),
+                    ),
+                    Relation::EMBED => array(
+                        'locationIds' => array(101),
+                        'contentIds' => array(100),
+                    ),
+                ),
+                array(
+                    Relation::FIELD => array(42 => array(100 => 0)),
+                    Relation::ASSET => array(42 => array(100 => 0)),
                     Relation::LINK => array(100 => 0, 200 => true),
                     Relation::EMBED => array(100 => 0, 201 => true),
                 ),
@@ -221,6 +263,7 @@ class RelationProcessorTest extends BaseServiceMockTest
                 $this->returnValue(
                     array(
                         Relation::FIELD => array(100),
+                        Relation::ASSET => array(100),
                         Relation::LINK => array(
                             'locationIds' => array(100),
                             'contentIds' => array(100),
@@ -257,6 +300,7 @@ class RelationProcessorTest extends BaseServiceMockTest
 
         $this->assertEquals(
             array(
+                Relation::ASSET => array(42 => array(100 => 0)),
                 Relation::FIELD => array(42 => array(100 => 0)),
                 Relation::LINK => array(100 => 0, 200 => true),
                 Relation::EMBED => array(100 => 0, 200 => true),
@@ -328,10 +372,15 @@ class RelationProcessorTest extends BaseServiceMockTest
         $contentHandlerMock = $this->getPersistenceMockHandler('Content\\Handler');
         $contentTypeMock = $this->getMockForAbstractClass(ContentType::class);
 
-        $contentTypeMock->expects($this->once())
+        $contentTypeMock->expects($this->at(0))
             ->method('getFieldDefinition')
             ->with($this->equalTo('identifier42'))
             ->will($this->returnValue(new FieldDefinition(array('id' => 42))));
+
+        $contentTypeMock->expects($this->at(1))
+            ->method('getFieldDefinition')
+            ->with($this->equalTo('identifier43'))
+            ->will($this->returnValue(new FieldDefinition(array('id' => 43))));
 
         $contentHandlerMock->expects($this->never())->method('addRelation');
         $contentHandlerMock->expects($this->never())->method('removeRelation');
@@ -366,11 +415,13 @@ class RelationProcessorTest extends BaseServiceMockTest
                 null,
                 17
             ),
+            $this->getStubbedRelation(9, Relation::ASSET, 43, 18),
         );
         $inputRelations = array(
             Relation::EMBED => array_flip(array(11, 14, 16, 17)),
             Relation::LINK => array_flip(array(12, 15, 16, 17)),
             Relation::FIELD => array(42 => array_flip(array(13))),
+            Relation::ASSET => array(43 => array_flip(array(18))),
         );
 
         $relationProcessor->processFieldRelations(
@@ -421,6 +472,7 @@ class RelationProcessorTest extends BaseServiceMockTest
             Relation::EMBED => array_flip(array(11, 14, 16, 17)),
             Relation::LINK => array_flip(array(12, 15, 16, 17)),
             Relation::FIELD => array(42 => array_flip(array(13))),
+            Relation::ASSET => array(44 => array_flip(array(18))),
         );
 
         $contentTypeMock->expects($this->never())->method('getFieldDefinition');
@@ -464,6 +516,20 @@ class RelationProcessorTest extends BaseServiceMockTest
                         'sourceFieldDefinitionId' => 42,
                         'destinationContentId' => 13,
                         'type' => Relation::FIELD,
+                    )
+                )
+            );
+
+        $contentHandlerMock->expects($this->at(3))
+            ->method('addRelation')
+            ->with(
+                new CreateStruct(
+                    array(
+                        'sourceContentId' => 24,
+                        'sourceContentVersionNo' => 2,
+                        'sourceFieldDefinitionId' => 44,
+                        'destinationContentId' => 18,
+                        'type' => Relation::ASSET,
                     )
                 )
             );
@@ -518,6 +584,7 @@ class RelationProcessorTest extends BaseServiceMockTest
                 null,
                 17
             ),
+            $this->getStubbedRelation(9, Relation::FIELD, 44, 18),
         );
         $inputRelations = array(
             Relation::EMBED => array_flip(array(11, 14, 17)),
@@ -526,10 +593,15 @@ class RelationProcessorTest extends BaseServiceMockTest
 
         $contentHandlerMock->expects($this->never())->method('addRelation');
 
-        $contentTypeMock->expects($this->once())
+        $contentTypeMock->expects($this->at(0))
             ->method('getFieldDefinition')
             ->with($this->equalTo('identifier42'))
             ->will($this->returnValue(new FieldDefinition(array('id' => 42))));
+
+        $contentTypeMock->expects($this->at(1))
+            ->method('getFieldDefinition')
+            ->with($this->equalTo('identifier44'))
+            ->will($this->returnValue(new FieldDefinition(array('id' => 44))));
 
         $contentHandlerMock->expects($this->at(0))
             ->method('removeRelation')
@@ -552,6 +624,13 @@ class RelationProcessorTest extends BaseServiceMockTest
                 $this->equalTo(Relation::FIELD)
             );
 
+        $contentHandlerMock->expects($this->at(3))
+            ->method('removeRelation')
+            ->with(
+                $this->equalTo(9),
+                $this->equalTo(Relation::FIELD)
+            );
+
         $relationProcessor->processFieldRelations(
             $inputRelations,
             24,
@@ -570,6 +649,7 @@ class RelationProcessorTest extends BaseServiceMockTest
     {
         $existingRelations = [
             $this->getStubbedRelation(2, Relation::FIELD, 43, 17),
+            $this->getStubbedRelation(2, Relation::ASSET, 44, 18),
         ];
 
         $contentTypeMock = $this->getMockForAbstractClass(ContentType::class);
@@ -577,6 +657,12 @@ class RelationProcessorTest extends BaseServiceMockTest
             ->expects($this->at(0))
             ->method('getFieldDefinition')
             ->with($this->equalTo('identifier43'))
+            ->will($this->returnValue(null));
+
+        $contentTypeMock
+            ->expects($this->at(1))
+            ->method('getFieldDefinition')
+            ->with($this->equalTo('identifier44'))
             ->will($this->returnValue(null));
 
         $relationProcessor = $this->getPartlyMockedRelationProcessor();

--- a/eZ/Publish/SPI/Persistence/Content/Relation.php
+++ b/eZ/Publish/SPI/Persistence/Content/Relation.php
@@ -57,6 +57,7 @@ class Relation extends ValueObject
      *      \eZ\Publish\API\Repository\Values\Content\Relation::EMBED,
      *      \eZ\Publish\API\Repository\Values\Content\Relation::LINK,
      *      \eZ\Publish\API\Repository\Values\Content\Relation::FIELD
+     *      \eZ\Publish\API\Repository\Values\Content\Relation::ASSET
      *
      * @var int
      */


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29408](https://jira.ez.no/browse/EZP-29408)
| **Required by** | ezsystems/ezplatform-admin-ui#591
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     |  yes
| **Doc needed**     | yes

This PR introduces a new type of relation type between content: `ASSET`. This allow to distinct the relation to the content items of type dedicated to represent assets (e.g Image, File, Media).

Typicaly a relation type created by ImageAsset, but also in the future by other "Asset" field types. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
