### PR TITLE
EZP-29510 allow last version to be removed if draft

### DIFF
--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -266,7 +266,7 @@ interface ContentService
      * Removes the given version.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is in
-     *         published state or is a last version of the Content and not a draft
+     *         published state or is a last version of Content in non draft state
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to remove this version
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -266,7 +266,7 @@ interface ContentService
      * Removes the given version.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is in
-     *         published state or is a last version of the Content
+     *         published state or is a last version of the Content and not a draft
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to remove this version
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1524,7 +1524,7 @@ class ContentService implements ContentServiceInterface
             2
         );
 
-        if (count($versionList) === 1) {
+        if (count($versionList) === 1 && !$versionInfo->isDraft()) {
             throw new BadStateException(
                 '$versionInfo',
                 'Version is the last version of the Content and can not be removed'

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1496,7 +1496,7 @@ class ContentService implements ContentServiceInterface
      * Removes the given version.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is in
-     *         published state or is the last version of the Content
+     *         published state or is the last version of the Content and not a draft
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to remove this version
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1496,7 +1496,7 @@ class ContentService implements ContentServiceInterface
      * Removes the given version.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is in
-     *         published state or is the last version of the Content and not a draft
+     *         published state or is a last version of Content in non draft state
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to remove this version
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo


### PR DESCRIPTION
This change allows users to remove the only existing version if it is a draft with only `content versionremove` permissions.  This is needed so that in admin ui if a user creates content but then decides to cancel the process they can do so. I believe `content remove` should only apply to published content.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://jira.ez.no/browse/EZP-29510
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.x`/`7.x`
| **BC breaks**      | yes/no
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

Version remove should work on last existing document if it is a draft.

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.

Refer to https://github.com/ezsystems/ezplatform-admin-ui/pull/594
