### PR TITLE
[WIP] EZP-29536: User isn't redirected to the login page when UnauthorizedException is thrown

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -100,6 +100,12 @@ class ContentViewBuilder implements ViewBuilder
         } elseif ($location instanceof Location) {
             // if we already have location load content true it so we avoid dual loading in case user does that in view
             $content = $location->getContent();
+            if (!$this->canRead($content, $location)) {
+                throw new UnauthorizedException(
+                    'content', 'read|view_embed',
+                    ['contentId' => $content->id, 'locationId' => $location->id]
+                );
+            }
         } else {
             if (isset($parameters['contentId'])) {
                 $contentId = $parameters['contentId'];


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29536](https://jira.ez.no/browse/EZP-29536)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.2` / `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR makes the behavior of handling lack of permissions consistent with v1 and legacy, as described in the JIRA ticket. 

Potentially, the permission checking could be moved to `loadLocation` method: https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php#L216
but:
- I'm not sure if it wouldn't be a BC break,
- most likely we will have to call `$location->getContent()` twice, for the first time in loadLocation method, and the second time in the place where it is already called (https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php#L102) 

wdyt @andrerom / @alongosz / @adamwojs?

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
