### PR TITLE
Optimize content bulk loading for use with larger batch sizes

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -73,8 +73,8 @@ class ContentHandlerTest extends AbstractCacheHandlerTest
         return [
             ['load', [2, 1], 'ez-content-2-1-' . ContentHandler::ALL_TRANSLATIONS_KEY, $content],
             ['load', [2, 1, ['eng-GB', 'eng-US']], 'ez-content-2-1-eng-GB|eng-US', $content],
-            ['loadContentList', [[new Content\LoadStruct(['id' => 2, 'versionNo' => 3])]], 'ez-content-2-3-' . ContentHandler::ALL_TRANSLATIONS_KEY, [2 => $content], true],
-            ['loadContentList', [[new Content\LoadStruct(['id' => 5, 'languages' => ['eng-GB', 'eng-US']])]], 'ez-content-5-eng-GB|eng-US', [5 => $content], true],
+            ['loadContentList', [[2]], 'ez-content-2-' . ContentHandler::ALL_TRANSLATIONS_KEY, [2 => $content], true],
+            ['loadContentList', [[5],['eng-GB', 'eng-US']], 'ez-content-5-eng-GB|eng-US', [5 => $content], true],
             ['loadContentInfo', [2], 'ez-content-info-2', $info],
             ['loadContentInfoList', [[2]], 'ez-content-info-2', [2 => $info], true],
             ['loadContentInfoByRemoteId', ['3d8jrj'], 'ez-content-info-byRemoteId-3d8jrj', $info],

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -74,7 +74,7 @@ class ContentHandlerTest extends AbstractCacheHandlerTest
             ['load', [2, 1], 'ez-content-2-1-' . ContentHandler::ALL_TRANSLATIONS_KEY, $content],
             ['load', [2, 1, ['eng-GB', 'eng-US']], 'ez-content-2-1-eng-GB|eng-US', $content],
             ['loadContentList', [[2]], 'ez-content-2-' . ContentHandler::ALL_TRANSLATIONS_KEY, [2 => $content], true],
-            ['loadContentList', [[5],['eng-GB', 'eng-US']], 'ez-content-5-eng-GB|eng-US', [5 => $content], true],
+            ['loadContentList', [[5], ['eng-GB', 'eng-US']], 'ez-content-5-eng-GB|eng-US', [5 => $content], true],
             ['loadContentInfo', [2], 'ez-content-info-2', $info],
             ['loadContentInfoList', [[2]], 'ez-content-info-2', [2 => $info], true],
             ['loadContentInfoByRemoteId', ['3d8jrj'], 'ez-content-info-byRemoteId-3d8jrj', $info],

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -154,12 +154,12 @@ abstract class Gateway
     /**
      * Loads current version for a list of content objects.
      *
-     * @param array[] $IdVersionTranslationPairs Hashes with 'id', optionally 'version', & optionally 'languages'
-     *                If version is not set current version will be loaded, if languages is not set ALL will be loaded.
+     * @param int[] $contentIds
+     * @param string[]|null $translations If languages is not set, ALL will be loaded.
      *
      * @return array[]
      */
-    abstract public function loadContentList(array $IdVersionTranslationPairs): array;
+    abstract public function loadContentList(array $contentIds, array $translations = null): array;
 
     /**
      * Loads info for a content object identified by its remote ID.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -904,20 +904,22 @@ class DoctrineDatabase extends Gateway
                 'c.id = t.contentobject_id AND t.node_id = t.main_node_id'
             );
 
-        if (empty($translations)) {
-            $where = $q->expr()->in('c.id', $q->createNamedParameter($contentIds, Connection::PARAM_INT_ARRAY));
-        } else {
-            $expr = $q->expr();
-            $where = $expr->andX(
-                $expr->in('c.id', $q->createNamedParameter($contentIds, Connection::PARAM_INT_ARRAY)),
+        $expr = $q->expr();
+        $q->where(
+            $expr->in(
+                'c.id',
+                $q->createNamedParameter($contentIds, Connection::PARAM_INT_ARRAY)
+            )
+        );
+
+        if (!empty($translations)) {
+            $q->andWhere(
                 $expr->in(
                     'a.language_code',
                     $q->createNamedParameter($translations, Connection::PARAM_STR_ARRAY)
                 )
             );
         }
-
-        $q->where($where);
 
         return $q->execute()->fetchAll();
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -279,10 +279,10 @@ class ExceptionConversion extends Gateway
     /**
      * {@inheritdoc}
      */
-    public function loadContentList(array $IdVersionTranslationPairs): array
+    public function loadContentList(array $contentIds, array $translations = null): array
     {
         try {
-            return $this->innerGateway->loadContentList($IdVersionTranslationPairs);
+            return $this->innerGateway->loadContentList($contentIds, $translations);
         } catch (DBALException | PDOException $e) {
             throw new RuntimeException('Database error', 0, $e);
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
@@ -529,18 +529,13 @@ class ContentHandlerTest extends TestCase
         $gatewayMock = $this->getGatewayMock();
         $mapperMock = $this->getMapperMock();
         $fieldHandlerMock = $this->getFieldHandlerMock();
-
-        $idVersionTranslationPairs = [
-            ['id' => 2, 'version' => 2, 'languages' => ['eng-GB']],
-            ['id' => 3, 'version' => null, 'languages' => ['eng-GB', 'eng-US']],
-        ];
         $contentRows = [
             ['ezcontentobject_id' => 2, 'ezcontentobject_version_version' => 2],
             ['ezcontentobject_id' => 3, 'ezcontentobject_version_version' => 1],
         ];
         $gatewayMock->expects($this->once())
             ->method('loadContentList')
-            ->with($this->equalTo($idVersionTranslationPairs))
+            ->with([2, 3], ['eng-GB', 'eng-US'])
             ->willReturn($contentRows);
 
         $gatewayMock->expects($this->once())
@@ -561,12 +556,7 @@ class ContentHandlerTest extends TestCase
             ->method('loadExternalFieldData')
             ->with($this->isInstanceOf(Content::class));
 
-        $loadStructList = [
-          new Content\LoadStruct(['id' => 2, 'versionNo' => 2, 'languages' => ['eng-GB']]),
-          new Content\LoadStruct(['id' => 3, 'languages' => ['eng-GB', 'eng-US']]),
-        ];
-
-        $result = $handler->loadContentList($loadStructList);
+        $result = $handler->loadContentList([2, 3], ['eng-GB', 'eng-US']);
 
         $this->assertEquals(
             $expected,

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -61,7 +61,7 @@ interface Handler
      *
      * @param int|string $id
      * @param int|string $version
-     * @param string[] $translations
+     * @param string[]|null $translations
      *
      * @return \eZ\Publish\SPI\Persistence\Content Content value object
      */
@@ -73,14 +73,20 @@ interface Handler
      * Missing items (NotFound) will be missing from the array and not cause an exception, it's up
      * to calling logic to determine if this should cause exception or not.
      *
-     * NOTE: Even if LoadStruct technically allows to load several versions of same content, this method does not allow
-     * this by design as content is returned as Map with key being content id.
+     * If items are missing but for other reasons then not being found, for instance exceptions during loading field
+     * data. Then the exception will be logged as warning or error depending on severity
+     * (TODO: Andrew should expand on the cases here, if it's just a matter of missing fieldtypes then maybe we should throw? In case of missing binary files, how was this handled in IO?)
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\LoadStruct[] $contentLoadStructs
+     * NOTE: If you want to take always available flag into account, append main language
+     * to the list of languages. In some edge cases you'll end up with a bit more data returned, but
+     * this makes sure execution time in storage engine is able to handle up to 10k items when you need that.
      *
-     * @return \eZ\Publish\SPI\Persistence\Content[<int>]
+     * @param int[] $contentIds
+     * @param string[]|null $translations
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content[]
      */
-    public function loadContentList(array $contentLoadStructs): array;
+    public function loadContentList(array $contentIds, array $translations = null): iterable;
 
     /**
      * Returns the metadata object for a content identified by $contentId.

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -74,12 +74,14 @@ interface Handler
      * to calling logic to determine if this should cause exception or not.
      *
      * If items are missing but for other reasons then not being found, for instance exceptions during loading field
-     * data. Then the exception will be logged as warning or error depending on severity
-     * (TODO: Andrew should expand on the cases here, if it's just a matter of missing fieldtypes then maybe we should throw? In case of missing binary files, how was this handled in IO?)
+     * data. Then the exception will be logged as warning or error depending on severity.
+     * The most common case of possible exceptions during loading of Content data is migration,
+     * where either custom Field Type configuration or implementation might not be aligned with new
+     * version of the system.
      *
-     * NOTE: If you want to take always available flag into account, append main language
-     * to the list of languages. In some edge cases you'll end up with a bit more data returned, but
-     * this makes sure execution time in storage engine is able to handle up to 10k items when you need that.
+     * NOTE!!: If you want to take always available flag into account, append main language
+     * to the list of languages(unless caller is asking for all languages). In some edge cases you'll end up with a
+     * bit more data returned, but upside is that storage engine is able to handle far larger datasets.
      *
      * @param int[] $contentIds
      * @param string[]|null $translations

--- a/eZ/Publish/SPI/Persistence/Content/LoadStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/LoadStruct.php
@@ -15,6 +15,8 @@ use eZ\Publish\SPI\Persistence\ValueObject;
  *
  * Design implies features such as always available and language logic needs to be done in API layer, so SPI gets
  * a specifc query to deal with for the lookup that can be safely cached.
+ *
+ * @deprecated Not in use anymore as of v7.2.3 as it was causing slow storage engine performance on large amount of bulk loading.
  */
 class LoadStruct extends ValueObject
 {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | See #2423,
| **Improvement**| yes
| **New feature**    | no
| **Target version** | 7.2+
| **BC breaks**      | yes for SPI, but we don't have BC promise there yet
| **Tests pass**     | yes
| **Doc needed**     | no

This is in order to enable work on #2423, @alongosz identified several issues with current bulk loading logic which slows it down on larger batches:
1. The SQL becomes to big as we build up a large OR expression, which also means we repeat language filtering per item
2. version filtering was not done on the join meaning DB had to do a lot more work to filter out correct items after all data is joined
3. loadVersionedNameData was given a lot of duplicated entries which caused the query there to be slowed down considerably as well

So as:
- version property on LoadStruct was not used and not advised to be used (to make sure you get published one)
- languages casues a lot of SQL being generated

It was decided / suggested to drop LoadStruct and rather do a bit dumber filtering which would allow storage engine to handle larger batches much better.

@alongosz will also do some additional fixes, but this PR will make it easier to avoid some of the conflicts once his work is done.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
