### PR TITLE
EZP-29328: Allow docbook tag "programlisting"

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RichTextHtml5ConverterPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RichTextHtml5ConverterPass.php
@@ -11,6 +11,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * Compiler pass for the RichText Aggregate converter tags.
@@ -21,13 +22,25 @@ class RichTextHtml5ConverterPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('ezpublish.fieldType.ezrichtext.converter.output.xhtml5')) {
-            return;
+        if ($container->hasDefinition('ezpublish.fieldType.ezrichtext.converter.output.xhtml5')) {
+            $html5OutputConverterDefinition = $container->getDefinition('ezpublish.fieldType.ezrichtext.converter.output.xhtml5');
+            $taggedOutputServiceIds = $container->findTaggedServiceIds('ezpublish.ezrichtext.converter.output.xhtml5');
+            $this->setConverterDefinitions($taggedOutputServiceIds, $html5OutputConverterDefinition);
         }
 
-        $html5ConverterDefinition = $container->getDefinition('ezpublish.fieldType.ezrichtext.converter.output.xhtml5');
-        $taggedServiceIds = $container->findTaggedServiceIds('ezpublish.ezrichtext.converter.output.xhtml5');
+        if ($container->hasDefinition('ezpublish.fieldType.ezrichtext.converter.input.xhtml5')) {
+            $html5InputConverterDefinition = $container->getDefinition('ezpublish.fieldType.ezrichtext.converter.input.xhtml5');
+            $taggedInputServiceIds = $container->findTaggedServiceIds('ezpublish.ezrichtext.converter.input.xhtml5');
+            $this->setConverterDefinitions($taggedInputServiceIds, $html5InputConverterDefinition);
+        }
+    }
 
+    /**
+     * @param array $taggedServiceIds
+     * @param Definition $converterDefinition
+     */
+    protected function setConverterDefinitions(array $taggedServiceIds, Definition $converterDefinition)
+    {
         $convertersByPriority = array();
         foreach ($taggedServiceIds as $id => $tags) {
             foreach ($tags as $tag) {
@@ -37,7 +50,7 @@ class RichTextHtml5ConverterPass implements CompilerPassInterface
         }
 
         if (count($convertersByPriority) > 0) {
-            $html5ConverterDefinition->setArguments(
+            $converterDefinition->setArguments(
                 array($this->sortConverters($convertersByPriority))
             );
         }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -18,6 +18,7 @@ parameters:
     ezpublish.fieldType.ezrichtext.converter.output.html5.class: eZ\Bundle\EzPublishCoreBundle\FieldType\RichText\Converter\Html5
     ezpublish.fieldType.ezrichtext.converter.edit.html5.class: eZ\Bundle\EzPublishCoreBundle\FieldType\RichText\Converter\Html5Edit
     ezpublish.fieldType.ezrichtext.converter.input.html5.class: eZ\Bundle\EzPublishCoreBundle\FieldType\RichText\Converter\Html5Input
+    ezpublish.fieldType.ezrichtext.converter.programlisting.class: eZ\Publish\Core\FieldType\RichText\Converter\ProgramListing
     ezpublish.fieldType.ezrichtext.converter.link.class: eZ\Publish\Core\FieldType\RichText\Converter\Link
     ezpublish.fieldType.ezrichtext.converter.embed.class: eZ\Publish\Core\FieldType\RichText\Converter\Render\Embed
     ezpublish.fieldType.ezrichtext.converter.template.class: eZ\Publish\Core\FieldType\RichText\Converter\Render\Template
@@ -116,11 +117,25 @@ services:
             - "http://ez.no/namespaces/ezpublish5/xhtml5/edit"
             - "%ezpublish.kernel.root_dir%/eZ/Publish/Core/FieldType/RichText/Resources/dtd/ezxhtml5_edit_html_character_entities.dtd"
 
-    ezpublish.fieldType.ezrichtext.converter.input.xhtml5:
+    ezpublish.fieldType.ezrichtext.converter.input.xhtml5.core:
         class: "%ezpublish.fieldType.ezrichtext.converter.input.html5.class%"
         arguments:
             - "%ezpublish.fieldType.ezrichtext.converter.input.xhtml5.resources%"
             - "@ezpublish.config.resolver"
+        tags:
+            - {name: ezpublish.ezrichtext.converter.input.xhtml5, priority: 50}
+
+    # Note: should run before xsl transformation
+    ezpublish.fieldType.ezrichtext.converter.input.xhtml5.programlisting:
+        class: "%ezpublish.fieldType.ezrichtext.converter.programlisting.class%"
+        tags:
+            - {name: ezpublish.ezrichtext.converter.input.xhtml5, priority: 10}
+
+    # Aggregate converter for XHTML5 input that other converters register to
+    # through service tags.
+    ezpublish.fieldType.ezrichtext.converter.input.xhtml5:
+        class: "%ezpublish.fieldType.ezrichtext.converter.aggregate.class%"
+        lazy: true
 
     ezpublish.fieldType.ezrichtext.converter.input.dispatcher:
         class: "%ezpublish.fieldType.ezrichtext.converter.dispatcher.class%"

--- a/eZ/Publish/Core/FieldType/RichText/Converter/ProgramListing.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/ProgramListing.php
@@ -13,7 +13,7 @@ use DOMDocument;
 use DOMXPath;
 
 /**
- * Class ProgramListing
+ * Class ProgramListing.
  *
  * Processes <code>programlisting</code> DocBook tag.
  */

--- a/eZ/Publish/Core/FieldType/RichText/Converter/ProgramListing.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/ProgramListing.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * File containing the ProgramListing class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\RichText\Converter;
+
+use eZ\Publish\Core\FieldType\RichText\Converter;
+use DOMDocument;
+use DOMXPath;
+
+/**
+ * Class ProgramListing
+ *
+ * Processes <code>programlisting</code> DocBook tag.
+ */
+class ProgramListing implements Converter
+{
+    /**
+     * CDATA's content cannot contain the sequence ']]>' as that will terminate the CDATA section.
+     * So, if the end sequence ']]>' appears in the string, we split the text into multiple CDATA sections.
+     *
+     * @param DOMDocument $document
+     * @return DOMDocument
+     */
+    public function convert(DOMDocument $document)
+    {
+        $xpath = new DOMXPath($document);
+        $xpathExpression = '//ns:pre';
+        $ns = $document->documentElement->namespaceURI;
+        $xpath->registerNamespace('ns', $ns);
+        $elements = $xpath->query($xpathExpression);
+
+        foreach ($elements as $element) {
+            $element->textContent = str_replace(']]>', ']]]]><![CDATA[>', $element->textContent);
+        }
+
+        return $document;
+    }
+}

--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -341,7 +341,6 @@
     <define name="db.productionset"><notAllowed/></define>
     <define name="db.productname"><notAllowed/></define>
     <define name="db.productnumber"><notAllowed/></define>
-    <define name="db.programlisting"><notAllowed/></define>
     <define name="db.programlistingco"><notAllowed/></define>
     <define name="db.prompt"><notAllowed/></define>
     <define name="db.property"><notAllowed/></define>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -667,6 +667,7 @@
     <define name="db.emphasis.attlist" combine="interleave"><ref name="ez.xhtml.class.attribute"/></define>
     <!--define name="db.html.table.attributes" combine="interleave"><ref name="ez.xhtml.class.attribute"/></define-->
     <define name="db.link.attlist" combine="interleave"><ref name="ez.xhtml.class.attribute"/></define>
+    <define name="db.programlisting.attlist" combine="interleave"><ref name="ez.xhtml.class.attribute"/></define>
     <define name="ez.xhtml.class.attribute">
       <optional>
         <attribute name="ezxhtml:class"><text/></attribute>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/ezxhtml5/output/changes.rst
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/ezxhtml5/output/changes.rst
@@ -12,3 +12,8 @@ Removed elements
 * <link>
 * <meta>
 * <body>
+
+Added attributes
+================
+
+* @data-language added for element <pre>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/ezxhtml5/output/ezxhtml5.xsd
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/ezxhtml5/output/ezxhtml5.xsd
@@ -249,13 +249,21 @@
     <xs:attributeGroup ref="globalAttributeGroup"/>
   </xs:complexType>
 
+  <xs:complexType name="prePhrasingContentElement">
+    <xs:complexContent>
+      <xs:extension base="phrasingContentElement">
+        <xs:attribute name="data-language" type="string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
   <xs:element name="hr">
     <xs:complexType>
       <xs:attributeGroup ref="globalAttributeGroup"/>
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="pre" type="phrasingContentElement"/>
+  <xs:element name="pre" type="prePhrasingContentElement"/>
 
   <xs:element name="blockquote">
     <xs:complexType>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -40,6 +40,23 @@
     </xsl:element>
   </xsl:template>
 
+  <xsl:template match="docbook:programlisting">
+    <xsl:element name="pre" namespace="{$outputNamespace}">
+      <xsl:if test="@ezxhtml:class">
+        <xsl:attribute name="class">
+          <xsl:value-of select="@ezxhtml:class"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:if test="@language">
+        <!-- Unsure about what to do with language attribute, adding it as a custom attribute for now -->
+        <xsl:attribute name="data-language">
+          <xsl:value-of select="@language"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:value-of select="./text()"/>
+    </xsl:element>
+  </xsl:template>
+
   <xsl:template match="docbook:blockquote">
     <xsl:element name="blockquote" namespace="{$outputNamespace}">
       <xsl:apply-templates/>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
@@ -18,6 +18,23 @@
     </xsl:if>
   </xsl:template>
 
+  <xsl:template match="docbook:programlisting">
+    <xsl:element name="pre" namespace="{$outputNamespace}">
+      <xsl:if test="@ezxhtml:class">
+        <xsl:attribute name="class">
+          <xsl:value-of select="@ezxhtml:class"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:if test="@language">
+        <!-- Unsure about what to do with language attribute, adding it as a custom attribute for now -->
+        <xsl:attribute name="data-language">
+          <xsl:value-of select="@language"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:value-of select="./text()"/>
+    </xsl:element>
+  </xsl:template>
+
   <xsl:template match="docbook:section">
     <xsl:element name="section" namespace="{$outputNamespace}">
       <xsl:apply-templates/>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -88,6 +88,24 @@
     </para>
   </xsl:template>
 
+  <xsl:template match="ezxhtml5:pre">
+    <xsl:element name="programlisting">
+      <xsl:if test="@class">
+        <xsl:attribute name="ezxhtml:class">
+          <xsl:value-of select="@class"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:if test="@data-language">
+        <xsl:attribute name="language">
+          <xsl:value-of select="@data-language"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text>
+      <xsl:value-of disable-output-escaping="yes" select="./text()"/>
+      <xsl:text disable-output-escaping="yes">]]&gt;</xsl:text>
+    </xsl:element>
+  </xsl:template>
+
   <xsl:template match="ezxhtml5:blockquote">
     <blockquote>
       <xsl:apply-templates/>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/Xhtml5ToDocbookTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/Xhtml5ToDocbookTest.php
@@ -8,6 +8,10 @@
  */
 namespace eZ\Publish\Core\FieldType\Tests\RichText\Converter\Xslt;
 
+use eZ\Publish\Core\FieldType\RichText\Converter\Aggregate;
+use eZ\Publish\Core\FieldType\RichText\Converter\ProgramListing;
+use eZ\Publish\Core\FieldType\RichText\Converter\Xslt;
+
 /**
  * Tests conversion from xhtml5 edit format to docbook.
  */
@@ -91,5 +95,25 @@ class Xhtml5ToDocbookTest extends BaseTest
             __DIR__ . '/_fixtures/docbook/custom_schemas/youtube.rng',
             __DIR__ . '/../../../../RichText/Resources/schemas/docbook/docbook.iso.sch.xsl',
         );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\FieldType\RichText\Converter\Xslt
+     */
+    protected function getConverter()
+    {
+        if ($this->converter === null) {
+            $this->converter = new Aggregate(
+                array(
+                    new ProgramListing(),
+                    new Xslt(
+                        $this->getConversionTransformationStylesheet(),
+                        $this->getCustomConversionTransformationStylesheets()
+                    ),
+                )
+            );
+        }
+
+        return $this->converter;
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/docbook/033-programlisting.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/docbook/033-programlisting.xml
@@ -1,0 +1,20 @@
+<section xmlns="http://docbook.org/ns/docbook" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
+    <programlisting><![CDATA[Literal with CNAME end sequence here : ]]]]><![CDATA[> and some more text here]]></programlisting>
+    <programlisting><![CDATA[ordinary literal]]></programlisting>
+    <programlisting><![CDATA[more
+            complicated
+             literal
+              tag]]></programlisting>
+    <para>the php one:</para>
+    <programlisting ezxhtml:class="red"><![CDATA[function foobar()
+{
+    thisIsSomePHPCode('string with special characters & < > â');
+    return 0;
+}]]></programlisting>
+    <para>the php one with language attribute:</para>
+    <programlisting language="php" ezxhtml:class="red">function foobar()
+{
+    thisIsSomePHPCode();
+    return 0;
+}</programlisting>
+</section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/033-programlisting.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/033-programlisting.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+  <pre>Literal with CNAME end sequence here : ]]&gt; and some more text here</pre>
+  <pre>ordinary literal</pre>
+  <pre>more
+            complicated
+             literal
+              tag</pre>
+  <p>the php one:</p>
+  <pre class="red">function foobar()
+{
+    thisIsSomePHPCode('string with special characters &amp; &lt; &gt; &#xe2;');
+    return 0;
+}</pre>
+  <p>the php one with language attribute:</p>
+  <pre class="red" data-language="php">function foobar()
+{
+    thisIsSomePHPCode();
+    return 0;
+}</pre>
+</section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/033-programlisting.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/033-programlisting.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
+  <pre>Literal with CNAME end sequence here : ]]&gt; and some more text here</pre>
+  <pre>ordinary literal</pre>
+  <pre>more
+            complicated
+             literal
+              tag</pre>
+  <p>the php one:</p>
+  <pre class="red">function foobar()
+{
+    thisIsSomePHPCode('string with special characters &amp; &lt; &gt; &#xe2;');
+    return 0;
+}</pre>
+  <p>the php one with language attribute:</p>
+  <pre class="red" data-language="php">function foobar()
+{
+    thisIsSomePHPCode();
+    return 0;
+}</pre>
+</section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29328](https://jira.ez.no/browse/EZP-29328)
| **Bug/Improvement**| improvment
| **New feature**    | yes
| **Target version** | `6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

We need `<programlisting>` for literal, see [EZP-29328](https://jira.ez.no/browse/EZP-29328)
See corresponding [PR for conversion script ( ezxmltext -> docbook )](https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/71)

With this PR, the alloy editor is able to edit existing programlistings, but button for creating new programlisting should be created in a separate admin-ui PR.

**TODO**:
- [x] Move to 6.13
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
