### PR TITLE
[Tests] Fixed Twig integration tests warning about method prototype

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
@@ -29,7 +29,7 @@ abstract class FileSystemTwigIntegrationTestCase extends Twig_Test_IntegrationTe
      * Overrides the default implementation to use the chain loader so that
      * templates used internally are correctly loaded.
      */
-    protected function doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs)
+    protected function doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
     {
         if ($condition) {
             eval('$ret = ' . $condition . ';');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`+
| **BC breaks**      | no
| **Tests pass**     | let's see...
| **Doc needed**     | no

In Twig 2.0 the prototype of `\Twig_Test_IntegrationTestCase::doIntegrationTest`
changed and since we extend that class, it results in a warning:

```
PHP Warning:  Declaration of eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension\FileSystemTwigIntegrationTestCase::doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs) should be compatible with Twig_Test_IntegrationTestCase::doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
```

Since we allow usage of PHP7 and Symfony 3.4 in ezpublish-kernel `6.7`, we should align our code here as well.

Note that for Twig 1.x it works as a forward compatibility layer, not resulting in any warning.

**TODO**:
- [x] Align the prototype of `eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension\FileSystemTwigIntegrationTestCase::doIntegrationTest` with the base method.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
