### PR TITLE
[TMP for QA] EZP-29474: 7.2 port of Fix wrong usage of hasAccess in repository

### DIFF
--- a/eZ/Publish/API/Repository/PermissionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionResolver.php
@@ -32,7 +32,11 @@ interface PermissionResolver
      * Returns boolean value or an array of limitations describing user's permissions
      * on the given module and function.
      *
-     * Note: boolean value describes full access (true) or no access at all (false).
+     * Note: boolean value describes full access (true) or no access at all (false), array can be seen as a maybe..
+     *
+     * WARNING: If possible strongly prefer to use canUser() as it is able to handle limitations!
+     *          This includes Role Assignment limitations, but also future policy limitations added in kernel
+     *          or as custom configuration/extension to the system (as this is possible as well now).
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If module or function is invalid.
      *

--- a/eZ/Publish/API/Repository/PermissionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionResolver.php
@@ -34,8 +34,8 @@ interface PermissionResolver
      * Note: boolean value describes full access (true) or no access at all (false), array can be seen as a maybe..
      *
      * WARNING: This is a low level method, if possible strongly prefer to use canUser() as it is able to handle limitations.
-     *          This includes Role Assignment limitations, but also future policy limitations added in kernel
-     *          or as custom configuration/extension to the system (by means of custom confiuration).
+     *          This includes Role Assignment limitations, but also future policy limitations added in kernel,
+     *          or as plain user configuration and/or extending the system.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If module or function is invalid.
      *

--- a/eZ/Publish/API/Repository/PermissionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionResolver.php
@@ -29,14 +29,13 @@ interface PermissionResolver
     public function setCurrentUserReference(UserReference $userReference);
 
     /**
-     * Returns boolean value or an array of limitations describing user's permissions
-     * on the given module and function.
+     * Low level permission function: Returns boolean value, or an array of limitations that permission for depens on.
      *
      * Note: boolean value describes full access (true) or no access at all (false), array can be seen as a maybe..
      *
-     * WARNING: If possible strongly prefer to use canUser() as it is able to handle limitations!
+     * WARNING: This is a low level method, if possible strongly prefer to use canUser() as it is able to handle limitations.
      *          This includes Role Assignment limitations, but also future policy limitations added in kernel
-     *          or as custom configuration/extension to the system (as this is possible as well now).
+     *          or as custom configuration/extension to the system (by means of custom confiuration).
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If module or function is invalid.
      *

--- a/eZ/Publish/API/Repository/PermissionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionResolver.php
@@ -29,7 +29,7 @@ interface PermissionResolver
     public function setCurrentUserReference(UserReference $userReference);
 
     /**
-     * Low level permission function: Returns boolean value, or an array of limitations that permission for depens on.
+     * Low level permission function: Returns boolean value, or an array of limitations that user permission depends on.
      *
      * Note: boolean value describes full access (true) or no access at all (false), array can be seen as a maybe..
      *

--- a/eZ/Publish/API/Repository/Tests/BaseTrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTrashServiceTest.php
@@ -35,7 +35,7 @@ abstract class BaseTrashServiceTest extends BaseTest
             $mediaRemoteId
         );
 
-        // Trash the "Community" page location
+        // Trash the "Media" page location
         $trashItem = $trashService->trash($mediaLocation);
         /* END: Inline */
 

--- a/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
@@ -151,7 +151,7 @@ class SectionServiceAuthorizationTest extends BaseTest
         $sections = $sectionService->loadSections();
         /* END: Use Case */
 
-        $this->assertEmpty($sections, "Expected to get zero sections back as user has nada section access");
+        $this->assertEmpty($sections, 'Expected to get zero sections back as user has nada section access');
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
@@ -120,9 +120,10 @@ class SectionServiceAuthorizationTest extends BaseTest
      * Test for the loadSections() method.
      *
      * @see \eZ\Publish\API\Repository\SectionService::loadSections()
-     * @depends \eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
      */
-    public function testLoadSectionsFiltersResults()
+    public function testLoadSectionsThrowsUnauthorizedException()
     {
         $repository = $this->getRepository();
 
@@ -148,10 +149,9 @@ class SectionServiceAuthorizationTest extends BaseTest
         // Set anonymous user
         $repository->setCurrentUser($userService->loadUser($anonymousUserId));
 
-        $sections = $sectionService->loadSections();
+        // This call will fail with a "UnauthorizedException"
+        $sectionService->loadSections();
         /* END: Use Case */
-
-        $this->assertEmpty($sections, 'Expected to get zero sections back as user has nada section access');
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
@@ -120,10 +120,9 @@ class SectionServiceAuthorizationTest extends BaseTest
      * Test for the loadSections() method.
      *
      * @see \eZ\Publish\API\Repository\SectionService::loadSections()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
+     * @depends \eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
      */
-    public function testLoadSectionsThrowsUnauthorizedException()
+    public function testLoadSectionsFiltersResults()
     {
         $repository = $this->getRepository();
 
@@ -149,9 +148,10 @@ class SectionServiceAuthorizationTest extends BaseTest
         // Set anonymous user
         $repository->setCurrentUser($userService->loadUser($anonymousUserId));
 
-        // This call will fail with a "UnauthorizedException"
-        $sectionService->loadSections();
+        $sections = $sectionService->loadSections();
         /* END: Use Case */
+
+        $this->assertEmpty($sections, "Expected to get zero sections back as user has nada section access");
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\API\Repository\Tests;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -339,8 +340,13 @@ class TrashServiceTest extends BaseTrashServiceTest
         $repository = $this->getRepository();
         $trashService = $repository->getTrashService();
 
-        $trashItem = new TrashItem(['id' => 12364, 'parentLocationId' => 12363]);
-        $trashService->recover($trashItem);
+        $trashService->recover(
+            $this->getTrashItemDouble(
+                12364,
+                12345,
+                12363
+            )
+        );
     }
 
     /**
@@ -797,8 +803,11 @@ class TrashServiceTest extends BaseTrashServiceTest
         $repository = $this->getRepository();
         $trashService = $repository->getTrashService();
 
-        $trashItem = new TrashItem(['id' => 123456]);
-        $trashService->deleteTrashItem($trashItem);
+        $trashService->deleteTrashItem($this->getTrashItemDouble(
+            12364,
+            12345,
+            12363
+        ));
     }
 
     /**
@@ -882,5 +891,17 @@ class TrashServiceTest extends BaseTrashServiceTest
         } catch (\eZ\Publish\API\Repository\Exceptions\NotFoundException $e) {
             $this->assertTrue(true);
         }
+    }
+
+    /**
+     * Get Test Double for TrashItem for exception testing and similar.
+     */
+    private function getTrashItemDouble(int $trashId, int $contentId = 44, int $parentLocationId = 2): TrashItem
+    {
+        return new TrashItem([
+            'id' => $trashId,
+            'parentLocationId' => $parentLocationId,
+            'contentInfo' => new ContentInfo(['id' => $contentId]),
+        ]);
     }
 }

--- a/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
@@ -137,10 +137,15 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
 
         // Load locations if no specific placement was provided
         if ($targets === null) {
-            if ($object->published) {
+            // Skip check if content is in trash and no location is provided to check against
+            if ($object->isTrashed()) {
+                return self::ACCESS_ABSTAIN;
+            }
+
+            if ($object->isPublished()) {
                 $targets = $this->persistence->locationHandler()->loadLocationsByContent($object->id);
             } else {
-                // @todo Need support for draft locations to to work correctly
+                // @todo Need support for draft locations to work correctly
                 $targets = $this->persistence->locationHandler()->loadParentLocationsForDraftContent($object->id);
             }
         }

--- a/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
@@ -268,20 +268,20 @@ class SubtreeLimitationTypeTest extends Base
         $versionInfoMock
             ->expects($this->once())
             ->method('getContentInfo')
-            ->will($this->returnValue(new ContentInfo(array('published' => true))));
+            ->willReturn(new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]));
 
         $versionInfoMock2 = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock2
             ->expects($this->once())
             ->method('getContentInfo')
-            ->will($this->returnValue(new ContentInfo(array('published' => true))));
+            ->willReturn(new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]));
 
         return array(
             // ContentInfo, with targets, no access
             array(
                 'limitation' => new SubtreeLimitation(),
-                'object' => new ContentInfo(array('published' => true)),
+                'object' => new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]),
                 'targets' => array(new Location()),
                 'persistence' => array(),
                 'expected' => LimitationType::ACCESS_DENIED,
@@ -289,7 +289,7 @@ class SubtreeLimitationTypeTest extends Base
             // ContentInfo, with targets, no access
             array(
                 'limitation' => new SubtreeLimitation(array('limitationValues' => array('/1/2/'))),
-                'object' => new ContentInfo(array('published' => true)),
+                'object' => new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]),
                 'targets' => array(new Location(array('pathString' => '/1/55/'))),
                 'persistence' => array(),
                 'expected' => LimitationType::ACCESS_DENIED,
@@ -297,7 +297,7 @@ class SubtreeLimitationTypeTest extends Base
             // ContentInfo, with targets, with access
             array(
                 'limitation' => new SubtreeLimitation(array('limitationValues' => array('/1/2/'))),
-                'object' => new ContentInfo(array('published' => true)),
+                'object' => new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]),
                 'targets' => array(new Location(array('pathString' => '/1/2/'))),
                 'persistence' => array(),
                 'expected' => LimitationType::ACCESS_GRANTED,
@@ -305,7 +305,7 @@ class SubtreeLimitationTypeTest extends Base
             // ContentInfo, no targets, with access
             array(
                 'limitation' => new SubtreeLimitation(array('limitationValues' => array('/1/2/'))),
-                'object' => new ContentInfo(array('published' => true)),
+                'object' => new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]),
                 'targets' => null,
                 'persistence' => array(new Location(array('pathString' => '/1/2/'))),
                 'expected' => LimitationType::ACCESS_GRANTED,
@@ -313,7 +313,7 @@ class SubtreeLimitationTypeTest extends Base
             // ContentInfo, no targets, no access
             array(
                 'limitation' => new SubtreeLimitation(array('limitationValues' => array('/1/2/', '/1/43/'))),
-                'object' => new ContentInfo(array('published' => true)),
+                'object' => new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]),
                 'targets' => null,
                 'persistence' => array(new Location(array('pathString' => '/1/55/'))),
                 'expected' => LimitationType::ACCESS_DENIED,
@@ -321,7 +321,7 @@ class SubtreeLimitationTypeTest extends Base
             // ContentInfo, no targets, un-published, with access
             array(
                 'limitation' => new SubtreeLimitation(array('limitationValues' => array('/1/2/'))),
-                'object' => new ContentInfo(array('published' => false)),
+                'object' => new ContentInfo(['published' => false, 'status' => ContentInfo::STATUS_DRAFT]),
                 'targets' => null,
                 'persistence' => array(new Location(array('pathString' => '/1/2/'))),
                 'expected' => LimitationType::ACCESS_GRANTED,
@@ -329,7 +329,7 @@ class SubtreeLimitationTypeTest extends Base
             // ContentInfo, no targets, un-published, no access
             array(
                 'limitation' => new SubtreeLimitation(array('limitationValues' => array('/1/2/', '/1/43/'))),
-                'object' => new ContentInfo(array('published' => false)),
+                'object' => new ContentInfo(['published' => false, 'status' => ContentInfo::STATUS_DRAFT]),
                 'targets' => null,
                 'persistence' => array(new Location(array('pathString' => '/1/55/'))),
                 'expected' => LimitationType::ACCESS_DENIED,
@@ -385,7 +385,7 @@ class SubtreeLimitationTypeTest extends Base
             // invalid target
             array(
                 'limitation' => new SubtreeLimitation(),
-                'object' => new ContentInfo(array('published' => true)),
+                'object' => new ContentInfo(['published' => true, 'status' => ContentInfo::STATUS_PUBLISHED]),
                 'targets' => array(new ObjectStateLimitation()),
                 'persistence' => array(),
                 'expected' => LimitationType::ACCESS_ABSTAIN,

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1086,6 +1086,7 @@ class ContentService implements ContentServiceInterface
         }
 
         // throw early if user has absolutely no access to versionread
+
         if ($this->repository->hasAccess('content', 'versionread') === false) {
             throw new UnauthorizedException('content', 'versionread');
         }
@@ -1094,6 +1095,7 @@ class ContentService implements ContentServiceInterface
         $versionInfoList = array();
         foreach ($spiVersionInfoList as $spiVersionInfo) {
             $versionInfo = $this->domainMapper->buildVersionInfoDomainObject($spiVersionInfo);
+            // TODO: Should we rather filter out items here? If so we can remove early permission check above and exception
             if (!$this->repository->canUser('content', 'versionread', $versionInfo)) {
                 throw new UnauthorizedException('content', 'versionread', array('contentId' => $versionInfo->contentInfo->id));
             }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1086,7 +1086,6 @@ class ContentService implements ContentServiceInterface
         }
 
         // throw early if user has absolutely no access to versionread
-
         if ($this->repository->hasAccess('content', 'versionread') === false) {
             throw new UnauthorizedException('content', 'versionread');
         }
@@ -1095,7 +1094,7 @@ class ContentService implements ContentServiceInterface
         $versionInfoList = array();
         foreach ($spiVersionInfoList as $spiVersionInfo) {
             $versionInfo = $this->domainMapper->buildVersionInfoDomainObject($spiVersionInfo);
-            // TODO: Should we rather filter out items here? If so we can remove early permission check above and exception
+            // @todo: Change this to filter returned drafts by permissions instead of throwing
             if (!$this->repository->canUser('content', 'versionread', $versionInfo)) {
                 throw new UnauthorizedException('content', 'versionread', array('contentId' => $versionInfo->contentInfo->id));
             }

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -116,7 +116,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function createContentTypeGroup(ContentTypeGroupCreateStruct  $contentTypeGroupCreateStruct)
     {
-        if ($this->repository->hasAccess('class', 'create') !== true) {
+        if (!$this->repository->canUser('class', 'create', $contentTypeGroupCreateStruct)) {
             throw new UnauthorizedException('ContentType', 'create');
         }
 
@@ -221,7 +221,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function updateContentTypeGroup(APIContentTypeGroup $contentTypeGroup, ContentTypeGroupUpdateStruct $contentTypeGroupUpdateStruct)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentTypeGroup)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -284,7 +284,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function deleteContentTypeGroup(APIContentTypeGroup $contentTypeGroup)
     {
-        if ($this->repository->hasAccess('class', 'delete') !== true) {
+        if (!$this->repository->canUser('class', 'delete', $contentTypeGroup)) {
             throw new UnauthorizedException('ContentType', 'delete');
         }
 
@@ -641,7 +641,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function createContentType(APIContentTypeCreateStruct $contentTypeCreateStruct, array $contentTypeGroups)
     {
-        if ($this->repository->hasAccess('class', 'create') !== true) {
+        if (!$this->repository->canUser('class', 'create', $contentTypeCreateStruct, $contentTypeGroups)) {
             throw new UnauthorizedException('ContentType', 'create');
         }
 
@@ -949,7 +949,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function createContentTypeDraft(APIContentType $contentType)
     {
-        if ($this->repository->hasAccess('class', 'create') !== true) {
+        if (!$this->repository->canUser('class', 'create', $contentType)) {
             throw new UnauthorizedException('ContentType', 'create');
         }
 
@@ -994,7 +994,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function updateContentTypeDraft(APIContentTypeDraft $contentTypeDraft, ContentTypeUpdateStruct $contentTypeUpdateStruct)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -1068,7 +1068,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function deleteContentType(APIContentType $contentType)
     {
-        if ($this->repository->hasAccess('class', 'delete') !== true) {
+        if (!$this->repository->canUser('class', 'delete', $contentType)) {
             throw new UnauthorizedException('ContentType', 'delete');
         }
 
@@ -1108,7 +1108,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function copyContentType(APIContentType $contentType, User $creator = null)
     {
-        if ($this->repository->hasAccess('class', 'create') !== true) {
+        if (!$this->repository->canUser('class', 'create', $contentType)) {
             throw new UnauthorizedException('ContentType', 'create');
         }
 
@@ -1143,7 +1143,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function assignContentTypeGroup(APIContentType $contentType, APIContentTypeGroup $contentTypeGroup)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentType)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -1185,7 +1185,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function unassignContentTypeGroup(APIContentType $contentType, APIContentTypeGroup $contentTypeGroup)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentType, [$contentTypeGroup])) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -1241,7 +1241,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function addFieldDefinition(APIContentTypeDraft $contentTypeDraft, FieldDefinitionCreateStruct $fieldDefinitionCreateStruct)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -1314,7 +1314,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function removeFieldDefinition(APIContentTypeDraft $contentTypeDraft, APIFieldDefinition $fieldDefinition)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -1358,7 +1358,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function updateFieldDefinition(APIContentTypeDraft $contentTypeDraft, APIFieldDefinition $fieldDefinition, FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
@@ -1413,7 +1413,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function publishContentTypeDraft(APIContentTypeDraft $contentTypeDraft)
     {
-        if ($this->repository->hasAccess('class', 'update') !== true) {
+        if (!$this->repository->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 

--- a/eZ/Publish/Core/Repository/LanguageService.php
+++ b/eZ/Publish/Core/Repository/LanguageService.php
@@ -83,7 +83,7 @@ class LanguageService implements LanguageServiceInterface
             throw new InvalidArgumentValue('enabled', $languageCreateStruct->enabled, 'LanguageCreateStruct');
         }
 
-        if ($this->repository->hasAccess('content', 'translations') !== true) {
+        if (!$this->repository->canUser('content', 'translations', $languageCreateStruct)) {
             throw new UnauthorizedException('content', 'translations');
         }
 
@@ -133,7 +133,7 @@ class LanguageService implements LanguageServiceInterface
             throw new InvalidArgumentValue('newName', $newName);
         }
 
-        if ($this->repository->hasAccess('content', 'translations') !== true) {
+        if (!$this->repository->canUser('content', 'translations', $language)) {
             throw new UnauthorizedException('content', 'translations');
         }
 
@@ -171,7 +171,7 @@ class LanguageService implements LanguageServiceInterface
      */
     public function enableLanguage(Language $language)
     {
-        if ($this->repository->hasAccess('content', 'translations') !== true) {
+        if (!$this->repository->canUser('content', 'translations', $language)) {
             throw new UnauthorizedException('content', 'translations');
         }
 
@@ -209,7 +209,7 @@ class LanguageService implements LanguageServiceInterface
      */
     public function disableLanguage(Language $language)
     {
-        if ($this->repository->hasAccess('content', 'translations') !== true) {
+        if (!$this->repository->canUser('content', 'translations', $language)) {
             throw new UnauthorizedException('content', 'translations');
         }
 
@@ -303,7 +303,7 @@ class LanguageService implements LanguageServiceInterface
      */
     public function deleteLanguage(Language $language)
     {
-        if ($this->repository->hasAccess('content', 'translations') !== true) {
+        if (!$this->repository->canUser('content', 'translations', $language)) {
             throw new UnauthorizedException('content', 'translations');
         }
 

--- a/eZ/Publish/Core/Repository/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/ObjectStateService.php
@@ -81,7 +81,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      */
     public function createObjectStateGroup(ObjectStateGroupCreateStruct $objectStateGroupCreateStruct)
     {
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectStateGroupCreateStruct)) {
             throw new UnauthorizedException('state', 'administrate');
         }
 
@@ -181,7 +181,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      */
     public function updateObjectStateGroup(APIObjectStateGroup $objectStateGroup, ObjectStateGroupUpdateStruct $objectStateGroupUpdateStruct)
     {
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectStateGroup)) {
             throw new UnauthorizedException('state', 'administrate');
         }
 
@@ -233,7 +233,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      */
     public function deleteObjectStateGroup(APIObjectStateGroup $objectStateGroup)
     {
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectStateGroup)) {
             throw new UnauthorizedException('state', 'administrate');
         }
 
@@ -265,7 +265,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      */
     public function createObjectState(APIObjectStateGroup $objectStateGroup, ObjectStateCreateStruct $objectStateCreateStruct)
     {
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectStateCreateStruct, [$objectStateGroup])) {
             throw new UnauthorizedException('state', 'administrate');
         }
 
@@ -333,7 +333,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      */
     public function updateObjectState(APIObjectState $objectState, ObjectStateUpdateStruct $objectStateUpdateStruct)
     {
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectState)) {
             throw new UnauthorizedException('state', 'administrate');
         }
 
@@ -394,7 +394,7 @@ class ObjectStateService implements ObjectStateServiceInterface
             throw new InvalidArgumentValue('priority', $priority);
         }
 
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectState)) {
             throw new UnauthorizedException('state', 'administrate');
         }
 
@@ -423,7 +423,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      */
     public function deleteObjectState(APIObjectState $objectState)
     {
-        if ($this->repository->hasAccess('state', 'administrate') !== true) {
+        if (!$this->repository->canUser('state', 'administrate', $objectState)) {
             throw new UnauthorizedException('state', 'administrate');
         }
 

--- a/eZ/Publish/Core/Repository/SectionService.php
+++ b/eZ/Publish/Core/Repository/SectionService.php
@@ -33,7 +33,9 @@ class SectionService implements SectionServiceInterface
      */
     protected $repository;
 
-    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    /**
+     * @var \eZ\Publish\API\Repository\PermissionResolver
+     */
     protected $permissionResolver;
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlWildcardTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlWildcardTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\Repository\Tests\Service\Integration;
+namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\API\Repository\Values\Content\URLWildcard;
@@ -296,20 +296,25 @@ class UrlWildcardTest extends BaseServiceMockTest
      */
     public function testRemoveThrowsUnauthorizedException()
     {
+        $wildcard = new URLWildcard(['id' => 'McBoom']);
+
         $mockedService = $this->getPartlyMockedURLWildcardService();
         $repositoryMock = $this->getRepositoryMock();
         $repositoryMock->expects(
             $this->once()
         )->method(
-            'hasAccess'
+            'canUser'
         )->with(
             $this->equalTo('content'),
-            $this->equalTo('urltranslator')
+            $this->equalTo('urltranslator'),
+            $this->equalTo($wildcard)
         )->will(
             $this->returnValue(false)
         );
 
-        $mockedService->remove(new URLWildcard());
+        $repositoryMock->expects($this->never())->method('beginTransaction');
+
+        $mockedService->remove($wildcard);
     }
 
     /**
@@ -320,6 +325,8 @@ class UrlWildcardTest extends BaseServiceMockTest
      */
     public function testRemove()
     {
+        $wildcard = new URLWildcard(['id' => 'McBomb']);
+
         $mockedService = $this->getPartlyMockedURLWildcardService();
         /** @var \PHPUnit\Framework\MockObject\MockObject $handlerMock */
         $handlerMock = $this->getPersistenceMock()->urlWildcardHandler();
@@ -328,10 +335,11 @@ class UrlWildcardTest extends BaseServiceMockTest
         $repositoryMock->expects(
             $this->once()
         )->method(
-            'hasAccess'
+            'canUser'
         )->with(
             $this->equalTo('content'),
-            $this->equalTo('urltranslator')
+            $this->equalTo('urltranslator'),
+            $this->equalTo($wildcard)
         )->will(
             $this->returnValue(true)
         );
@@ -347,7 +355,7 @@ class UrlWildcardTest extends BaseServiceMockTest
             $this->equalTo('McBomb')
         );
 
-        $mockedService->remove(new URLWildcard(array('id' => 'McBomb')));
+        $mockedService->remove($wildcard);
     }
 
     /**
@@ -359,6 +367,8 @@ class UrlWildcardTest extends BaseServiceMockTest
      */
     public function testRemoveWithRollback()
     {
+        $wildcard = new URLWildcard(['id' => 'McBoo']);
+
         $mockedService = $this->getPartlyMockedURLWildcardService();
         /** @var \PHPUnit\Framework\MockObject\MockObject $handlerMock */
         $handlerMock = $this->getPersistenceMock()->urlWildcardHandler();
@@ -367,10 +377,11 @@ class UrlWildcardTest extends BaseServiceMockTest
         $repositoryMock->expects(
             $this->once()
         )->method(
-            'hasAccess'
+            'canUser'
         )->with(
             $this->equalTo('content'),
-            $this->equalTo('urltranslator')
+            $this->equalTo('urltranslator'),
+            $this->equalTo($wildcard)
         )->will(
             $this->returnValue(true)
         );
@@ -388,7 +399,7 @@ class UrlWildcardTest extends BaseServiceMockTest
             $this->throwException(new \Exception())
         );
 
-        $mockedService->remove(new URLWildcard(array('id' => 'McBoo')));
+        $mockedService->remove($wildcard);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -97,8 +97,6 @@ class TrashService implements TrashServiceInterface
             throw new UnauthorizedException('content', 'read');
         }
 
-        // TODO: Need to check (integration tests + self + QA) how Role limitation will behave with this (as there is no location)
-        // we could pass trash as target (same goes for content/read above), but again would need to check how it will behave.
         if (!$this->repository->canUser('content', 'restore', $trash->getContentInfo())) {
             throw new UnauthorizedException('content', 'restore');
         }

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -122,7 +122,7 @@ class TrashService implements TrashServiceInterface
             throw new InvalidArgumentValue('id', $location->id, 'Location');
         }
 
-        if (!$this->repository->canUser('content', 'remove', $location->getContentInfo(), $location)) {
+        if (!$this->repository->canUser('content', 'remove', $location->getContentInfo(), [$location])) {
             throw new UnauthorizedException('content', 'remove');
         }
 
@@ -179,7 +179,7 @@ class TrashService implements TrashServiceInterface
             'content',
             'restore',
             $trashItem->getContentInfo(),
-            $newParentLocation ? [$newParentLocation] : null
+            [$newParentLocation ?: $trashItem]
         )) {
             throw new UnauthorizedException('content', 'restore');
         }

--- a/eZ/Publish/Core/Repository/URLWildcardService.php
+++ b/eZ/Publish/Core/Repository/URLWildcardService.php
@@ -139,7 +139,7 @@ class URLWildcardService implements URLWildcardServiceInterface
      */
     public function remove(URLWildcard $urlWildcard)
     {
-        if ($this->repository->hasAccess('content', 'urltranslator') !== true) {
+        if (!$this->repository->canUser('content', 'urltranslator', $urlWildcard)) {
             throw new UnauthorizedException('content', 'urltranslator');
         }
 


### PR DESCRIPTION
7.2 branch rebase of #2413 for QA
Conflicts/Changes form that only on now removed integration tests in Core (TrashBase.php), **and** the need to apply same fix done there to Integration tests: 1f5e999

This is ready for QA (ping @barbaragr).

NOTE: CI failure on functional tests is due to changes _(deprecations)_ in Buzz package affecting all new PRs. Plan is anyway to get rid of Buzz usage in kernel, which afaik should be possible now with httpCache out of Kernel as of 7.1.