### PR TITLE
[WiP] Exception is not thrown when accessing Location's lazy-loaded not available Content

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\API\Repository\Tests;
 
 use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
 use eZ\Publish\API\Repository\Tests\PHPUnitConstraint\ValidationErrorOccurs as PHPUnitConstraintValidationErrorOccurs;
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use PHPUnit\Framework\TestCase;
@@ -660,5 +661,28 @@ abstract class BaseTest extends TestCase
         );
 
         return $contentService->publishVersion($contentDraft->versionInfo);
+    }
+
+    /**
+     * Add new Language to the Repository.
+     *
+     * @param string $languageCode
+     * @param string $name
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Language
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    protected function createLanguage(string $languageCode, string $name): Language
+    {
+        $repository = $this->getRepository(false);
+
+        $languageService = $repository->getContentLanguageService();
+        $languageStruct = $languageService->newLanguageCreateStruct();
+        $languageStruct->name = $name;
+        $languageStruct->languageCode = $languageCode;
+
+        return $languageService->createLanguage($languageStruct);
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | TBD
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.2`+
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | no

This happens for the use case where a `Location` has been loaded via SiteAccessAware Repository, but the underlying Content is not available for the languages specified by the SiteAccess prioritized languages list. 

Note: It applies only to not always available Content items.

**TODO**:
- [ ] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
