### PR TITLE
EZP-29139: Added more info about clearing HTTP cache after running cmd

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
@@ -33,6 +33,7 @@ class RegenerateUrlAliasesCommand extends Command
 - Take installation offline, during the script execution the database should not be modified.
 - Run this command without memory limit, i.e. processing of 300k Locations can take up to 1 GB of RAM.
 - Run this command in production environment using <info>--env=prod</info>
+- Manually clear HTTP cache after running this command.
 EOT;
 
     /**
@@ -148,6 +149,7 @@ EOT
         $progressBar->finish();
         $output->writeln('');
         $output->writeln('<info>Done.</info>');
+        $output->writeln('<comment>Make sure to clear HTTP cache afterwards.</comment>');
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Follow-up for [EZP-29139](https://jira.ez.no/browse/EZP-29139)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`, `7.2`, `7.3` (`master`)
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | maybe (if not present yet)

This PR adds to the `ezplatform:urls:regenerate-aliases` command an info, requested by @mnocon, about a need to manually clear HTTP cache afterwards in the following places:
- before the command is executed,
- after the command ends.

Since HTTP Cache got decoupled from Kernel in `1.13`/`6.13`, I'm targeting this PR to `6.13` and up. In `6.7` it was possible to inject cache purger service to this command, so it's not needed there.

**TODO**:
- [x] Added more info about the need to manually clear HTTP cache.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
