### PR TITLE
[Unit Tests] Replaced deprecated getMock with createMock

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/BackgroundIndexingTerminateListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/BackgroundIndexingTerminateListenerTest.php
@@ -10,7 +10,6 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;
 
 use eZ\Bundle\EzPublishCoreBundle\EventListener\BackgroundIndexingTerminateListener;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
-use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\SPI\Persistence\Content\Location;
@@ -23,8 +22,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class BackgroundIndexingTerminateListenerTest extends TestCase
 {
-    use PHPUnit5CompatTrait;
-
     /**
      * @var \eZ\Bundle\EzPublishCoreBundle\EventListener\BackgroundIndexingTerminateListener
      */

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
@@ -12,7 +12,6 @@ use eZ\Bundle\EzPublishCoreBundle\Imagine\AliasGenerator;
 use eZ\Bundle\EzPublishCoreBundle\Imagine\Variation\ImagineAwareAliasGenerator;
 use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
 use eZ\Publish\API\Repository\Values\Content\Field;
-use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
 use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
 use eZ\Publish\SPI\FieldType\Value as FieldTypeValue;
@@ -33,8 +32,6 @@ use Psr\Log\LoggerInterface;
 
 class AliasGeneratorTest extends TestCase
 {
-    use PHPUnit5CompatTrait;
-
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Liip\ImagineBundle\Binary\Loader\LoaderInterface
      */

--- a/eZ/Publish/Core/Base/Tests/PHPUnit5CompatTrait.php
+++ b/eZ/Publish/Core/Base/Tests/PHPUnit5CompatTrait.php
@@ -9,6 +9,8 @@ namespace eZ\Publish\Core\Base\Tests;
 
 /**
  * Trait for PHPUnit 5 Forward Compatibility, for PHPUnit 4.8 use and up.
+ *
+ * @deprecated since 6.13.5, use createMock from PHPUnit package instead.
  */
 trait PHPUnit5CompatTrait
 {
@@ -30,24 +32,5 @@ trait PHPUnit5CompatTrait
             $callOriginalMethods,
             $proxyTarget
         );
-    }
-
-    /**
-     * Returns a test double for the specified class.
-     *
-     * @internal Forward compatibility with PHPUnit 5/6, so unit tests written on 6.7 & backported to 5.4 can use this.
-     *
-     * @param string $originalClassName
-     *
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function createMock($originalClassName)
-    {
-        return $this->getMockBuilder($originalClassName)
-            ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning()
-            //->disallowMockingUnknownTypes() Not defined in PHPunit 4.8
-            ->getMock();
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/RichText/InternalLinkValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/InternalLinkValidatorTest.php
@@ -10,15 +10,12 @@ namespace eZ\Publish\Core\FieldType\Tests\RichText;
 
 use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
-use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\FieldType\RichText\InternalLinkValidator;
 use PHPUnit\Framework\TestCase;
 
 class InternalLinkValidatorTest extends TestCase
 {
-    use PHPUnit5CompatTrait;
-
     /** @var \eZ\Publish\SPI\Persistence\Content\Handler|\PHPUnit_Framework_MockObject_MockObject */
     private $contentHandler;
 

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/InstantCachePurgerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/InstantCachePurgerTest.php
@@ -11,7 +11,6 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\User\UserReference;
-use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\InstantCachePurger;
 use eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface;
 use eZ\Publish\Core\MVC\Symfony\Event\ContentCacheClearEvent;
@@ -28,8 +27,6 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class InstantCachePurgerTest extends TestCase
 {
-    use PHPUnit5CompatTrait;
-
     /**
      * @var \eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface|\PHPUnit_Framework_MockObject_MockObject
      */

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
@@ -11,7 +11,6 @@ namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\User\User as ApiUser;
 use eZ\Publish\API\Repository\Values\User\UserReference;
-use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 use eZ\Publish\Core\MVC\Symfony\Security\Authentication\RememberMeRepositoryAuthenticationProvider;
 use eZ\Publish\Core\MVC\Symfony\Security\User;
 use eZ\Publish\Core\Repository\Helper\LimitationService;
@@ -26,8 +25,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class RememberMeRepositoryAuthenticationProviderTest extends TestCase
 {
-    use PHPUnit5CompatTrait;
-
     /**
      * @var RememberMeRepositoryAuthenticationProvider
      */

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -303,7 +303,7 @@ class ContentHandlerTest extends HandlerTest
     public function testLoadVersionInfoCacheIsMiss()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock(ItemInterface::class);
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -320,7 +320,7 @@ class ContentHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock(Handler::class);
+        $innerHandlerMock = $this->createMock(Handler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentHandler')
@@ -357,7 +357,7 @@ class ContentHandlerTest extends HandlerTest
     public function testLoadVersionInfoHasCache()
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
-        $cacheItemMock = $this->getMock(ItemInterface::class);
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/TestCase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/TestCase.php
@@ -8,7 +8,6 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests;
 
-use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 use eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use PHPUnit\Framework\TestCase as BaseTestCase;
@@ -21,8 +20,6 @@ use Exception;
  */
 abstract class TestCase extends BaseTestCase
 {
-    use PHPUnit5CompatTrait;
-
     /**
      * DSN used for the DB backend.
      *

--- a/eZ/Publish/Core/REST/Server/Tests/Security/CsrfTokenManagerTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Security/CsrfTokenManagerTest.php
@@ -8,7 +8,6 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Security;
 
-use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 use eZ\Publish\Core\REST\Server\Security\CsrfTokenManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,8 +17,6 @@ use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
 
 class CsrfTokenManagerTest extends TestCase
 {
-    use PHPUnit5CompatTrait;
-
     const CSRF_TOKEN_INTENTION = 'csrf';
 
     /** @var \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface */

--- a/eZ/Publish/Core/REST/Server/Tests/Security/RestLogoutHandlerTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Security/RestLogoutHandlerTest.php
@@ -8,7 +8,6 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Security;
 
-use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\REST\Server\Security\RestLogoutHandler;
 use PHPUnit\Framework\TestCase;
@@ -20,8 +19,6 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class RestLogoutHandlerTest extends TestCase
 {
-    use PHPUnit5CompatTrait;
-
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -6,7 +6,6 @@
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
-use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 use eZ\Publish\Core\Repository\Helper\RelationProcessor;
 use eZ\Publish\Core\Search\Common\BackgroundIndexer\NullIndexer;
 use PHPUnit\Framework\TestCase;
@@ -21,8 +20,6 @@ use eZ\Publish\Core\Repository\Values\User\User;
  */
 abstract class Base extends TestCase
 {
-    use PHPUnit5CompatTrait;
-
     /**
      * @var \eZ\Publish\API\Repository\Repository
      */
@@ -203,12 +200,7 @@ abstract class Base extends TestCase
 
     protected function getRelationProcessorMock()
     {
-        return $this->getMock(RelationProcessor::class,
-            array(),
-            array(),
-            '',
-            false
-        );
+        return $this->createMock(RelationProcessor::class);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
@@ -266,7 +266,7 @@ class RelationProcessorTest extends BaseServiceMockTest
     public function testAppendFieldRelationsLogsMissingLocations()
     {
         $fieldValueMock = $this->getMockForAbstractClass(Value::class);
-        $fieldTypeMock = $this->getMock(FieldType::class);
+        $fieldTypeMock = $this->createMock(FieldType::class);
 
         $locationId = 123465;
         $fieldDefinitionId = 42;
@@ -290,9 +290,9 @@ class RelationProcessorTest extends BaseServiceMockTest
             ->expects($this->any())
             ->method('load')
             ->with($locationId)
-            ->willThrowException($this->getMock(NotFoundException::class));
+            ->willThrowException($this->createMock(NotFoundException::class));
 
-        $logger = $this->getMock(LoggerInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
         $logger
             ->expects($this->once())
             ->method('error')


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR replaces PHPUnit's deprecated getMock with createMock and deprecates PHPUnit5CompatTrait.
It's been causing [a lot of warnings](https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/428329482#L899) when executing tests, so it's the highest time to improve that.

**TODO**:
- [x] Replace deprecated getMock with createMock
- [x] Deprecate `PHPUnit5CompatTrait`
- [x] Remove `createMock` from `PHPUnit5CompatTrait` as current version of PHPUnit has it.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
