### PR TITLE
Add additional databases setup on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,11 @@ matrix:
       env: TEST_CONFIG="phpunit.xml"
     - php: 7.2
       env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
+    - name: Legacy Integration with MariaDB 10.3
+      php: 7.1
+      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mariadb" DATABASE="mysql://root@localhost/testdb"
+      addons:
+        mariadb: 10.3
 
 
 # test only master, stable branches and pull requests

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       env: TEST_CONFIG="phpunit.xml"
     - php: 7.2
       env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
-    - name: Legacy Integration with MariaDB 10.3
+    - name: Legacy Storage engine tests with MariaDB 10.3
       php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mariadb" DATABASE="mysql://root@localhost/testdb"
       addons:

--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -22,7 +22,7 @@ if [ "$CUSTOM_CACHE_POOL" = "singleredis" ] ; then
 fi
 
 # Setup DB
-if [ "$DB" = "mysql" ] ; then
+if [ "$DB" = "mysql" ] || [ "$DB" = "mariadb" ] ; then
     # https://github.com/travis-ci/travis-ci/issues/3049
     # make sure we don't run out of entropy apparently (see link above)
     sudo apt-get -y install haveged


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29740](https://jira.ez.no/browse/EZP-29740)
| **Bug/Improvement**| Improvement
| **New feature**    | no
| **Target version** | 7.3, master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Adds a job running Legacy integration tests on MariaDB 10.3. This PR contains two commits:
https://github.com/ezsystems/ezpublish-kernel/pull/2468/commits/cd6779360e61463927c3b1de9ac47a297cd49f11 adds the job, https://github.com/ezsystems/ezpublish-kernel/pull/2468/commits/cbaceec1b8bae6b782f89edcdd8363e49af349a7 is a temporary one that verifies that `mysql` command is in fact MariaDB 10.3. (`mysql -uroot -V` returns `mysql  Ver 15.1 Distrib 10.3.10-MariaDB, for debian-linux-gnu (x86_64) using readline 5.2`)