### PR TITLE
EZP-29474: Fix wrong usage of hasAccess in repository

### DIFF
--- a/eZ/Publish/API/Repository/PermissionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionResolver.php
@@ -29,14 +29,13 @@ interface PermissionResolver
     public function setCurrentUserReference(UserReference $userReference);
 
     /**
-     * Returns boolean value or an array of limitations describing user's permissions
-     * on the given module and function.
+     * Low level permission function: Returns boolean value, or an array of limitations that permission for depens on.
      *
      * Note: boolean value describes full access (true) or no access at all (false), array can be seen as a maybe..
      *
-     * WARNING: If possible strongly prefer to use canUser() as it is able to handle limitations!
+     * WARNING: This is a low level method, if possible strongly prefer to use canUser() as it is able to handle limitations.
      *          This includes Role Assignment limitations, but also future policy limitations added in kernel
-     *          or as custom configuration/extension to the system (as this is possible as well now).
+     *          or as custom configuration/extension to the system (by means of custom confiuration).
      *
      * @param string $module The module, aka controller identifier to check permissions on
      * @param string $function The function, aka the controller action to check permissions on

--- a/eZ/Publish/API/Repository/PermissionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionResolver.php
@@ -34,8 +34,8 @@ interface PermissionResolver
      * Note: boolean value describes full access (true) or no access at all (false), array can be seen as a maybe..
      *
      * WARNING: This is a low level method, if possible strongly prefer to use canUser() as it is able to handle limitations.
-     *          This includes Role Assignment limitations, but also future policy limitations added in kernel
-     *          or as custom configuration/extension to the system (by means of custom confiuration).
+     *          This includes Role Assignment limitations, but also future policy limitations added in kernel,
+     *          or as plain user configuration and/or extending the system.
      *
      * @param string $module The module, aka controller identifier to check permissions on
      * @param string $function The function, aka the controller action to check permissions on

--- a/eZ/Publish/API/Repository/PermissionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionResolver.php
@@ -32,7 +32,11 @@ interface PermissionResolver
      * Returns boolean value or an array of limitations describing user's permissions
      * on the given module and function.
      *
-     * Note: boolean value describes full access (true) or no access at all (false).
+     * Note: boolean value describes full access (true) or no access at all (false), array can be seen as a maybe..
+     *
+     * WARNING: If possible strongly prefer to use canUser() as it is able to handle limitations!
+     *          This includes Role Assignment limitations, but also future policy limitations added in kernel
+     *          or as custom configuration/extension to the system (as this is possible as well now).
      *
      * @param string $module The module, aka controller identifier to check permissions on
      * @param string $function The function, aka the controller action to check permissions on

--- a/eZ/Publish/API/Repository/PermissionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionResolver.php
@@ -29,7 +29,7 @@ interface PermissionResolver
     public function setCurrentUserReference(UserReference $userReference);
 
     /**
-     * Low level permission function: Returns boolean value, or an array of limitations that permission for depens on.
+     * Low level permission function: Returns boolean value, or an array of limitations that user permission depends on.
      *
      * Note: boolean value describes full access (true) or no access at all (false), array can be seen as a maybe..
      *

--- a/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
@@ -151,7 +151,7 @@ class SectionServiceAuthorizationTest extends BaseTest
         $sections = $sectionService->loadSections();
         /* END: Use Case */
 
-        $this->assertEmpty($sections, "Expected to get zero sections back as user has nada section access");
+        $this->assertEmpty($sections, 'Expected to get zero sections back as user has nada section access');
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
@@ -120,9 +120,10 @@ class SectionServiceAuthorizationTest extends BaseTest
      * Test for the loadSections() method.
      *
      * @see \eZ\Publish\API\Repository\SectionService::loadSections()
-     * @depends \eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
      */
-    public function testLoadSectionsFiltersResults()
+    public function testLoadSectionsThrowsUnauthorizedException()
     {
         $repository = $this->getRepository();
 
@@ -148,10 +149,9 @@ class SectionServiceAuthorizationTest extends BaseTest
         // Set anonymous user
         $repository->setCurrentUser($userService->loadUser($anonymousUserId));
 
-        $sections = $sectionService->loadSections();
+        // This call will fail with a "UnauthorizedException"
+        $sectionService->loadSections();
         /* END: Use Case */
-
-        $this->assertEmpty($sections, 'Expected to get zero sections back as user has nada section access');
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
@@ -120,10 +120,9 @@ class SectionServiceAuthorizationTest extends BaseTest
      * Test for the loadSections() method.
      *
      * @see \eZ\Publish\API\Repository\SectionService::loadSections()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
+     * @depends \eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
      */
-    public function testLoadSectionsThrowsUnauthorizedException()
+    public function testLoadSectionsFiltersResults()
     {
         $repository = $this->getRepository();
 
@@ -149,9 +148,10 @@ class SectionServiceAuthorizationTest extends BaseTest
         // Set anonymous user
         $repository->setCurrentUser($userService->loadUser($anonymousUserId));
 
-        // This call will fail with a "UnauthorizedException"
-        $sectionService->loadSections();
+        $sections = $sectionService->loadSections();
         /* END: Use Case */
+
+        $this->assertEmpty($sections, "Expected to get zero sections back as user has nada section access");
     }
 
     /**

--- a/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
@@ -137,10 +137,15 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
 
         // Load locations if no specific placement was provided
         if ($targets === null) {
-            if ($object->published) {
+            // Skip check if content is in trash and no location is provided to check against
+            if ($object->isTrashed()) {
+                return self::ACCESS_ABSTAIN;
+            }
+
+            if ($object->isPublished()) {
                 $targets = $this->persistence->locationHandler()->loadLocationsByContent($object->id);
             } else {
-                // @todo Need support for draft locations to to work correctly
+                // @todo Need support for draft locations to work correctly
                 $targets = $this->persistence->locationHandler()->loadParentLocationsForDraftContent($object->id);
             }
         }

--- a/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
@@ -283,7 +283,7 @@ class SubtreeLimitationTypeTest extends Base
         $versionInfoMock
             ->expects($this->once())
             ->method('getContentInfo')
-            ->will($this->returnValue(new ContentInfo(array('published' => true))));
+            ->willReturn(new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]));
 
         $versionInfoMock2 = $this->getMock(
             'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
@@ -296,13 +296,13 @@ class SubtreeLimitationTypeTest extends Base
         $versionInfoMock2
             ->expects($this->once())
             ->method('getContentInfo')
-            ->will($this->returnValue(new ContentInfo(array('published' => true))));
+            ->willReturn(new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]));
 
         return array(
             // ContentInfo, with targets, no access
             array(
                 'limitation' => new SubtreeLimitation(),
-                'object' => new ContentInfo(array('published' => true)),
+                'object' => new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]),
                 'targets' => array(new Location()),
                 'persistence' => array(),
                 'expected' => LimitationType::ACCESS_DENIED,
@@ -310,7 +310,7 @@ class SubtreeLimitationTypeTest extends Base
             // ContentInfo, with targets, no access
             array(
                 'limitation' => new SubtreeLimitation(array('limitationValues' => array('/1/2/'))),
-                'object' => new ContentInfo(array('published' => true)),
+                'object' => new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]),
                 'targets' => array(new Location(array('pathString' => '/1/55/'))),
                 'persistence' => array(),
                 'expected' => LimitationType::ACCESS_DENIED,
@@ -318,7 +318,7 @@ class SubtreeLimitationTypeTest extends Base
             // ContentInfo, with targets, with access
             array(
                 'limitation' => new SubtreeLimitation(array('limitationValues' => array('/1/2/'))),
-                'object' => new ContentInfo(array('published' => true)),
+                'object' => new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]),
                 'targets' => array(new Location(array('pathString' => '/1/2/'))),
                 'persistence' => array(),
                 'expected' => LimitationType::ACCESS_GRANTED,
@@ -326,7 +326,7 @@ class SubtreeLimitationTypeTest extends Base
             // ContentInfo, no targets, with access
             array(
                 'limitation' => new SubtreeLimitation(array('limitationValues' => array('/1/2/'))),
-                'object' => new ContentInfo(array('published' => true)),
+                'object' => new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]),
                 'targets' => null,
                 'persistence' => array(new Location(array('pathString' => '/1/2/'))),
                 'expected' => LimitationType::ACCESS_GRANTED,
@@ -334,7 +334,7 @@ class SubtreeLimitationTypeTest extends Base
             // ContentInfo, no targets, no access
             array(
                 'limitation' => new SubtreeLimitation(array('limitationValues' => array('/1/2/', '/1/43/'))),
-                'object' => new ContentInfo(array('published' => true)),
+                'object' => new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]),
                 'targets' => null,
                 'persistence' => array(new Location(array('pathString' => '/1/55/'))),
                 'expected' => LimitationType::ACCESS_DENIED,
@@ -342,7 +342,7 @@ class SubtreeLimitationTypeTest extends Base
             // ContentInfo, no targets, un-published, with access
             array(
                 'limitation' => new SubtreeLimitation(array('limitationValues' => array('/1/2/'))),
-                'object' => new ContentInfo(array('published' => false)),
+                'object' => new ContentInfo(['published' => false, 'status' => ContentInfo::STATUS_DRAFT]),
                 'targets' => null,
                 'persistence' => array(new Location(array('pathString' => '/1/2/'))),
                 'expected' => LimitationType::ACCESS_GRANTED,
@@ -350,7 +350,7 @@ class SubtreeLimitationTypeTest extends Base
             // ContentInfo, no targets, un-published, no access
             array(
                 'limitation' => new SubtreeLimitation(array('limitationValues' => array('/1/2/', '/1/43/'))),
-                'object' => new ContentInfo(array('published' => false)),
+                'object' => new ContentInfo(['published' => false, 'status' => ContentInfo::STATUS_DRAFT]),
                 'targets' => null,
                 'persistence' => array(new Location(array('pathString' => '/1/55/'))),
                 'expected' => LimitationType::ACCESS_DENIED,
@@ -406,7 +406,7 @@ class SubtreeLimitationTypeTest extends Base
             // invalid target
             array(
                 'limitation' => new SubtreeLimitation(),
-                'object' => new ContentInfo(array('published' => true)),
+                'object' => new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]),
                 'targets' => array(new ObjectStateLimitation()),
                 'persistence' => array(),
                 'expected' => LimitationType::ACCESS_ABSTAIN,

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1103,7 +1103,6 @@ class ContentService implements ContentServiceInterface
         }
 
         // throw early if user has absolutely no access to versionread
-
         if ($this->repository->hasAccess('content', 'versionread') === false) {
             throw new UnauthorizedException('content', 'versionread');
         }
@@ -1112,7 +1111,7 @@ class ContentService implements ContentServiceInterface
         $versionInfoList = array();
         foreach ($spiVersionInfoList as $spiVersionInfo) {
             $versionInfo = $this->domainMapper->buildVersionInfoDomainObject($spiVersionInfo);
-            // TODO: Should we rather filter out items here? If so we can remove early permission check above and exception
+            // @todo: Change this to filter returned drafts by permissions instead of throwing
             if (!$this->repository->canUser('content', 'versionread', $versionInfo)) {
                 throw new UnauthorizedException('content', 'versionread', array('contentId' => $versionInfo->contentInfo->id));
             }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1103,6 +1103,7 @@ class ContentService implements ContentServiceInterface
         }
 
         // throw early if user has absolutely no access to versionread
+
         if ($this->repository->hasAccess('content', 'versionread') === false) {
             throw new UnauthorizedException('content', 'versionread');
         }
@@ -1111,6 +1112,7 @@ class ContentService implements ContentServiceInterface
         $versionInfoList = array();
         foreach ($spiVersionInfoList as $spiVersionInfo) {
             $versionInfo = $this->domainMapper->buildVersionInfoDomainObject($spiVersionInfo);
+            // TODO: Should we rather filter out items here? If so we can remove early permission check above and exception
             if (!$this->repository->canUser('content', 'versionread', $versionInfo)) {
                 throw new UnauthorizedException('content', 'versionread', array('contentId' => $versionInfo->contentInfo->id));
             }

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -116,7 +116,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function createContentTypeGroup(ContentTypeGroupCreateStruct  $contentTypeGroupCreateStruct)
     {
-        if ($this->repository->hasAccess('class', 'create') !== true) {
+        if (!$this->repository->canUser('class', 'create', $contentTypeGroupCreateStruct)) {
             throw new UnauthorizedException('ContentType', 'create');
         }
 
@@ -235,7 +235,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function updateContentTypeGroup(APIContentTypeGroup $contentTypeGroup, ContentTypeGroupUpdateStruct $contentTypeGroupUpdateStruct)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentTypeGroup)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -298,7 +298,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function deleteContentTypeGroup(APIContentTypeGroup $contentTypeGroup)
     {
-        if ($this->repository->hasAccess('class', 'delete') !== true) {
+        if (!$this->repository->canUser('class', 'delete', $contentTypeGroup)) {
             throw new UnauthorizedException('ContentType', 'delete');
         }
 
@@ -655,7 +655,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function createContentType(APIContentTypeCreateStruct $contentTypeCreateStruct, array $contentTypeGroups)
     {
-        if ($this->repository->hasAccess('class', 'create') !== true) {
+        if (!$this->repository->canUser('class', 'create', $contentTypeCreateStruct, $contentTypeGroups)) {
             throw new UnauthorizedException('ContentType', 'create');
         }
 
@@ -1022,7 +1022,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function createContentTypeDraft(APIContentType $contentType)
     {
-        if ($this->repository->hasAccess('class', 'create') !== true) {
+        if (!$this->repository->canUser('class', 'create', $contentType)) {
             throw new UnauthorizedException('ContentType', 'create');
         }
 
@@ -1075,7 +1075,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function updateContentTypeDraft(APIContentTypeDraft $contentTypeDraft, ContentTypeUpdateStruct $contentTypeUpdateStruct)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -1149,7 +1149,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function deleteContentType(APIContentType $contentType)
     {
-        if ($this->repository->hasAccess('class', 'delete') !== true) {
+        if (!$this->repository->canUser('class', 'delete', $contentType)) {
             throw new UnauthorizedException('ContentType', 'delete');
         }
 
@@ -1189,7 +1189,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function copyContentType(APIContentType $contentType, User $creator = null)
     {
-        if ($this->repository->hasAccess('class', 'create') !== true) {
+        if (!$this->repository->canUser('class', 'create', $contentType)) {
             throw new UnauthorizedException('ContentType', 'create');
         }
 
@@ -1224,7 +1224,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function assignContentTypeGroup(APIContentType $contentType, APIContentTypeGroup $contentTypeGroup)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentType)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -1266,7 +1266,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function unassignContentTypeGroup(APIContentType $contentType, APIContentTypeGroup $contentTypeGroup)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentType, [$contentTypeGroup])) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -1322,7 +1322,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function addFieldDefinition(APIContentTypeDraft $contentTypeDraft, FieldDefinitionCreateStruct $fieldDefinitionCreateStruct)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -1395,7 +1395,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function removeFieldDefinition(APIContentTypeDraft $contentTypeDraft, APIFieldDefinition $fieldDefinition)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -1439,7 +1439,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function updateFieldDefinition(APIContentTypeDraft $contentTypeDraft, APIFieldDefinition $fieldDefinition, FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -1494,7 +1494,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function publishContentTypeDraft(APIContentTypeDraft $contentTypeDraft)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 

--- a/eZ/Publish/Core/Repository/LanguageService.php
+++ b/eZ/Publish/Core/Repository/LanguageService.php
@@ -83,7 +83,7 @@ class LanguageService implements LanguageServiceInterface
             throw new InvalidArgumentValue('enabled', $languageCreateStruct->enabled, 'LanguageCreateStruct');
         }
 
-        if ($this->repository->hasAccess('content', 'translations') !== true) {
+        if (!$this->repository->canUser('content', 'translations', $languageCreateStruct)) {
             throw new UnauthorizedException('content', 'translations');
         }
 
@@ -133,7 +133,7 @@ class LanguageService implements LanguageServiceInterface
             throw new InvalidArgumentValue('newName', $newName);
         }
 
-        if ($this->repository->hasAccess('content', 'translations') !== true) {
+        if (!$this->repository->canUser('content', 'translations', $language)) {
             throw new UnauthorizedException('content', 'translations');
         }
 
@@ -171,7 +171,7 @@ class LanguageService implements LanguageServiceInterface
      */
     public function enableLanguage(Language $language)
     {
-        if ($this->repository->hasAccess('content', 'translations') !== true) {
+        if (!$this->repository->canUser('content', 'translations', $language)) {
             throw new UnauthorizedException('content', 'translations');
         }
 
@@ -209,7 +209,7 @@ class LanguageService implements LanguageServiceInterface
      */
     public function disableLanguage(Language $language)
     {
-        if ($this->repository->hasAccess('content', 'translations') !== true) {
+        if (!$this->repository->canUser('content', 'translations', $language)) {
             throw new UnauthorizedException('content', 'translations');
         }
 
@@ -303,7 +303,7 @@ class LanguageService implements LanguageServiceInterface
      */
     public function deleteLanguage(Language $language)
     {
-        if ($this->repository->hasAccess('content', 'translations') !== true) {
+        if (!$this->repository->canUser('content', 'translations', $language)) {
             throw new UnauthorizedException('content', 'translations');
         }
 

--- a/eZ/Publish/Core/Repository/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/ObjectStateService.php
@@ -81,7 +81,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      */
     public function createObjectStateGroup(ObjectStateGroupCreateStruct $objectStateGroupCreateStruct)
     {
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectStateGroupCreateStruct)) {
             throw new UnauthorizedException('state', 'administrate');
         }
 
@@ -182,7 +182,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      */
     public function updateObjectStateGroup(APIObjectStateGroup $objectStateGroup, ObjectStateGroupUpdateStruct $objectStateGroupUpdateStruct)
     {
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectStateGroup)) {
             throw new UnauthorizedException('state', 'administrate');
         }
 
@@ -234,7 +234,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      */
     public function deleteObjectStateGroup(APIObjectStateGroup $objectStateGroup)
     {
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectStateGroup)) {
             throw new UnauthorizedException('state', 'administrate');
         }
 
@@ -266,7 +266,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      */
     public function createObjectState(APIObjectStateGroup $objectStateGroup, ObjectStateCreateStruct $objectStateCreateStruct)
     {
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectStateCreateStruct, [$objectStateGroup])) {
             throw new UnauthorizedException('state', 'administrate');
         }
 
@@ -340,7 +340,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      */
     public function updateObjectState(APIObjectState $objectState, ObjectStateUpdateStruct $objectStateUpdateStruct)
     {
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectState)) {
             throw new UnauthorizedException('state', 'administrate');
         }
 
@@ -401,7 +401,7 @@ class ObjectStateService implements ObjectStateServiceInterface
             throw new InvalidArgumentValue('priority', $priority);
         }
 
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectState)) {
             throw new UnauthorizedException('state', 'administrate');
         }
 
@@ -430,7 +430,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      */
     public function deleteObjectState(APIObjectState $objectState)
     {
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectState)) {
             throw new UnauthorizedException('state', 'administrate');
         }
 

--- a/eZ/Publish/Core/Repository/SectionService.php
+++ b/eZ/Publish/Core/Repository/SectionService.php
@@ -33,7 +33,9 @@ class SectionService implements SectionServiceInterface
      */
     protected $repository;
 
-    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    /**
+     * @var \eZ\Publish\API\Repository\PermissionResolver
+     */
     protected $permissionResolver;
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/TrashBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/TrashBase.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Integration;
 
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\Repository\Tests\Service\Integration\Base as BaseServiceTest;
 use eZ\Publish\Core\Repository\Values\Content\TrashItem;
 use eZ\Publish\Core\Repository\Values\Content\Location;
@@ -288,8 +289,9 @@ abstract class TrashBase extends BaseServiceTest
     {
         $trashService = $this->repository->getTrashService();
 
-        $trashItem = new TrashItem(array('id' => APIBaseTest::DB_INT_MAX, 'parentLocationId' => APIBaseTest::DB_INT_MAX));
-        $trashService->recover($trashItem);
+        $trashService->recover(
+            $this->getTrashItem(APIBaseTest::DB_INT_MAX, 2, APIBaseTest::DB_INT_MAX)
+        );
     }
 
     /**
@@ -398,8 +400,9 @@ abstract class TrashBase extends BaseServiceTest
     {
         $trashService = $this->repository->getTrashService();
 
-        $trashItem = new TrashItem(array('id' => APIBaseTest::DB_INT_MAX));
-        $trashService->deleteTrashItem($trashItem);
+        $trashService->deleteTrashItem(
+            $this->getTrashItem(APIBaseTest::DB_INT_MAX)
+        );
     }
 
     /**
@@ -471,5 +474,14 @@ abstract class TrashBase extends BaseServiceTest
                 $locationCreates
             )->versionInfo
         );
+    }
+
+    private function getTrashItem($id, $contentId = 44, $parentLocationId = 2)
+    {
+        return new TrashItem([
+            'id' => $id,
+            'parentLocationId' => $parentLocationId,
+            'contentInfo' => new ContentInfo(['id' => $contentId]),
+        ]);
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlWildcardTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlWildcardTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\Repository\Tests\Service\Integration;
+namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\API\Repository\Values\Content\URLWildcard;
@@ -295,20 +295,25 @@ class UrlWildcardTest extends BaseServiceMockTest
      */
     public function testRemoveThrowsUnauthorizedException()
     {
+        $wildcard = new URLWildcard(['id' => 'McBoom']);
+
         $mockedService = $this->getPartlyMockedURLWildcardService();
         $repositoryMock = $this->getRepositoryMock();
         $repositoryMock->expects(
             $this->once()
         )->method(
-            'hasAccess'
+            'canUser'
         )->with(
             $this->equalTo('content'),
-            $this->equalTo('urltranslator')
+            $this->equalTo('urltranslator'),
+            $this->equalTo($wildcard)
         )->will(
             $this->returnValue(false)
         );
 
-        $mockedService->remove(new URLWildcard());
+        $repositoryMock->expects($this->never())->method('beginTransaction');
+
+        $mockedService->remove($wildcard);
     }
 
     /**
@@ -319,6 +324,8 @@ class UrlWildcardTest extends BaseServiceMockTest
      */
     public function testRemove()
     {
+        $wildcard = new URLWildcard(['id' => 'McBomb']);
+
         $mockedService = $this->getPartlyMockedURLWildcardService();
         /** @var \PHPUnit_Framework_MockObject_MockObject $handlerMock */
         $handlerMock = $this->getPersistenceMock()->urlWildcardHandler();
@@ -327,10 +334,11 @@ class UrlWildcardTest extends BaseServiceMockTest
         $repositoryMock->expects(
             $this->once()
         )->method(
-            'hasAccess'
+            'canUser'
         )->with(
             $this->equalTo('content'),
-            $this->equalTo('urltranslator')
+            $this->equalTo('urltranslator'),
+            $this->equalTo($wildcard)
         )->will(
             $this->returnValue(true)
         );
@@ -346,7 +354,7 @@ class UrlWildcardTest extends BaseServiceMockTest
             $this->equalTo('McBomb')
         );
 
-        $mockedService->remove(new URLWildcard(array('id' => 'McBomb')));
+        $mockedService->remove($wildcard);
     }
 
     /**
@@ -358,6 +366,8 @@ class UrlWildcardTest extends BaseServiceMockTest
      */
     public function testRemoveWithRollback()
     {
+        $wildcard = new URLWildcard(['id' => 'McBoo']);
+
         $mockedService = $this->getPartlyMockedURLWildcardService();
         /** @var \PHPUnit_Framework_MockObject_MockObject $handlerMock */
         $handlerMock = $this->getPersistenceMock()->urlWildcardHandler();
@@ -366,10 +376,11 @@ class UrlWildcardTest extends BaseServiceMockTest
         $repositoryMock->expects(
             $this->once()
         )->method(
-            'hasAccess'
+            'canUser'
         )->with(
             $this->equalTo('content'),
-            $this->equalTo('urltranslator')
+            $this->equalTo('urltranslator'),
+            $this->equalTo($wildcard)
         )->will(
             $this->returnValue(true)
         );
@@ -387,7 +398,7 @@ class UrlWildcardTest extends BaseServiceMockTest
             $this->throwException(new \Exception())
         );
 
-        $mockedService->remove(new URLWildcard(array('id' => 'McBoo')));
+        $mockedService->remove($wildcard);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -92,8 +92,6 @@ class TrashService implements TrashServiceInterface
             throw new UnauthorizedException('content', 'read');
         }
 
-        // TODO: Need to check (integration tests + self + QA) how Role limitation will behave with this (as there is no location)
-        // we could pass trash as target (same goes for content/read above), but again would need to check how it will behave.
         if (!$this->repository->canUser('content', 'restore', $trash->getContentInfo())) {
             throw new UnauthorizedException('content', 'restore');
         }

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -86,14 +86,16 @@ class TrashService implements TrashServiceInterface
      */
     public function loadTrashItem($trashItemId)
     {
-        if ($this->repository->hasAccess('content', 'restore') !== true) {
-            throw new UnauthorizedException('content', 'restore');
-        }
-
         $spiTrashItem = $this->persistenceHandler->trashHandler()->loadTrashItem($trashItemId);
         $trash = $this->buildDomainTrashItemObject($spiTrashItem);
         if (!$this->repository->canUser('content', 'read', $trash->getContentInfo())) {
             throw new UnauthorizedException('content', 'read');
+        }
+
+        // TODO: Need to check (integration tests + self + QA) how Role limitation will behave with this (as there is no location)
+        // we could pass trash as target (same goes for content/read above), but again would need to check how it will behave.
+        if (!$this->repository->canUser('content', 'restore', $trash->getContentInfo())) {
+            throw new UnauthorizedException('content', 'restore');
         }
 
         return $trash;
@@ -171,7 +173,12 @@ class TrashService implements TrashServiceInterface
             throw new InvalidArgumentValue('parentLocationId', $newParentLocation->id, 'Location');
         }
 
-        if ($this->repository->hasAccess('content', 'restore') !== true) {
+        if (!$this->repository->canUser(
+            'content',
+            'restore',
+            $trashItem->getContentInfo(),
+            $newParentLocation ? [$newParentLocation] : null
+        )) {
             throw new UnauthorizedException('content', 'restore');
         }
 
@@ -216,6 +223,9 @@ class TrashService implements TrashServiceInterface
      */
     public function emptyTrash()
     {
+        // Will throw if you have Role assignment limitation where you have content/cleantrash permission.
+        // This is by design and means you can only delete one and one trash item, or you'll need to change how
+        // permissions is assigned to be on separate role with no Role assignment limitation.
         if ($this->repository->hasAccess('content', 'cleantrash') !== true) {
             throw new UnauthorizedException('content', 'cleantrash');
         }
@@ -242,7 +252,7 @@ class TrashService implements TrashServiceInterface
      */
     public function deleteTrashItem(APITrashItem $trashItem)
     {
-        if ($this->repository->hasAccess('content', 'cleantrash') !== true) {
+        if (!$this->repository->canUser('content', 'cleantrash', $trashItem->getContentInfo())) {
             throw new UnauthorizedException('content', 'cleantrash');
         }
 

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -117,7 +117,7 @@ class TrashService implements TrashServiceInterface
             throw new InvalidArgumentValue('id', $location->id, 'Location');
         }
 
-        if (!$this->repository->canUser('content', 'remove', $location->getContentInfo(), $location)) {
+        if (!$this->repository->canUser('content', 'remove', $location->getContentInfo(), [$location])) {
             throw new UnauthorizedException('content', 'remove');
         }
 
@@ -175,7 +175,7 @@ class TrashService implements TrashServiceInterface
             'content',
             'restore',
             $trashItem->getContentInfo(),
-            $newParentLocation ? [$newParentLocation] : null
+            [$newParentLocation ?: $trashItem]
         )) {
             throw new UnauthorizedException('content', 'restore');
         }

--- a/eZ/Publish/Core/Repository/URLWildcardService.php
+++ b/eZ/Publish/Core/Repository/URLWildcardService.php
@@ -139,7 +139,7 @@ class URLWildcardService implements URLWildcardServiceInterface
      */
     public function remove(URLWildcard $urlWildcard)
     {
-        if ($this->repository->hasAccess('content', 'urltranslator') !== true) {
+        if (!$this->repository->canUser('content', 'urltranslator', $urlWildcard)) {
             throw new UnauthorizedException('content', 'urltranslator');
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29474](https://jira.ez.no/browse/EZP-29474)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | yes _(2, see below)_
| **Tests pass**     | yes
| **Doc needed**     | afaik no

Fix wrong usage\* of `hasAccess()` in repository in favor of `canUser()` in order to solve:
- Issues when there are Role Assignment Limitation, as in this case they will return info to permission system they `abstain` from "voting"
- As policies are now extendable, make code prepared in case someone needs to customize and add limitations to any of these functions, or we end up adding it out of the box ourselves.

In effect this makes Repo more correctly use permissions system, and will avoid quite some unneeded edge case exceptions all across the repo on these cases, the issue reported by QA is afaik just scratching the surface here _(see diff)_.

There is also two behavior changes _(in terms of api spec)_ which will simplify API usage:
- _Done in PR_: loadSections(): PR proposes to change this to just filter sections _(preparing it for we/others adding policy limitations on the function, & avoiding issue with role limitation)_
- _Proposed in PR in inline comment_: load user drafts: Same, proposes to filter the returned drafts instead of throwing

\* _Long story short, we forgot about Role limitations + extensibility when coding this, and made shortcuts hard coding that assumption, this PR fixes that._


### What about #2408?
Hopefully this solves the bug, meaning the proposed changes in #2408 will hopefully get some more time to mature as a separate _(new)_ feature/Story. As it basically changes the behavior to not follow API spec anymore, which is indication that it needs some more baking and probably we should rather design a new api method for cases where we don't have an object, as the code involved *at least* would need to know what kind of object _(interface FQN for instance)_ was expected to be able to tell the permission system to safely ignore a given limitation or not _(for instance abstain feature of role limitations could be extracted into new role limitations type interface as a start to try to better separate between policy and role limitation responsibilities, and can be used to check this without having object, ping me if unclear I can also do a POC on it for discussion)_.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [ ] Open question maybe more for a follow PR: Should we deprecate `hasAccess` given it can be miss-leading? _(aka people only expecting it to return boolean, while it really is designed to give you a yes/no/maybe anwear, in the latter case the system needs more context basically, but besides canUser other use case have not been solved in API for this like `whatCotnentTypeCanUserCreateHere(Location)`)_ So.. what should we call it? And what should it return? What do you need?