### PR TITLE
Added Author Field Type default prefilling BC break note

### DIFF
--- a/doc/bc/changes-7.3.md
+++ b/doc/bc/changes-7.3.md
@@ -4,7 +4,7 @@ Changes affecting version compatibility with former or future versions.
 
 ## Changes
 
-* Author Field Type will now be prefilled with current user by default. This behavior could be configured with an option: `defaultAuthor` in Content Type creation view.
+* Author Field Type will now be prefilled with current user by default, like done in eZ Publish admin-interface and in eZ Platform 1.x UI. This behavior could be configured with an option: `defaultAuthor` in Content Type creation view.
 
 ## Deprecations
 

--- a/doc/bc/changes-7.3.md
+++ b/doc/bc/changes-7.3.md
@@ -1,0 +1,11 @@
+# Backwards compatibility changes
+
+Changes affecting version compatibility with former or future versions.
+
+## Changes
+
+* Author Field Type will now be prefilled with current user by default. This behavior could be configured with an option: `defaultAuthor` in Content Type creation view.
+
+## Deprecations
+
+## Removed features


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29290](https://jira.ez.no/browse/EZP-29290)
| **New feature**    | yes
| **Target version** | `master`

This PR adds a note regarding BC caused by prefilling Author Field Type by default.
