### PR TITLE
EZP-29619: StashPass should check if config[caches] is set

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/StashPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/StashPass.php
@@ -30,9 +30,11 @@ class StashPass implements CompilerPassInterface
 
         $config = $container->getExtensionConfig('stash');
         $config = reset($config);
-        foreach ($config['caches'] as $name => $configuration) {
-            if (in_array('Redis', $configuration['drivers'], true)) {
-                $this->configureRedis($container, $igbinary, $lzf);
+        if (isset($config['caches'])) {
+            foreach ($config['caches'] as $name => $configuration) {
+                if (in_array('Redis', $configuration['drivers'], true)) {
+                    $this->configureRedis($container, $igbinary, $lzf);
+                }
             }
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29619](https://jira.ez.no/browse/EZP-29619)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`/`6.13` (`5.4`: https://github.com/ezsystems/ezpublish-kernel-ee/pull/186)
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

As mentioned in the JIRA ticket, there should be an additional check if the Stash configuration even exists. 


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
