### PR TITLE
EZP-29554: As an editor, I want to be able to apply custom styles to part of my text

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -590,7 +590,7 @@ EOT;
     {
         return $ezRichTextNode
                 ->arrayNode('custom_styles')
-                // workaround: take into account Custom Tag names when merging configs
+                // workaround: take into account Custom Styles names when merging configs
                 ->useAttributeAsKey('style')
                 ->arrayPrototype()
                     ->children()

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -479,9 +479,10 @@ EOT;
      */
     private function addRichTextSection(ArrayNodeDefinition $rootNode)
     {
-        $this->addCustomTagsSection(
-            $rootNode->children()->arrayNode('ezrichtext')->children()
-        )->end()->end()->end();
+        $ezRichTextNode = $rootNode->children()->arrayNode('ezrichtext')->children();
+        $this->addCustomTagsSection($ezRichTextNode);
+        $this->addCustomStylesSection($ezRichTextNode);
+        $ezRichTextNode->end()->end()->end();
     }
 
     /**
@@ -564,6 +565,40 @@ EOT;
                                     ->end()
                                 ->end()
                             ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * Define RichText Custom Styles Semantic Configuration.
+     *
+     * The configuration is available at:
+     * <code>
+     * ezpublish:
+     *     ezrichtext:
+     *         custom_styles:
+     * </code>
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $ezRichTextNode
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition
+     */
+    private function addCustomStylesSection(NodeBuilder $ezRichTextNode)
+    {
+        return $ezRichTextNode
+                ->arrayNode('custom_styles')
+                // workaround: take into account Custom Tag names when merging configs
+                ->useAttributeAsKey('style')
+                ->arrayPrototype()
+                    ->children()
+                        ->scalarNode('template')
+                            ->defaultNull()
+                        ->end()
+                        ->scalarNode('inline')
+                            ->defaultFalse()
                         ->end()
                     ->end()
                 ->end()

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -167,6 +167,13 @@ class RichText extends AbstractFieldTypeParser
                 ->info('List of RichText Custom Tags enabled for the current scope. The Custom Tags must be defined in ezpublish.ezrichtext.custom_tags Node.')
                 ->scalarPrototype()->end()
             ->end();
+
+        // RichText Custom Styles configuration (list of Custom Styles enabled for current SiteAccess scope)
+        $nodeBuilder
+            ->arrayNode('custom_styles')
+                ->info('List of RichText Custom Styles enabled for the current scope. The Custom Styles must be defined in ezpublish.ezrichtext.custom_styles Node.')
+                ->scalarPrototype()->end()
+            ->end();
     }
 
     /**
@@ -217,6 +224,17 @@ class RichText extends AbstractFieldTypeParser
                     $scopeSettings['fieldtypes']['ezrichtext']['custom_tags']
                 );
             }
+            if (isset($scopeSettings['fieldtypes']['ezrichtext']['custom_styles'])) {
+                $this->validateCustomStylesConfiguration(
+                    $contextualizer->getContainer(),
+                    $scopeSettings['fieldtypes']['ezrichtext']['custom_styles']
+                );
+                $contextualizer->setContextualParameter(
+                    'fieldtypes.ezrichtext.custom_styles',
+                    $currentScope,
+                    $scopeSettings['fieldtypes']['ezrichtext']['custom_styles']
+                );
+            }
 
             if (isset($scopeSettings['fieldtypes']['ezrichtext']['tags'])) {
                 foreach ($scopeSettings['fieldtypes']['ezrichtext']['tags'] as $name => $tagSettings) {
@@ -264,6 +282,28 @@ class RichText extends AbstractFieldTypeParser
             if (!in_array($customTagName, $definedCustomTags)) {
                 throw new InvalidConfigurationException(
                     "Unknown RichText Custom Tag '{$customTagName}'"
+                );
+            }
+        }
+    }
+
+    /**
+     * Validate SiteAccess-defined Custom Styles configuration against global one.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+     * @param array $enabledCustomStyles List of Custom Styles enabled for the current scope/SiteAccess
+     */
+    private function validateCustomStylesConfiguration(
+        ContainerInterface $container,
+        array $enabledCustomStyles
+    ) {
+        $definedCustomStyles = array_keys(
+            $container->getParameter(EzPublishCoreExtension::RICHTEXT_CUSTOM_STYLES_PARAMETER)
+        );
+        foreach ($enabledCustomStyles as $customStyleName) {
+            if (!in_array($customStyleName, $definedCustomStyles)) {
+                throw new InvalidConfigurationException(
+                    "Unknown RichText Custom Style '{$customStyleName}'"
                 );
             }
         }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -27,6 +27,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterf
 
 class EzPublishCoreExtension extends Extension
 {
+    const RICHTEXT_CUSTOM_STYLES_PARAMETER = 'ezplatform.ezrichtext.custom_styles';
     const RICHTEXT_CUSTOM_TAGS_PARAMETER = 'ezplatform.ezrichtext.custom_tags';
 
     /**
@@ -295,6 +296,12 @@ class EzPublishCoreExtension extends Extension
             $container->setParameter(
                 static::RICHTEXT_CUSTOM_TAGS_PARAMETER,
                 $config['ezrichtext']['custom_tags']
+            );
+        }
+        if (isset($config['ezrichtext']['custom_styles'])) {
+            $container->setParameter(
+                static::RICHTEXT_CUSTOM_STYLES_PARAMETER,
+                $config['ezrichtext']['custom_styles']
             );
         }
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -26,6 +26,11 @@ parameters:
     # Rich Text Custom Tags default scope (for SiteAccess) configuration
     ezsettings.default.fieldtypes.ezrichtext.custom_tags: []
 
+    # Rich Text Custom Styles global configuration
+    ezplatform.ezrichtext.custom_styles: {}
+    # Rich Text Custom Styles default scope (for SiteAccess) configuration
+    ezsettings.default.fieldtypes.ezrichtext.custom_styles: []
+
     # Image Asset mappings
     ezsettings.default.fieldtypes.ezimageasset.mappings:
         content_type_identifier: image
@@ -128,6 +133,13 @@ parameters:
         template: EzPublishCoreBundle:FieldType/RichText/tag:default.html.twig
     ezsettings.default.fieldtypes.ezrichtext.tags.default_inline:
         template: EzPublishCoreBundle:FieldType/RichText/tag:default_inline.html.twig
+
+    # RichText field type template style settings
+    # 'default' and 'default_inline' tag identifiers are reserved for fallback
+    ezsettings.default.fieldtypes.ezrichtext.styles.default:
+        template: EzPublishCoreBundle:FieldType/RichText/style:default.html.twig
+    ezsettings.default.fieldtypes.ezrichtext.styles.default_inline:
+        template: EzPublishCoreBundle:FieldType/RichText/style:default_inline.html.twig
 
     # RichText field type embed settings
     ezsettings.default.fieldtypes.ezrichtext.embed.content:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -21,9 +21,11 @@ parameters:
     ezpublish.fieldType.ezrichtext.converter.link.class: eZ\Publish\Core\FieldType\RichText\Converter\Link
     ezpublish.fieldType.ezrichtext.converter.embed.class: eZ\Publish\Core\FieldType\RichText\Converter\Render\Embed
     ezpublish.fieldType.ezrichtext.converter.template.class: eZ\Publish\Core\FieldType\RichText\Converter\Render\Template
+    ezpublish.fieldType.ezrichtext.converter.style.class: eZ\Publish\Core\FieldType\RichText\Converter\Render\Style
     ezpublish.fieldType.ezrichtext.embed_renderer.class: eZ\Publish\Core\MVC\Symfony\FieldType\RichText\EmbedRenderer
     ezpublish.fieldType.ezrichtext.renderer.class: eZ\Publish\Core\MVC\Symfony\FieldType\RichText\Renderer
     ezpublish.fieldType.ezrichtext.tag.namespace: fieldtypes.ezrichtext.tags
+    ezpublish.fieldType.ezrichtext.style.namespace: fieldtypes.ezrichtext.styles
     ezpublish.fieldType.ezrichtext.embed.namespace: fieldtypes.ezrichtext.embed
     ezpublish.fieldType.ezrichtext.converter.dispatcher.class: eZ\Publish\Core\FieldType\RichText\ConverterDispatcher
     ezpublish.fieldType.ezrichtext.validator.xml.class: eZ\Publish\Core\FieldType\RichText\Validator
@@ -152,9 +154,19 @@ services:
             - "@ezpublish.config.resolver"
             - "@templating"
             - "%ezpublish.fieldType.ezrichtext.tag.namespace%"
+            - "%ezpublish.fieldType.ezrichtext.style.namespace%"
             - "%ezpublish.fieldType.ezrichtext.embed.namespace%"
             - "@?logger"
             - "%ezplatform.ezrichtext.custom_tags%"
+            - "%ezplatform.ezrichtext.custom_styles%"
+
+    ezpublish.fieldType.ezrichtext.converter.style:
+        class: "%ezpublish.fieldType.ezrichtext.converter.style.class%"
+        arguments:
+            - "@ezpublish.fieldType.ezrichtext.renderer"
+            - "@ezpublish.fieldType.ezrichtext.converter.output.xhtml5"
+        tags:
+            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 10}
 
     ezpublish.fieldType.ezrichtext.converter.template:
         class: "%ezpublish.fieldType.ezrichtext.converter.template.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/style/default.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/style/default.html.twig
@@ -1,0 +1,1 @@
+<div class="{% if align is defined %}align-{{ align }}{% endif %} ezstyle-{{ name }}">{% spaceless %}{{ content|raw }}{% endspaceless %}</div>

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/style/default_inline.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/style/default_inline.html.twig
@@ -1,0 +1,1 @@
+<span class="ezstyle-{{ name }}">{% spaceless %}{{ content|raw }}{% endspaceless %}</span>

--- a/eZ/Publish/Core/FieldType/RichText/Converter/Render/Style.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Render/Style.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * File containing the eZ\Publish\Core\FieldType\RichText\Converter\Render\Style class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license   For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\RichText\Converter\Render;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMXPath;
+use eZ\Publish\Core\FieldType\RichText\Converter;
+use eZ\Publish\Core\FieldType\RichText\Converter\Render;
+use eZ\Publish\Core\FieldType\RichText\RendererInterface;
+
+/**
+ * RichText Style converter injects rendered style payloads into style elements.
+ */
+class Style extends Render implements Converter
+{
+    /**
+     * @var Converter
+     */
+    private $richTextConverter;
+
+    /**
+     * Style constructor.
+     *
+     * @param RendererInterface $renderer
+     * @param Converter         $richTextConverter
+     */
+    public function __construct(RendererInterface $renderer, Converter $richTextConverter)
+    {
+        $this->richTextConverter = $richTextConverter;
+        parent::__construct($renderer);
+    }
+
+    /**
+     * Injects rendered payloads into template tag elements.
+     *
+     * @param \DOMDocument $document
+     *
+     * @return \DOMDocument
+     */
+    public function convert(DOMDocument $document)
+    {
+        $xpath = new DOMXPath($document);
+        $xpath->registerNamespace('docbook', 'http://docbook.org/ns/docbook');
+        $xpathExpression = '//docbook:ezstyle | //docbook:ezstyleinline';
+
+        $styles = $xpath->query($xpathExpression);
+        /** @var \DOMElement[] $stylesSorted */
+        $stylesSorted = [];
+        $maxDepth = 0;
+
+        foreach ($styles as $style) {
+            $depth = $this->getNodeDepth($style);
+            if ($depth > $maxDepth) {
+                $maxDepth = $depth;
+            }
+            $stylesSorted[$depth][] = $style;
+        }
+
+        ksort($stylesSorted, SORT_NUMERIC);
+        foreach ($stylesSorted as $styles) {
+            foreach ($styles as $style) {
+                $this->processStyle($document, $style);
+            }
+        }
+
+        return $document;
+    }
+
+    /**
+     * Processes given template $style in a given $document.
+     *
+     * @param \DOMDocument $document
+     * @param \DOMElement  $style
+     */
+    protected function processStyle(DOMDocument $document, DOMElement $style)
+    {
+        $content = null;
+        $styleName = $style->getAttribute('name');
+        $parameters = [
+            'name' => $styleName,
+            'content' => $this->saveNodeXML($style),
+        ];
+
+        if ($style->hasAttribute('ezxhtml:align')) {
+            $parameters['align'] = $style->getAttribute('ezxhtml:align');
+        }
+
+        $content = $this->renderer->renderStyle(
+            $styleName,
+            $parameters,
+            $style->localName === 'ezstyleinline'
+        );
+
+        if (isset($content)) {
+            // If current tag is wrapped inside another template tag we can't use CDATA section
+            // for its content as these can't be nested.
+            // CDATA section will be used only for content of root wrapping tag, content of tags
+            // inside it will be added as XML fragments.
+            if ($this->isWrapped($style)) {
+                $fragment = $document->createDocumentFragment();
+                $fragment->appendXML($content);
+                $style->parentNode->replaceChild($fragment, $style);
+            } else {
+                $payload = $document->createElement('ezpayload');
+                $payload->appendChild($document->createCDATASection($content));
+                $style->appendChild($payload);
+            }
+        }
+    }
+
+    /**
+     * Returns if the given $node is wrapped inside another template node.
+     *
+     * @param \DOMNode $node
+     *
+     * @return bool
+     */
+    protected function isWrapped(DomNode $node)
+    {
+        while ($node = $node->parentNode) {
+            if ($node->localName === 'ezstyle' || $node->localName === 'ezstyleinline') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns depth of given $node in a DOMDocument.
+     *
+     * @param \DOMNode $node
+     *
+     * @return int
+     */
+    protected function getNodeDepth(DomNode $node)
+    {
+        $depth = -2;
+
+        while ($node) {
+            ++$depth;
+            $node = $node->parentNode;
+        }
+
+        return $depth;
+    }
+
+    /**
+     * Returns XML fragment string for given $node.
+     *
+     * @param \DOMNode $node
+     *
+     * @return string
+     */
+    protected function saveNodeXML(DOMNode $node)
+    {
+        $innerDoc = new DOMDocument();
+
+        /** @var \DOMNode $child */
+        foreach ($node->childNodes as $child) {
+            $innerDoc->appendChild($innerDoc->importNode($child, true));
+        }
+
+        $convertedInnerDoc = $this->richTextConverter->convert($innerDoc);
+
+        return trim($convertedInnerDoc ? $convertedInnerDoc->saveHTML() : $innerDoc->saveHTML());
+    }
+}

--- a/eZ/Publish/Core/FieldType/RichText/Converter/Render/Style.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Render/Style.php
@@ -39,7 +39,7 @@ class Style extends Render implements Converter
     }
 
     /**
-     * Injects rendered payloads into template tag elements.
+     * Injects rendered payloads into Custom Style elements.
      *
      * @param \DOMDocument $document
      *
@@ -100,7 +100,7 @@ class Style extends Render implements Converter
         );
 
         if (isset($content)) {
-            // If current tag is wrapped inside another template tag we can't use CDATA section
+            // If current tag is wrapped inside another Custom Style tag we can't use CDATA section
             // for its content as these can't be nested.
             // CDATA section will be used only for content of root wrapping tag, content of tags
             // inside it will be added as XML fragments.
@@ -143,6 +143,7 @@ class Style extends Render implements Converter
      */
     protected function getNodeDepth(DomNode $node)
     {
+        // initial depth for top level elements (to avoid "ifs")
         $depth = -2;
 
         while ($node) {

--- a/eZ/Publish/Core/FieldType/RichText/RendererInterface.php
+++ b/eZ/Publish/Core/FieldType/RichText/RendererInterface.php
@@ -14,6 +14,17 @@ namespace eZ\Publish\Core\FieldType\RichText;
 interface RendererInterface
 {
     /**
+     * Renders template style.
+     *
+     * @param string $name
+     * @param array $parameters
+     * @param bool $isInline
+     *
+     * @return string
+     */
+    public function renderStyle($name, array $parameters, $isInline);
+
+    /**
      * Renders template tag.
      *
      * @param string $name

--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -610,6 +610,61 @@
     </define>
   </div>
 
+  <div>
+    <a:documentation>
+      eZ Publish custom styles
+    </a:documentation>
+    <define name="ez.style">
+      <element name="ezstyle">
+        <ref name="ez.style.contentmodel"/>
+      </element>
+    </define>
+    <define name="ez.styleinline">
+      <element name="ezstyleinline">
+        <ref name="ez.style.contentmodel.inline"/>
+      </element>
+    </define>
+    <define name="ez.style.contentmodel">
+      <ref name="ez.style.attlist"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="db.all.inlines"/>
+          <ref name="db.recursive.blocks.or.sections"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+    <define name="ez.style.contentmodel.inline">
+      <ref name="ez.style.attlist.inline"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="db.all.inlines"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+    <define name="ez.style.attlist.inline">
+      <ref name="ez.style.attributes.inline"/>
+    </define>
+    <define name="ez.style.attributes.inline">
+      <attribute name="name">
+        <data type="string">
+          <param name="pattern">[A-Za-z][A-Za-z0-9_\-]*</param>
+        </data>
+      </attribute>
+      <optional>
+        <ref name="ez.xhtml.class.attribute"/>
+      </optional>
+    </define>
+    <define name="ez.style.attlist">
+      <ref name="ez.style.attributes"/>
+    </define>
+    <define name="ez.style.attributes">
+      <optional>
+        <ref name="ez.xhtml.align"/>
+      </optional>
+      <ref name="ez.style.attributes.inline"/>
+    </define>
+  </div>
+
   <define name="ez.embed.attributes">
     <ref name="db.xlink.href.attribute"/>
     <optional>
@@ -777,6 +832,7 @@
       <choice>
         <ref name="ez.embedinline"/>
         <ref name="ez.templateinline"/>
+        <ref name="ez.styleinline"/>
         <ref name="ez.extension.inlines"/>
       </choice>
     </zeroOrMore>
@@ -796,6 +852,7 @@
         <ref name="db.title"/>
         <ref name="ez.embed"/>
         <ref name="ez.template"/>
+        <ref name="ez.style"/>
         <ref name="ez.extension.blocks"/>
       </choice>
     </zeroOrMore>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -627,6 +627,34 @@
     </xsl:element>
   </xsl:template>
 
+  <!-- Custom style tag code -->
+  <xsl:template match="docbook:ezstyle">
+    <xsl:element name="div" namespace="{$outputNamespace}">
+      <xsl:if test="@name">
+        <xsl:attribute name="data-ezstyle">
+          <xsl:value-of select="@name"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:if test="@ezxhtml:align">
+        <xsl:attribute name="data-ezalign">
+          <xsl:value-of select="@ezxhtml:align"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="docbook:ezstyleinline">
+    <xsl:element name="span" namespace="{$outputNamespace}">
+      <xsl:if test="@name">
+        <xsl:attribute name="data-ezstyle">
+          <xsl:value-of select="@name"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
   <xsl:template name="extractStyleValue">
     <xsl:param name="style"/>
     <xsl:param name="property"/>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
@@ -505,6 +505,12 @@
 
   <xsl:template match="docbook:eztemplate | docbook:eztemplateinline"/>
 
+  <xsl:template match="docbook:ezstyle[ezpayload] | docbook:ezstyleinline[ezpayload]">
+    <xsl:value-of select="ezpayload/text()" disable-output-escaping="yes"/>
+  </xsl:template>
+
+  <xsl:template match="docbook:ezstyle | docbook:ezstyleinline"/>
+
   <xsl:template name="extractStyleValue">
     <xsl:param name="style"/>
     <xsl:param name="property"/>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -622,4 +622,27 @@
     <xsl:value-of select="translate( substring-before( substring-after( concat( substring-after( $style, $property ), ';' ), ':' ), ';' ), ' ', '' )"/>
   </xsl:template>
 
+  <xsl:template match="ezxhtml5:div[@data-ezstyle]">
+    <xsl:element name="ezstyle" namespace="http://docbook.org/ns/docbook">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@data-ezstyle"/>
+      </xsl:attribute>
+      <xsl:if test="@data-ezalign">
+        <xsl:attribute name="ezxhtml:align">
+          <xsl:value-of select="@data-ezalign"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="ezxhtml5:span[@data-ezstyle]">
+    <xsl:element name="ezstyleinline" namespace="http://docbook.org/ns/docbook">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@data-ezstyle"/>
+      </xsl:attribute>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/EmbedTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/EmbedTest.php
@@ -479,6 +479,7 @@ class EmbedTest extends TestCase
             $this->loggerMock->expects($this->never())->method('error');
         }
 
+        $this->rendererMock->expects($this->never())->method('renderStyle');
         $this->rendererMock->expects($this->never())->method('renderTag');
 
         if (!empty($renderParams)) {

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/StyleTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/StyleTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * File containing the RichText Template Render converter test.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license   For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Tests\RichText\Converter\Render;
+
+use DOMDocument;
+use eZ\Publish\Core\FieldType\RichText\Converter;
+use eZ\Publish\Core\FieldType\RichText\Converter\Render\Style;
+use eZ\Publish\Core\FieldType\RichText\RendererInterface;
+use PHPUnit\Framework\TestCase;
+
+class StyleTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->rendererMock = $this->getRendererMock();
+        $this->converterMock = $this->getConverterMock();
+        parent::setUp();
+    }
+
+    public function providerForTestConvert()
+    {
+        return [
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook">
+  <ezstyle name="style1">style 1 content</ezstyle>
+</section>',
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook">
+  <ezstyle name="style1">style 1 content<ezpayload><![CDATA[style1]]></ezpayload></ezstyle>
+</section>',
+                [
+                    [
+                        'name' => 'style1',
+                        'is_inline' => false,
+                        'params' => [
+                            'name' => 'style1',
+                            'content' => 'style 1 content',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook">
+  <ezstyle name="style2">style 2 content</ezstyle>
+  <ezstyleinline name="style3">style 3 content</ezstyleinline>
+</section>',
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook">
+  <ezstyle name="style2">style 2 content<ezpayload><![CDATA[style2]]></ezpayload></ezstyle>
+  <ezstyleinline name="style3">style 3 content<ezpayload><![CDATA[style3]]></ezpayload></ezstyleinline>
+</section>',
+                [
+                    [
+                        'name' => 'style2',
+                        'is_inline' => false,
+                        'params' => [
+                            'name' => 'style2',
+                            'content' => 'style 2 content',
+                        ],
+                    ],
+                    [
+                        'name' => 'style3',
+                        'is_inline' => true,
+                        'params' => [
+                            'name' => 'style3',
+                            'content' => 'style 3 content',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestConvert
+     */
+    public function testConvert($xmlString, $expectedXmlString, array $renderParams)
+    {
+        $this->rendererMock->expects($this->never())->method('renderContentEmbed');
+        $this->rendererMock->expects($this->never())->method('renderLocationEmbed');
+        $this->rendererMock->expects($this->never())->method('renderTag');
+
+        if (!empty($renderParams)) {
+            foreach ($renderParams as $index => $params) {
+                $this->rendererMock
+                    ->expects($this->at($index))
+                    ->method('renderStyle')
+                    ->with(
+                        $params['name'],
+                        $params['params'],
+                        $params['is_inline']
+                    )
+                    ->will($this->returnValue($params['name']));
+            }
+        } else {
+            $this->rendererMock->expects($this->never())->method('renderStyle');
+        }
+
+        $document = new DOMDocument();
+        $document->preserveWhiteSpace = false;
+        $document->formatOutput = false;
+        $document->loadXML($xmlString);
+
+        $document = $this->getConverter()->convert($document);
+
+        $expectedDocument = new DOMDocument();
+        $expectedDocument->preserveWhiteSpace = false;
+        $expectedDocument->formatOutput = false;
+        $expectedDocument->loadXML($expectedXmlString);
+
+        $this->assertEquals($expectedDocument, $document);
+    }
+
+    protected function getConverter()
+    {
+        return new Style($this->rendererMock, $this->converterMock);
+    }
+
+    /**
+     * @var \eZ\Publish\Core\FieldType\RichText\RendererInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $rendererMock;
+
+    /**
+     * @var \eZ\Publish\Core\FieldType\RichText\Converter|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $converterMock;
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function getRendererMock()
+    {
+        return $this->createMock(RendererInterface::class);
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function getConverterMock()
+    {
+        return $this->createMock(Converter::class);
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/StyleTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/StyleTest.php
@@ -14,8 +14,21 @@ use eZ\Publish\Core\FieldType\RichText\Converter\Render\Style;
 use eZ\Publish\Core\FieldType\RichText\RendererInterface;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Test cases for RichText Custom Styles Renderer.
+ */
 class StyleTest extends TestCase
 {
+    /**
+     * @var \eZ\Publish\Core\FieldType\RichText\RendererInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $rendererMock;
+
+    /**
+     * @var \eZ\Publish\Core\FieldType\RichText\Converter|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $converterMock;
+
     public function setUp()
     {
         $this->rendererMock = $this->getRendererMock();
@@ -123,16 +136,6 @@ class StyleTest extends TestCase
     {
         return new Style($this->rendererMock, $this->converterMock);
     }
-
-    /**
-     * @var \eZ\Publish\Core\FieldType\RichText\RendererInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $rendererMock;
-
-    /**
-     * @var \eZ\Publish\Core\FieldType\RichText\Converter|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $converterMock;
 
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/TemplateTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/TemplateTest.php
@@ -273,6 +273,7 @@ class TemplateTest extends TestCase
     {
         $this->rendererMock->expects($this->never())->method('renderContentEmbed');
         $this->rendererMock->expects($this->never())->method('renderLocationEmbed');
+        $this->rendererMock->expects($this->never())->method('renderStyle');
 
         if (!empty($renderParams)) {
             foreach ($renderParams as $index => $params) {

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/docbook/031-ezstyle.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/docbook/031-ezstyle.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+    <ezstyle name="highlighted_block" ezxhtml:align="left">
+        Highlighted block with "left" align.
+    </ezstyle>
+    <ezstyle name="highlighted_block" ezxhtml:align="right">
+        Highlighted block with "right" align.
+    </ezstyle>
+    <ezstyle name="highlighted_block" ezxhtml:align="center">
+        Highlighted block with "center" align.
+    </ezstyle>
+</section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/docbook/032-ezstyleinline.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/docbook/032-ezstyleinline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+    <para>Some <ezstyleinline name="highlighted_word">highlighted words</ezstyleinline> for the otherwise unremarkable paragraph.</para>
+</section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/031-ezstyle.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/031-ezstyle.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+    <div data-ezstyle="highlighted_block" data-ezalign="left">
+        Highlighted block with "left" align.
+    </div>
+    <div data-ezstyle="highlighted_block" data-ezalign="right">
+        Highlighted block with "right" align.
+    </div>
+    <div data-ezstyle="highlighted_block" data-ezalign="center">
+        Highlighted block with "center" align.
+    </div>
+</section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/032-ezstyleinline.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/032-ezstyleinline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+    <p>Some <span data-ezstyle="highlighted_word">highlighted words</span> for the otherwise unremarkable paragraph.</p>
+</section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/031-ezstyle.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/031-ezstyle.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5"/>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/032-ezstyleinline.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/032-ezstyleinline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
+    <p>Some  for the otherwise unremarkable paragraph.</p>
+</section>

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/RichText/Renderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/RichText/Renderer.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\Core\FieldType\RichText\RendererInterface;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
@@ -47,6 +48,11 @@ class Renderer implements RendererInterface
     /**
      * @var string
      */
+    protected $styleConfigurationNamespace;
+
+    /**
+     * @var string
+     */
     protected $embedConfigurationNamespace;
 
     /**
@@ -70,14 +76,21 @@ class Renderer implements RendererInterface
     private $customTagsConfiguration;
 
     /**
+     * @var array
+     */
+    private $customStylesConfiguration;
+
+    /**
      * @param \eZ\Publish\API\Repository\Repository $repository
      * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface $authorizationChecker
      * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
      * @param \Symfony\Component\Templating\EngineInterface $templateEngine
      * @param string $tagConfigurationNamespace
+     * @param string $styleConfigurationNamespace
      * @param string $embedConfigurationNamespace
      * @param null|\Psr\Log\LoggerInterface $logger
      * @param array $customTagsConfiguration
+     * @param array $customStylesConfiguration
      */
     public function __construct(
         Repository $repository,
@@ -85,18 +98,45 @@ class Renderer implements RendererInterface
         ConfigResolverInterface $configResolver,
         EngineInterface $templateEngine,
         $tagConfigurationNamespace,
+        $styleConfigurationNamespace,
         $embedConfigurationNamespace,
         LoggerInterface $logger = null,
-        array $customTagsConfiguration = []
+        array $customTagsConfiguration = [],
+        array $customStylesConfiguration = []
     ) {
         $this->repository = $repository;
         $this->authorizationChecker = $authorizationChecker;
         $this->configResolver = $configResolver;
         $this->templateEngine = $templateEngine;
         $this->tagConfigurationNamespace = $tagConfigurationNamespace;
+        $this->styleConfigurationNamespace = $styleConfigurationNamespace;
         $this->embedConfigurationNamespace = $embedConfigurationNamespace;
-        $this->logger = $logger;
+        $this->logger = $logger ?? new NullLogger();
         $this->customTagsConfiguration = $customTagsConfiguration;
+        $this->customStylesConfiguration = $customStylesConfiguration;
+    }
+
+    public function renderStyle($name, array $parameters, $isInline)
+    {
+        $templateName = $this->getStyleTemplateName($name, $isInline);
+
+        if ($templateName === null) {
+            $this->logger->error(
+                "Could not render template style '{$name}': no template configured"
+            );
+
+            return null;
+        }
+
+        if (!$this->templateEngine->exists($templateName)) {
+            $this->logger->error(
+                "Could not render template style '{$name}': template '{$templateName}' does not exists"
+            );
+
+            return null;
+        }
+
+        return $this->render($templateName, $parameters);
     }
 
     public function renderTag($name, array $parameters, $isInline)
@@ -104,21 +144,17 @@ class Renderer implements RendererInterface
         $templateName = $this->getTagTemplateName($name, $isInline);
 
         if ($templateName === null) {
-            if (isset($this->logger)) {
-                $this->logger->error(
-                    "Could not render template tag '{$name}': no template configured"
-                );
-            }
+            $this->logger->error(
+                "Could not render template tag '{$name}': no template configured"
+            );
 
             return null;
         }
 
         if (!$this->templateEngine->exists($templateName)) {
-            if (isset($this->logger)) {
-                $this->logger->error(
-                    "Could not render template tag '{$name}': template '{$templateName}' does not exists"
-                );
-            }
+            $this->logger->error(
+                "Could not render template tag '{$name}': template '{$templateName}' does not exists"
+            );
 
             return null;
         }
@@ -139,31 +175,25 @@ class Renderer implements RendererInterface
             );
 
             if (!$content->contentInfo->mainLocationId) {
-                if (isset($this->logger)) {
-                    $this->logger->error(
-                        "Could not render embedded resource: Content #{$contentId} is trashed."
-                    );
-                }
+                $this->logger->error(
+                    "Could not render embedded resource: Content #{$contentId} is trashed."
+                );
 
                 return null;
             }
 
             $this->checkContentPermissions($content);
         } catch (AccessDeniedException $e) {
-            if (isset($this->logger)) {
-                $this->logger->error(
-                    "Could not render embedded resource: access denied to embed Content #{$contentId}"
-                );
-            }
+            $this->logger->error(
+                "Could not render embedded resource: access denied to embed Content #{$contentId}"
+            );
 
             $isDenied = true;
         } catch (Exception $e) {
             if ($e instanceof NotFoundHttpException || $e instanceof NotFoundException) {
-                if (isset($this->logger)) {
-                    $this->logger->error(
-                        "Could not render embedded resource: Content #{$contentId} not found"
-                    );
-                }
+                $this->logger->error(
+                    "Could not render embedded resource: Content #{$contentId} not found"
+                );
 
                 return null;
             } else {
@@ -186,11 +216,9 @@ class Renderer implements RendererInterface
         }
 
         if (!$this->templateEngine->exists($templateName)) {
-            if (isset($this->logger)) {
-                $this->logger->error(
-                    "Could not render embedded resource: template '{$templateName}' does not exists"
-                );
-            }
+            $this->logger->error(
+                "Could not render embedded resource: template '{$templateName}' does not exists"
+            );
 
             return null;
         }
@@ -206,29 +234,23 @@ class Renderer implements RendererInterface
             $location = $this->checkLocation($locationId);
 
             if ($location->invisible) {
-                if (isset($this->logger)) {
-                    $this->logger->error(
-                        "Could not render embedded resource: Location #{$locationId} is not visible"
-                    );
-                }
+                $this->logger->error(
+                    "Could not render embedded resource: Location #{$locationId} is not visible"
+                );
 
                 return null;
             }
         } catch (AccessDeniedException $e) {
-            if (isset($this->logger)) {
-                $this->logger->error(
-                    "Could not render embedded resource: access denied to embed Location #{$locationId}"
-                );
-            }
+            $this->logger->error(
+                "Could not render embedded resource: access denied to embed Location #{$locationId}"
+            );
 
             $isDenied = true;
         } catch (Exception $e) {
             if ($e instanceof NotFoundHttpException || $e instanceof NotFoundException) {
-                if (isset($this->logger)) {
-                    $this->logger->error(
-                        "Could not render embedded resource: Location #{$locationId} not found"
-                    );
-                }
+                $this->logger->error(
+                    "Could not render embedded resource: Location #{$locationId} not found"
+                );
 
                 return null;
             } else {
@@ -251,11 +273,9 @@ class Renderer implements RendererInterface
         }
 
         if (!$this->templateEngine->exists($templateName)) {
-            if (isset($this->logger)) {
-                $this->logger->error(
-                    "Could not render embedded resource: template '{$templateName}' does not exists"
-                );
-            }
+            $this->logger->error(
+                "Could not render embedded resource: template '{$templateName}' does not exists"
+            );
 
             return null;
         }
@@ -287,6 +307,43 @@ class Renderer implements RendererInterface
      *
      * @return null|string
      */
+    protected function getStyleTemplateName($identifier, $isInline)
+    {
+        if (isset($this->customStylesConfiguration[$identifier]) && !empty($this->customStylesConfiguration[$identifier]['template'])) {
+            return $this->customStylesConfiguration[$identifier]['template'];
+        }
+
+        $this->logger->warning(
+            "Template style '{$identifier}' configuration was not found"
+        );
+
+        if ($isInline) {
+            $configurationReference = $this->styleConfigurationNamespace . '.default_inline';
+        } else {
+            $configurationReference = $this->styleConfigurationNamespace . '.default';
+        }
+
+        if ($this->configResolver->hasParameter($configurationReference)) {
+            $configuration = $this->configResolver->getParameter($configurationReference);
+
+            return $configuration['template'];
+        }
+
+        $this->logger->warning(
+            "Template style '{$identifier}' default configuration was not found"
+        );
+
+        return null;
+    }
+
+    /**
+     * Returns configured template name for the given template tag identifier.
+     *
+     * @param string $identifier
+     * @param bool $isInline
+     *
+     * @return null|string
+     */
     protected function getTagTemplateName($identifier, $isInline)
     {
         if (isset($this->customTagsConfiguration[$identifier])) {
@@ -303,11 +360,9 @@ class Renderer implements RendererInterface
         }
         // End of BC layer --/
 
-        if (isset($this->logger)) {
-            $this->logger->warning(
-                "Template tag '{$identifier}' configuration was not found"
-            );
-        }
+        $this->logger->warning(
+            "Template tag '{$identifier}' configuration was not found"
+        );
 
         if ($isInline) {
             $configurationReference = $this->tagConfigurationNamespace . '.default_inline';
@@ -321,11 +376,9 @@ class Renderer implements RendererInterface
             return $configuration['template'];
         }
 
-        if (isset($this->logger)) {
-            $this->logger->warning(
-                "Template tag '{$identifier}' default configuration was not found"
-            );
-        }
+        $this->logger->warning(
+            "Template tag '{$identifier}' default configuration was not found"
+        );
 
         return null;
     }
@@ -363,11 +416,9 @@ class Renderer implements RendererInterface
             return $configuration['template'];
         }
 
-        if (isset($this->logger)) {
-            $this->logger->warning(
-                "Embed tag configuration '{$configurationReference}' was not found"
-            );
-        }
+        $this->logger->warning(
+            "Embed tag configuration '{$configurationReference}' was not found"
+        );
 
         $configurationReference = $this->embedConfigurationNamespace;
 
@@ -383,11 +434,9 @@ class Renderer implements RendererInterface
             return $configuration['template'];
         }
 
-        if (isset($this->logger)) {
-            $this->logger->warning(
-                "Embed tag default configuration '{$configurationReference}' was not found"
-            );
-        }
+        $this->logger->warning(
+            "Embed tag default configuration '{$configurationReference}' was not found"
+        );
 
         return null;
     }

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/RichText/Renderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/RichText/Renderer.php
@@ -116,6 +116,9 @@ class Renderer implements RendererInterface
         $this->customStylesConfiguration = $customStylesConfiguration;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function renderStyle($name, array $parameters, $isInline)
     {
         $templateName = $this->getStyleTemplateName($name, $isInline);
@@ -139,6 +142,9 @@ class Renderer implements RendererInterface
         return $this->render($templateName, $parameters);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function renderTag($name, array $parameters, $isInline)
     {
         $templateName = $this->getTagTemplateName($name, $isInline);
@@ -162,6 +168,9 @@ class Renderer implements RendererInterface
         return $this->render($templateName, $parameters);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function renderContentEmbed($contentId, $viewType, array $parameters, $isInline)
     {
         $isDenied = false;
@@ -226,6 +235,9 @@ class Renderer implements RendererInterface
         return $this->render($templateName, $parameters);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function renderLocationEmbed($locationId, $viewType, array $parameters, $isInline)
     {
         $isDenied = false;
@@ -300,7 +312,7 @@ class Renderer implements RendererInterface
     }
 
     /**
-     * Returns configured template name for the given template tag identifier.
+     * Returns configured template name for the given Custom Style identifier.
      *
      * @param string $identifier
      * @param bool $isInline
@@ -309,7 +321,7 @@ class Renderer implements RendererInterface
      */
     protected function getStyleTemplateName($identifier, $isInline)
     {
-        if (isset($this->customStylesConfiguration[$identifier]) && !empty($this->customStylesConfiguration[$identifier]['template'])) {
+        if (!empty($this->customStylesConfiguration[$identifier]['template'])) {
             return $this->customStylesConfiguration[$identifier]['template'];
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RichText/RendererTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RichText/RendererTest.php
@@ -1402,6 +1402,7 @@ class RendererTest extends TestCase
                     $this->configResolverMock,
                     $this->templateEngineMock,
                     'test.name.space.tag',
+                    'test.name.space.style',
                     'test.name.space.embed',
                     $this->loggerMock,
                 )


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://jira.ez.no/browse/EZP-29554
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `7.x`
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | yes

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.


Added a way to declare and use custom "styles" in richtext (https://alloyeditor.com/docs/features/styles.html)

PR for the admin ui : https://github.com/ezsystems/ezplatform-admin-ui/pull/602

## Configure the custom style


``` yaml
ezpublish:
    system:
        default:
            fieldtypes:
                ezrichtext:
                    custom_styles: [highlighted_block, highlighted_word]
    
    ezrichtext:
        custom_styles:
            highlighted_word:
                template: '@ezdesign/field_type/ezrichtext/custom_style/highlighted_word.html.twig'
                inline: true
            highlighted_block:
                template: '@ezdesign/field_type/ezrichtext/custom_style/highlighted_block.html.twig'
                inline: false
```

### Default templates

Block template :
```twig
<div class="{% if align is defined %}align-{{ align }}{% endif %} style-{{ name }}">{% spaceless %}{{ content|raw }}{% endspaceless %}</div>
```

Inline template :
```twig
<span class="style-{{ name }}">{% spaceless %}{{ content|raw }}{% endspaceless %}</span>
```

## Labels

Custom styles label are generated using SF translation. 
Translation domain is "custom_styles".

``` yaml
ezrichtext.custom_styles.highlighted_block.label: Highlighted block
ezrichtext.custom_styles.highlighted_word.label: Highlighted word
```