### PR TITLE
EZP-29279: Fix value displayed by the Date Field Type being affected by server time zone

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -83,7 +83,7 @@
 {% block ezdate_field %}
 {% spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
-        {% set field_value = field.value.date|localizeddate( 'short', 'none', parameters.locale ) %}
+        {% set field_value = field.value.date|localizeddate( 'short', 'none', parameters.locale, false ) %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
 {% endspaceless %}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29279](https://jira.ez.no/browse/EZP-29279)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | minor
| **Tests pass**     | yes
| **Doc needed**     | no

Currently, the value for Date Field Type displayed in the front office is affected by the server's timezone, meaning that if the server has timezone below (west of) UTC, then the previous day is displayed.
The value stored in the database is always midnight in UTC.
Twig by default applies the server's timezone when using its `localizeddate` method, so in this PR I fix the issue by making sure it doesn't.

The minor BC break that I mentioned is that someone could rely on the wrong behavior (but they really shouldn't).

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests (skipped).
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
