### PR TITLE
[Travis] Fix integration test failure on Solr with all branches

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -534,6 +534,8 @@ class UserServiceTest extends BaseTest
         $userService->moveUserGroup($userGroup, $membersUserGroup);
         /* END: Use Case */
 
+        $this->refreshSearch($repository);
+
         $mainUserGroup = $userService->loadUserGroup($this->generateId('group', 4));
 
         $this->assertEquals(5, $mainUserGroup->subGroupCount);


### PR DESCRIPTION
Attempt at fixing the integration test failure on travis when using Solr, the test is missing a `refreshSearch()` so attempting to add it to see if that is the culprit.

As for why this pops up now, probably because we now set config slightly different as of 1.5.3/1.5.4,
we now also set auto soft commit time even for CI runs so might be something in regards to that.

Todo:
- [x] Wait for Travis to go green _(or not)_