### PR TITLE
EZP-29223: Implement permissions for "Content/Translate"

### DIFF
--- a/doc/bc/changes-7.4.md
+++ b/doc/bc/changes-7.4.md
@@ -1,0 +1,11 @@
+# Backwards compatibility changes
+
+Changes affecting version compatibility with former or future versions.
+
+## Changes
+
+* New content/translate Policy has been added. You can use new `eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/AddContentTranslatePolicyCommand` to add new Policy to existing Roles. See documentation for more details.
+
+## Deprecations
+
+## Removed features

--- a/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/AddContentTranslatePolicyCommand.php
+++ b/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/AddContentTranslatePolicyCommand.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishMigrationBundle\Command\LegacyStorage;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Input\InputOption;
+use eZ\Publish\Core\Repository\Values\User\PolicyCreateStruct;
+use eZ\Publish\API\Repository\Values\User\Role;
+
+class AddContentTranslatePolicyCommand extends ContainerAwareCommand
+{
+    /**
+     * @var \eZ\Publish\API\Repository\RoleService
+     */
+    private $roleService;
+
+    protected function configure()
+    {
+        $this
+            ->setName('ezpublish:update:legacy_storage_add_content_translate_policy')
+            ->addOption(
+                'user',
+                'u',
+                InputOption::VALUE_OPTIONAL,
+                'eZ Platform username (with Role containing at least Role policies: read, create, update)',
+                'admin'
+            )
+            ->setDescription('Assign content/translate policy to role who has content/edit policy.')
+            ->setHelp(
+                <<<EOT
+The command <info>%command.name%</info> assigns content/translate policy to role who has content/edit policy. See: https://jira.ez.no/browse/EZP-29223
+
+<warning>During the script execution the database should not be modified.
+
+To avoid surprises you are advised to create a backup or execute a dry run:
+ 
+    %command.name% dry-run
+    
+before proceeding with actual update.</warning>
+
+Since this script can potentially run for a very long time, to avoid memory
+exhaustion run it in production environment using the <info>--env=prod</info> switch.
+EOT
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $roles = $this->filterRoles($this->roleService->loadRoles());
+        $totalCount = count($roles);
+        $output->writeln('Found total roles that have "content/edit" policy: ' . $totalCount);
+
+        if ($totalCount === 0) {
+            $output->writeln('Nothing to process, exiting.');
+
+            return;
+        }
+
+        $rolesIdentifiers = implode(',', array_map(function ($role) {
+            return $role->identifier;
+        }, $roles));
+
+        $output->writeln('Roles with "content/edit" policy are: ' . $rolesIdentifiers);
+
+        if ($this->confirmExecution($input, $output)) {
+            foreach ($roles as $role) {
+                $this->addContentTranslatePolicyToRole($role);
+
+                $output->writeln('Added policy "content/translate" to role ' . $role->identifier);
+            }
+        }
+
+        $output->writeln('');
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+
+        /** @var \eZ\Publish\API\Repository\Repository $repository */
+        $repository = $this->getContainer()->get('ezpublish.api.repository');
+        $this->roleService = $repository->getRoleService();
+
+        $repository->getPermissionResolver()->setCurrentUserReference(
+            $repository->getUserService()->loadUserByLogin($input->getOption('user'))
+        );
+    }
+
+    protected function confirmExecution(InputInterface $input, OutputInterface $output)
+    {
+        $question = new ConfirmationQuestion('<question>Are you sure you want to proceed?</question> ', false);
+
+        return $this
+            ->getHelper('question')
+            ->ask($input, $output, $question);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\User\Role[]
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Role[]
+     */
+    private function filterRoles(array $roles): array
+    {
+        $rolesWithContentEdit = [];
+
+        /** @var \eZ\Publish\API\Repository\Values\User\Role $role */
+        foreach ($roles as $role) {
+            $hasContentEdit = false;
+            $hasContentTranslate = false;
+
+            foreach ($role->getPolicies() as $policy) {
+                if ($policy->module === 'content' && $policy->function === 'edit') {
+                    $hasContentEdit = true;
+                }
+
+                if ($policy->module === 'content' && $policy->function === 'translate') {
+                    $hasContentTranslate = true;
+                }
+            }
+
+            if ($hasContentEdit && !$hasContentTranslate) {
+                $rolesWithContentEdit[] = $role;
+            }
+        }
+
+        return $rolesWithContentEdit;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\User\Role
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    private function addContentTranslatePolicyToRole(Role $role): void
+    {
+        $policyCreateStruct = $this->getPolicyCreateStruct();
+        $roleDraft = $this->roleService->createRoleDraft($role);
+        $roleDraft = $this->roleService->addPolicyByRoleDraft($roleDraft, $policyCreateStruct);
+        $this->roleService->publishRoleDraft($roleDraft);
+    }
+
+    /**
+     * @return \eZ\Publish\Core\Repository\Values\User\PolicyCreateStruct
+     */
+    private function getPolicyCreateStruct(): PolicyCreateStruct
+    {
+        $policyCreateStruct = new PolicyCreateStruct([
+            'module' => 'content',
+            'function' => 'translate',
+        ]);
+
+        return $policyCreateStruct;
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -9,13 +9,14 @@
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 
 /**
  * Test case for the {@link \eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation}
  * class.
  *
- * @see eZ\Publish\API\Repository\Values\User\Limitation
- * @see eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation
+ * @see \eZ\Publish\API\Repository\Values\User\Limitation
+ * @see \eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation
  * @group integration
  * @group limitation
  */
@@ -147,5 +148,231 @@ class LanguageLimitationTest extends BaseLimitationTest
             $contentService->loadContentInfo($contentId)
         );
         /* END: Use Case */
+    }
+
+    public function testUserIsAllowedToTranslateContent()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $this->createRoleWithPolicies('Publisher', [
+            ['module' => 'content', 'function' => 'read'],
+            ['module' => 'content', 'function' => 'create'],
+            ['module' => 'content', 'function' => 'publish'],
+        ]);
+
+        $publisherUser = $this->createCustomUserWithLogin(
+            'publisher',
+            'publisher@example.com',
+            'Publishers',
+            'Publisher'
+        );
+
+        $this->createRoleWithPolicies('Translator', [
+            ['module' => 'content', 'function' => 'read'],
+            ['module' => 'content', 'function' => 'edit'],
+            ['module' => 'content', 'function' => 'versionread'],
+            [
+                'module' => 'content',
+                'function' => 'translate',
+                'limitations' => [new LanguageLimitation(['limitationValues' => ['eng-GB']])],
+            ],
+        ]);
+
+        $translatorUser = $this->createCustomUserWithLogin(
+            'translator',
+            'translator@example.com',
+            'Translators',
+            'Translator'
+        );
+
+        $repository->getPermissionResolver()->setCurrentUserReference($publisherUser);
+        // this will create eng-US Content
+        $content = $this->createWikiPage();
+
+        $contentService->loadContent($content->id);
+
+        $repository->getPermissionResolver()->setCurrentUserReference($translatorUser);
+
+        $contentUpdate = $contentService->newContentUpdateStruct();
+        $contentUpdate->initialLanguageCode = 'eng-GB';
+        $contentUpdate->setField('title', 'An awesome wiki page GB');
+
+        $draft = $contentService->createContentDraft(
+            $contentService->loadContentInfo($content->id)
+        );
+
+        // Update content object
+        $draft = $contentService->updateContent(
+            $draft->versionInfo,
+            $contentUpdate
+        );
+
+        $repository->getPermissionResolver()->setCurrentUserReference($publisherUser);
+        $contentService->publishVersion($draft->versionInfo);
+
+        $this->assertEquals(
+            'An awesome wiki page GB',
+            $contentService->loadContent($content->id, ['eng-GB'])
+                ->getFieldValue('title')->text
+        );
+
+        // Update translated content
+        $repository->getPermissionResolver()->setCurrentUserReference($translatorUser);
+
+        $contentUpdate = $contentService->newContentUpdateStruct();
+        $contentUpdate->initialLanguageCode = 'eng-GB';
+        $contentUpdate->setField('title', 'An awesome wiki page GB - second update');
+
+        $draft = $contentService->createContentDraft(
+            $contentService->loadContentInfo($content->id)
+        );
+
+        // Update content object
+        $contentService->updateContent(
+            $draft->versionInfo,
+            $contentUpdate
+        );
+
+        $repository->getPermissionResolver()->setCurrentUserReference($publisherUser);
+        $contentService->publishVersion($draft->versionInfo);
+
+        $this->assertEquals(
+            'An awesome wiki page GB - second update',
+            $contentService->loadContent($content->id, ['eng-GB'])
+                ->getFieldValue('title')->text
+        );
+    }
+
+    public function testUserIsNotAllowedToTranslateContent()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $this->createRoleWithPolicies('Publisher', [
+            ['module' => 'content', 'function' => 'read'],
+            ['module' => 'content', 'function' => 'create'],
+            ['module' => 'content', 'function' => 'publish'],
+        ]);
+
+        $publisherUser = $this->createCustomUserWithLogin(
+            'publisher',
+            'publisher@example.com',
+            'Publishers',
+            'Publisher'
+        );
+
+        $this->createRoleWithPolicies('Translator', [
+            ['module' => 'content', 'function' => 'read'],
+            ['module' => 'content', 'function' => 'edit'],
+            ['module' => 'content', 'function' => 'versionread'],
+            [
+                'module' => 'content',
+                'function' => 'translate',
+                'limitations' => [new LanguageLimitation(['limitationValues' => ['eng-US']])],
+            ],
+        ]);
+
+        $translatorUser = $this->createCustomUserWithLogin(
+            'translator',
+            'translator@example.com',
+            'Translators',
+            'Translator'
+        );
+
+        /* BEGIN: Use Case */
+        $repository->getPermissionResolver()->setCurrentUserReference($publisherUser);
+        $content = $this->createWikiPage();
+
+        $contentService->loadContent($content->id);
+
+        $repository->getPermissionResolver()->setCurrentUserReference($translatorUser);
+
+        $contentUpdate = $contentService->newContentUpdateStruct();
+        $contentUpdate->initialLanguageCode = 'eng-GB';
+        $contentUpdate->setField('title', 'An awesome wiki page GB');
+
+        $draft = $contentService->createContentDraft(
+            $contentService->loadContentInfo($content->id)
+        );
+        /* END: Use Case */
+
+        // This call will fail with an UnauthorizedException
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage('User does not have access to \'translate\' \'content\' with: contentId \'' . $content->id . '\'');
+
+        $contentService->updateContent(
+            $draft->versionInfo,
+            $contentUpdate
+        );
+    }
+
+    public function testTwoUsersIsAllowedToTranslateContent()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $languageLimitationUS = new LanguageLimitation(['limitationValues' => ['eng-US']]);
+        $this->createRoleWithPolicies('TranslatorUS', [
+            ['module' => 'content', 'function' => 'read'],
+            ['module' => 'content', 'function' => 'versionread'],
+            ['module' => 'content', 'function' => 'create', 'limitations' => [$languageLimitationUS]],
+            ['module' => 'content', 'function' => 'edit', 'limitations' => [$languageLimitationUS]],
+            ['module' => 'content', 'function' => 'publish', 'limitations' => [$languageLimitationUS]],
+            ['module' => 'content', 'function' => 'translate', 'limitations' => [$languageLimitationUS]],
+        ]);
+        $translatorUS = $this->createCustomUserWithLogin(
+            'translatorUS',
+            'translatorUS@example.com',
+            'Translators',
+            'TranslatorUS'
+        );
+
+        $languageLimitationGB = new LanguageLimitation(['limitationValues' => ['eng-GB']]);
+        $this->createRoleWithPolicies('TranslatorGB', [
+            ['module' => 'content', 'function' => 'read'],
+            ['module' => 'content', 'function' => 'versionread'],
+            ['module' => 'content', 'function' => 'create', 'limitations' => [$languageLimitationGB]],
+            ['module' => 'content', 'function' => 'edit', 'limitations' => [$languageLimitationUS]],
+            ['module' => 'content', 'function' => 'publish', 'limitations' => [$languageLimitationGB]],
+            ['module' => 'content', 'function' => 'translate', 'limitations' => [$languageLimitationGB]],
+        ]);
+        $translatorGB = $this->createCustomUserWithLogin(
+            'translatorGB',
+            'translatorGB@example.com',
+            'Translators',
+            'TranslatorGB'
+        );
+
+        $repository->getPermissionResolver()->setCurrentUserReference($translatorUS);
+
+        // this will create eng-US Content
+        $content = $this->createWikiPage();
+
+        $contentService->loadContent($content->id);
+
+        $repository->getPermissionResolver()->setCurrentUserReference($translatorGB);
+
+        $contentUpdate = $contentService->newContentUpdateStruct();
+        $contentUpdate->initialLanguageCode = 'eng-GB';
+        $contentUpdate->setField('title', 'An awesome wiki page GB');
+
+        $draft = $contentService->createContentDraft(
+            $contentService->loadContentInfo($content->id)
+        );
+
+        // Update content object
+        $draft = $contentService->updateContent(
+            $draft->versionInfo,
+            $contentUpdate
+        );
+
+        $contentService->publishVersion($draft->versionInfo);
+
+        $this->assertEquals(
+            'An awesome wiki page GB',
+            $contentService->loadContent($content->id, ['eng-GB'])
+                ->getFieldValue('title')->text
+        );
     }
 }

--- a/eZ/Publish/Core/Limitation/ContentTypeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ContentTypeLimitationType.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
+use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
@@ -119,7 +120,9 @@ class ContentTypeLimitationType extends AbstractPersistenceLimitationType implem
             $object = $object->getVersionInfo()->getContentInfo();
         } elseif ($object instanceof VersionInfo) {
             $object = $object->getContentInfo();
-        } elseif (!$object instanceof ContentInfo && !$object instanceof ContentCreateStruct) {
+        } elseif ($object instanceof ContentUpdateStruct) {
+            $object = $object->contentDraft->getVersionInfo()->getContentInfo();
+        } elseif (!$object instanceof ContentInfo && !$object instanceof ContentCreateStruct && !$object instanceof ContentUpdateStruct) {
             throw new InvalidArgumentException(
                 '$object',
                 'Must be of type: ContentCreateStruct, Content, VersionInfo or ContentInfo'
@@ -130,7 +133,7 @@ class ContentTypeLimitationType extends AbstractPersistenceLimitationType implem
             return false;
         }
 
-        if ($object instanceof ContentCreateStruct) {
+        if ($object instanceof ContentCreateStruct || $object instanceof ContentUpdateStruct) {
             return in_array($object->contentType->id, $value->limitationValues);
         }
 

--- a/eZ/Publish/Core/Limitation/LanguageLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitationType.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
+use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
@@ -117,10 +118,14 @@ class LanguageLimitationType extends AbstractPersistenceLimitationType implement
 
         if ($object instanceof Content) {
             $object = $object->getVersionInfo();
-        } elseif (!$object instanceof VersionInfo && !$object instanceof ContentInfo && !$object instanceof ContentCreateStruct) {
+        } elseif (!$object instanceof VersionInfo
+            && !$object instanceof ContentInfo
+            && !$object instanceof ContentCreateStruct
+            && !$object instanceof ContentUpdateStruct
+        ) {
             throw new InvalidArgumentException(
                 '$object',
-                'Must be of type: ContentCreateStruct, Content, VersionInfo or ContentInfo'
+                'Must be of type: ContentCreateStruct, ContentUpdateStruct, Content, VersionInfo or ContentInfo'
             );
         }
 
@@ -130,6 +135,10 @@ class LanguageLimitationType extends AbstractPersistenceLimitationType implement
 
         if ($object instanceof ContentInfo || $object instanceof ContentCreateStruct) {
             return in_array($object->mainLanguageCode, $value->limitationValues, true);
+        }
+
+        if ($object instanceof ContentUpdateStruct) {
+            return in_array($object->initialLanguageCode, $value->limitationValues, true);
         }
 
         /*

--- a/eZ/Publish/Core/Limitation/LocationLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LocationLimitationType.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
+use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
@@ -120,6 +121,8 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
 
         if ($object instanceof ContentCreateStruct) {
             return $this->evaluateForContentCreateStruct($value, $targets);
+        } elseif ($object instanceof ContentUpdateStruct) {
+            $object = $object->contentDraft->getVersionInfo()->getContentInfo();
         } elseif ($object instanceof Content) {
             $object = $object->getVersionInfo()->getContentInfo();
         } elseif ($object instanceof VersionInfo) {

--- a/eZ/Publish/Core/Limitation/OwnerLimitationType.php
+++ b/eZ/Publish/Core/Limitation/OwnerLimitationType.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Limitation;
 
+use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
@@ -129,7 +130,9 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
             $object = $object->getVersionInfo()->getContentInfo();
         } elseif ($object instanceof VersionInfo) {
             $object = $object->getContentInfo();
-        } elseif (!$object instanceof ContentInfo && !$object instanceof ContentCreateStruct) {
+        } elseif ($object instanceof ContentUpdateStruct) {
+            $object = $object->contentDraft->getVersionInfo()->getContentInfo();
+        } elseif (!$object instanceof ContentInfo && !$object instanceof ContentCreateStruct && !$object instanceof ContentUpdateStruct) {
             throw new InvalidArgumentException(
                 '$object',
                 'Must be of type: ContentCreateStruct, Content, VersionInfo or ContentInfo'

--- a/eZ/Publish/Core/Limitation/SectionLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SectionLimitationType.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
+use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
@@ -131,7 +132,9 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
             $object = $object->getVersionInfo()->getContentInfo();
         } elseif ($object instanceof VersionInfo) {
             $object = $object->getContentInfo();
-        } elseif (!$object instanceof ContentInfo && !$object instanceof ContentCreateStruct) {
+        } elseif ($object instanceof ContentUpdateStruct) {
+            $object = $object->contentDraft->getVersionInfo()->getContentInfo();
+        } elseif (!$object instanceof ContentInfo && !$object instanceof ContentCreateStruct && !$object instanceof ContentUpdateStruct) {
             // As this is Role limitation we need to signal abstain on unsupported $object
             return self::ACCESS_ABSTAIN;
         }

--- a/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
+use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
@@ -126,6 +127,8 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
 
         if ($object instanceof ContentCreateStruct) {
             return $this->evaluateForContentCreateStruct($value, $targets);
+        } elseif ($object instanceof ContentUpdateStruct) {
+            $object = $object->contentDraft->getVersionInfo()->getContentInfo();
         } elseif ($object instanceof Content) {
             $object = $object->getVersionInfo()->getContentInfo();
         } elseif ($object instanceof VersionInfo) {

--- a/eZ/Publish/Core/Limitation/Tests/LanguageLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/LanguageLimitationTypeTest.php
@@ -1,0 +1,435 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Limitation\Tests;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LanguageCode;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Limitation\LanguageLimitationType;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
+use eZ\Publish\Core\Repository\Values\Content\ContentUpdateStruct;
+use eZ\Publish\SPI\Persistence\Content\Language\Handler as SPIHandler;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+use RuntimeException;
+
+class LanguageLimitationTypeTest extends Base
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Language\Handler|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $contentLanguageHandlerMock;
+
+    /**
+     * @var \eZ\Publish\Core\Limitation\LanguageLimitationType
+     */
+    private $languageLimitationType;
+
+    /**
+     * Setup Language Handler mock.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->contentLanguageHandlerMock = $this->createMock(SPIHandler::class);
+        $this->languageLimitationType = new LanguageLimitationType($this->getPersistenceMock());
+    }
+
+    /**
+     * Tear down Language Handler mock.
+     */
+    public function tearDown()
+    {
+        unset($this->contentLanguageHandlerMock, $this->languageLimitationType);
+        parent::tearDown();
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestAcceptValue(): array
+    {
+        return [
+            [new LanguageLimitation()],
+            [new LanguageLimitation([])],
+            [new LanguageLimitation(['limitationValues' => ['2', 's3fdaf32r']])],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestAcceptValue
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation $limitation
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testAcceptValue(LanguageLimitation $limitation): void
+    {
+        $this->languageLimitationType->acceptValue($limitation);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestAcceptValueException(): array
+    {
+        return [
+            [new ObjectStateLimitation()],
+            [new LanguageLimitation(['limitationValues' => [true]])],
+            [new LanguageLimitation(['limitationValues' => [0]])],
+            [new LanguageLimitation(['limitationValues' => [PHP_INT_MAX]])],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestAcceptValueException
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitation
+     */
+    public function testAcceptValueException(Limitation $limitation): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->languageLimitationType->acceptValue($limitation);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestValidatePass(): array
+    {
+        return [
+            [new LanguageLimitation()],
+            [new LanguageLimitation([])],
+            [new LanguageLimitation(['limitationValues' => ['pol-PL']])],
+            [new LanguageLimitation(['limitationValues' => ['pol-PL', 'ger-DE']])],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestValidatePass
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation $limitation
+     */
+    public function testValidatePass(LanguageLimitation $limitation): void
+    {
+        if (!empty($limitation->limitationValues)) {
+            $this->getPersistenceMock()
+                ->method('contentLanguageHandler')
+                ->will($this->returnValue($this->contentLanguageHandlerMock));
+
+            foreach ($limitation->limitationValues as $key => $value) {
+                $this->contentLanguageHandlerMock
+                    ->expects($this->at($key))
+                    ->method('loadByLanguageCode')
+                    ->with($value);
+            }
+        }
+
+        $limitationType = $this->languageLimitationType;
+
+        $validationErrors = $limitationType->validate($limitation);
+
+        self::assertEmpty($validationErrors);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestValidateError(): array
+    {
+        return [
+            [new LanguageLimitation(), 0],
+            [new LanguageLimitation(['limitationValues' => [0]]), 1],
+            [new LanguageLimitation(['limitationValues' => [0, PHP_INT_MAX]]), 2],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestValidateError
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation $limitation
+     * @param int $errorCount
+     */
+    public function testValidateError(LanguageLimitation $limitation, $errorCount): void
+    {
+        if (!empty($limitation->limitationValues)) {
+            $this->getPersistenceMock()
+                ->method('contentLanguageHandler')
+                ->will($this->returnValue($this->contentLanguageHandlerMock));
+
+            foreach ($limitation->limitationValues as $key => $value) {
+                $this->contentLanguageHandlerMock
+                    ->expects($this->at($key))
+                    ->method('loadByLanguageCode')
+                    ->with($value)
+                    ->will($this->throwException(new NotFoundException('Language', $value)));
+            }
+        } else {
+            $this->getPersistenceMock()
+                ->expects($this->never())
+                ->method($this->anything());
+        }
+
+        $limitationType = $this->languageLimitationType;
+
+        $validationErrors = $limitationType->validate($limitation);
+        self::assertCount($errorCount, $validationErrors);
+    }
+
+    public function testBuildValue(): void
+    {
+        $expected = ['test', 'test' => 9];
+        $value = $this->languageLimitationType->buildValue($expected);
+
+        self::assertInstanceOf(LanguageLimitation::class, $value);
+        self::assertInternalType('array', $value->limitationValues);
+        self::assertEquals($expected, $value->limitationValues);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestEvaluate(): array
+    {
+        return [
+            // ContentInfo, no access
+            [
+                'limitation' => new LanguageLimitation(),
+                'object' => new ContentInfo(),
+                'expected' => false,
+            ],
+            // ContentInfo, with access
+            [
+                'limitation' => new LanguageLimitation(['limitationValues' => ['pol-PL']]),
+                'object' => new ContentInfo(['mainLanguageCode' => 'pol-PL']),
+                'expected' => true,
+            ],
+            // ContentInfo, no access
+            [
+                'limitation' => new LanguageLimitation(['limitationValues' => ['pol-PL']]),
+                'object' => new ContentInfo(['mainLanguageCode' => 'eng-GB']),
+                'expected' => false,
+            ],
+            // ContentCreateStruct, with access
+            [
+                'limitation' => new LanguageLimitation(['limitationValues' => ['pol-PL']]),
+                'object' => new ContentCreateStruct(['mainLanguageCode' => 'pol-PL']),
+                'expected' => true,
+            ],
+            // ContentCreateStruct, no access
+            [
+                'limitation' => new LanguageLimitation(['limitationValues' => ['pol-PL']]),
+                'object' => new ContentCreateStruct(['mainLanguageCode' => 'eng-GB']),
+                'expected' => false,
+            ],
+            // ContentUpdateStruct, with access
+            [
+                'limitation' => new LanguageLimitation(['limitationValues' => ['pol-PL']]),
+                'object' => new ContentUpdateStruct(['initialLanguageCode' => 'pol-PL']),
+                'expected' => true,
+            ],
+            // ContentUpdateStruct, no access
+            [
+                'limitation' => new LanguageLimitation(['limitationValues' => ['pol-PL']]),
+                'object' => new ContentUpdateStruct(['initialLanguageCode' => 'eng-GB']),
+                'expected' => false,
+            ],
+            // VersionInfo, with access, VersionInfo initialLanguageCode (pol-PL) is in array of limitationValues
+            [
+                'limitation' => new LanguageLimitation(['limitationValues' => ['eng-GB', 'pol-PL']]),
+                'object' => $this->getVersionInfo(),
+                'expected' => true,
+            ],
+            // VersionInfo, with access, one of limitationValues is in VersionInfo->languageCodes
+            [
+                'limitation' => new LanguageLimitation(['limitationValues' => ['eng-GB', 'pol-PL']]),
+                'object' => $this->getVersionInfo('fra-FR', ['pol-PL']),
+                'expected' => true,
+            ],
+            // VersionInfo, no access, VersionInfo initialLanguageCode (pol-PL) is NOT in array of limitationValues
+            [
+                'limitation' => new LanguageLimitation(['limitationValues' => ['eng-GB', 'pol-PL']]),
+                'object' => $this->getVersionInfo('fra-FR'),
+                'expected' => false,
+            ],
+            // VersionInfo, no access, NONE of limitationValues is in VersionInfo->languageCodes
+            [
+                'limitation' => new LanguageLimitation(['limitationValues' => ['eng-GB', 'pol-PL']]),
+                'object' => $this->getVersionInfo('fra-FR', ['nor-NO']),
+                'expected' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestEvaluate
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation $limitation
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $object
+     * @param $expected
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testEvaluate(
+        LanguageLimitation $limitation,
+        ValueObject $object,
+        $expected
+    ): void {
+        $limitationType = $this->languageLimitationType;
+
+        $userMock = $this->getUserMock();
+        $userMock
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $value = $limitationType->evaluate(
+            $limitation,
+            $userMock,
+            $object
+        );
+
+        self::assertInternalType('boolean', $value);
+        self::assertEquals($expected, $value);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestEvaluateInvalidArgument(): array
+    {
+        return [
+            // invalid limitation
+            [
+                'limitation' => new ObjectStateLimitation(),
+                'object' => new ContentInfo(),
+                'targets' => null,
+                'persistence' => [],
+            ],
+            // invalid object
+            [
+                'limitation' => new LanguageLimitation(),
+                'object' => new ObjectStateLimitation(),
+                'targets' => [new Location()],
+                'persistence' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestEvaluateInvalidArgument
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitation
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $object
+     * @param $targets
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testEvaluateInvalidArgument(
+        Limitation $limitation,
+        ValueObject $object,
+        $targets
+    ): void {
+        $limitationType = $this->languageLimitationType;
+
+        $userMock = $this->getUserMock();
+        $userMock
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $persistenceMock = $this->getPersistenceMock();
+        $persistenceMock
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $limitationType->evaluate(
+            $limitation,
+            $userMock,
+            $object,
+            $targets
+        );
+    }
+
+    public function testGetCriterionInvalidValue(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->languageLimitationType->getCriterion(
+            new LanguageLimitation([]),
+            $this->getUserMock()
+        );
+    }
+
+    public function testGetCriterionSingleValue(): void
+    {
+        $criterion = $this->languageLimitationType->getCriterion(
+            new LanguageLimitation(['limitationValues' => ['pol-PL']]),
+            $this->getUserMock()
+        );
+
+        self::assertInstanceOf(LanguageCode::class, $criterion);
+        self::assertInternalType('array', $criterion->value);
+        self::assertInternalType('string', $criterion->operator);
+        self::assertEquals(Operator::EQ, $criterion->operator);
+        self::assertEquals(['pol-PL'], $criterion->value);
+    }
+
+    public function testGetCriterionMultipleValues(): void
+    {
+        $criterion = $this->languageLimitationType->getCriterion(
+            new LanguageLimitation(['limitationValues' => ['pol-PL', 'ger-DE']]),
+            $this->getUserMock()
+        );
+
+        self::assertInstanceOf(LanguageCode::class, $criterion);
+        self::assertInternalType('array', $criterion->value);
+        self::assertInternalType('string', $criterion->operator);
+        self::assertEquals(Operator::IN, $criterion->operator);
+        self::assertEquals(['pol-PL', 'ger-DE'], $criterion->value);
+    }
+
+    public function testValueSchema(): void
+    {
+        $this->expectException(NotImplementedException::class);
+
+        $this->languageLimitationType->valueSchema();
+    }
+
+    /**
+     * @param string $initialLanguageCode
+     * @param array $languageCodes
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function getVersionInfo(string $initialLanguageCode = 'pol-PL', array $languageCodes = []): VersionInfo
+    {
+        $versionInfo = $this->createMock(VersionInfo::class);
+        $versionInfo
+            ->method('__get')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['initialLanguageCode', $initialLanguageCode],
+                        ['languageCodes', $languageCodes],
+                    ]
+                )
+            );
+
+        return $versionInfo;
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29223](https://jira.ez.no/browse/EZP-29223)
| **Bug/Improvement**|no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     |no

<!-- Replace this comment with Pull Request description -->

This PR adds a command `ezpublish:update:legacy_storage_add_content_translate_policy` to add new "content/translate" policy to those roles, which already has "content/edit" policy.

depends on [https://github.com/ezsystems/ezplatform-admin-ui/pull/695](https://github.com/ezsystems/ezplatform-admin-ui/pull/695)

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
