### PR TITLE
EZP-28888: Custom cache_service_name can not be set from siteaccess group

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -58,7 +58,6 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
             ->end()
             ->scalarNode('cache_service_name')
                 ->example('cache.app')
-                ->defaultValue('cache.app')
                 ->info('The cache pool service name to use for a siteaccess / siteaccess-group, *must* be present.')
             ->end()
             ->scalarNode('var_dir')


### PR DESCRIPTION
Issues can be seen doing for instance this where we would expect frontend to crash:
```
ezpublish:
    system:
        site:
            # This part is important to trigger the bug, basically if a SA is set, but w/o cache_service_name
            # it will be dumped with default config (cache.app), so no fallbacks to group as we would expect
            languages: [eng-GB]
        site_group:
            # Defining invalid cache service, correct behavior when loading site would be exception
            cache_service_name: cache.xxxx
```


Checked what differed between 6.x and 7.x and noticed that I added default value for 7.x's `cache_service_name` parameter compared to 6.x `cache_pool` parameter which did not have any.

### Further investigation on cache values _(without the  patch)_
```
$ grep --include=\*.xml  -rnw var/cache/ -e 'cache_service_name'
var/cache//dev/appDevDebugProjectContainer.xml:846:    <parameter key="ezsettings.default.cache_service_name">cache.app</parameter>
var/cache//dev/appDevDebugProjectContainer.xml:3867:    <parameter key="ezsettings.admin_group.cache_service_name">%env(CACHE_POOL)%</parameter>
var/cache//dev/appDevDebugProjectContainer.xml:3934:    <parameter key="ezsettings.site.cache_service_name">cache.app</parameter>
var/cache//dev/appDevDebugProjectContainer.xml:3940:    <parameter key="ezsettings.site_group.cache_service_name">cache.xxxx</parameter>
```

So seems default value gets set on site, even if we don't intend/want that, which gets confirmed by blankse and emodric below as a good old issue.

###  Followup discussion
WWe probably have this issues on all site-access aware settings with default values(?), I see 8 usages of defaultValue() / defaultNull() in core bundle alone..

So I think we should try to solve this from happing other places to, so I have opened forum thread on it: 
https://discuss.ezplatform.com/t/config-parsers-how-can-we-avoid-issues-with-siteaccess-settings-on-defaultvalue-defaultnull-usage/407
cc @lolautruche @emodric @bdunogier @blankse


However as this specific issue is hitting a lot of people I'm herby moving tyhis PR for review as is.