### PR TITLE
EZP-29518: ContentType option "Default field for sorting children" has no effect on new created objects

### DIFF
--- a/eZ/Publish/Core/REST/Client/LocationService.php
+++ b/eZ/Publish/Core/REST/Client/LocationService.php
@@ -80,7 +80,7 @@ class LocationService implements APILocationService, Sessionable
      * Instantiates a new location create class.
      *
      * @param mixed $parentLocationId the parent under which the new location should be created
-     * @param ContentType|null $contentType
+     * @param eZ\Publish\API\Repository\Values\ContentType\ContentType|null $contentType
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct
      */

--- a/eZ/Publish/Core/REST/Client/LocationService.php
+++ b/eZ/Publish/Core/REST/Client/LocationService.php
@@ -17,6 +17,7 @@ use eZ\Publish\Core\REST\Common\RequestParser;
 use eZ\Publish\Core\REST\Common\Input\Dispatcher;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 use eZ\Publish\Core\REST\Common\Message;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
 /**
  * Location service, used for complex subtree operations.
@@ -79,16 +80,20 @@ class LocationService implements APILocationService, Sessionable
      * Instantiates a new location create class.
      *
      * @param mixed $parentLocationId the parent under which the new location should be created
+     * @param ContentType|null $contentType
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct
      */
-    public function newLocationCreateStruct($parentLocationId)
+    public function newLocationCreateStruct($parentLocationId, ContentType $contentType = null)
     {
-        return new LocationCreateStruct(
-            array(
-                'parentLocationId' => $parentLocationId,
-            )
-        );
+        $properties = [
+            'parentLocationId' => $parentLocationId,
+        ];
+        if ($contentType) {
+            $properties['sortField'] = $contentType->defaultSortField;
+            $properties['sortOrder'] = $contentType->defaultSortOrder;
+        }
+        return new LocationCreateStruct($properties);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/LocationService.php
+++ b/eZ/Publish/Core/REST/Client/LocationService.php
@@ -93,6 +93,7 @@ class LocationService implements APILocationService, Sessionable
             $properties['sortField'] = $contentType->defaultSortField;
             $properties['sortOrder'] = $contentType->defaultSortOrder;
         }
+
         return new LocationCreateStruct($properties);
     }
 

--- a/eZ/Publish/Core/REST/Server/Controller/Content.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Content.php
@@ -731,8 +731,12 @@ class Content extends RestController
     protected function doCreateContent(Request $request, RestContentCreateStruct $contentCreate)
     {
         try {
+            $contentCreateStruct = $contentCreate->contentCreateStruct;
+            $contentCreate->locationCreateStruct->sortField = $contentCreateStruct->contentType->defaultSortField;
+            $contentCreate->locationCreateStruct->sortOrder = $contentCreateStruct->contentType->defaultSortOrder;
+
             $content = $this->repository->getContentService()->createContent(
-                $contentCreate->contentCreateStruct,
+                $contentCreateStruct,
                 array($contentCreate->locationCreateStruct)
             );
         } catch (ContentValidationException $e) {

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\Repository;
 use eZ\Publish\API\Repository\ContentService as ContentServiceInterface;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\SPI\Persistence\Handler;
 use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct as APIContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
@@ -873,6 +874,14 @@ class ContentService implements ContentServiceInterface
                     '$locationCreateStructs',
                     "Multiple LocationCreateStructs with the same parent Location '{$locationCreateStruct->parentLocationId}' are given"
                 );
+            }
+
+            if (!isset(Location::SORT_FIELD_MAP[$locationCreateStruct->sortField])) {
+                $locationCreateStruct->sortField = Location::SORT_FIELD_NAME;
+            }
+
+            if (!isset(Location::SORT_ORDER_MAP[$locationCreateStruct->sortOrder])) {
+                $locationCreateStruct->sortOrder = Location::SORT_ORDER_ASC;
             }
 
             $parentLocationIdSet[$locationCreateStruct->parentLocationId] = true;

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -876,11 +876,11 @@ class ContentService implements ContentServiceInterface
                 );
             }
 
-            if (!isset(Location::SORT_FIELD_MAP[$locationCreateStruct->sortField])) {
+            if (!array_key_exists($locationCreateStruct->sortField, Location::SORT_FIELD_MAP)) {
                 $locationCreateStruct->sortField = Location::SORT_FIELD_NAME;
             }
 
-            if (!isset(Location::SORT_ORDER_MAP[$locationCreateStruct->sortOrder])) {
+            if (!array_key_exists($locationCreateStruct->sortOrder, Location::SORT_ORDER_MAP)) {
                 $locationCreateStruct->sortOrder = Location::SORT_ORDER_ASC;
             }
 

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -33,6 +33,7 @@ use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
 /**
  * Location service, used for complex subtree operations.
@@ -722,16 +723,20 @@ class LocationService implements LocationServiceInterface
      * Instantiates a new location create class.
      *
      * @param mixed $parentLocationId the parent under which the new location should be created
+     * @param ContentType|null $contentType
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct
      */
-    public function newLocationCreateStruct($parentLocationId)
+    public function newLocationCreateStruct($parentLocationId, ContentType $contentType = null)
     {
-        return new LocationCreateStruct(
-            array(
-                'parentLocationId' => $parentLocationId,
-            )
-        );
+        $properties = [
+            'parentLocationId' => $parentLocationId,
+        ];
+        if ($contentType) {
+            $properties['sortField'] = $contentType->defaultSortField;
+            $properties['sortOrder'] = $contentType->defaultSortOrder;
+        }
+        return new LocationCreateStruct($properties);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -723,7 +723,7 @@ class LocationService implements LocationServiceInterface
      * Instantiates a new location create class.
      *
      * @param mixed $parentLocationId the parent under which the new location should be created
-     * @param ContentType|null $contentType
+     * @param eZ\Publish\API\Repository\Values\ContentType\ContentType|null $contentType
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct
      */

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -736,6 +736,7 @@ class LocationService implements LocationServiceInterface
             $properties['sortField'] = $contentType->defaultSortField;
             $properties['sortOrder'] = $contentType->defaultSortOrder;
         }
+
         return new LocationCreateStruct($properties);
     }
 

--- a/eZ/Publish/Core/SignalSlot/LocationService.php
+++ b/eZ/Publish/Core/SignalSlot/LocationService.php
@@ -21,6 +21,7 @@ use eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal;
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal;
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal;
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
 /**
  * LocationService class.
@@ -350,12 +351,13 @@ class LocationService implements LocationServiceInterface
      * Instantiates a new location create class.
      *
      * @param mixed $parentLocationId the parent under which the new location should be created
+     * @param ContentType|null $contentType
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct
      */
-    public function newLocationCreateStruct($parentLocationId)
+    public function newLocationCreateStruct($parentLocationId, ContentType $contentType = null)
     {
-        return $this->service->newLocationCreateStruct($parentLocationId);
+        return $this->service->newLocationCreateStruct($parentLocationId, $contentType);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/LocationService.php
+++ b/eZ/Publish/Core/SignalSlot/LocationService.php
@@ -351,7 +351,7 @@ class LocationService implements LocationServiceInterface
      * Instantiates a new location create class.
      *
      * @param mixed $parentLocationId the parent under which the new location should be created
-     * @param ContentType|null $contentType
+     * @param eZ\Publish\API\Repository\Values\ContentType\ContentType|null $contentType
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct
      */

--- a/eZ/Publish/Core/SignalSlot/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/LocationServiceTest.php
@@ -202,7 +202,7 @@ class LocationServiceTest extends ServiceTest
             ),
             array(
                 'newLocationCreateStruct',
-                array($rootId),
+                array($rootId, null),
                 $locationCreateStruct,
                 0,
             ),


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29518](https://jira.ez.no/browse/EZP-29518)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `6.7+`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Setting ContentType option "Default field for sorting children" had no effect on newly created Content Object of said ContentType - they were always set to default "Content Name Ascending". This PR fixes it.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement/fix tests.
- [x] Ask for Code Review.

**TODO ON MERGE**
- Adapt SiteAccessAware Repo when merging to 2.2