### PR TITLE
EZP-29613: As a developer I want access to ContentType on Content to avoid re-loading it

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -180,7 +180,6 @@ services:
         class: "%ezpublish.twig.extension.field_rendering.class%"
         arguments:
             - "@ezpublish.templating.field_block_renderer"
-            - "@ezpublish.api.service.content_type"
             - "@ezpublish.fieldType.parameterProviderRegistry"
             - "@ezpublish.translation_helper"
         tags:

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -709,7 +709,7 @@ services:
     ezpublish_rest.output.value_object_visitor.RestExecutedView:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestExecutedView.class%"
-        arguments: [ "@ezpublish.api.service.location", "@ezpublish.api.service.content", "@ezpublish.api.service.content_type" ]
+        arguments: [ "@ezpublish.api.service.location", "@ezpublish.api.service.content" ]
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\RestExecutedView }
 

--- a/eZ/Publish/API/Repository/ContentTypeService.php
+++ b/eZ/Publish/API/Repository/ContentTypeService.php
@@ -162,6 +162,20 @@ interface ContentTypeService
     public function loadContentTypeDraft($contentTypeId);
 
     /**
+     * Bulk-load Content Type objects by ids.
+     *
+     * Note: it does not throw exceptions on load, just ignores erroneous items.
+     *
+     * @since 7.3
+     *
+     * @param mixed[] $contentTypeIds
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType[]|iterable
+     */
+    public function loadContentTypeList(array $contentTypeIds, array $prioritizedLanguages = []): iterable;
+
+    /**
      * Get Content Type objects which belong to the given content type group.
      *
      * @param \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup $contentTypeGroup

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -267,6 +267,35 @@ class ContentServiceTest extends BaseContentServiceTest
     /**
      * Test for the createContent() method.
      *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @see \eZ\Publish\API\Repository\ContentService::createContent()
+     * @depends testCreateContent
+     */
+    public function testCreateContentSetsExpectedContentType($content)
+    {
+        $contentType = $content->getContentType();
+
+        $this->assertEquals(
+            [
+                $contentType->id,
+                // Won't match as it's set to true in createContentDraftVersion1()
+                //$contentType->defaultAlwaysAvailable,
+                //$contentType->defaultSortField,
+                //$contentType->defaultSortOrder,
+            ],
+            [
+                $content->contentInfo->contentTypeId,
+                //$content->contentInfo->alwaysAvailable,
+                //$location->sortField,
+                //$location->sortOrder,
+            ]
+        );
+    }
+
+    /**
+     * Test for the createContent() method.
+     *
      * @see \eZ\Publish\API\Repository\ContentService::createContent()
      * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testCreateContent
@@ -1006,6 +1035,35 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->assertTrue($content->getVersionInfo()->isPublished());
         $this->assertFalse($content->getVersionInfo()->isDraft());
         $this->assertFalse($content->getVersionInfo()->isArchived());
+    }
+
+    /**
+     * Test for the publishVersion() method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @see \eZ\Publish\API\Repository\ContentService::publishVersion()
+     * @depends testPublishVersion
+     */
+    public function testPublishVersionSetsExpectedContentType($content)
+    {
+        $contentType = $content->getContentType();
+
+        $this->assertEquals(
+            [
+                $contentType->id,
+                // won't be a match as it's set to true in createContentDraftVersion1()
+                //$contentType->defaultAlwaysAvailable,
+                //$contentType->defaultSortField,
+                //$contentType->defaultSortOrder,
+            ],
+            [
+                $content->contentInfo->contentTypeId,
+                //$content->contentInfo->alwaysAvailable,
+                //$location->sortField,
+                //$location->sortOrder,
+            ]
+        );
     }
 
     /**

--- a/eZ/Publish/API/Repository/Values/Content/Content.php
+++ b/eZ/Publish/API/Repository/Values/Content/Content.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
 /**
  * this class represents a content object in a specific version.
@@ -97,4 +98,11 @@ abstract class Content extends ValueObject
      * @return \eZ\Publish\API\Repository\Values\Content\Field|null A {@link Field} or null if nothing is found
      */
     abstract public function getField($fieldDefIdentifier, $languageCode = null);
+
+    /**
+     * Returns the ContentType for this content.
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType
+     */
+    abstract public function getContentType(): ContentType;
 }

--- a/eZ/Publish/Core/Helper/FieldHelper.php
+++ b/eZ/Publish/Core/Helper/FieldHelper.php
@@ -49,7 +49,7 @@ class FieldHelper
     public function isFieldEmpty(Content $content, $fieldDefIdentifier, $forcedLanguage = null)
     {
         $field = $this->translationHelper->getTranslatedField($content, $fieldDefIdentifier, $forcedLanguage);
-        $fieldDefinition = $this->getFieldDefinition($content->contentInfo, $fieldDefIdentifier);
+        $fieldDefinition = $content->getContentType()->getFieldDefinition($fieldDefIdentifier);
 
         return $this
             ->fieldTypeService
@@ -59,6 +59,8 @@ class FieldHelper
 
     /**
      * Returns FieldDefinition object based on $contentInfo and $fieldDefIdentifier.
+     *
+     * @deprecated If you have Content you can instead do: $content->getContentType()->getFieldDefinition($identifier)
      *
      * @param ContentInfo $contentInfo
      * @param string $fieldDefIdentifier

--- a/eZ/Publish/Core/Helper/Tests/FieldHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/FieldHelperTest.php
@@ -78,11 +78,10 @@ class FieldHelperTest extends TestCase
             ->with($fieldDefIdentifier)
             ->will($this->returnValue($fieldDefinition));
 
-        $this->contentTypeServiceMock
-            ->expects($this->once())
-            ->method('loadContentType')
-            ->with($contentTypeId)
-            ->will($this->returnValue($contentType));
+        $content
+            ->expects($this->any())
+            ->method('getContentType')
+            ->willReturn($contentType);
 
         $this->translationHelper
             ->expects($this->once())
@@ -125,11 +124,10 @@ class FieldHelperTest extends TestCase
             ->with($fieldDefIdentifier)
             ->will($this->returnValue($fieldDefinition));
 
-        $this->contentTypeServiceMock
-            ->expects($this->once())
-            ->method('loadContentType')
-            ->with($contentTypeId)
-            ->will($this->returnValue($contentType));
+        $content
+            ->expects($this->any())
+            ->method('getContentType')
+            ->willReturn($contentType);
 
         $this->translationHelper
             ->expects($this->once())

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
@@ -9,7 +9,6 @@
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;
 
 use eZ\Publish\API\Repository\ContentService;
-use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\Core\Helper\TranslationHelper;
@@ -69,7 +68,6 @@ class FieldRenderingExtensionIntegrationTest extends FileSystemTwigIntegrationTe
         return array(
             new FieldRenderingExtension(
                 $fieldBlockRenderer,
-                $this->getContentTypeServiceMock(),
                 $this->createMock(ParameterProviderRegistryInterface::class),
                 new TranslationHelper(
                     $configResolver,
@@ -129,6 +127,12 @@ class FieldRenderingExtensionIntegrationTest extends FileSystemTwigIntegrationTe
         $content = new Content(
             array(
                 'internalFields' => $fields,
+                'contentType' => new ContentType([
+                    'id' => $contentTypeIdentifier,
+                    'identifier' => $contentTypeIdentifier,
+                    'mainLanguageCode' => 'fre-FR',
+                    'fieldDefinitions' => $this->fieldDefinitions[$contentTypeIdentifier],
+                ]),
                 'versionInfo' => new VersionInfo(
                     array(
                         'versionNo' => 64,
@@ -171,32 +175,6 @@ class FieldRenderingExtensionIntegrationTest extends FileSystemTwigIntegrationTe
                             array('fre-FR', 'eng-US'),
                         ),
                     )
-                )
-            );
-
-        return $mock;
-    }
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getContentTypeServiceMock()
-    {
-        $mock = $this->createMock(ContentTypeService::class);
-
-        $mock->expects($this->any())
-            ->method('loadContentType')
-            ->will(
-                $this->returnCallback(
-                    function ($contentTypeId) {
-                        return new ContentType(
-                            array(
-                                'identifier' => $contentTypeId,
-                                'mainLanguageCode' => 'fre-FR',
-                                'fieldDefinitions' => $this->fieldDefinitions[$contentTypeId],
-                            )
-                        );
-                    }
                 )
             );
 

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -288,10 +288,9 @@ class ContentExtension extends Twig_Extension
     public function getFirstFilledImageFieldIdentifier(Content $content)
     {
         foreach ($content->getFieldsByLanguage() as $field) {
-            $fieldTypeIdentifier = $this->fieldHelper->getFieldDefinition(
-                $content->contentInfo,
-                $field->fieldDefIdentifier
-            )->fieldTypeIdentifier;
+            $fieldTypeIdentifier = $content->getContentType()
+                ->getFieldDefinition($field->fieldDefIdentifier)
+                ->fieldTypeIdentifier;
 
             if ($fieldTypeIdentifier !== 'ezimage') {
                 continue;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtension.php
@@ -8,7 +8,6 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;
 
-use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
@@ -31,11 +30,6 @@ class FieldRenderingExtension extends Twig_Extension
     private $fieldBlockRenderer;
 
     /**
-     * @var ContentTypeService
-     */
-    private $contentTypeService;
-
-    /**
      * @var ParameterProviderRegistryInterface
      */
     private $parameterProviderRegistry;
@@ -54,12 +48,10 @@ class FieldRenderingExtension extends Twig_Extension
 
     public function __construct(
         FieldBlockRendererInterface $fieldBlockRenderer,
-        ContentTypeService $contentTypeService,
         ParameterProviderRegistryInterface $parameterProviderRegistry,
         TranslationHelper $translationHelper
     ) {
         $this->fieldBlockRenderer = $fieldBlockRenderer;
-        $this->contentTypeService = $contentTypeService;
         $this->parameterProviderRegistry = $parameterProviderRegistry;
         $this->translationHelper = $translationHelper;
     }
@@ -152,7 +144,7 @@ class FieldRenderingExtension extends Twig_Extension
 
         $versionInfo = $content->getVersionInfo();
         $contentInfo = $versionInfo->getContentInfo();
-        $contentType = $this->contentTypeService->loadContentType($contentInfo->contentTypeId);
+        $contentType = $content->getContentType();
         $fieldDefinition = $contentType->getFieldDefinition($field->fieldDefIdentifier);
         // Adding Field, FieldSettings and ContentInfo objects to
         // parameters to be passed to the template
@@ -192,11 +184,10 @@ class FieldRenderingExtension extends Twig_Extension
      */
     private function getFieldTypeIdentifier(Content $content, Field $field)
     {
-        $contentInfo = $content->getVersionInfo()->getContentInfo();
-        $key = $contentInfo->contentTypeId . '  ' . $field->fieldDefIdentifier;
+        $contentType = $content->getContentType();
+        $key = $contentType->id . '  ' . $field->fieldDefIdentifier;
 
         if (!isset($this->fieldTypeIdentifiers[$key])) {
-            $contentType = $this->contentTypeService->loadContentType($contentInfo->contentTypeId);
             $this->fieldTypeIdentifiers[$key] = $contentType
                 ->getFieldDefinition($field->fieldDefIdentifier)
                 ->fieldTypeIdentifier;

--- a/eZ/Publish/Core/Persistence/Cache/AbstractHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractHandler.php
@@ -64,7 +64,8 @@ abstract class AbstractHandler
      * @param callable $missingLoader Function for loading missing objects, gets array with missing id's as argument,
      *                                expects return value to be array with id as key. Missing items should be missing.
      * @param callable $loadedTagger Function for tagging loaded object, gets object as argument, return array of tags.
-     * @param array $keySuffixes Optional, key is id as provided in $ids, and value is a key suffix e.g. "-eng-Gb"
+     * @param string|array $keySuffix Optional, if array key is id as provided in $ids, and value (when string or array)
+     *                                is a key suffix e.g. "-eng-Gb"
      *
      * @return array
      */
@@ -73,7 +74,7 @@ abstract class AbstractHandler
         string $keyPrefix,
         callable $missingLoader,
         callable $loadedTagger,
-        array $keySuffixes = []
+        $keySuffix = ''
     ): array {
         if (empty($ids)) {
             return [];
@@ -82,7 +83,7 @@ abstract class AbstractHandler
         // Generate unique cache keys
         $cacheKeys = [];
         foreach (array_unique($ids) as $id) {
-            $cacheKeys[] = $keyPrefix . $id . ($keySuffixes[$id] ?? '');
+            $cacheKeys[] = $keyPrefix . $id . (is_array($keySuffix) ? $keySuffix[$id] ?? '' : ($keySuffix ?: ''));
         }
 
         // Load cache items by cache keys (will contain hits and misses)
@@ -91,7 +92,7 @@ abstract class AbstractHandler
         $keyPrefixLength = strlen($keyPrefix);
         foreach ($this->cache->getItems($cacheKeys) as $key => $cacheItem) {
             $id = substr($key, $keyPrefixLength);
-            if (!empty($keySuffixes)) {
+            if (!empty($keySuffix)) {
                 $id = explode('-', $id, 2)[0];
             }
 

--- a/eZ/Publish/Core/Persistence/Cache/AbstractHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractHandler.php
@@ -64,8 +64,7 @@ abstract class AbstractHandler
      * @param callable $missingLoader Function for loading missing objects, gets array with missing id's as argument,
      *                                expects return value to be array with id as key. Missing items should be missing.
      * @param callable $loadedTagger Function for tagging loaded object, gets object as argument, return array of tags.
-     * @param string|array $keySuffix Optional, if array key is id as provided in $ids, and value (when string or array)
-     *                                is a key suffix e.g. "-eng-Gb"
+     * @param array $keySuffixes Optional, key is id as provided in $ids, and value is a key suffix e.g. "-eng-Gb"
      *
      * @return array
      */
@@ -74,7 +73,7 @@ abstract class AbstractHandler
         string $keyPrefix,
         callable $missingLoader,
         callable $loadedTagger,
-        $keySuffix = ''
+        array $keySuffixes = []
     ): array {
         if (empty($ids)) {
             return [];
@@ -83,7 +82,7 @@ abstract class AbstractHandler
         // Generate unique cache keys
         $cacheKeys = [];
         foreach (array_unique($ids) as $id) {
-            $cacheKeys[] = $keyPrefix . $id . (is_array($keySuffix) ? $keySuffix[$id] ?? '' : ($keySuffix ?: ''));
+            $cacheKeys[] = $keyPrefix . $id . ($keySuffixes[$id] ?? '');
         }
 
         // Load cache items by cache keys (will contain hits and misses)
@@ -92,7 +91,7 @@ abstract class AbstractHandler
         $keyPrefixLength = strlen($keyPrefix);
         foreach ($this->cache->getItems($cacheKeys) as $key => $cacheItem) {
             $id = substr($key, $keyPrefixLength);
-            if (!empty($keySuffix)) {
+            if (!empty($keySuffixes)) {
                 $id = explode('-', $id, 2)[0];
             }
 

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -161,6 +161,23 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
         return $types;
     }
 
+    public function loadContentTypeList(array $contentTypeIds): array
+    {
+        return $this->getMultipleCacheItems(
+            $contentTypeIds,
+            'ez-content-type-',
+            function (array $cacheMissIds) {
+                $this->logger->logCall(__CLASS__ . '::loadContentTypeList', ['type' => $cacheMissIds]);
+
+                return $this->persistenceHandler->contentTypeHandler()->loadContentTypeList($cacheMissIds);
+            },
+            function (Type $type) {
+                return ['type-' . $type->id];
+            },
+            '-' . Type::STATUS_DEFINED
+        );
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -174,7 +174,7 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
             function (Type $type) {
                 return ['type-' . $type->id];
             },
-            '-' . Type::STATUS_DEFINED
+            array_fill_keys($contentTypeIds, '-' . Type::STATUS_DEFINED)
         );
     }
 

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
@@ -37,7 +37,7 @@ class ContentTypeHandlerTest extends AbstractCacheHandlerTest
      */
     public function providerForUnCachedMethods(): array
     {
-        // string $method, array $arguments, array? $tags, string? $key
+        // string $method, array $arguments, array? $tags, string? $key, mixed? $returnValue
         return [
             ['createGroup', [new SPITypeGroupCreateStruct()]],
             ['updateGroup', [new SPITypeGroupUpdateStruct(['id' => 3])], ['type-group-3']],
@@ -76,12 +76,13 @@ class ContentTypeHandlerTest extends AbstractCacheHandlerTest
         $group = new SPITypeGroup(['id' => 3]);
         $type = new SPIType(['id' => 5]);
 
-        // string $method, array $arguments, string $key, mixed? $data
+        // string $method, array $arguments, string $key, mixed? $data, bool? $multi, array? $additionalCalls
         return [
             ['loadGroup', [3], 'ez-content-type-group-3', $group],
             ['loadGroups', [[3]], 'ez-content-type-group-3', [3 => $group], true],
             ['loadGroupByIdentifier', ['content'], 'ez-content-type-group-content-by-identifier', $group],
             ['loadContentTypes', [3, 0], 'ez-content-type-list-by-group-3', [$type]],
+            ['loadContentTypeList', [[5]], 'ez-content-type-5-0', [5 => $type], true],
             ['load', [5, 0], 'ez-content-type-5-0', $type],
             ['loadByIdentifier', ['article'], 'ez-content-type-article-by-identifier', $type],
             ['loadByRemoteId', ['f34tg45gf'], 'ez-content-type-f34tg45gf-by-remote', $type],

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
@@ -186,6 +186,15 @@ abstract class Gateway
     abstract public function updateType($typeId, $status, UpdateStruct $updateStruct);
 
     /**
+     * Loads an array with data about several Types in defined status..
+     *
+     * @param array $typeIds
+     *
+     * @return array Data rows.
+     */
+    abstract public function loadTypesDataList(array $typeIds): array;
+
+    /**
      * Loads an array with data about $typeId in $status.
      *
      * @param mixed $typeId

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
@@ -186,13 +186,13 @@ abstract class Gateway
     abstract public function updateType($typeId, $status, UpdateStruct $updateStruct);
 
     /**
-     * Loads an array with data about several Types in defined status..
+     * Loads an array with data about several Types in defined status.
      *
      * @param array $typeIds
      *
      * @return array Data rows.
      */
-    abstract public function loadTypesDataList(array $typeIds): array;
+    abstract public function loadTypesListData(array $typeIds): array;
 
     /**
      * Loads an array with data about $typeId in $status.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -573,7 +573,7 @@ class DoctrineDatabase extends Gateway
         $q
             ->where('g.group_id = :gid')
             ->andWhere('c.version = :version')
-            ->addOrderBy('c.id')
+            ->addOrderBy('c.identifier')
             ->setParameter('gid', $groupId, ParameterType::INTEGER)
             ->setParameter('version', $status, ParameterType::INTEGER);
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -884,6 +884,32 @@ class DoctrineDatabase extends Gateway
         $this->insertTypeNameData($typeId, $status, $updateStruct->name);
     }
 
+    public function loadTypesDataList(array $typeIds): array
+    {
+        // @todo change getLoadTypeQuery() to use doctrine query, use it partly here for array binding
+        $doctrineQueryBuilder = $this->connection->createQueryBuilder();
+
+        $q = $this->getLoadTypeQuery();
+        $q->where(
+            $q->expr->lAnd(
+                $q->expr->eq(
+                    $this->dbHandler->quoteColumn('id', 'ezcontentclass'),
+                    $doctrineQueryBuilder->createNamedParameter($typeIds, Connection::PARAM_INT_ARRAY)
+                ),
+                $q->expr->eq(
+                    $this->dbHandler->quoteColumn('version', 'ezcontentclass'),
+                    $q->bindValue(Type::STATUS_DEFINED, null, \PDO::PARAM_INT)
+                )
+            )
+        );
+        $q->orderBy($this->dbHandler->quoteColumn('id', 'ezcontentclass'));
+
+        $stmt = $q->prepare();
+        $stmt->execute();
+
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
     /**
      * Loads an array with data about $typeId in $status.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -9,6 +9,8 @@
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator;
@@ -567,31 +569,15 @@ class DoctrineDatabase extends Gateway
      */
     public function loadTypesDataForGroup($groupId, $status)
     {
-        $q = $this->getLoadTypeQuery();
-        $q->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn(
-                        'group_id',
-                        'ezcontentclass_classgroup'
-                    ),
-                    $q->bindValue($groupId, null, \PDO::PARAM_INT)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn(
-                        'version',
-                        'ezcontentclass'
-                    ),
-                    $q->bindValue($status, null, \PDO::PARAM_INT)
-                )
-            )
-        );
-        $q->orderBy($this->dbHandler->quoteColumn('identifier', 'ezcontentclass'));
+        $q = $this->getLoadTypeQueryBuilder();
+        $q
+            ->where('g.group_id = :gid')
+            ->andWhere('c.version = :version')
+            ->addOrderBy('c.id')
+            ->setParameter('gid', $groupId, ParameterType::INTEGER)
+            ->setParameter('version', $status, ParameterType::INTEGER);
 
-        $stmt = $q->prepare();
-        $stmt->execute();
-
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return $q->execute()->fetchAll();
     }
 
     /**
@@ -886,28 +872,13 @@ class DoctrineDatabase extends Gateway
 
     public function loadTypesDataList(array $typeIds): array
     {
-        // @todo change getLoadTypeQuery() to use doctrine query, use it partly here for array binding
-        $doctrineQueryBuilder = $this->connection->createQueryBuilder();
+        $q = $this->getLoadTypeQueryBuilder();
+        $q
+            ->where('c.id IN (:ids)')
+            ->andWhere($q->expr()->eq('c.version', Type::STATUS_DEFINED))
+            ->setParameter('ids', $typeIds, Connection::PARAM_INT_ARRAY);
 
-        $q = $this->getLoadTypeQuery();
-        $q->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('id', 'ezcontentclass'),
-                    $doctrineQueryBuilder->createNamedParameter($typeIds, Connection::PARAM_INT_ARRAY)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('version', 'ezcontentclass'),
-                    $q->bindValue(Type::STATUS_DEFINED, null, \PDO::PARAM_INT)
-                )
-            )
-        );
-        $q->orderBy($this->dbHandler->quoteColumn('id', 'ezcontentclass'));
-
-        $stmt = $q->prepare();
-        $stmt->execute();
-
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return $q->execute()->fetchAll();
     }
 
     /**
@@ -920,23 +891,14 @@ class DoctrineDatabase extends Gateway
      */
     public function loadTypeData($typeId, $status)
     {
-        $q = $this->getLoadTypeQuery();
-        $q->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('id', 'ezcontentclass'),
-                    $q->bindValue($typeId, null, \PDO::PARAM_INT)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('version', 'ezcontentclass'),
-                    $q->bindValue($status, null, \PDO::PARAM_INT)
-                )
-            )
-        );
-        $stmt = $q->prepare();
-        $stmt->execute();
+        $q = $this->getLoadTypeQueryBuilder();
+        $q
+            ->where('c.id = :id')
+            ->andWhere('c.version = :version')
+            ->setParameter('id', $typeId, ParameterType::INTEGER)
+            ->setParameter('version', $status, ParameterType::INTEGER);
 
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return $q->execute()->fetchAll();
     }
 
     /**
@@ -950,23 +912,14 @@ class DoctrineDatabase extends Gateway
      */
     public function loadTypeDataByIdentifier($identifier, $status)
     {
-        $q = $this->getLoadTypeQuery();
-        $q->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('identifier', 'ezcontentclass'),
-                    $q->bindValue($identifier)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('version', 'ezcontentclass'),
-                    $q->bindValue($status)
-                )
-            )
-        );
-        $stmt = $q->prepare();
-        $stmt->execute();
+        $q = $this->getLoadTypeQueryBuilder();
+        $q
+            ->where('c.identifier = :identifier')
+            ->andWhere('c.version = :version')
+            ->setParameter('identifier', $identifier, ParameterType::STRING)
+            ->setParameter('version', $status, ParameterType::INTEGER);
 
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return $q->execute()->fetchAll();
     }
 
     /**
@@ -980,94 +933,84 @@ class DoctrineDatabase extends Gateway
      */
     public function loadTypeDataByRemoteId($remoteId, $status)
     {
-        $q = $this->getLoadTypeQuery();
-        $q->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('remote_id', 'ezcontentclass'),
-                    $q->bindValue($remoteId)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('version', 'ezcontentclass'),
-                    $q->bindValue($status)
-                )
-            )
-        );
-        $stmt = $q->prepare();
-        $stmt->execute();
+        $q = $this->getLoadTypeQueryBuilder();
+        $q
+            ->where('c.remote_id = :remote')
+            ->andWhere('c.version = :version')
+            ->setParameter('remote', $remoteId, ParameterType::STRING)
+            ->setParameter('version', $status, ParameterType::INTEGER);
 
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return $q->execute()->fetchAll();
     }
 
     /**
      * Returns a basic query to retrieve Type data.
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\SelectQuery
      */
-    protected function getLoadTypeQuery()
+    private function getLoadTypeQueryBuilder(): QueryBuilder
     {
-        $q = $this->dbHandler->createSelectQuery();
+        $q = $this->connection->createQueryBuilder();
+        $q
+            ->select([
+                'c.id AS ezcontentclass_id',
+                'c.version AS ezcontentclass_version',
+                'c.serialized_name_list AS ezcontentclass_serialized_name_list',
+                'c.serialized_description_list AS ezcontentclass_serialized_description_list',
+                'c.identifier AS ezcontentclass_identifier',
+                'c.created AS ezcontentclass_created',
+                'c.modified AS ezcontentclass_modified',
+                'c.modifier_id AS ezcontentclass_modifier_id',
+                'c.creator_id AS ezcontentclass_creator_id',
+                'c.remote_id AS ezcontentclass_remote_id',
+                'c.url_alias_name AS ezcontentclass_url_alias_name',
+                'c.contentobject_name AS ezcontentclass_contentobject_name',
+                'c.is_container AS ezcontentclass_is_container',
+                'c.initial_language_id AS ezcontentclass_initial_language_id',
+                'c.always_available AS ezcontentclass_always_available',
+                'c.sort_field AS ezcontentclass_sort_field',
+                'c.sort_order AS ezcontentclass_sort_order',
 
-        $this->selectColumns($q, 'ezcontentclass');
-        $this->selectColumns($q, 'ezcontentclass_attribute');
-        $q->select(
-            $this->dbHandler->aliasedColumn(
-                $q,
-                'group_id',
-                'ezcontentclass_classgroup'
+                'a.id AS ezcontentclass_attribute_id',
+                'a.serialized_name_list AS ezcontentclass_attribute_serialized_name_list',
+                'a.serialized_description_list AS ezcontentclass_attribute_serialized_description_list',
+                'a.identifier AS ezcontentclass_attribute_identifier',
+                'a.category AS ezcontentclass_attribute_category',
+                'a.data_type_string AS ezcontentclass_attribute_data_type_string',
+                'a.can_translate AS ezcontentclass_attribute_can_translate',
+                'a.is_required AS ezcontentclass_attribute_is_required',
+                'a.is_information_collector AS ezcontentclass_attribute_is_information_collector',
+                'a.is_searchable AS ezcontentclass_attribute_is_searchable',
+                'a.placement AS ezcontentclass_attribute_placement',
+                'a.data_float1 AS ezcontentclass_attribute_data_float1',
+                'a.data_float2 AS ezcontentclass_attribute_data_float2',
+                'a.data_float3 AS ezcontentclass_attribute_data_float3',
+                'a.data_float4 AS ezcontentclass_attribute_data_float4',
+                'a.data_int1 AS ezcontentclass_attribute_data_int1',
+                'a.data_int2 AS ezcontentclass_attribute_data_int2',
+                'a.data_int3 AS ezcontentclass_attribute_data_int3',
+                'a.data_int4 AS ezcontentclass_attribute_data_int4',
+                'a.data_text1 AS ezcontentclass_attribute_data_text1',
+                'a.data_text2 AS ezcontentclass_attribute_data_text2',
+                'a.data_text3 AS ezcontentclass_attribute_data_text3',
+                'a.data_text4 AS ezcontentclass_attribute_data_text4',
+                'a.data_text5 AS ezcontentclass_attribute_data_text5',
+                'a.serialized_data_text AS ezcontentclass_attribute_serialized_data_text',
+
+                'g.group_id AS ezcontentclass_classgroup_group_id',
+            ])
+            ->from('ezcontentclass', 'c')
+            ->leftJoin(
+                'c',
+                'ezcontentclass_attribute',
+                'a',
+                'c.id = a.contentclass_id AND c.version = a.version'
             )
-        );
-        $q->from(
-            $this->dbHandler->quoteTable('ezcontentclass')
-        )->leftJoin(
-            $this->dbHandler->quoteTable('ezcontentclass_attribute'),
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn(
-                        'id',
-                        'ezcontentclass'
-                    ),
-                    $this->dbHandler->quoteColumn(
-                        'contentclass_id',
-                        'ezcontentclass_attribute'
-                    )
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn(
-                        'version',
-                        'ezcontentclass'
-                    ),
-                    $this->dbHandler->quoteColumn(
-                        'version',
-                        'ezcontentclass_attribute'
-                    )
-                )
+            ->leftJoin(
+                'c',
+                'ezcontentclass_classgroup',
+                'g',
+                'c.id = g.contentclass_id AND c.version = g.contentclass_version'
             )
-        )->leftJoin(
-            $this->dbHandler->quoteTable('ezcontentclass_classgroup'),
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn(
-                        'id',
-                        'ezcontentclass'
-                    ),
-                    $this->dbHandler->quoteColumn(
-                        'contentclass_id',
-                        'ezcontentclass_classgroup'
-                    )
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn(
-                        'version',
-                        'ezcontentclass'
-                    ),
-                    $this->dbHandler->quoteColumn(
-                        'contentclass_version',
-                        'ezcontentclass_classgroup'
-                    )
-                )
-            )
-        )->orderBy($this->dbHandler->quoteColumn('placement', 'ezcontentclass_attribute'));
+            ->orderBy('a.placement');
 
         return $q;
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -870,7 +870,7 @@ class DoctrineDatabase extends Gateway
         $this->insertTypeNameData($typeId, $status, $updateStruct->name);
     }
 
-    public function loadTypesDataList(array $typeIds): array
+    public function loadTypesListData(array $typeIds): array
     {
         $q = $this->getLoadTypeQueryBuilder();
         $q

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -350,6 +350,15 @@ class ExceptionConversion extends Gateway
         }
     }
 
+    public function loadTypesDataList(array $typeIds): array
+    {
+        try {
+            return $this->innerGateway->loadTypesDataList($typeIds);
+        } catch (PDOException | DBALException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
+
     /**
      * Loads an array with data about $typeId in $status.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -350,10 +350,10 @@ class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadTypesDataList(array $typeIds): array
+    public function loadTypesListData(array $typeIds): array
     {
         try {
-            return $this->innerGateway->loadTypesDataList($typeIds);
+            return $this->innerGateway->loadTypesListData($typeIds);
         } catch (PDOException | DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -187,6 +187,14 @@ class Handler implements BaseContentTypeHandler
         );
     }
 
+    public function loadContentTypeList(array $contentTypeIds): array
+    {
+        return $this->mapper->extractTypesFromRows(
+            $this->contentTypeGateway->loadTypesDataList($contentTypeIds),
+            true
+        );
+    }
+
     /**
      * Loads a content type by id and status.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -190,7 +190,7 @@ class Handler implements BaseContentTypeHandler
     public function loadContentTypeList(array $contentTypeIds): array
     {
         return $this->mapper->extractTypesFromRows(
-            $this->contentTypeGateway->loadTypesDataList($contentTypeIds),
+            $this->contentTypeGateway->loadTypesListData($contentTypeIds),
             true
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
@@ -97,10 +97,11 @@ class Mapper
      * Extracts types and related data from the given $rows.
      *
      * @param array $rows
+     * @param bool $keepTypeIdAsKey
      *
      * @return array(Type)
      */
-    public function extractTypesFromRows(array $rows)
+    public function extractTypesFromRows(array $rows, bool $keepTypeIdAsKey = false)
     {
         $types = array();
         $fields = array();
@@ -120,6 +121,10 @@ class Mapper
             if (!in_array($groupId, $types[$typeId]->groupIds)) {
                 $types[$typeId]->groupIds[] = $groupId;
             }
+        }
+
+        if ($keepTypeIdAsKey) {
+            return $types;
         }
 
         // Re-index $types to avoid people relying on ID keys

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
@@ -169,6 +169,20 @@ class MemoryCachingHandler implements BaseContentTypeHandler
         return $this->innerHandler->loadContentTypes($groupId, $status);
     }
 
+    public function loadContentTypeList(array $contentTypeIds): array
+    {
+        $contentTypes = [];
+        foreach ($contentTypeIds as $contentTypeId) {
+            if (isset($this->contentTypes[$contentTypeId])) {
+                $contentTypes[$contentTypeId] = $this->contentTypes[$contentTypeId];
+            } else {
+                $contentTypes[$contentTypeId] = $this->contentTypes[$contentTypeId] = $this->innerHandler->load($contentTypeId);
+            }
+        }
+
+        return $contentTypes;
+    }
+
     /**
      * @param int $contentTypeId
      * @param int $status

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
@@ -31,14 +31,14 @@ class MemoryCachingHandler implements BaseContentTypeHandler
      *
      * @var array
      */
-    protected $groups;
+    protected $groups = [];
 
     /**
      * Local in-memory cache for content types in one single request.
      *
      * @var array
      */
-    protected $contentTypes;
+    protected $contentTypes = [];
 
     /**
      * Local in-memory cache for field definitions in one single request.

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
@@ -301,6 +301,33 @@ class ContentTypeHandlerTest extends TestCase
     }
 
     /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler::loadContentTypeList
+     */
+    public function testLoadContentTypeList(): void
+    {
+        $gatewayMock = $this->getGatewayMock();
+        $gatewayMock->expects($this->once())
+            ->method('loadTypesDataList')
+            ->with($this->equalTo([23, 24]))
+            ->willReturn([]);
+
+        $mapperMock = $this->getMapperMock();
+        $mapperMock->expects($this->once())
+            ->method('extractTypesFromRows')
+            ->with($this->equalTo([]))
+            ->willReturn([23 => new Type()]);
+
+        $handler = $this->getHandler();
+        $types = $handler->loadContentTypeList([23, 24]);
+
+        $this->assertEquals(
+            [23 => new Type()],
+            $types,
+            'Types not loaded correctly'
+        );
+    }
+
+    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler::load
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler::loadFromRows
      */

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
@@ -307,7 +307,7 @@ class ContentTypeHandlerTest extends TestCase
     {
         $gatewayMock = $this->getGatewayMock();
         $gatewayMock->expects($this->once())
-            ->method('loadTypesDataList')
+            ->method('loadTypesListData')
             ->with($this->equalTo([23, 24]))
             ->willReturn([]);
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
@@ -399,7 +399,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
             count($rows)
         );
         $this->assertEquals(
-            45,
+            43,
             count($rows[0])
         );
 
@@ -432,7 +432,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
             count($rows)
         );
         $this->assertEquals(
-            45,
+            43,
             count($rows[0])
         );
     }
@@ -456,7 +456,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
             count($rows)
         );
         $this->assertEquals(
-            45,
+            43,
             count($rows[0])
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/TestCase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/TestCase.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use InvalidArgumentException;
+use ReflectionObject;
 use PDOException;
 use Exception;
 
@@ -37,6 +38,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * Database handler -- to not be constructed twice for one test.
      *
+     * @internal
      * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected $handler;
@@ -44,16 +46,10 @@ abstract class TestCase extends BaseTestCase
     /**
      * Doctrine Database connection -- to not be constructed twice for one test.
      *
+     * @internal
      * @var \Doctrine\DBAL\Connection
      */
     protected $connection;
-
-    /**
-     * Property which holds the state if this is the initial test run, so that
-     * we should set up the database, or if this is any of the following test
-     * runs, where it is sufficient to reset the database.
-     */
-    protected static $initial = true;
 
     /**
      * Get data source name.
@@ -86,7 +82,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return \eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler
      */
-    public function getDatabaseHandler()
+    final public function getDatabaseHandler()
     {
         if (!$this->handler) {
             $this->handler = ConnectionHandler::createFromConnection($this->getDatabaseConnection());
@@ -101,7 +97,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return \Doctrine\DBAL\Connection
      */
-    public function getDatabaseConnection()
+    final public function getDatabaseConnection()
     {
         if (!$this->connection) {
             $this->connection = ConnectionHandler::createConnectionFromDSN($this->getDsn());
@@ -132,14 +128,12 @@ abstract class TestCase extends BaseTestCase
         }
 
         $this->resetSequences();
-
-        // Set "global" static var, that we are behind the initial run
-        self::$initial = false;
     }
 
     protected function tearDown()
     {
         unset($this->handler);
+        unset($this->connection);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/ContentTypeService.php
+++ b/eZ/Publish/Core/REST/Client/ContentTypeService.php
@@ -590,6 +590,14 @@ class ContentTypeService implements APIContentTypeService, Sessionable
     /**
      * {@inheritdoc}
      */
+    public function loadContentTypeList(array $contentTypeIds, array $prioritizedLanguages = []): iterable
+    {
+        throw new \RuntimeException('@todo: Implement.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [])
     {
         $response = $this->client->request(

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
@@ -14,7 +14,6 @@ use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 use eZ\Publish\API\Repository\ContentService;
-use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\REST\Server\Values\RestContent as RestContentValue;
 
@@ -38,25 +37,15 @@ class RestExecutedView extends ValueObjectVisitor
     protected $contentService;
 
     /**
-     * ContentType service.
-     *
-     * @var \eZ\Publish\API\Repository\ContentTypeService
-     */
-    protected $contentTypeService;
-
-    /**
      * @param \eZ\Publish\API\Repository\LocationService $locationService
      * @param \eZ\Publish\API\Repository\ContentService $contentService
-     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      */
     public function __construct(
         LocationService $locationService,
-        ContentService $contentService,
-        ContentTypeService $contentTypeService
+        ContentService $contentService
     ) {
         $this->locationService = $locationService;
         $this->contentService = $contentService;
-        $this->contentTypeService = $contentTypeService;
     }
 
     /**
@@ -124,13 +113,13 @@ class RestExecutedView extends ValueObjectVisitor
 
             // @todo Refactor
             if ($searchHit->valueObject instanceof ApiValues\Content) {
-                /** @var \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo */
+                /** @var \eZ\Publish\API\Repository\Values\Content\Content $searchHit->valueObject */
                 $contentInfo = $searchHit->valueObject->contentInfo;
                 $valueObject = new RestContentValue(
                     $contentInfo,
                     $this->locationService->loadLocation($contentInfo->mainLocationId),
                     $searchHit->valueObject,
-                    $this->contentTypeService->loadContentType($contentInfo->contentTypeId),
+                    $searchHit->valueObject->getContentType(),
                     $this->contentService->loadRelations($searchHit->valueObject->getVersionInfo())
                 );
             } elseif ($searchHit->valueObject instanceof ApiValues\Location) {

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestExecutedViewTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestExecutedViewTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values\Content;
@@ -151,6 +152,7 @@ class RestExecutedViewTest extends ValueObjectVisitorBaseTest
             'index' => 'alexandria',
             'valueObject' => new ApiValues\Content([
                 'versionInfo' => new Content\VersionInfo(['contentInfo' => new ContentInfo()]),
+                'contentType' => new ContentType(),
             ]),
         ]);
     }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -465,7 +465,6 @@ class ContentService implements ContentServiceInterface
             }
         }
 
-
         $contentList = [];
         $translations = array_unique($translations);
         $spiContentList = $this->persistenceHandler->contentHandler()->loadContentList(

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -453,27 +453,34 @@ class ContentService implements ContentServiceInterface
     ) {
         $loadAllLanguages = $languages === Language::ALL;
         $contentIds = [];
+        $contentTypeIds = [];
         $translations = $languages;
         foreach ($contentInfoList as $contentInfo) {
             $contentIds[] = $contentInfo->id;
+            $contentTypeIds[] = $contentInfo->contentTypeId;
             // Unless we are told to load all languages, we add main language to translations so they are loaded too
             // Might in some case load more languages then intended, but prioritised handling will pick right one
             if (!$loadAllLanguages && $useAlwaysAvailable && $contentInfo->alwaysAvailable) {
                 $translations[] = $contentInfo->mainLanguageCode;
             }
         }
-        $translations = array_unique($translations);
 
+
+        $contentList = [];
+        $translations = array_unique($translations);
         $spiContentList = $this->persistenceHandler->contentHandler()->loadContentList(
             $contentIds,
             $translations
         );
-        $contentList = [];
+        $contentTypeList = $this->repository->getContentTypeService()->loadContentTypeList(
+            array_unique($contentTypeIds),
+            $languages
+        );
         foreach ($spiContentList as $contentId => $spiContent) {
             $contentInfo = $spiContent->versionInfo->contentInfo;
             $contentList[$contentId] = $this->domainMapper->buildContentDomainObject(
                 $spiContent,
-                null,
+                $contentTypeList[$contentInfo->contentTypeId],
                 $languages,
                 $contentInfo->alwaysAvailable ? $contentInfo->mainLanguageCode : null
             );

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -390,7 +390,9 @@ class ContentService implements ContentServiceInterface
 
         return $this->domainMapper->buildContentDomainObject(
             $spiContent,
-            null,
+            $this->repository->getContentTypeService()->loadContentType(
+                $spiContent->versionInfo->contentInfo->contentTypeId
+            ),
             $languages ?? [],
             $alwaysAvailableLanguageCode
         );
@@ -702,7 +704,10 @@ class ContentService implements ContentServiceInterface
             throw $e;
         }
 
-        return $this->domainMapper->buildContentDomainObject($spiContent);
+        return $this->domainMapper->buildContentDomainObject(
+            $spiContent,
+            $contentCreateStruct->contentType
+        );
     }
 
     /**
@@ -1125,7 +1130,12 @@ class ContentService implements ContentServiceInterface
             throw $e;
         }
 
-        return $this->domainMapper->buildContentDomainObject($spiContent);
+        return $this->domainMapper->buildContentDomainObject(
+            $spiContent,
+            $this->repository->getContentTypeService()->loadContentType(
+                $spiContent->versionInfo->contentInfo->contentTypeId
+            )
+        );
     }
 
     /**
@@ -1529,7 +1539,12 @@ class ContentService implements ContentServiceInterface
             $metadataUpdateStruct
         );
 
-        $content = $this->domainMapper->buildContentDomainObject($spiContent);
+        $content = $this->domainMapper->buildContentDomainObject(
+            $spiContent,
+            $this->repository->getContentTypeService()->loadContentType(
+                $spiContent->versionInfo->contentInfo->contentTypeId
+            )
+        );
 
         $this->publishUrlAliasesForContent($content);
 
@@ -2083,7 +2098,12 @@ class ContentService implements ContentServiceInterface
             );
             $this->repository->commit();
 
-            return $this->domainMapper->buildContentDomainObject($spiContent);
+            return $this->domainMapper->buildContentDomainObject(
+                $spiContent,
+                $this->repository->getContentTypeService()->loadContentType(
+                    $spiContent->versionInfo->contentInfo->contentTypeId
+                )
+            );
         } catch (APINotFoundException $e) {
             // avoid wrapping expected NotFoundException in BadStateException handled below
             $this->repository->rollback();

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -916,6 +916,25 @@ class ContentTypeService implements ContentTypeServiceInterface
     /**
      * {@inheritdoc}
      */
+    public function loadContentTypeList(array $contentTypeIds, array $prioritizedLanguages = []): iterable
+    {
+        $spiContentTypes = $this->contentTypeHandler->loadContentTypeList($contentTypeIds);
+        $contentTypes = array();
+
+        // @todo We could bulk load content type group proxies involved in the future & pass those relevant per type to mapper
+        foreach ($spiContentTypes as $spiContentType) {
+            $contentTypes[$spiContentType->id] = $this->contentTypeDomainMapper->buildContentTypeDomainObject(
+                $spiContentType,
+                $prioritizedLanguages
+            );
+        }
+
+        return $contentTypes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function loadContentTypes(APIContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [])
     {
         $spiContentTypes = $this->contentTypeHandler->loadContentTypes(

--- a/eZ/Publish/Core/Repository/Helper/DomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/DomainMapper.php
@@ -106,7 +106,7 @@ class DomainMapper
      * Builds a Content domain object from value object returned from persistence.
      *
      * @param \eZ\Publish\SPI\Persistence\Content $spiContent
-     * @param ContentType $contentType
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
      * @param array $prioritizedLanguages Prioritized language codes to filter fields on
      * @param string|null $fieldAlwaysAvailableLanguage Language code fallback if a given field is not found in $prioritizedLanguages
      *

--- a/eZ/Publish/Core/Repository/Helper/DomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/DomainMapper.php
@@ -73,7 +73,7 @@ class DomainMapper
     protected $contentLanguageHandler;
 
     /**
-     * @var FieldTypeRegistry
+     * @var \eZ\Publish\Core\Repository\Helper\FieldTypeRegistry
      */
     protected $fieldTypeRegistry;
 
@@ -83,8 +83,9 @@ class DomainMapper
      * @param \eZ\Publish\SPI\Persistence\Content\Handler $contentHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     * @param \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper $contentTypeDomainMapper
      * @param \eZ\Publish\SPI\Persistence\Content\Language\Handler $contentLanguageHandler
-     * @param FieldTypeRegistry $fieldTypeRegistry
+     * @param \eZ\Publish\Core\Repository\Helper\FieldTypeRegistry $fieldTypeRegistry
      */
     public function __construct(
         ContentHandler $contentHandler,

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -952,6 +952,7 @@ class Repository implements RepositoryInterface
             $this->persistenceHandler->contentHandler(),
             $this->persistenceHandler->locationHandler(),
             $this->persistenceHandler->contentTypeHandler(),
+            $this->getContentTypeDomainMapper(),
             $this->persistenceHandler->contentLanguageHandler(),
             $this->getFieldTypeRegistry()
         );

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
@@ -114,6 +114,13 @@ class ContentTypeService implements ContentTypeServiceInterface
         return $this->service->loadContentTypeDraft($contentTypeId);
     }
 
+    public function loadContentTypeList(array $contentTypeIds, array $prioritizedLanguages = []): iterable
+    {
+        $prioritizedLanguages = $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages);
+
+        return $this->service->loadContentTypeList($contentTypeIds, $prioritizedLanguages);
+    }
+
     public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = null)
     {
         $prioritizedLanguages = $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages);

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Repository as APIRepository;
 use eZ\Publish\Core\Repository\Values\User\User;
 use eZ\Publish\Core\Repository\FieldTypeService;
+use eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper;
 use eZ\Publish\Core\Repository\Helper\FieldTypeRegistry;
 use eZ\Publish\Core\Repository\Helper\NameableFieldTypeRegistry;
 use eZ\Publish\SPI\Persistence\Handler;
@@ -48,6 +49,11 @@ abstract class Base extends TestCase
      * @see getPersistenceMockHandler()
      */
     private $spiMockHandlers = array();
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper
+     */
+    private $contentTypeDomainMapperMock;
 
     /**
      * Get Real repository with mocked dependencies.
@@ -130,6 +136,18 @@ abstract class Base extends TestCase
         }
 
         return $this->repositoryMock;
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper
+     */
+    protected function getContentTypeDomainMapperMock()
+    {
+        if (!isset($this->contentTypeDomainMapperMock)) {
+            $this->contentTypeDomainMapperMock = $this->createMock(ContentTypeDomainMapper::class);
+        }
+
+        return $this->contentTypeDomainMapperMock;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5835,40 +5835,19 @@ class ContentTest extends BaseServiceMockTest
      */
     protected function mockPublishVersion($publicationDate = null, $modificationDate = null)
     {
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
+        $contentInfoMock = $this->createMock(APIContentInfo::class);
         /* @var \PHPUnit\Framework\MockObject\MockObject $contentHandlerMock */
         $contentHandlerMock = $this->getPersistenceMock()->contentHandler();
         $metadataUpdateStruct = new SPIMetadataUpdateStruct();
-
-        $currentTime = time();
-        if ($publicationDate === null && $versionInfoMock->versionNo === 1) {
-            $publicationDate = $currentTime;
-        }
-
-        // Account for 1 second of test execution time
-        $metadataUpdateStruct->publicationDate = $publicationDate;
-        $metadataUpdateStruct->modificationDate = $currentTime;
-        $metadataUpdateStruct2 = clone $metadataUpdateStruct;
-        ++$metadataUpdateStruct2->publicationDate;
-        ++$metadataUpdateStruct2->modificationDate;
 
         $spiContent = new SPIContent([
             'versionInfo' => new VersionInfo([
                     'contentInfo' => new ContentInfo(['id' => 42, 'contentTypeId' => 123]),
             ]),
         ]);
-        $contentHandlerMock->expects($this->once())
-            ->method('publish')
-            ->with(
-                42,
-                123,
-                $this->logicalOr($metadataUpdateStruct, $metadataUpdateStruct2)
-            )
-            ->will($this->returnValue($spiContent));
 
         $contentMock = $this->mockBuildContentDomainObject($spiContent);
-        $versionInfoMock = $this->createMock(APIVersionInfo::class);
-        $contentInfoMock = $this->createMock(APIContentInfo::class);
-
         $contentMock->expects($this->any())
             ->method('__get')
             ->will(
@@ -5915,7 +5894,6 @@ class ContentTest extends BaseServiceMockTest
         $metadataUpdateStruct->publicationDate = $publicationDate;
         $metadataUpdateStruct->modificationDate = $modificationDate ?? $currentTime;
 
-        $spiContent = new SPIContent();
         $contentHandlerMock->expects($this->once())
             ->method('publish')
             ->with(
@@ -5924,11 +5902,6 @@ class ContentTest extends BaseServiceMockTest
                 $metadataUpdateStruct
             )
             ->will($this->returnValue($spiContent));
-
-        $domainMapperMock->expects($this->once())
-            ->method('buildContentDomainObject')
-            ->with($spiContent)
-            ->will($this->returnValue($contentMock));
 
         /* @var \eZ\Publish\API\Repository\Values\Content\Content $contentMock */
         $this->mockPublishUrlAliasesForContent($contentMock);

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
@@ -173,6 +173,7 @@ class DomainMapperTest extends BaseServiceMockTest
             $this->getContentHandlerMock(),
             $this->getPersistenceMockHandler('Content\\Location\\Handler'),
             $this->getTypeHandlerMock(),
+            $this->getContentTypeDomainMapperMock(),
             $this->getLanguageHandlerMock(),
             $this->getFieldTypeRegistryMock()
         );

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/NameSchemaTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/NameSchemaTest.php
@@ -12,7 +12,6 @@ use eZ\Publish\Core\Repository\Helper\NameSchemaService;
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
-use eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\API\Repository\Values\Content\Field;
@@ -393,19 +392,5 @@ class NameSchemaTest extends BaseServiceMockTest
                 ]
             )
             ->getMock();
-    }
-
-    protected $contentTypeDomainMapperMock;
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper
-     */
-    protected function getContentTypeDomainMapperMock()
-    {
-        if (!isset($this->contentTypeDomainMapperMock)) {
-            $this->contentTypeDomainMapperMock = $this->createMock(ContentTypeDomainMapper::class);
-        }
-
-        return $this->contentTypeDomainMapperMock;
     }
 }

--- a/eZ/Publish/Core/Repository/Values/Content/Content.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Content.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
 /**
  * this class represents a content object in a specific version.
@@ -32,6 +33,11 @@ class Content extends APIContent
      * @var \eZ\Publish\API\Repository\Values\Content\VersionInfo
      */
     protected $versionInfo;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\ContentType\ContentType
+     */
+    protected $contentType;
 
     /**
      * @var \eZ\Publish\API\Repository\Values\Content\Field[] An array of {@link Field}
@@ -65,6 +71,14 @@ class Content extends APIContent
     public function getVersionInfo()
     {
         return $this->versionInfo;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContentType(): ContentType
+    {
+        return $this->contentType;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Values/Content/ContentProxy.php
+++ b/eZ/Publish/Core/Repository/Values/Content/ContentProxy.php
@@ -7,6 +7,7 @@
 namespace eZ\Publish\Core\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\GeneratorProxyTrait;
 
 /**
@@ -88,6 +89,15 @@ class ContentProxy extends APIContent
         }
 
         return $this->object->getVersionInfo();
+    }
+
+    public function getContentType(): ContentType
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return $this->object->getContentType();
     }
 
     public function getFieldValue($fieldDefIdentifier, $languageCode = null)

--- a/eZ/Publish/Core/Repository/Values/User/User.php
+++ b/eZ/Publish/Core/Repository/Values/User/User.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
 /**
  * This class represents a user value.
@@ -32,6 +33,11 @@ class User extends APIUser
     public function getVersionInfo()
     {
         return $this->content->getVersionInfo();
+    }
+
+    public function getContentType(): ContentType
+    {
+        return $this->content->getContentType();
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Values/User/UserGroup.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserGroup.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\User\UserGroup as APIUserGroup;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
 /**
  * This class represents a user group.
@@ -32,6 +33,11 @@ class UserGroup extends APIUserGroup
     public function getVersionInfo()
     {
         return $this->content->getVersionInfo();
+    }
+
+    public function getContentType(): ContentType
+    {
+        return $this->content->getContentType();
     }
 
     /**

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Tests\Content;
+
+use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper as ContentTypeMapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as ContentTypeUpdateHandler;
+
+/**
+ * Abstract test suite for legacy search.
+ */
+class AbstractTestCase extends LanguageAwareTestCase
+{
+    private static $setup;
+
+    /**
+     * Field registry mock.
+     *
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry
+     */
+    private $converterRegistry;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    private $contentTypeHandler;
+
+    /**
+     * Only set up once for these read only tests on a large fixture.
+     *
+     * Skipping the reset-up, since setting up for these tests takes quite some
+     * time, which is not required to spent, since we are only reading from the
+     * database anyways.
+     */
+    public function setUp()
+    {
+        if (!self::$setup) {
+            parent::setUp();
+            $this->insertDatabaseFixture(__DIR__ . '/../_fixtures/full_dump.php');
+            self::$setup = $this->handler;
+        } else {
+            $this->handler = self::$setup;
+            $this->connection = $this->handler->getConnection();
+        }
+    }
+
+    /**
+     * Assert that the elements are.
+     */
+    protected function assertSearchResults($expectedIds, $searchResult)
+    {
+        $ids = $this->getIds($searchResult);
+        $this->assertEquals($expectedIds, $ids);
+    }
+
+    protected function getIds($searchResult)
+    {
+        $ids = array_map(
+            function ($hit) {
+                return $hit->valueObject->id;
+            },
+            $searchResult->searchHits
+        );
+
+        sort($ids);
+
+        return $ids;
+    }
+
+    protected function getContentTypeHandler()
+    {
+        if (!isset($this->contentTypeHandler)) {
+            // @todo InMemory handler
+            $this->contentTypeHandler = new ContentTypeHandler(
+                new ContentTypeGateway(
+                    $this->getDatabaseHandler(),
+                    $this->getDatabaseConnection(),
+                    $this->getLanguageMaskGenerator()
+                ),
+                new ContentTypeMapper($this->getConverterRegistry()),
+                $this->createMock(ContentTypeUpdateHandler::class)
+            );
+        }
+
+        return $this->contentTypeHandler;
+    }
+
+    protected function getConverterRegistry()
+    {
+        if (!isset($this->converterRegistry)) {
+            $this->converterRegistry = new ConverterRegistry(
+                array(
+                    'ezdatetime' => new Converter\DateAndTimeConverter(),
+                    'ezinteger' => new Converter\IntegerConverter(),
+                    'ezstring' => new Converter\TextLineConverter(),
+                    'ezprice' => new Converter\IntegerConverter(),
+                    'ezurl' => new Converter\UrlConverter(),
+                    'ezrichtext' => new Converter\RichTextConverter(),
+                    'ezboolean' => new Converter\CheckboxConverter(),
+                    'ezkeyword' => new Converter\KeywordConverter(),
+                    'ezauthor' => new Converter\AuthorConverter(),
+                    'ezimage' => new Converter\NullConverter(),
+                    'ezsrrating' => new Converter\NullConverter(),
+                    'ezmultioption' => new Converter\NullConverter(),
+                )
+            );
+        }
+
+        return $this->converterRegistry;
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
@@ -80,7 +80,6 @@ class AbstractTestCase extends LanguageAwareTestCase
     protected function getContentTypeHandler()
     {
         if (!isset($this->contentTypeHandler)) {
-            // @todo InMemory handler
             $this->contentTypeHandler = new ContentTypeHandler(
                 new ContentTypeGateway(
                     $this->getDatabaseHandler(),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
@@ -8,54 +8,28 @@
  */
 namespace eZ\Publish\Core\Search\Legacy\Tests\Content;
 
-use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
 use eZ\Publish\Core\Search\Legacy\Content;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Query;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandler;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper as ContentTypeMapper;
 use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway as LocationGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as ContentTypeUpdateHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldHandler;
 
 /**
  * Content Search test case for ContentSearchHandler.
  */
-class HandlerContentSortTest extends LanguageAwareTestCase
+class HandlerContentSortTest extends AbstractTestCase
 {
-    protected static $setUp = false;
-
     /**
      * Field registry mock.
      *
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry
      */
     protected $fieldRegistry;
-
-    /**
-     * Only set up once for these read only tests on a large fixture.
-     *
-     * Skipping the reset-up, since setting up for these tests takes quite some
-     * time, which is not required to spent, since we are only reading from the
-     * database anyways.
-     */
-    public function setUp()
-    {
-        if (!self::$setUp) {
-            parent::setUp();
-            $this->insertDatabaseFixture(__DIR__ . '/../_fixtures/full_dump.php');
-            self::$setUp = $this->handler;
-        } else {
-            $this->handler = self::$setUp;
-        }
-    }
 
     /**
      * Returns the content search handler to test.
@@ -114,42 +88,6 @@ class HandlerContentSortTest extends LanguageAwareTestCase
             $this->getLanguageHandler(),
             $this->getFullTextMapper($this->getContentTypeHandler())
         );
-    }
-
-    protected $contentTypeHandler;
-
-    protected function getContentTypeHandler()
-    {
-        if (!isset($this->contentTypeHandler)) {
-            $this->contentTypeHandler = new ContentTypeHandler(
-                new ContentTypeGateway(
-                    $this->getDatabaseHandler(),
-                    $this->getDatabaseConnection(),
-                    $this->getLanguageMaskGenerator()
-                ),
-                new ContentTypeMapper(
-                    new ConverterRegistry(
-                        array(
-                            'ezdatetime' => new Converter\DateAndTimeConverter(),
-                            'ezinteger' => new Converter\IntegerConverter(),
-                            'ezstring' => new Converter\TextLineConverter(),
-                            'ezprice' => new Converter\IntegerConverter(),
-                            'ezurl' => new Converter\UrlConverter(),
-                            'ezrichtext' => new Converter\RichTextConverter(),
-                            'ezboolean' => new Converter\CheckboxConverter(),
-                            'ezkeyword' => new Converter\KeywordConverter(),
-                            'ezauthor' => new Converter\AuthorConverter(),
-                            'ezimage' => new Converter\NullConverter(),
-                            'ezsrrating' => new Converter\NullConverter(),
-                            'ezmultioption' => new Converter\NullConverter(),
-                        )
-                    )
-                ),
-                $this->createMock(ContentTypeUpdateHandler::class)
-            );
-        }
-
-        return $this->contentTypeHandler;
     }
 
     /**

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -8,73 +8,22 @@
  */
 namespace eZ\Publish\Core\Search\Legacy\Tests\Content;
 
-use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
 use eZ\Publish\Core\Persistence;
 use eZ\Publish\Core\Search\Legacy\Content;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandler;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper as ContentTypeMapper;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
 use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway as LocationGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as ContentTypeUpdateHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldHandler;
 
 /**
  * Content Search test case for ContentSearchHandler.
  */
-class HandlerContentTest extends LanguageAwareTestCase
+class HandlerContentTest extends AbstractTestCase
 {
-    protected static $setUp = false;
-
-    /**
-     * Field registry mock.
-     *
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry
-     */
-    protected $fieldRegistry;
-
-    /**
-     * Only set up once for these read only tests on a large fixture.
-     *
-     * Skipping the reset-up, since setting up for these tests takes quite some
-     * time, which is not required to spent, since we are only reading from the
-     * database anyways.
-     */
-    public function setUp()
-    {
-        if (!self::$setUp) {
-            parent::setUp();
-            $this->insertDatabaseFixture(__DIR__ . '/../_fixtures/full_dump.php');
-            self::$setUp = $this->handler;
-        } else {
-            $this->handler = self::$setUp;
-        }
-    }
-
-    /**
-     * Assert that the elements are.
-     */
-    protected function assertSearchResults($expectedIds, $searchResult)
-    {
-        $result = array_map(
-            function ($hit) {
-                return $hit->valueObject->id;
-            },
-            $searchResult->searchHits
-        );
-
-        sort($result);
-
-        $this->assertEquals($expectedIds, $result);
-    }
-
     /**
      * Returns the content search handler to test.
      *
@@ -235,45 +184,6 @@ class HandlerContentTest extends LanguageAwareTestCase
         );
     }
 
-    protected $contentTypeHandler;
-
-    protected function getContentTypeHandler()
-    {
-        if (!isset($this->contentTypeHandler)) {
-            $this->contentTypeHandler = new ContentTypeHandler(
-                new ContentTypeGateway(
-                    $this->getDatabaseHandler(),
-                    $this->getDatabaseConnection(),
-                    $this->getLanguageMaskGenerator()
-                ),
-                new ContentTypeMapper($this->getConverterRegistry()),
-                $this->createMock(ContentTypeUpdateHandler::class)
-            );
-        }
-
-        return $this->contentTypeHandler;
-    }
-
-    protected function getConverterRegistry()
-    {
-        if (!isset($this->fieldRegistry)) {
-            $this->fieldRegistry = new ConverterRegistry(
-                array(
-                    'ezdatetime' => new Converter\DateAndTimeConverter(),
-                    'ezinteger' => new Converter\IntegerConverter(),
-                    'ezstring' => new Converter\TextLineConverter(),
-                    'ezprice' => new Converter\IntegerConverter(),
-                    'ezurl' => new Converter\UrlConverter(),
-                    'ezrichtext' => new Converter\RichTextConverter(),
-                    'ezboolean' => new Converter\CheckboxConverter(),
-                    'ezkeyword' => new Converter\KeywordConverter(),
-                )
-            );
-        }
-
-        return $this->fieldRegistry;
-    }
-
     /**
      * Returns a content mapper mock.
      *
@@ -284,7 +194,7 @@ class HandlerContentTest extends LanguageAwareTestCase
         $mapperMock = $this->getMockBuilder(ContentMapper::class)
             ->setConstructorArgs(
                 array(
-                    $this->fieldRegistry,
+                    $this->getConverterRegistry(),
                     $this->getLanguageHandler(),
                 )
             )

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
@@ -8,7 +8,6 @@
  */
 namespace eZ\Publish\Core\Search\Legacy\Tests\Content;
 
-use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
 use eZ\Publish\Core\Search\Legacy\Content;
 use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
@@ -20,50 +19,15 @@ use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler as L
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseConverter;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler as CommonSortClauseHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler as LocationSortClauseHandler;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandler;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper as ContentTypeMapper;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
 use eZ\Publish\Core\Search\Legacy\Content\Gateway as ContentGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as ContentTypeUpdateHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
 
 /**
  * Location Search test case for ContentSearchHandler.
  */
-class HandlerLocationSortTest extends LanguageAwareTestCase
+class HandlerLocationSortTest extends AbstractTestCase
 {
-    protected static $setUp = false;
-
-    /**
-     * Only set up once for these read only tests on a large fixture.
-     *
-     * Skipping the reset-up, since setting up for these tests takes quite some
-     * time, which is not required to spent, since we are only reading from the
-     * database anyways.
-     */
-    public function setUp()
-    {
-        if (!self::$setUp) {
-            parent::setUp();
-            $this->insertDatabaseFixture(__DIR__ . '/../_fixtures/full_dump.php');
-            self::$setUp = $this->handler;
-        } else {
-            $this->handler = self::$setUp;
-        }
-    }
-
-    /**
-     * Assert that the elements are.
-     */
-    protected function assertSearchResults($expectedIds, $locations)
-    {
-        $ids = $this->getIds($locations);
-        $this->assertEquals($expectedIds, $ids);
-    }
-
     protected function getIds($searchResult)
     {
         $ids = array_map(
@@ -137,51 +101,6 @@ class HandlerLocationSortTest extends LanguageAwareTestCase
             $this->getLanguageHandler(),
             $this->getFullTextMapper($this->getContentTypeHandler())
         );
-    }
-
-    protected $contentTypeHandler;
-
-    protected function getContentTypeHandler()
-    {
-        if (!isset($this->contentTypeHandler)) {
-            $this->contentTypeHandler = new ContentTypeHandler(
-                new ContentTypeGateway(
-                    $this->getDatabaseHandler(),
-                    $this->getDatabaseConnection(),
-                    $this->getLanguageMaskGenerator()
-                ),
-                new ContentTypeMapper($this->getConverterRegistry()),
-                $this->createMock(ContentTypeUpdateHandler::class)
-            );
-        }
-
-        return $this->contentTypeHandler;
-    }
-
-    protected $fieldRegistry;
-
-    protected function getConverterRegistry()
-    {
-        if (!isset($this->fieldRegistry)) {
-            $this->fieldRegistry = new ConverterRegistry(
-                array(
-                    'ezdatetime' => new Converter\DateAndTimeConverter(),
-                    'ezinteger' => new Converter\IntegerConverter(),
-                    'ezstring' => new Converter\TextLineConverter(),
-                    'ezprice' => new Converter\IntegerConverter(),
-                    'ezurl' => new Converter\UrlConverter(),
-                    'ezrichtext' => new Converter\RichTextConverter(),
-                    'ezboolean' => new Converter\CheckboxConverter(),
-                    'ezkeyword' => new Converter\KeywordConverter(),
-                    'ezauthor' => new Converter\AuthorConverter(),
-                    'ezimage' => new Converter\NullConverter(),
-                    'ezsrrating' => new Converter\NullConverter(),
-                    'ezmultioption' => new Converter\NullConverter(),
-                )
-            );
-        }
-
-        return $this->fieldRegistry;
     }
 
     /**

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
@@ -8,7 +8,6 @@
  */
 namespace eZ\Publish\Core\Search\Legacy\Tests\Content;
 
-use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
 use eZ\Publish\Core\Persistence;
 use eZ\Publish\Core\Search\Legacy\Content;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
@@ -21,58 +20,15 @@ use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler as L
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler as CommonCriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler as LocationSortClauseHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler as CommonSortClauseHandler;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper as ContentTypeMapper;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Gateway as ContentGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as ContentTypeUpdateHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
 
 /**
  * Location Search test case for ContentSearchHandler.
  */
-class HandlerLocationTest extends LanguageAwareTestCase
+class HandlerLocationTest extends AbstractTestCase
 {
-    protected static $setUp = false;
-
-    /**
-     * Only set up once for these read only tests on a large fixture.
-     *
-     * Skipping the reset-up, since setting up for these tests takes quite some
-     * time, which is not required to spent, since we are only reading from the
-     * database anyways.
-     */
-    public function setUp()
-    {
-        if (!self::$setUp) {
-            parent::setUp();
-            $this->insertDatabaseFixture(__DIR__ . '/../_fixtures/full_dump.php');
-            self::$setUp = $this->handler;
-        } else {
-            $this->handler = self::$setUp;
-        }
-    }
-
-    /**
-     * Assert that the elements are.
-     */
-    protected function assertSearchResults($expectedIds, $searchResult)
-    {
-        $ids = array_map(
-            function ($hit) {
-                return $hit->valueObject->id;
-            },
-            $searchResult->searchHits
-        );
-
-        sort($ids);
-
-        $this->assertEquals($expectedIds, $ids);
-    }
-
     /**
      * Returns the location search handler to test.
      *
@@ -205,47 +161,6 @@ class HandlerLocationTest extends LanguageAwareTestCase
             $this->getLanguageHandler(),
             $this->getFullTextMapper($this->getContentTypeHandler())
         );
-    }
-
-    protected $contentTypeHandler;
-
-    protected function getContentTypeHandler()
-    {
-        if (!isset($this->contentTypeHandler)) {
-            $this->contentTypeHandler = new ContentTypeHandler(
-                new ContentTypeGateway(
-                    $this->getDatabaseHandler(),
-                    $this->getDatabaseConnection(),
-                    $this->getLanguageMaskGenerator()
-                ),
-                new ContentTypeMapper($this->getConverterRegistry()),
-                $this->createMock(ContentTypeUpdateHandler::class)
-            );
-        }
-
-        return $this->contentTypeHandler;
-    }
-
-    protected $fieldRegistry;
-
-    protected function getConverterRegistry()
-    {
-        if (!isset($this->fieldRegistry)) {
-            $this->fieldRegistry = new ConverterRegistry(
-                array(
-                    'ezdatetime' => new Converter\DateAndTimeConverter(),
-                    'ezinteger' => new Converter\IntegerConverter(),
-                    'ezstring' => new Converter\TextLineConverter(),
-                    'ezprice' => new Converter\IntegerConverter(),
-                    'ezurl' => new Converter\UrlConverter(),
-                    'ezrichtext' => new Converter\RichTextConverter(),
-                    'ezboolean' => new Converter\CheckboxConverter(),
-                    'ezkeyword' => new Converter\KeywordConverter(),
-                )
-            );
-        }
-
-        return $this->fieldRegistry;
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/ContentTypeService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentTypeService.php
@@ -238,6 +238,14 @@ class ContentTypeService implements ContentTypeServiceInterface
     /**
      * {@inheritdoc}
      */
+    public function loadContentTypeList(array $contentTypeIds, array $prioritizedLanguages = []): iterable
+    {
+        return $this->service->loadContentTypeList($contentTypeIds, $prioritizedLanguages);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [])
     {
         return $this->service->loadContentTypes($contentTypeGroup, $prioritizedLanguages);

--- a/eZ/Publish/SPI/Persistence/Content/Type.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\ValueObject;
 
 /**
- * @todo What about sort_field and sort_order?
+ * SPI Persistence Content\Type value object.
  */
 class Type extends ValueObject
 {
@@ -173,14 +173,17 @@ class Type extends ValueObject
     public $groupIds = array();
 
     /**
-     * Content fields in this type.
+     * Definitions for Content fields in this type.
      *
      * @var \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition[]
      */
     public $fieldDefinitions = array();
 
     /**
-     * @todo: Document.
+     * Defines if content objects should have always available enabled or not by default.
+     *
+     * Always available (when enabled) means main language is always available, and works as a editorial fallback
+     * language on load operations when translation filter is provided but no match is found.
      *
      * @var bool
      */

--- a/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
@@ -82,6 +82,18 @@ interface Handler
     public function loadContentTypes($groupId, $status = Type::STATUS_DEFINED);
 
     /**
+     * Return list of unique Content Types, with type id as key.
+     *
+     * Missing items (NotFound) will be missing from the array and not cause an exception, it's up
+     * to calling logic to determine if this should cause exception or not.
+     *
+     * @param mixed $contentTypeIds
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\Type[]
+     */
+    public function loadContentTypeList(array $contentTypeIds): array;
+
+    /**
      * Loads a content type by id and status.
      *
      * Note: This method is responsible of having the Field Definitions of the loaded ContentType sorted by placement.

--- a/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
@@ -87,7 +87,7 @@ interface Handler
      * Missing items (NotFound) will be missing from the array and not cause an exception, it's up
      * to calling logic to determine if this should cause exception or not.
      *
-     * @param mixed $contentTypeIds
+     * @param mixed[] $contentTypeIds
      *
      * @return \eZ\Publish\SPI\Persistence\Content\Type[]
      */

--- a/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
@@ -87,7 +87,7 @@ interface Handler
      * Missing items (NotFound) will be missing from the array and not cause an exception, it's up
      * to calling logic to determine if this should cause exception or not.
      *
-     * @param mixed[] $contentTypeIds
+     * @param array $contentTypeIds
      *
      * @return \eZ\Publish\SPI\Persistence\Content\Type[]
      */


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29613](https://jira.ez.no/browse/EZP-29613)
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Like in #2328 where `Location->getContent()` was added, this is about adding `Content->getContentType()` to avoid having to deal with loading logic **and** also furthermore to avoid repeated loads of content types in the system when we already have the Type _(as we need it to build Content anyway)_ and can thus pass it around on Content Items.

This breaks the internal `Repository\Helper\DomainMapper->buildContentDomainObject()` a bit in that it now requires ContentType to be passed instead of implicit loading it for you from SPI if not provided. This is done to make us more aware of the loading going on and take advantage to optimize _(done several places in this PR)_.


This implicit involves improving performance:
- No repeated content types loading when calling field functions in Twig, as they can now use this
  - No implicit repeated loads for same language when having to build these content types
- Add possibility to bulk load ContentTypes in SPI in order to handle this even more efficient when bulk loading content _(when bulk load Content and on Location/Content Search results)_

Reduced cache lookups just with this on clean install: 84/184 => 44/139
Heavy use of twig field functions will see more noticeable gains, and there might be cases in other bundles (PageBuilder?) where we can now optimize and take advantage of `getContent()` and `getContentType()`. But for other cases re-introducing a safe form of inMemory cache will provide grater gains _(For more context/info on that see JIRA issue)_.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [x] Take advantage in Admin UI: https://github.com/ezsystems/ezplatform-admin-ui/pull/633
