### PR TITLE
[Composer][7.3] Switched eZ Platform branch for behat tests to 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
     "extra": {
         "_ci_branch-comment_": "Keep ci branch up-to-date with master or branch if on stable. ci is never on github but convention used for ci behat testing!",
         "_ezplatform_branch_for_behat_tests_comment_": "ezplatform branch to use to run Behat tests",
-        "_ezplatform_branch_for_behat_tests": "master",
+        "_ezplatform_branch_for_behat_tests": "2.3",
         "branch-alias": {
             "dev-master": "7.3.x-dev",
             "dev-tmp_ci_branch": "7.3.x-dev"


### PR DESCRIPTION
> **Target version**: `7.3`

Switched composer.json `extra->_ezplatform_branch_for_behat_tests` to 2.3 to test `7.3` bug fixes on `2.3` branch.

**TODO**:
- [x] Wait for Travis to confirm
- [ ] On merge up to master: make sure branch is master again