### PR TITLE
[POC] EZP-29659: As a v2 User I want support for InMemory SPI cache

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/CacheFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/CacheFactory.php
@@ -17,7 +17,9 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 /**
  * Class CacheFactory.
  *
- * Service "ezpublish.cache_pool", selects a Symfony cache service based on siteaccess[-group] setting "cache_service_name"
+ * Private service "ezpublish.cache_pool_inner", selects a Symfony cache service based on siteaccess[-group] setting "cache_service_name".
+ *
+ * Will either as alias or decorated returned as part of public "ezpublish.cache_pool".
  */
 class CacheFactory implements ContainerAwareInterface
 {

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
@@ -1,9 +1,5 @@
 services:
     # This overrides default cache pool in eZ/Publish/Core/settings/storage_engines/cache.yml
-    ezpublish.cache_pool:
-      class: eZ\Publish\Core\Persistence\Cache\Adapter\InMemoryCacheAdapter
-      arguments: ["@ezpublish.cache_pool_inner"]
-
     ezpublish.cache_pool_inner:
         class: Symfony\Component\Cache\Adapter\TagAwareAdapterInterface
         lazy: true

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
@@ -1,20 +1,21 @@
-parameters:
-    ezpublish.cache_pool.factory.class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\CacheFactory
-
 services:
-    # Parameter %ezpublish.cache_pool.class% and cache decorator service are defined
-    # in Core configuration, see eZ/Publish/Core/settings/storage_engines/cache.yml for details
+    # This overrides default cache pool in eZ/Publish/Core/settings/storage_engines/cache.yml
     ezpublish.cache_pool:
-        class: "%ezpublish.cache_pool.class%"
+      class: eZ\Publish\Core\Persistence\Cache\Adapter\InMemoryCacheAdapter
+      arguments: ["@ezpublish.cache_pool_inner"]
+
+    ezpublish.cache_pool_inner:
+        class: Symfony\Component\Cache\Adapter\TagAwareAdapterInterface
         lazy: true
         factory: ["@ezpublish.cache_pool.factory", getCachePool]
         arguments: ["@ezpublish.config.resolver"]
 
     ezpublish.cache_pool.factory:
-        class: "%ezpublish.cache_pool.factory.class%"
+        class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\CacheFactory
         calls:
             - [setContainer, ["@service_container"]]
 
+    # Cache warmer to rest config resolver on cache clear/warmup
     ezpublish.cache_warmer.config_resolver_cleanup:
         class: eZ\Bundle\EzPublishCoreBundle\Cache\Warmer\ConfigResolverCleanup
         calls:

--- a/eZ/Publish/API/Repository/Tests/Regression/EnvTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EnvTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\API\Repository\Tests\Regression;
 
 use eZ\Publish\API\Repository\Tests\BaseTest;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
@@ -25,6 +26,7 @@ class EnvTest extends BaseTest
     {
         $pool = $this->getSetupFactory()->getServiceContainer()->get('ezpublish.cache_pool');
 
+        $this->assertInstanceOf(TagAwareAdapterInterface::class, $pool);
         $this->assertInstanceOf(TagAwareAdapter::class, $pool);
 
         $reflectionPool = new \ReflectionProperty($pool, 'pool');

--- a/eZ/Publish/API/Repository/Tests/Regression/EnvTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EnvTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\API\Repository\Tests\Regression;
 
 use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\Core\Persistence\Cache\Adapter\InMemoryCacheAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
@@ -25,6 +26,13 @@ class EnvTest extends BaseTest
     public function testVerifyCacheDriver()
     {
         $pool = $this->getSetupFactory()->getServiceContainer()->get('ezpublish.cache_pool');
+
+        $this->assertInstanceOf(TagAwareAdapterInterface::class, $pool);
+        $this->assertInstanceOf(InMemoryCacheAdapter::class, $pool);
+
+        $reflectionPool = new \ReflectionProperty($pool, 'pool');
+        $reflectionPool->setAccessible(true);
+        $pool = $reflectionPool->getValue($pool);
 
         $this->assertInstanceOf(TagAwareAdapterInterface::class, $pool);
         $this->assertInstanceOf(TagAwareAdapter::class, $pool);

--- a/eZ/Publish/Core/Persistence/Cache/Adapter/InMemoryCacheAdapter.php
+++ b/eZ/Publish/Core/Persistence/Cache/Adapter/InMemoryCacheAdapter.php
@@ -1,0 +1,268 @@
+<?php
+
+/**
+ * File containing the ContentHandler implementation.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Cache\Adapter;
+
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Variation\Values\Variation;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Psr\Cache\CacheItemInterface;
+
+final class InMemoryCacheAdapter implements TagAwareAdapterInterface
+{
+    /**
+     * Default limits to in-memory cache usage, max objects cached and max ttl to live in-memory.
+     */
+    private const LIMIT = 100;
+    private const TTL = 10;
+
+    /**
+     * Indication of content classes for cache discrimination.
+     *
+     * By design we prefer to keep meta info (type, sections, ..) in cache for as long as possible and rather cleanup
+     * cache representing content when we need to vacuum the cache (when reaching limits) first.
+     *
+     * Reason for that is:
+     * - meta data more likely to be attempted to be loaded again
+     * - content more likely to get updates more frequently
+     *
+     * So for those reasons content in-memory cache only aims to cache content for short bursts where code typically
+     * deals with a given content before it moves on to the next, while keeping meta cache around for a bit longer.
+     */
+    private const CONTENT_CLASSES = [
+        Content::class,
+        Content\ContentInfo::class,
+        Content\Location::class, // Will also match Content\Location\Trashed
+        Content\VersionInfo::class,
+        Content\Relation::class,
+        Variation::class,
+    ];
+
+    /**
+     * @var \Symfony\Component\Cache\CacheItem[] Cache of cache items by their keys.
+     */
+    private $cacheItems = [];
+
+    /**
+     * @var array Timestamp per cache key for TTL checks.
+     */
+    private $cacheItemsTS = [];
+
+    /**
+     * @var TagAwareAdapterInterface
+     */
+    private $inner;
+
+    /**
+     * @var int
+     */
+    private $limit;
+
+    /**
+     * @var int
+     */
+    private $ttl;
+
+    public function __construct(TagAwareAdapterInterface $inner, int $limit = self::LIMIT, int $ttl = self::TTL)
+    {
+        $this->inner = $inner;
+        $this->limit = $limit;
+        $this->ttl = $ttl;
+    }
+
+    public function getItem($key)
+    {
+        if ($items = $this->getValidInMemoryCacheItems([$key])) {
+            return $items[$key];
+        }
+
+        $item = $this->inner->getItem($key);
+        $this->saveInMemoryCacheItems([$key => $item]);
+
+        return $item;
+    }
+
+    public function getItems(array $keys = [])
+    {
+        $missingKeys = [];
+        $items = $this->getValidInMemoryCacheItems($keys, $missingKeys);
+
+        if (!empty($missingKeys)) {
+            $items += $newItems = $this->inner->getItems($missingKeys);
+            $this->saveInMemoryCacheItems($newItems);
+        }
+
+        return $items;
+    }
+
+    public function hasItem($key)
+    {
+        // We are not interested in trying to cache if we don't have the item, but if we do we can return true
+        if (isset($this->cacheItems[$key])) {
+            return true;
+        }
+
+        return $this->inner->hasItem($key);
+    }
+
+    public function clear()
+    {
+        $this->cacheItems = [];
+        $this->cacheItemsTS = [];
+
+        return $this->inner->clear();
+    }
+
+    public function deleteItem($key)
+    {
+        if (isset($this->cacheItems[$key])) {
+            unset($this->cacheItems[$key], $this->cacheItemsTS[$key]);
+        }
+
+        return $this->inner->deleteItem($key);
+    }
+
+    public function deleteItems(array $keys)
+    {
+        foreach ($keys as $key) {
+            if (isset($this->cacheItems[$key])) {
+                unset($this->cacheItems[$key], $this->cacheItemsTS[$key]);
+            }
+        }
+
+        return $this->inner->deleteItems($keys);
+    }
+
+    public function save(CacheItemInterface $item)
+    {
+        $this->saveInMemoryCacheItems([$item->getKey() => $item]);
+
+        return $this->inner->save($item);
+    }
+
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        // Symfony commits the deferred items as soon as getItem(s) is called on it later or on destruct.
+        // So seems we can safely save in-memory, also we don't at the time of writing use saveDeferred().
+        $this->saveInMemoryCacheItems([$item->getKey() => $item]);
+
+        return $this->inner->saveDeferred($item);
+    }
+
+    public function commit()
+    {
+        return $this->inner->commit();
+    }
+
+    public function invalidateTags(array $tags)
+    {
+        // Cleanup in-Memory cache items affected
+        foreach ($this->cacheItems as $key => $item) {
+            if (array_intersect($item->getPreviousTags(), $tags)) {
+                unset($this->cacheItems[$key], $this->cacheItemsTS[$key]);
+            }
+        }
+
+        return $this->inner->invalidateTags($tags);
+    }
+
+    /**
+     * @param \Psr\Cache\CacheItemInterface[] $items Cache items with cache key as array key.
+     */
+    private function saveInMemoryCacheItems(array $items): void
+    {
+        if (empty($items)) {
+            return;
+        }
+
+        // If items accounts for more then 20% of our limit, assume it's bulk content load and skip saving in-memory
+        if (\count($items) >= $this->limit / 5) {
+            return;
+        }
+
+        // Filter out cache misses as they will immediately be re-generated
+        foreach ($items as $key => $item) {
+            if (!$item->isHit()) {
+                unset($items[$key]);
+            }
+        }
+
+        // Will we stay clear of the limit? If so return early
+        if (\count($items) + \count($this->cacheItems) < $this->limit) {
+            $this->cacheItems += $items;
+            $this->cacheItemsTS += \array_fill_keys(\array_keys($items), \time());
+
+            return;
+        }
+
+        // # Vacuuming cache in bulk so we don't end up doing this all the time
+        // 1. Discriminate against content cache, remove up to 1/3 of max limit starting from oldest items
+        $removeCount = 0;
+        $removeTarget = floor($this->limit / 3);
+        foreach ($this->cacheItems as $key => $item) {
+            $cache = $item->get();
+            foreach (self::CONTENT_CLASSES as $className) {
+                if ($cache instanceof $className) {
+                    unset($this->cacheItems[$key]);
+                    ++$removeCount;
+
+                    break;
+                }
+            }
+
+            if ($removeCount >= $removeTarget) {
+                break;
+            }
+        }
+
+        // 2. Does cache still exceed the 80% of limit? if so remove everything above 66%
+        // NOTE: This on purpose keeps the oldest cache around, getValidInMemoryCacheItems() handles ttl checks on that
+        if (\count($this->cacheItems) >= $this->limit / 1.5) {
+            $this->cacheItems = \array_slice($this->cacheItems, 0, floor($this->limit / 1.5));
+        }
+
+        $this->cacheItems += $items;
+        $this->cacheItemsTS += \array_fill_keys(\array_keys($items), \time());
+    }
+
+    /**
+     * @param array $keys
+     * @param array $missingKeys
+     *
+     * @return array
+     */
+    public function getValidInMemoryCacheItems(array $keys = [], array &$missingKeys = []): array
+    {
+        // 1. Validate TTL and remove items that have exceeded it
+        $expiredTime = time() - $this->ttl;
+        foreach ($this->cacheItemsTS as $key => $ts) {
+            if ($ts <= $expiredTime) {
+                unset($this->cacheItemsTS[$key]);
+
+                // Cache items might have been removed in saveInMemoryCacheItems() when enforcing limit
+                if (isset($this->cacheItems[$key])) {
+                    unset($this->cacheItems[$key]);
+                }
+            }
+        }
+
+        // 2. Get valid items
+        $items = [];
+        foreach ($keys as $key) {
+            if (isset($this->cacheItems[$key])) {
+                $items[$key] = $this->cacheItems[$key];
+            } else {
+                $missingKeys[] = $key;
+            }
+        }
+
+        return $items;
+    }
+}

--- a/eZ/Publish/Core/Persistence/Cache/Adapter/Tests/InMemoryCacheAdapterTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Adapter/Tests/InMemoryCacheAdapterTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Cache\Adapter\Tests;
+
+use eZ\Publish\Core\Persistence\Cache\Adapter\InMemoryCacheAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\Cache\CacheItem;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Abstract test case for spi cache impl.
+ */
+class InMemoryCacheAdapterTest extends TestCase
+{
+    /**
+     * @var \eZ\Publish\Core\Persistence\Cache\Adapter\InMemoryCacheAdapter
+     */
+    protected $cache;
+
+    /**
+     * @var \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $cacheMock;
+
+    /**
+     * @var \Closure
+     */
+    private $cacheItemsClosure;
+
+    /**
+     * Setup the HandlerTest.
+     */
+    final protected function setUp()
+    {
+        parent::setUp();
+
+        $this->cacheMock = $this->createMock(TagAwareAdapterInterface::class);
+
+        $this->cache = new InMemoryCacheAdapter(
+            $this->cacheMock,
+            20,
+            3
+        );
+
+        $this->cacheItemsClosure = \Closure::bind(
+            function ($key, $value, $isHit, $defaultLifetime = 0) {
+                $item = new CacheItem();
+                $item->key = $key;
+                $item->value = $value;
+                $item->isHit = $isHit;
+                $item->defaultLifetime = $defaultLifetime;
+
+                return $item;
+            },
+            null,
+            CacheItem::class
+        );
+    }
+
+    /**
+     * Tear down test (properties).
+     */
+    final protected function tearDown()
+    {
+        unset($this->cache);
+        unset($this->cacheMock);
+        unset($this->cacheItemsClosure);
+        parent::tearDown();
+    }
+
+    public function testGetItemOnlyCalledOnce()
+    {
+        $item = $this->getCacheItem('some_key', true);
+
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('getItem')
+            ->with('some_key')
+            ->willReturn($item);
+
+        $returnedItem = $this->cache->getItem('some_key');
+        $this->assertSame($item, $returnedItem);
+
+        $returnedItem = $this->cache->getItem('some_key');
+        $this->assertSame($item, $returnedItem);
+    }
+
+    public function testGetItemsOnlyCalledOnce()
+    {
+        $items = [
+            'first_key' => $this->getCacheItem('first_key', true),
+            'second_key' => $this->getCacheItem('second_key', true),
+        ];
+
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('getItems')
+            ->with(['first_key', 'second_key'])
+            ->willReturn($items);
+
+        $returnedItems = $this->cache->getItems(['first_key', 'second_key']);
+        $this->assertSame($items, $returnedItems);
+
+        $returnedItems = $this->cache->getItems(['first_key', 'second_key']);
+        $this->assertSame($items, $returnedItems);
+    }
+
+    /**
+     * @param $key
+     * @param null $value If null the cache item will be assumed to be a cache miss here.
+     * @param int $defaultLifetime
+     *
+     * @return CacheItem
+     */
+    final protected function getCacheItem($key, $value = null, $defaultLifetime = 0)
+    {
+        $cacheItemsClosure = $this->cacheItemsClosure;
+
+        return $cacheItemsClosure($key, $value, (bool)$value, $defaultLifetime);
+    }
+}

--- a/eZ/Publish/Core/Persistence/Cache/Adapter/Tests/InMemoryCacheAdapterTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Adapter/Tests/InMemoryCacheAdapterTest.php
@@ -26,7 +26,7 @@ class InMemoryCacheAdapterTest extends TestCase
     /**
      * @var \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $cacheMock;
+    protected $innerCacheMock;
 
     /**
      * @var \Closure
@@ -40,20 +40,21 @@ class InMemoryCacheAdapterTest extends TestCase
     {
         parent::setUp();
 
-        $this->cacheMock = $this->createMock(TagAwareAdapterInterface::class);
+        $this->innerCacheMock = $this->createMock(TagAwareAdapterInterface::class);
 
         $this->cache = new InMemoryCacheAdapter(
-            $this->cacheMock,
-            20,
+            $this->innerCacheMock,
+            12,
             3
         );
 
         $this->cacheItemsClosure = \Closure::bind(
-            function ($key, $value, $isHit, $defaultLifetime = 0) {
+            function ($key, $value, $isHit, $defaultLifetime = 0, $tags = []) {
                 $item = new CacheItem();
                 $item->key = $key;
                 $item->value = $value;
                 $item->isHit = $isHit;
+                $item->prevTags = $tags;
                 $item->defaultLifetime = $defaultLifetime;
 
                 return $item;
@@ -68,47 +69,302 @@ class InMemoryCacheAdapterTest extends TestCase
      */
     final protected function tearDown()
     {
+        $this->cache->clear();
+
         unset($this->cache);
-        unset($this->cacheMock);
+        unset($this->innerCacheMock);
         unset($this->cacheItemsClosure);
+        unset($GLOBALS['override_time']);
         parent::tearDown();
     }
 
     public function testGetItemOnlyCalledOnce()
     {
-        $item = $this->getCacheItem('some_key', true);
+        $item = $this->getCacheItem('first');
 
-        $this->cacheMock
+        $this->innerCacheMock
             ->expects($this->once())
             ->method('getItem')
-            ->with('some_key')
+            ->with('first')
             ->willReturn($item);
 
-        $returnedItem = $this->cache->getItem('some_key');
+        $returnedItem = $this->cache->getItem('first');
         $this->assertSame($item, $returnedItem);
 
-        $returnedItem = $this->cache->getItem('some_key');
+        $returnedItem = $this->cache->getItem('first');
         $this->assertSame($item, $returnedItem);
+    }
+
+    /**
+     * @depends testGetItemOnlyCalledOnce
+     */
+    public function testGetItemTTL()
+    {
+        $item = $this->getCacheItem('first');
+
+        $this->innerCacheMock
+            ->expects($this->exactly(2))
+            ->method('getItem')
+            ->with('first')
+            ->willReturn($item);
+
+        $this->cache->getItem('first');
+
+        $GLOBALS['override_time'] = time() + 4;
+
+        $this->cache->getItem('first');
+    }
+
+    /**
+     * @depends testGetItemOnlyCalledOnce
+     */
+    public function testGetItemLastRemovedFromMemoryWhenReachingLimit()
+    {
+        $this->cache = new InMemoryCacheAdapter(
+            $this->innerCacheMock,
+            6,
+            3
+        );
+
+        $this->innerCacheMock
+            ->expects($this->at(0))
+            ->method('getItem')
+            ->with('first')
+            ->willReturn($this->getCacheItem('first'));
+
+        $this->innerCacheMock
+            ->expects($this->at(1))
+            ->method('getItem')
+            ->with('second')
+            ->willReturn($this->getCacheItem('second'));
+
+        $this->innerCacheMock
+            ->expects($this->at(2))
+            ->method('getItem')
+            ->with('third')
+            ->willReturn($this->getCacheItem('third'));
+
+        $this->innerCacheMock
+            ->expects($this->at(3))
+            ->method('getItem')
+            ->with('fourth')
+            ->willReturn($this->getCacheItem('fourth'));
+
+        $this->innerCacheMock
+            ->expects($this->at(4))
+            ->method('getItem')
+            ->with('fifth')
+            ->willReturn($this->getCacheItem('fifth'));
+
+        // At this point cache should start clearing cache from the end of the list
+        $this->innerCacheMock
+            ->expects($this->at(5))
+            ->method('getItem')
+            ->with('sixth')
+            ->willReturn($this->getCacheItem('sixth'));
+
+        $this->innerCacheMock
+            ->expects($this->once())
+            ->method('getItems')
+            ->with(['fifth'])
+            ->willReturn([
+                'fifth' => $this->getCacheItem('fifth'),
+            ]);
+
+        // On purpose these are called twice, they should not result in cache extra calls
+        $this->cache->getItem('first');
+        $this->cache->getItem('first');
+
+        $this->cache->getItem('second');
+        $this->cache->getItem('second');
+
+        $this->cache->getItem('third');
+        $this->cache->getItem('third');
+
+        // Should not result in extra lookups at this point
+        iterator_to_array($this->cache->getItems(['first', 'second', 'third']));
+
+        $this->cache->getItem('fourth');
+        $this->cache->getItem('fourth');
+
+        $this->cache->getItem('fifth');
+        $this->cache->getItem('fifth');
+
+        $this->cache->getItem('sixth');
+        $this->cache->getItem('sixth');
+
+        // Should results in lookup for fifth
+        iterator_to_array($this->cache->getItems(['first', 'second', 'third', 'fourth', 'fifth', 'sixth']));
+    }
+
+    public function testHasItem()
+    {
+        $this->innerCacheMock
+            ->expects($this->once())
+            ->method('getItem')
+            ->with('first')
+            ->willReturn($this->getCacheItem('first'));
+
+        $this->innerCacheMock
+            ->expects($this->once())
+            ->method('hasItem')
+            ->with('first')
+            ->willReturn(true);
+
+        $this->cache->hasItem('first');
+
+        // populate cache
+        $this->cache->getItem('first');
+
+        $this->cache->hasItem('first');
     }
 
     public function testGetItemsOnlyCalledOnce()
     {
         $items = [
-            'first_key' => $this->getCacheItem('first_key', true),
-            'second_key' => $this->getCacheItem('second_key', true),
+            'first' => $this->getCacheItem('first'),
+            'second' => $this->getCacheItem('second'),
         ];
 
-        $this->cacheMock
+        $this->innerCacheMock
             ->expects($this->once())
             ->method('getItems')
-            ->with(['first_key', 'second_key'])
+            ->with(['first', 'second'])
             ->willReturn($items);
 
-        $returnedItems = $this->cache->getItems(['first_key', 'second_key']);
+        $returnedItems = iterator_to_array($this->cache->getItems(['first', 'second']));
         $this->assertSame($items, $returnedItems);
 
-        $returnedItems = $this->cache->getItems(['first_key', 'second_key']);
+        $returnedItems = iterator_to_array($this->cache->getItems(['first', 'second']));
         $this->assertSame($items, $returnedItems);
+    }
+
+    /**
+     * Symfony uses generators with getItems() so we need to make sure we handle that.
+     */
+    public function testGetItemsWithGenerator()
+    {
+        $items = [
+            'first' => $this->getCacheItem('first'),
+            'second' => $this->getCacheItem('second'),
+        ];
+
+        $this->innerCacheMock
+            ->expects($this->once())
+            ->method('getItems')
+            ->with(['first', 'second'])
+            ->willReturn($this->arrayAsGenerator($items));
+
+        $returnedItems = iterator_to_array($this->cache->getItems(['first', 'second']));
+        $this->assertSame($items, $returnedItems);
+
+        $returnedItems = iterator_to_array($this->cache->getItems(['first', 'second']));
+        $this->assertSame($items, $returnedItems);
+    }
+
+    /**
+     * @depends testGetItemsOnlyCalledOnce
+     */
+    public function testGetItemsTTL()
+    {
+        $items = [
+            'first' => $this->getCacheItem('first'),
+            'second' => $this->getCacheItem('second'),
+        ];
+
+        $this->innerCacheMock
+            ->expects($this->exactly(2))
+            ->method('getItems')
+            ->with(['first', 'second'])
+            ->willReturn($items);
+
+        iterator_to_array($this->cache->getItems(['first', 'second']));
+
+        $GLOBALS['override_time'] = time() + 4;
+
+        iterator_to_array($item = $this->cache->getItems(['first', 'second']));
+    }
+
+    /**
+     * @depends testGetItemsOnlyCalledOnce
+     */
+    public function testGetItemsNotPlacedInMemoryIfEmpty()
+    {
+        $items = [];
+
+        $this->innerCacheMock
+            ->expects($this->exactly(2))
+            ->method('getItems')
+            ->with(['first', 'second', 'third'])
+            ->willReturn($items);
+
+        iterator_to_array($this->cache->getItems(['first', 'second', 'third']));
+        iterator_to_array($this->cache->getItems(['first', 'second', 'third']));
+    }
+
+    /**
+     * @depends testGetItemsOnlyCalledOnce
+     */
+    public function testGetItemsNotPlacedInMemoryIfLargerList()
+    {
+        $items = [
+            'first' => $this->getCacheItem('first'),
+            'second' => $this->getCacheItem('second'),
+            'third' => $this->getCacheItem('third'),
+        ];
+
+        $this->innerCacheMock
+            ->expects($this->exactly(2))
+            ->method('getItems')
+            ->with(['first', 'second', 'third'])
+            ->willReturn($items);
+
+        iterator_to_array($this->cache->getItems(['first', 'second', 'third']));
+        iterator_to_array($this->cache->getItems(['first', 'second', 'third']));
+    }
+
+    /**
+     * @dataProvider providerForInvalidation
+     */
+    public function testCacheClearing(string $method, $argument, int $expectedCount)
+    {
+        $this->innerCacheMock
+            ->expects($this->exactly($expectedCount))
+            ->method('getItem')
+            ->with('first')
+            ->willReturn($this->getCacheItem('first', ['my_tag']));
+
+        $this->innerCacheMock
+            ->expects($this->never())
+            ->method('getItems')
+            ->with(['first']);
+
+        // should only lookup once
+        $this->cache->getItem('first');
+        $this->cache->getItem('first');
+        iterator_to_array($this->cache->getItems(['first']));
+
+        // invalidate it
+        $this->cache->$method($argument);
+
+        // again, should only lookup once
+        $this->cache->getItem('first');
+        $this->cache->getItem('first');
+        iterator_to_array($this->cache->getItems(['first']));
+    }
+
+    public function providerForInvalidation(): array
+    {
+        return [
+            ['deleteItem', 'first', 2],
+            ['deleteItems', ['first'], 2],
+            ['invalidateTags', ['my_tag'], 2],
+            ['clear', null, 2],
+            // negative cases
+            ['deleteItem', 'second', 1],
+            ['deleteItems', ['second'], 1],
+            ['invalidateTags', ['some_other_tag'], 1],
+        ];
     }
 
     /**
@@ -118,10 +374,33 @@ class InMemoryCacheAdapterTest extends TestCase
      *
      * @return CacheItem
      */
-    final protected function getCacheItem($key, $value = null, $defaultLifetime = 0)
+    private function getCacheItem($key, $tags = [], $value = true)
     {
         $cacheItemsClosure = $this->cacheItemsClosure;
 
-        return $cacheItemsClosure($key, $value, (bool)$value, $defaultLifetime);
+        return $cacheItemsClosure($key, $value, (bool) $value, 0, $tags);
     }
+
+    private function arrayAsGenerator(array $array)
+    {
+        foreach ($array as $key => $item) {
+            yield $key => $item;
+        }
+    }
+}
+
+namespace eZ\Publish\Core\Persistence\Cache\Adapter;
+
+/**
+ * Overload time call used in InMemoryCacheAdapter in order to be able to test expiry.
+ *
+ * @return mixed
+ */
+function time()
+{
+    if (isset($GLOBALS['override_time'])) {
+        return $GLOBALS['override_time'];
+    }
+
+    return \time();
 }

--- a/eZ/Publish/Core/settings/containerBuilder.php
+++ b/eZ/Publish/Core/settings/containerBuilder.php
@@ -16,6 +16,7 @@ use eZ\Publish\Core\Base\Container\Compiler;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Config\Resource\FileResource;
 
+
 if (!isset($installDir)) {
     throw new \RuntimeException('$installDir not provided to ' . __FILE__);
 }

--- a/eZ/Publish/Core/settings/containerBuilder.php
+++ b/eZ/Publish/Core/settings/containerBuilder.php
@@ -16,7 +16,6 @@ use eZ\Publish\Core\Base\Container\Compiler;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Config\Resource\FileResource;
 
-
 if (!isset($installDir)) {
     throw new \RuntimeException('$installDir not provided to ' . __FILE__);
 }

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -1,7 +1,4 @@
 parameters:
-    ezpublish.cache_pool.class: Symfony\Component\Cache\Adapter\TagAwareAdapter
-    ezpublish.cache_pool.driver.class: Symfony\Component\Cache\Adapter\FilesystemAdapter
-
     ezpublish.spi.persistence.cache.class: eZ\Publish\Core\Persistence\Cache\Handler
     ezpublish.spi.persistence.cache.abstractHandler.class: eZ\Publish\Core\Persistence\Cache\AbstractHandler
     ezpublish.spi.persistence.cache.sectionHandler.class: eZ\Publish\Core\Persistence\Cache\SectionHandler
@@ -25,14 +22,19 @@ parameters:
     ezpublish.spi.persistence.cache.persistenceLogger.enableCallLogging: "%kernel.debug%"
 
 services:
+    # Setup cache pool, with InMemoryCacheAdapter as decorator
     ezpublish.cache_pool:
-        class: "%ezpublish.cache_pool.class%"
+        class: eZ\Publish\Core\Persistence\Cache\Adapter\InMemoryCacheAdapter
+        arguments: ["@ezpublish.cache_pool_inner"]
+
+    ezpublish.cache_pool_inner:
+        class: Symfony\Component\Cache\Adapter\TagAwareAdapter
         arguments: ["@ezpublish.cache_pool.driver"]
 
     # Note for tests: Default changed to in-memory Array cache in tests/common.yml by default, and opt in for redis
     # testing is defined in containerBuilder.php
     ezpublish.cache_pool.driver:
-        class: "%ezpublish.cache_pool.driver.class%"
+        class: Symfony\Component\Cache\Adapter\FilesystemAdapter
         arguments: ["", 120]
 
     ezpublish.spi.persistence.cache.persistenceLogger:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29659](https://jira.ez.no/browse/EZP-29659)
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | _maybe on trouble shooting section, or places explaining caching_

As a System Administrator & Developer I'd like SPI cache to re-introduce support for in-memory cache.

However unlike 1.x it must be:
- limited to not eat up all available memory
- time limited so data does not risk becoming stale

Thus allowing it to be used also on long running command line scripts without need to document special ways to run them.

As it it to be limited memory wise it should also be:
- When hitting limits and in need of making space: prefer to use available space for non content cache (meta data) which is frequently needed by the system, and in-frequently changed

---

Brings cache lookups down to the following on clean install in combination with https://github.com/ezsystems/ezplatform-admin-ui/pull/633 & #2444 compared to clean master/2.3-beta1:
- Front: from `74 / 184` to `22 / 59` cache calls => **3x less** cache calls
- Admin Dashboard: from `478 / 1452` to `52 / 156` cache calls => **9x less** cache calls
- Admin Content structure: from `484 / 1421`  to `70 / 204` cache calls => **7x less** cache calls

This will especially benefit users on clusters where (Redis) cache server is on different host _(latency)_.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
