### PR TITLE
EZP-29034: Cannot install ezplatform on 1.7 branch

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ConsoleCacheWarmupPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ConsoleCacheWarmupPass.php
@@ -21,6 +21,7 @@ class ConsoleCacheWarmupPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
+        // This pass is CLI only as CLI class cache warmup conflicts with web access, see EZP-29034
         if (PHP_SAPI !== 'cli' ||
             !$container->hasDefinition('kernel.class_cache.cache_warmer')) {
             return;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ConsoleCacheWarmupPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ConsoleCacheWarmupPass.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * File containing the ConsoleCacheWarmupPass class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Cache related compiler pass.
+ *
+ * Ensures class cache warmup is disabled in console mode.
+ */
+class ConsoleCacheWarmupPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (PHP_SAPI !== 'cli' ||
+            !$container->hasDefinition('kernel.class_cache.cache_warmer')) {
+            return;
+        }
+
+        $warmers = array();
+        foreach ($container->findTaggedServiceIds('kernel.cache_warmer') as $id => $attributes) {
+            if ($id === 'kernel.class_cache.cache_warmer') {
+                continue;
+            }
+
+            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
+            $warmers[$priority][] = new Reference($id);
+        }
+
+        if (empty($warmers)) {
+            return;
+        }
+
+        // sort by priority and flatten
+        krsort($warmers);
+        $warmers = \call_user_func_array('array_merge', $warmers);
+
+        $container->getDefinition('cache_warmer')->replaceArgument(0, $warmers);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -12,6 +12,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\AsseticPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\BinaryContentDownloadPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ComplexSettingsPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ConfigResolverParameterPass;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ConsoleCacheWarmupPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\FieldTypeParameterProviderRegistryPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\FragmentPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\HttpCachePass;
@@ -91,6 +92,7 @@ class EzPublishCoreBundle extends Bundle
         );
         $container->addCompilerPass(new BinaryContentDownloadPass());
         $container->addCompilerPass(new ViewProvidersPass());
+        $container->addCompilerPass(new ConsoleCacheWarmupPass());
 
         // Storage passes
         $container->addCompilerPass(new ExternalStorageRegistryPass());


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29034](https://jira.ez.no/browse/EZP-29034)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | kinda: disables class cache warmer
| **Tests pass**     | 
| **Doc needed**     | maybe: mention that class cache warmer is disabled on cli?

Add ConsoleCacheWarmupPass which disables class cache warmer on CLI.

Part of https://github.com/ezsystems/ezplatform/pull/317
Replaces hack: https://github.com/ezsystems/ezplatform/commit/7e6b4716480d16e45d0ac4bd75b2b319cff42ff7
Based on Symfony `AddCacheWarmerPass`: https://github.com/symfony/symfony/blob/2.8/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheWarmerPass.php

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
