### PR TITLE
EZP-29721: Broken URL alias history is not restored after regenerating aliases

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
@@ -131,14 +131,6 @@ EOT
             return;
         }
 
-        $output->writeln('<info>Cleaning up corrupted URL aliases...</info>');
-        $corruptedAliasesCount = $this->repository->sudo(
-            function (Repository $repository) {
-                return $repository->getURLAliasService()->deleteCorruptedUrlAliases();
-            }
-        );
-        $output->writeln("<info>Done. Deleted {$corruptedAliasesCount} entries.</info>");
-
         $output->writeln('Regenerating System URL aliases...');
 
         $progressBar = $this->getProgressBar($locationsCount, $output);
@@ -160,6 +152,14 @@ EOT
         $output->writeln('Purging HTTP cache...');
         $this->cachePurger->purgeAll();
         $output->writeln('<info>Done.</info>');
+
+        $output->writeln('<info>Cleaning up corrupted URL aliases...</info>');
+        $corruptedAliasesCount = $this->repository->sudo(
+            function (Repository $repository) {
+                return $repository->getURLAliasService()->deleteCorruptedUrlAliases();
+            }
+        );
+        $output->writeln("<info>Done. Deleted {$corruptedAliasesCount} entries.</info>");
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -569,7 +569,7 @@ abstract class BaseTest extends TestCase
 
         if (!$connection instanceof Connection) {
             throw new \RuntimeException(
-                sprintf('Expected %s got something else', Connection::class)
+                sprintf('Expected %s got %s', Connection::class, get_class($connection))
             );
         }
 

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use Doctrine\DBAL\Connection;
 use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
 use eZ\Publish\API\Repository\Tests\PHPUnitConstraint\ValidationErrorOccurs as PHPUnitConstraintValidationErrorOccurs;
 use eZ\Publish\API\Repository\Values\Content\Location;
@@ -553,6 +554,60 @@ abstract class BaseTest extends TestCase
             $repository->rollback();
             throw $ex;
         }
+    }
+
+    /**
+     * @return \Doctrine\DBAL\Connection
+     *
+     * @throws \ErrorException
+     */
+    protected function getRawDatabaseConnection()
+    {
+        $connection = $this
+            ->getSetupFactory()
+            ->getServiceContainer()->get('ezpublish.api.storage_engine.legacy.connection');
+
+        if (!$connection instanceof Connection) {
+            throw new \RuntimeException(
+                sprintf('Expected %s got something else', Connection::class)
+            );
+        }
+
+        return $connection;
+    }
+
+    /**
+     * Executes the given callback passing raw Database Connection (\Doctrine\DBAL\Connection).
+     * Returns the result returned by the given callback.
+     *
+     * **Note**: The method clears the entire persistence cache pool.
+     *
+     * @throws \Exception
+     *
+     * @param callable $callback
+     *
+     * @return mixed the return result of the given callback
+     */
+    public function performRawDatabaseOperation(callable $callback)
+    {
+        $repository = $this->getRepository(false);
+        $repository->beginTransaction();
+        try {
+            $callback(
+                $this->getRawDatabaseConnection()
+            );
+            $repository->commit();
+        } catch (Exception $e) {
+            $repository->rollback();
+            throw $e;
+        }
+
+        /** @var \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface $cachePool */
+        $cachePool = $this
+            ->getSetupFactory()
+            ->getServiceContainer()->get('ezpublish.cache_pool');
+
+        $cachePool->clear();
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -393,4 +393,22 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
 
         return $deletedCount;
     }
+
+    /**
+     * Attempt repairing auto-generated URL aliases for the given Location (including history).
+     *
+     * Note: it is assumed that at this point original, working, URL Alias for Location is published.
+     *
+     * @param int $locationId
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\BadStateException
+     */
+    public function repairBrokenUrlAliasesForLocation($locationId)
+    {
+        $this->logger->logCall(__METHOD__, ['locationId' => $locationId]);
+
+        $this->persistenceHandler->urlAliasHandler()->repairBrokenUrlAliasesForLocation($locationId);
+
+        $this->clearLocation($locationId);
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway.php
@@ -259,4 +259,12 @@ abstract class Gateway
      * Note: Typically link column value is used to determine original alias for an archived entries.
      */
     abstract public function deleteUrlAliasesWithBrokenLink();
+
+    /**
+     * Attempt repairing data corruption for broken archived URL aliases for Location,
+     * assuming there exists restored original (current) entry.
+     *
+     * @param int $locationId
+     */
+    abstract public function repairBrokenUrlAliasesForLocation($locationId);
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -10,10 +10,10 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use eZ\Publish\Core\Base\Exceptions\BadStateException;
-use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
-use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator as LanguageMaskGenerator;
 use eZ\Publish\Core\Persistence\Database\Query;
+use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator as LanguageMaskGenerator;
+use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway;
 use RuntimeException;
 
 /**
@@ -1311,6 +1311,93 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
+     * Attempt repairing data corruption for broken archived URL aliases for Location,
+     * assuming there exists restored original (current) entry.
+     *
+     * @param int $locationId
+     */
+    public function repairBrokenUrlAliasesForLocation($locationId)
+    {
+        $urlAliasesData = $this->getUrlAliasesForLocation($locationId);
+
+        $originalUrlAliases = $this->filterOriginalAliases($urlAliasesData);
+
+        if (count($originalUrlAliases) === count($urlAliasesData)) {
+            // no archived aliases - nothing to fix
+            return;
+        }
+
+        $updateQueryBuilder = $this->connection->createQueryBuilder();
+        $expr = $updateQueryBuilder->expr();
+        $updateQueryBuilder
+            ->update('ezurlalias_ml')
+            ->set('link', ':linkId')
+            ->set('parent', ':parentId')
+            ->where(
+                $expr->eq('action', ':action')
+            )
+            ->andWhere(
+                $expr->eq(
+                    'is_original',
+                    $updateQueryBuilder->createNamedParameter(0, \PDO::PARAM_INT)
+                )
+            )
+            ->andWhere(
+                $expr->eq('parent', ':oldParentId')
+            )
+            ->andWhere(
+                $expr->eq('text_md5', ':textMD5')
+            )
+            ->setParameter(':action', "eznode:{$locationId}");
+
+        foreach ($urlAliasesData as $urlAliasData) {
+            if ($urlAliasData['is_original'] === 1 || !isset($originalUrlAliases[$urlAliasData['lang_mask']])) {
+                // ignore non-archived entries and deleted Translations
+                continue;
+            }
+
+            $originalUrlAlias = $originalUrlAliases[$urlAliasData['lang_mask']];
+
+            if ($urlAliasData['link'] === $originalUrlAlias['link']) {
+                // ignore correct entries to avoid unnecessary updates
+                continue;
+            }
+
+            $updateQueryBuilder
+                ->setParameter(':linkId', $originalUrlAlias['link'], \PDO::PARAM_INT)
+                ->setParameter(':parentId', $originalUrlAlias['parent'], \PDO::PARAM_INT)
+                ->setParameter(':oldParentId', $urlAliasData['parent'], \PDO::PARAM_INT)
+                ->setParameter(':textMD5', $urlAliasData['text_md5']);
+
+            $updateQueryBuilder->execute();
+        }
+    }
+
+    /**
+     * Filter from the given result set original (current) only URL aliases and index them by language_mask.
+     *
+     * Note: each language_mask can have one URL Alias.
+     *
+     * @param array $urlAliasesData
+     *
+     * @return array
+     */
+    private function filterOriginalAliases(array $urlAliasesData)
+    {
+        $originalUrlAliases = array_filter(
+            $urlAliasesData,
+            function ($urlAliasData) {
+                return (int)$urlAliasData['is_original'] === 1;
+            }
+        );
+        // return language_mask-indexed array
+        return array_combine(
+            array_column($originalUrlAliases, 'lang_mask'),
+            $originalUrlAliases
+        );
+    }
+
+    /**
      * Get subquery for IDs of all URL aliases.
      *
      * @return string Query
@@ -1380,5 +1467,28 @@ class DoctrineDatabase extends Gateway
             default:
                 return 'integer';
         }
+    }
+
+    /**
+     * Get all URL aliases for the given Location (including archived ones).
+     *
+     * @param int $locationId
+     *
+     * @return array
+     */
+    protected function getUrlAliasesForLocation($locationId)
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
+            ->select('id', 'is_original', 'lang_mask', 'link', 'parent', 'text_md5')
+            ->from($this->table)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'action',
+                    $queryBuilder->createPositionalParameter("eznode:{$locationId}")
+                )
+            );
+
+        return $queryBuilder->execute()->fetchAll(\PDO::FETCH_ASSOC);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/ExceptionConversion.php
@@ -458,4 +458,18 @@ class ExceptionConversion extends Gateway
             throw new \RuntimeException('Database error', 0, $e);
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function repairBrokenUrlAliasesForLocation($locationId)
+    {
+        try {
+            return $this->innerGateway->repairBrokenUrlAliasesForLocation($locationId);
+        } catch (DBALException $e) {
+            throw new \RuntimeException('Database error', 0, $e);
+        } catch (PDOException $e) {
+            throw new \RuntimeException('Database error', 0, $e);
+        }
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -1033,16 +1033,12 @@ class Handler implements UrlAliasHandlerInterface
     {
         $parentId = $this->getRealAliasId($parentLocationId);
 
+        $data = $this->gateway->loadLocationEntries($locationId);
         // filter removed Translations
-        $urlAliases = $this->listURLAliasesForLocation($locationId);
-        $removedLanguages = [];
-        foreach ($urlAliases as $urlAlias) {
-            foreach ($urlAlias->languageCodes as $languageCode) {
-                if (!in_array($languageCode, $languageCodes)) {
-                    $removedLanguages[] = $languageCode;
-                }
-            }
-        }
+        $removedLanguages = array_diff(
+            $this->mapper->extractLanguageCodesFromData($data),
+            $languageCodes
+        );
 
         if (empty($removedLanguages)) {
             return;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -8,12 +8,12 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias;
 
+use eZ\Publish\Core\Base\Exceptions\BadStateException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator;
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\DTO\SwappedLocationProperties;
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\DTO\UrlAliasForSwappedLocation;
 use eZ\Publish\SPI\Persistence\Content\Language;
-use eZ\Publish\SPI\Persistence\Content\UrlAlias;
 use eZ\Publish\SPI\Persistence\Content\UrlAlias\Handler as UrlAliasHandlerInterface;
 use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
@@ -1080,6 +1080,24 @@ class Handler implements UrlAliasHandlerInterface
         } catch (\Exception $e) {
             $this->transactionHandler->rollback();
             throw $e;
+        }
+    }
+
+    /**
+     * Attempt repairing auto-generated URL aliases for the given Location (including history).
+     *
+     * Note: it is assumed that at this point original, working, URL Alias for Location is published.
+     *
+     * @param int $locationId
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\BadStateException
+     */
+    public function repairBrokenUrlAliasesForLocation($locationId)
+    {
+        try {
+            $this->gateway->repairBrokenUrlAliasesForLocation($locationId);
+        } catch (\RuntimeException $e) {
+            throw new BadStateException('locationId', $e->getMessage(), $e);
         }
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Mapper.php
@@ -84,15 +84,12 @@ class Mapper
      */
     public function extractLanguageCodesFromData(array $rows)
     {
-        $languageCodes = [];
+        $languageMask = 0;
         foreach ($rows as $row) {
-            $languageCodes = array_merge(
-                $languageCodes,
-                $this->languageMaskGenerator->extractLanguageCodesFromMask($row['lang_mask'])
-            );
+            $languageMask |= $row['lang_mask'];
         }
 
-        return array_unique($languageCodes);
+        return $this->languageMaskGenerator->extractLanguageCodesFromMask($languageMask);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Mapper.php
@@ -76,6 +76,26 @@ class Mapper
     }
 
     /**
+     * Extracts language codes from database $rows.
+     *
+     * @param array $rows
+     *
+     * @return array
+     */
+    public function extractLanguageCodesFromData(array $rows)
+    {
+        $languageCodes = [];
+        foreach ($rows as $row) {
+            $languageCodes = array_merge(
+                $languageCodes,
+                $this->languageMaskGenerator->extractLanguageCodesFromMask($row['lang_mask'])
+            );
+        }
+
+        return array_unique($languageCodes);
+    }
+
+    /**
      * @throws \RuntimeException
      *
      * @param string $action

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasMapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasMapperTest.php
@@ -97,6 +97,23 @@ class UrlAliasMapperTest extends LanguageAwareTestCase
             'is_alias' => '0',
             'alias_redirects' => '1',
         ),
+        4 => array(
+            'action' => 'nop:',
+            'parent' => '3',
+            'text_md5' => '1d8d2fd0a99802b89eb356a86e029d25',
+            'raw_path_data' => array(
+                0 => array(
+                    array(
+                        'lang_mask' => 8,
+                        'text' => 'drei',
+                    ),
+                ),
+            ),
+            'lang_mask' => 8,
+            'is_original' => '0',
+            'is_alias' => '0',
+            'alias_redirects' => '1',
+        ),
     );
 
     protected function getExpectation()
@@ -190,6 +207,26 @@ class UrlAliasMapperTest extends LanguageAwareTestCase
                     'forward' => false,
                 )
             ),
+            4 => new UrlAlias(
+                array(
+                    'id' => '3-1d8d2fd0a99802b89eb356a86e029d25',
+                    'type' => UrlAlias::VIRTUAL,
+                    'destination' => null,
+                    'pathData' => array(
+                        array(
+                            'always-available' => false,
+                            'translations' => array(
+                                'ger-DE' => 'drei',
+                            ),
+                        ),
+                    ),
+                    'languageCodes' => array('ger-DE'),
+                    'alwaysAvailable' => false,
+                    'isHistory' => true,
+                    'isCustom' => false,
+                    'forward' => false,
+                )
+            ),
         );
     }
 
@@ -230,6 +267,21 @@ class UrlAliasMapperTest extends LanguageAwareTestCase
         self::assertEquals(
             $this->getExpectation(),
             $mapper->extractUrlAliasListFromData($this->fixture)
+        );
+    }
+
+    /**
+     * Test for the extractLanguageCodesFromData method.
+     *
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Mapper::extractLanguageCodesFromData
+     */
+    public function testExtractLanguageCodesFromData()
+    {
+        $mapper = $this->getMapper();
+
+        self::assertEquals(
+            ['eng-US', 'eng-GB', 'ger-DE'],
+            $mapper->extractLanguageCodesFromData($this->fixture)
         );
     }
 

--- a/eZ/Publish/Core/Repository/URLAliasService.php
+++ b/eZ/Publish/Core/Repository/URLAliasService.php
@@ -771,12 +771,15 @@ class URLAliasService implements URLAliasServiceInterface
                     $content->contentInfo->alwaysAvailable
                 );
             }
+            $this->urlAliasHandler->repairBrokenUrlAliasesForLocation($location->id);
+
             // handle URL aliases for missing Translations
             $this->urlAliasHandler->archiveUrlAliasesForDeletedTranslations(
                 $location->id,
                 $location->parentLocationId,
                 $content->getVersionInfo()->languageCodes
             );
+
             $this->repository->commit();
         } catch (APINotFoundException $e) {
             $this->repository->rollback();

--- a/eZ/Publish/SPI/Persistence/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/UrlAlias/Handler.php
@@ -182,4 +182,15 @@ interface Handler
      * @return int Number of deleted URL aliases
      */
     public function deleteCorruptedUrlAliases();
+
+    /**
+     * Attempt repairing auto-generated URL aliases for the given Location (including history).
+     *
+     * Note: it is assumed that at this point original, working, URL Alias for Location is published.
+     *
+     * @param int $locationId
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\BadStateException
+     */
+    public function repairBrokenUrlAliasesForLocation($locationId);
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29721](https://jira.ez.no/browse/EZP-29721), follow-up to [EZP-29139](https://jira.ez.no/browse/EZP-29139)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `5.4`, `6.7`+
| **BC breaks**      | not yet
| **Tests pass**     | no
| **Doc needed**     | no

This is an attempt to fix edge case discovered by @mnocon - when parent of a nested URL alias was gone due to data corruption, the command displayed error referring to itself. It was fixed by moving cleanup prior to regenerating aliases, which was rather a workaround.

## Solution

This solution consists of several parts:
1. Cleaning corrupted aliases is done after performing refresh (21a5726).
2. `URLAliasService::refreshSystemUrlAliasesForLocation` performs cleanup of `link` and `parent` Ids based on the original (current) URL alias entry (99b2da5).
3. The method `UrlAlias\Handler::archiveUrlAliasesForDeletedTranslations` which caused the error mentioned earlier was refactored and optimized to avoid building path at this point as it is not necessary for the method to work (13a8a70). Doing cleanup of what causes an issue here for each Location would be a performance bottleneck. It's done globally later on by calling `URLAliasService::deleteCorruptedUrlAliases`.
4. There is an integration test showing the use case (3209535).

**TODO**:
- [x] Restore broken history.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
