### PR TITLE
Fix EZP-29504 : add siteaccess parameter to ezplatform:reindex

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -44,6 +44,11 @@ class ReindexCommand extends ContainerAwareCommand
      * @var \Psr\Log\LoggerInterface
      */
     private $logger;
+    
+    /**
+     * @var string
+     */
+    private $siteaccess;
 
     /**
      * Initialize objects required by {@see execute()}.
@@ -143,6 +148,7 @@ EOT
     {
         $commit = !$input->getOption('no-commit');
         $iterationCount = $input->getOption('iteration-count');
+        $this->siteaccess = $input->getOption('siteaccess');
         if (!is_numeric($iterationCount) || (int) $iterationCount < 1) {
             throw new RuntimeException("'--iteration-count' option should be > 0, got '{$iterationCount}'");
         }
@@ -371,6 +377,7 @@ EOT
     {
         $process = new ProcessBuilder([
             file_exists('bin/console') ? 'bin/console' : 'app/console',
+            $this->siteaccess ? '--siteaccess=' . $this->siteaccess : null,
             'ezplatform:reindex',
             '--content-ids=' . implode(',', $contentIds),
         ]);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29504](https://jira.ez.no/browse/EZP-29504)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `6.x`/`7.x` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Add siteaccess parameter when ezplatform:reindex is run in multi-process
