### PR TITLE
[REST Tests] Aligned code with Buzz v0.17.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-curl": "*",
         "symfony/symfony": "^3.4",
         "symfony-cmf/routing": "^1.1|^2.0",
-        "kriswallsmith/buzz": "~0.17.0",
+        "kriswallsmith/buzz": "^0.17.2",
         "sensio/distribution-bundle": "^5.0",
         "nelmio/cors-bundle": "^1.3.3",
         "hautelook/templated-uri-bundle": "^2.0",

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/SessionTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/SessionTest.php
@@ -5,7 +5,6 @@
  */
 namespace eZ\Bundle\EzPublishRestBundle\Tests\Functional;
 
-use Buzz\Browser;
 use DOMDocument;
 use DOMXPath;
 use Psr\Http\Message\RequestInterface;
@@ -96,7 +95,7 @@ class SessionTest extends TestCase
     public function testLoginWithExistingFrontendSession()
     {
         $baseURI = $this->getBaseURI();
-        $browser = new Browser();
+        $browser = $this->createBrowser();
 
         $response = $browser->get("{$baseURI}/login");
         self::assertHttpResponseCodeEquals($response, 200);


### PR DESCRIPTION
Our REST tests executed from eZ Platform meta-repository fail when any code triggers deprecations. It allows us to quickly identify potential near-future issues.

This PR aligns code with the most recent changes in `kriswallsmith/buzz` ([`v0.17.2`](https://github.com/kriswallsmith/Buzz/blob/0.17.2/CHANGELOG.md#0172)) to avoid deprecation failures.

| Question    |  Answer
| ------------------ | ------------------
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.2`+

**TODO**:
- [x] Explicitly bump `kriswallsmith/buzz` to `^0.17.2`.
- [x] Trigger tests [to confirm failure](https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/425260852#L1325).
- [x] Align code with `kriswallsmith/buzz v0.17.2`.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.


