### PR TITLE
[Tests] Speed up tests by using paratest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "twig/twig": "^1.35.4 | ~2.5"
     },
     "require-dev": {
+        "brianium/paratest": "^2.2",
         "friendsofphp/php-cs-fixer": "~2.7.5",
         "phpunit/phpunit": "^7.0",
         "matthiasnoback/symfony-dependency-injection-test": "~3.0",
@@ -66,10 +67,12 @@
         }
     },
     "scripts": {
-        "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating",
+        "fix-cs": "php-cs-fixer fix -v --show-progress=estimating",
+        "unit": "paratest -p half -c phpunit.xml --runner=WrapperRunner",
+        "integration": "paratest -p half -c phpunit-integration-legacy.xml --runner=WrapperRunner",
         "test": [
-            "phpunit -c phpunit.xml",
-            "phpunit -c phpunit-integration-legacy.xml"
+            "@unit",
+            "@integration"
         ]
     },
     "scripts-descriptions": {

--- a/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
@@ -78,7 +78,11 @@ class Legacy extends SetupFactory
     {
         self::$dsn = getenv('DATABASE');
         if (!self::$dsn) {
+            // use sqlite in-memory by default (does not need special handling for paratest as it's per process)
             self::$dsn = 'sqlite://:memory:';
+        } elseif (getenv('TEST_TOKEN') !== false) {
+            // Using paratest, assuming dsn ends with db name here...
+            self::$dsn .= '_' . getenv('TEST_TOKEN');
         }
 
         if ($repositoryReference = getenv('REPOSITORY_SERVICE_ID')) {

--- a/phpunit-integration-legacy-elasticsearch.xml
+++ b/phpunit-integration-legacy-elasticsearch.xml
@@ -54,7 +54,6 @@
           <file>eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php</file>
-          <file>eZ/Publish/API/Repository/Tests/LimitationTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php</file>
         </testsuite>
     </testsuites>

--- a/phpunit-integration-legacy-solr.xml
+++ b/phpunit-integration-legacy-solr.xml
@@ -57,7 +57,6 @@
             <file>eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php</file>
-            <file>eZ/Publish/API/Repository/Tests/LimitationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php</file>
         </testsuite>
         <testsuite name="eZ\Publish\API\Repository\Tests\Regression">

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -17,10 +17,10 @@
     </php>
     <testsuites>
         <testsuite name="eZ\Publish\API\Repository">
+            <directory>eZ/Publish/API/Repository/Tests/Values/Content</directory>
             <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
             <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
-            <file>eZ/Publish/API/Repository/Tests/PermissionServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/PermissionResolverTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceTest.php</file>
@@ -53,11 +53,10 @@
             <file>eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php</file>
-            <file>eZ/Publish/API/Repository/Tests/LimitationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/BookmarkServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/NotificationServiceTest.php</file>
-            <file>eZ/Publish/API/Repository/Tests/UserPreferencesServiceTest.php</file>
+            <file>eZ/Publish/API/Repository/Tests/UserPreferenceServiceTest.php</file>
         </testsuite>
         <testsuite name="eZ\Publish\API\Repository\Tests\Regression">
             <directory>eZ/Publish/API/Repository/Tests/Regression/</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -43,12 +43,6 @@
     <testsuite name="eZ\Publish\Core\Search">
       <directory>eZ/Publish/Core/Search/Tests</directory>
     </testsuite>
-    <testsuite name="eZ\Publish\Core\Search\Solr">
-      <directory>eZ/Publish/Core/Search/Solr/Tests</directory>
-    </testsuite>
-    <testsuite name="eZ\Publish\Core\Search\Elasticsearch">
-      <directory>eZ/Publish/Core/Search/Elasticsearch/Tests</directory>
-    </testsuite>
     <testsuite name="eZ\Publish\Core\IO">
       <directory>eZ/Publish/Core/IO/Tests</directory>
     </testsuite>
@@ -56,9 +50,6 @@
       <directory>eZ/Publish/Core/MVC/Symfony</directory>
       <directory>eZ/Bundle</directory>
       <exclude>eZ/Bundle/EzPublishRestBundle/Tests/Functional</exclude>
-    </testsuite>
-    <testsuite name="eZ Publish legacy test suite">
-        <directory>eZ/Publish/Core/MVC/Legacy</directory>
     </testsuite>
     <testsuite name="eZ Publish REST test suite">
         <directory>eZ/Publish/Core/REST</directory>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Bug/Improvement**| yes/no
| **New feature**    | yes/no
| **Target version** | `7.x` _(paratest requires php7)_
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | no

I don't expect this to pass with mysql/postgres/sorl, as we should setup different databases for the different processes using [test token](https://github.com/paratestphp/paratest#test-token).


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.

