### PR TITLE
[Travis] Set correct metarepo branch for 7.2 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
     "extra": {
         "_ci_branch-comment_": "Keep ci branch up-to-date with master or branch if on stable. ci is never on github but convention used for ci behat testing!",
         "_ezplatform_branch_for_behat_tests_comment_": "ezplatform branch to use to run Behat tests",
-        "_ezplatform_branch_for_behat_tests": "master",
+        "_ezplatform_branch_for_behat_tests": "2.2",
         "branch-alias": {
             "dev-master": "7.2.x-dev",
             "dev-tmp_ci_branch": "7.2.x-dev"


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| n/a
| **New feature**    | n/a
| **Target version** | 7.2, when merged to master should be set to master
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | no

Kernel tests are failing because they are using the master branch on metarepo, which contains incompatible changes with 7.2 kernel. These tests should use the 2.2 branch.
