### PR TITLE
 EZP-29508: As an editor I want to manage ALT field with an image asset field type

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -422,9 +422,13 @@
 <figure {{ block( 'field_attributes' ) }}>
     {% set imageAlias = ez_image_alias( field, versionInfo, parameters.alias|default( 'original' ) ) %}
     {% set src = imageAlias ? asset( imageAlias.uri ) : "//:0" %}
-    {% set width = parameters.width is defined ? parameters.width : (imageAlias ? imageAlias.width : '') %}
-    {% set height = parameters.height is defined ? parameters.height : (imageAlias ? imageAlias.height : '') %}
-    <img src="{{ src }}"{% if width %} width="{{ width }}"{% endif %}{% if height %} height="{{ height }}"{% endif %} alt="{% if parameters.alternativeText is defined and parameters.alternativeText is not empty %}{{ parameters.alternativeText }}{% else %}{{ field.value.alternativeText }}{% endif %}"{% if parameters.class is defined and parameters.class is not empty %} class="{{ parameters.class }}"{% endif %} />
+    {% set attrs = {
+        class: parameters.class|default(''),
+        height: parameters.height is defined ? parameters.height : (imageAlias ? imageAlias.height : ''),
+        width: parameters.width is defined ? parameters.width : (imageAlias ? imageAlias.width : ''),
+    } %}
+
+    <img src="{{ src }}" alt="{{ parameters.alternativeText|default(field.value.alternativeText) }}" {% for attrname, attrvalue in attrs if attrvalue %}{{ attrname }}="{{ attrvalue }} " {% endfor %}/>
 </figure>
 {% endif %}
 {% endspaceless %}
@@ -440,7 +444,7 @@
                     viewType: 'asset_image',
                     noLayout: true,
                     params: {
-                        parameters: parameters|default({'alias': 'original'})|merge({ alternativeText: field.value.alternativeText })
+                        parameters: parameters|default({'alias': 'original'})|merge({'alternativeText': field.value.alternativeText })
                     }
                 }))}}
             </div>

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -424,7 +424,7 @@
     {% set src = imageAlias ? asset( imageAlias.uri ) : "//:0" %}
     {% set width = parameters.width is defined ? parameters.width : (imageAlias ? imageAlias.width : '') %}
     {% set height = parameters.height is defined ? parameters.height : (imageAlias ? imageAlias.height : '') %}
-    <img src="{{ src }}"{% if width %} width="{{ width }}"{% endif %}{% if height %} height="{{ height }}"{% endif %} alt="{{ field.value.alternativeText }}"{% if parameters.class is defined and parameters.class is not empty %} class="{{ parameters.class }}"{% endif %} />
+    <img src="{{ src }}"{% if width %} width="{{ width }}"{% endif %}{% if height %} height="{{ height }}"{% endif %} alt="{% if parameters.alternativeText is defined and parameters.alternativeText is not empty %}{{ parameters.alternativeText }}{% else %}{{ field.value.alternativeText }}{% endif %}"{% if parameters.class is defined and parameters.class is not empty %} class="{{ parameters.class }}"{% endif %} />
 </figure>
 {% endif %}
 {% endspaceless %}
@@ -440,7 +440,7 @@
                     viewType: 'asset_image',
                     noLayout: true,
                     params: {
-                        parameters: parameters|default({'alias': 'original'})
+                        parameters: parameters|default({'alias': 'original'})|merge({ alternativeText: field.value.alternativeText })
                     }
                 }))}}
             </div>

--- a/eZ/Publish/Core/FieldType/ImageAsset/Type.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/Type.php
@@ -219,7 +219,7 @@ class Type extends FieldType
     {
         return [
             'destinationContentId' => $value->destinationContentId,
-            'alternativeText' => $value->alternativeText
+            'alternativeText' => $value->alternativeText,
         ];
     }
 

--- a/eZ/Publish/Core/FieldType/ImageAsset/Type.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/Type.php
@@ -169,6 +169,14 @@ class Type extends FieldType
                 $value->destinationContentId
             );
         }
+
+        if ($value->alternativeText !== null && !is_string($value->alternativeText)) {
+            throw new InvalidArgumentType(
+                '$value->alternativeText',
+                'string|null',
+                $value->alternativeText
+            );
+        }
     }
 
     /**
@@ -194,7 +202,7 @@ class Type extends FieldType
     public function fromHash($hash): Value
     {
         if ($hash) {
-            return new Value($hash['destinationContentId']);
+            return new Value($hash['destinationContentId'], $hash['alternativeText']);
         }
 
         return new Value();
@@ -211,6 +219,7 @@ class Type extends FieldType
     {
         return [
             'destinationContentId' => $value->destinationContentId,
+            'alternativeText' => $value->alternativeText
         ];
     }
 

--- a/eZ/Publish/Core/FieldType/ImageAsset/Value.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/Value.php
@@ -20,12 +20,21 @@ class Value extends BaseValue
     public $destinationContentId;
 
     /**
-     * @param mixed|null $destinationContentId
+     * The alternative image text (for example "Picture of an apple.").
+     *
+     * @var string|null
      */
-    public function __construct($destinationContentId = null)
+    public $alternativeText;
+
+    /**
+     * @param mixed|null $destinationContentId
+     * @param string|null $alternativeText
+     */
+    public function __construct($destinationContentId = null, ?string $alternativeText = null)
     {
         parent::__construct([
             'destinationContentId' => $destinationContentId,
+            'alternativeText' => $alternativeText
         ]);
     }
 

--- a/eZ/Publish/Core/FieldType/ImageAsset/Value.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/Value.php
@@ -34,7 +34,7 @@ class Value extends BaseValue
     {
         parent::__construct([
             'destinationContentId' => $destinationContentId,
-            'alternativeText' => $alternativeText
+            'alternativeText' => $alternativeText,
         ]);
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
@@ -129,7 +129,7 @@ class ImageAssetTest extends FieldTypeTest
                     'id' => $destinationContentId,
                 ]),
                 new ImageAsset\Value($destinationContentId),
-            ]
+            ],
         ];
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
@@ -147,7 +147,7 @@ class ImageAssetTest extends FieldTypeTest
                 new ImageAsset\Value(),
                 [
                     'destinationContentId' => null,
-                    'alternativeText' => null
+                    'alternativeText' => null,
                 ],
             ],
             [
@@ -183,14 +183,14 @@ class ImageAssetTest extends FieldTypeTest
             [
                 [
                     'destinationContentId' => $destinationContentId,
-                    'alternativeText' => null
+                    'alternativeText' => null,
                 ],
                 new ImageAsset\Value($destinationContentId),
             ],
             [
                 [
                     'destinationContentId' => $destinationContentId,
-                    'alternativeText' => $alternativeText
+                    'alternativeText' => $alternativeText,
                 ],
                 new ImageAsset\Value($destinationContentId, $alternativeText),
             ],

--- a/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
@@ -114,6 +114,7 @@ class ImageAssetTest extends FieldTypeTest
     public function provideValidInputForAcceptValue(): array
     {
         $destinationContentId = 7;
+        $alternativeText = 'The alternative text for image';
 
         return [
             [
@@ -139,18 +140,28 @@ class ImageAssetTest extends FieldTypeTest
     public function provideInputForToHash(): array
     {
         $destinationContentId = 7;
+        $alternativeText = 'The alternative text for image';
 
         return [
             [
                 new ImageAsset\Value(),
                 [
                     'destinationContentId' => null,
+                    'alternativeText' => null
                 ],
             ],
             [
                 new ImageAsset\Value($destinationContentId),
                 [
                     'destinationContentId' => $destinationContentId,
+                    'alternativeText' => null,
+                ],
+            ],
+            [
+                new ImageAsset\Value($destinationContentId, $alternativeText),
+                [
+                    'destinationContentId' => $destinationContentId,
+                    'alternativeText' => $alternativeText,
                 ],
             ],
         ];
@@ -162,6 +173,7 @@ class ImageAssetTest extends FieldTypeTest
     public function provideInputForFromHash(): array
     {
         $destinationContentId = 7;
+        $alternativeText = 'The alternative text for image';
 
         return [
             [
@@ -171,8 +183,16 @@ class ImageAssetTest extends FieldTypeTest
             [
                 [
                     'destinationContentId' => $destinationContentId,
+                    'alternativeText' => null
                 ],
                 new ImageAsset\Value($destinationContentId),
+            ],
+            [
+                [
+                    'destinationContentId' => $destinationContentId,
+                    'alternativeText' => $alternativeText
+                ],
+                new ImageAsset\Value($destinationContentId, $alternativeText),
             ],
         ];
     }

--- a/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
@@ -114,7 +114,6 @@ class ImageAssetTest extends FieldTypeTest
     public function provideValidInputForAcceptValue(): array
     {
         $destinationContentId = 7;
-        $alternativeText = 'The alternative text for image';
 
         return [
             [
@@ -130,7 +129,7 @@ class ImageAssetTest extends FieldTypeTest
                     'id' => $destinationContentId,
                 ]),
                 new ImageAsset\Value($destinationContentId),
-            ],
+            ]
         ];
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageAssetConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageAssetConverter.php
@@ -27,6 +27,9 @@ class ImageAssetConverter implements Converter
         $storageFieldValue->dataInt = !empty($value->data['destinationContentId'])
             ? $value->data['destinationContentId']
             : null;
+        $storageFieldValue->dataText = !empty($value->data['alternativeText'])
+            ? $value->data['alternativeText']
+            : null;
         $storageFieldValue->sortKeyInt = (int)$value->sortKey;
     }
 
@@ -40,6 +43,7 @@ class ImageAssetConverter implements Converter
     {
         $fieldValue->data = [
             'destinationContentId' => $value->dataInt ?: null,
+            'alternativeText' => $value->dataText ?: null,
         ];
         $fieldValue->sortKey = (int)$value->sortKeyInt;
     }

--- a/eZ/Publish/SPI/Tests/FieldType/ImageAssetIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageAssetIntegrationTest.php
@@ -87,7 +87,7 @@ class ImageAssetIntegrationTest extends BaseIntegrationTest
             [
                 'data' => [
                     'destinationContentId' => 1,
-                    'alternativeText' => null
+                    'alternativeText' => null,
                 ],
                 'externalData' => null,
                 'sortKey' => null,
@@ -95,7 +95,7 @@ class ImageAssetIntegrationTest extends BaseIntegrationTest
             [
                 'data' => [
                     'destinationContentId' => 1,
-                    'alternativeText' => 'The alternative text'
+                    'alternativeText' => 'The alternative text',
                 ],
                 'externalData' => null,
                 'sortKey' => null,
@@ -112,7 +112,7 @@ class ImageAssetIntegrationTest extends BaseIntegrationTest
             [
                 'data' => [
                     'destinationContentId' => 2,
-                    'alternativeText' => null
+                    'alternativeText' => null,
                 ],
                 'externalData' => null,
                 'sortKey' => null,
@@ -120,7 +120,7 @@ class ImageAssetIntegrationTest extends BaseIntegrationTest
             [
                 'data' => [
                     'destinationContentId' => 2,
-                    'alternativeText' => 'The alternative text'
+                    'alternativeText' => 'The alternative text',
                 ],
                 'externalData' => null,
                 'sortKey' => null,

--- a/eZ/Publish/SPI/Tests/FieldType/ImageAssetIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageAssetIntegrationTest.php
@@ -87,6 +87,15 @@ class ImageAssetIntegrationTest extends BaseIntegrationTest
             [
                 'data' => [
                     'destinationContentId' => 1,
+                    'alternativeText' => null
+                ],
+                'externalData' => null,
+                'sortKey' => null,
+            ],
+            [
+                'data' => [
+                    'destinationContentId' => 1,
+                    'alternativeText' => 'The alternative text'
                 ],
                 'externalData' => null,
                 'sortKey' => null,
@@ -103,6 +112,15 @@ class ImageAssetIntegrationTest extends BaseIntegrationTest
             [
                 'data' => [
                     'destinationContentId' => 2,
+                    'alternativeText' => null
+                ],
+                'externalData' => null,
+                'sortKey' => null,
+            ],
+            [
+                'data' => [
+                    'destinationContentId' => 2,
+                    'alternativeText' => 'The alternative text'
                 ],
                 'externalData' => null,
                 'sortKey' => null,


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29508](https://jira.ez.no/browse/EZP-29508)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Impl. possibility to define Alternative Text for Image Asset. 

<img width="1016" alt="zrzut ekranu 2018-09-18 o 13 03 44" src="https://user-images.githubusercontent.com/211967/45683251-49ca5580-bb43-11e8-8709-7ae707155106.png">

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
