### PR TITLE
[WIP] EZP-29740: Run integration tests on mysql 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,16 +52,8 @@ matrix:
 #       env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
     - name: Legacy Integration with mysql 8.0
       php: 7.1
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@127.0.0.1/testdb" COMMAND="mysql -uroot -V"
-      addons:
-        apt:
-          update: true
-          sources:
-          - sourceline: 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-8.0'
-            key_url: 'http://pool.sks-keyservers.net/pks/lookup?op=get&search=0x8C718D3B5072E1F5'
-          packages:
-          - mysql-server
-          - mysql-client
+      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@0.0.0.0:33306/testdb" MYSQL_VERSION=8.0
+      services: docker
 
 # test only master, stable branches and pull requests
 branches:
@@ -79,6 +71,7 @@ before_install:
   - if [ "$ENABLE_LZF" = true ] ; then printf "no\n" | pecl install lzf ; fi
   # Prepare system
   - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
+  - if [ "$MYSQL_VERSION" == "8.0" ] ; then ./bin/.travis/install_mysql8.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] || [ "$REST_TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
   # Execute Symfony command if specified
   - if [ "$SF_CMD" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/console $SF_CMD" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,27 +30,38 @@ matrix:
   fast_finish: true
   include:
 # 7.1
-    - php: 7.1
-      env: TEST_CONFIG="phpunit.xml"
-    - php: 7.1
-      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
-    - php: 7.1
-      env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat
-    - php: 7.1
-      env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
-    - php: 7.1
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
-    - php: 7.1
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
-# Disabled as it currently fails, integration tests are not written for language config awareness in Repo, should probably be opt in by test
-#    - php: 7.1
-#      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" REPOSITORY_SERVICE_ID="ezpublish.siteaccessaware.repository"
-# 7.2
-    - php: 7.2
-      env: TEST_CONFIG="phpunit.xml"
-    - php: 7.2
-      env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
-
+#     - php: 7.1
+#       env: TEST_CONFIG="phpunit.xml"
+#     - php: 7.1
+#       env: REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
+#     - php: 7.1
+#       env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat
+#     - php: 7.1
+#       env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
+#     - php: 7.1
+#       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
+#     - php: 7.1
+#       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
+# # Disabled as it currently fails, integration tests are not written for language config awareness in Repo, should probably be opt in by test
+# #    - php: 7.1
+# #      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" REPOSITORY_SERVICE_ID="ezpublish.siteaccessaware.repository"
+# # 7.2
+#     - php: 7.2
+#       env: TEST_CONFIG="phpunit.xml"
+#     - php: 7.2
+#       env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
+    - name: Legacy Integration with mysql 8.0
+      php: 7.1
+      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@127.0.0.1/testdb" COMMAND="mysql -uroot -V"
+      addons:
+        apt:
+          update: true
+          sources:
+          - sourceline: 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-8.0'
+            key_url: 'http://pool.sks-keyservers.net/pks/lookup?op=get&search=0x8C718D3B5072E1F5'
+          packages:
+          - mysql-server
+          - mysql-client
 
 # test only master, stable branches and pull requests
 branches:
@@ -60,6 +71,7 @@ branches:
 
 # setup requirements for running unit/integration/behat tests
 before_install:
+  - $COMMAND
   # Disable memory_limit for composer
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   # Install igbinary & lzf PHP extensions if necessary

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,19 @@ sudo: required
 
 language: php
 
+services:
+  - mysql
+  - postgresql
+  - redis-server
+
+# Mysql isn't installed on trusty (only client is), so we need to specifically install it
+addons:
+  apt:
+    packages:
+    - mysql-server-5.6
+    - mysql-client-core-5.6
+    - mysql-client-5.6
+
 cache:
   directories:
     - $HOME/.composer/cache/files
@@ -40,15 +53,7 @@ matrix:
     - name: Legacy Integration with mysql 8.0
       php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@0.0.0.0:33306/testdb" MYSQL_VERSION=8.0
-      dist: xenial
-      addons:
-         apt:
-           update: true
-           sources:
-            - sourceline: 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-8.0'
-              key_url: 'http://pool.sks-keyservers.net/pks/lookup?op=get&search=0x8C718D3B5072E1F5'
-           packages:
-            - mysql-server
+      services: docker
 
 # test only master, stable branches and pull requests
 branches:
@@ -66,7 +71,7 @@ before_install:
   - if [ "$ENABLE_LZF" = true ] ; then printf "no\n" | pecl install lzf ; fi
   # Prepare system
   #- if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
-  #- if [ "$MYSQL_VERSION" == "8.0" ] ; then ./bin/.travis/install_mysql8.sh ; fi
+  - if [ "$MYSQL_VERSION" == "8.0" ] ; then ./bin/.travis/install_mysql8.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] || [ "$REST_TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
   # Execute Symfony command if specified
   - if [ "$SF_CMD" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/console $SF_CMD" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_install:
   - if [ "$ENABLE_IGBINARY" = true ] ; then pecl install igbinary ; fi
   - if [ "$ENABLE_LZF" = true ] ; then printf "no\n" | pecl install lzf ; fi
   # Prepare system
-  - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
+  #- if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
   - if [ "$MYSQL_VERSION" == "8.0" ] ; then ./bin/.travis/install_mysql8.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] || [ "$REST_TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
   # Execute Symfony command if specified

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,6 @@ sudo: required
 
 language: php
 
-services:
-  - mysql
-  - postgresql
-  - redis-server
-
-# Mysql isn't installed on trusty (only client is), so we need to specifically install it
-addons:
-  apt:
-    packages:
-    - mysql-server-5.6
-    - mysql-client-core-5.6
-    - mysql-client-5.6
-
 cache:
   directories:
     - $HOME/.composer/cache/files
@@ -53,7 +40,15 @@ matrix:
     - name: Legacy Integration with mysql 8.0
       php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@0.0.0.0:33306/testdb" MYSQL_VERSION=8.0
-      services: docker
+      dist: xenial
+      addons:
+         apt:
+           update: true
+           sources:
+            - sourceline: 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-8.0'
+              key_url: 'http://pool.sks-keyservers.net/pks/lookup?op=get&search=0x8C718D3B5072E1F5'
+           packages:
+            - mysql-server
 
 # test only master, stable branches and pull requests
 branches:
@@ -71,7 +66,7 @@ before_install:
   - if [ "$ENABLE_LZF" = true ] ; then printf "no\n" | pecl install lzf ; fi
   # Prepare system
   #- if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
-  - if [ "$MYSQL_VERSION" == "8.0" ] ; then ./bin/.travis/install_mysql8.sh ; fi
+  #- if [ "$MYSQL_VERSION" == "8.0" ] ; then ./bin/.travis/install_mysql8.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] || [ "$REST_TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
   # Execute Symfony command if specified
   - if [ "$SF_CMD" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/console $SF_CMD" ; fi

--- a/bin/.travis/install_mysql8.sh
+++ b/bin/.travis/install_mysql8.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Starting MySQL 8.0..."
+
+echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password" > /tmp/mysql-auth.cnf
+
+docker pull mysql:8.0
+docker run \
+    -d \
+    -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+    -e MYSQL_DATABASE=testdb \
+    -v /tmp/mysql-auth.cnf:/etc/mysql/conf.d/auth.cnf:ro \
+    -p 33306:3306 \
+    --name mysql80 \
+    mysql:8.0

--- a/bin/.travis/install_mysql8.sh
+++ b/bin/.travis/install_mysql8.sh
@@ -9,7 +9,8 @@ sudo stop mysql
 echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password\nskip-log-bin\nssl=0" > /tmp/mysql-auth.cnf
 
 docker pull mysql:8.0
-docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=testdb -v /tmp/mysql-auth.cnf:/etc/mysql/conf.d/auth.cnf:ro -v /mnt/ramdisk:/var/lib/mysql -p 33306:3306 --name mysql80 mysql:8.0
+docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -v /tmp/mysql-auth.cnf:/etc/mysql/conf.d/auth.cnf:ro -v /mnt/ramdisk:/var/lib/mysql -p 33306:3306 --name mysql80 mysql:8.0
 docker exec mysql80 apt-get update
 docker exec mysql80 apt-get -y install haveged
 docker exec mysql80 service haveged start
+docker exec mysql21 mysql -u root -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;";

--- a/bin/.travis/install_mysql8.sh
+++ b/bin/.travis/install_mysql8.sh
@@ -10,7 +10,7 @@ echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password\nskip-log
 
 docker pull mysql:8.0
 docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -v /tmp/mysql-auth.cnf:/etc/mysql/conf.d/auth.cnf:ro -v /mnt/ramdisk:/var/lib/mysql -p 33306:3306 --name mysql80 mysql:8.0
-docker exec mysql80 apt-get update
-docker exec mysql80 apt-get -y install haveged
-docker exec mysql80 service haveged start
+# docker exec mysql80 apt-get update
+# docker exec mysql80 apt-get -y install haveged
+# docker exec mysql80 service haveged start
 docker exec mysql80 mysql -u root -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;";

--- a/bin/.travis/install_mysql8.sh
+++ b/bin/.travis/install_mysql8.sh
@@ -2,16 +2,15 @@
 
 set -ex
 
-echo "Starting MySQL 8.0..."
+sudo mkdir /mnt/ramdisk
+sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
+sudo stop mysql
+sudo start mysql
 
 echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password" > /tmp/mysql-auth.cnf
 
 docker pull mysql:8.0
-docker run \
-    -d \
-    -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
-    -e MYSQL_DATABASE=testdb \
-    -v /tmp/mysql-auth.cnf:/etc/mysql/conf.d/auth.cnf:ro \
-    -p 33306:3306 \
-    --name mysql80 \
-    mysql:8.0
+docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=testdb -v /tmp/mysql-auth.cnf:/etc/mysql/conf.d/auth.cnf:ro -v /mnt/ramdisk:/var/lib/mysql -p 33306:3306 --name mysql80 mysql:8.0
+docker exec mysql80 apt-get update
+docker exec mysql80 apt-get -y install haveged
+docker exec mysql80 service haveged start

--- a/bin/.travis/install_mysql8.sh
+++ b/bin/.travis/install_mysql8.sh
@@ -8,7 +8,7 @@ sudo stop mysql
 
 echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password\nskip-log-bin\nssl=0" > /tmp/mysql-auth.cnf
 
-docker pull mysql:8.0
+docker pull mysql:8.0.11
 docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -v /tmp/mysql-auth.cnf:/etc/mysql/conf.d/auth.cnf:ro -v /mnt/ramdisk:/var/lib/mysql -p 33306:3306 --name mysql80 mysql:8.0.11
 docker exec mysql80 apt-get update
 docker exec mysql80 apt-get -y install haveged

--- a/bin/.travis/install_mysql8.sh
+++ b/bin/.travis/install_mysql8.sh
@@ -9,8 +9,8 @@ sudo stop mysql
 echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password\nskip-log-bin\nssl=0" > /tmp/mysql-auth.cnf
 
 docker pull mysql:8.0
-docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -v /tmp/mysql-auth.cnf:/etc/mysql/conf.d/auth.cnf:ro -v /mnt/ramdisk:/var/lib/mysql -p 33306:3306 --name mysql80 mysql:8.0
-# docker exec mysql80 apt-get update
-# docker exec mysql80 apt-get -y install haveged
-# docker exec mysql80 service haveged start
+docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -v /tmp/mysql-auth.cnf:/etc/mysql/conf.d/auth.cnf:ro -v /mnt/ramdisk:/var/lib/mysql -p 33306:3306 --name mysql80 mysql:8.0.11
+docker exec mysql80 apt-get update
+docker exec mysql80 apt-get -y install haveged
+docker exec mysql80 service haveged start
 docker exec mysql80 mysql -u root -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;";

--- a/bin/.travis/install_mysql8.sh
+++ b/bin/.travis/install_mysql8.sh
@@ -13,4 +13,4 @@ docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -v /tmp/mysql-auth.cnf:/etc/mysq
 docker exec mysql80 apt-get update
 docker exec mysql80 apt-get -y install haveged
 docker exec mysql80 service haveged start
-docker exec mysql21 mysql -u root -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;";
+docker exec mysql80 mysql -u root -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;";

--- a/bin/.travis/install_mysql8.sh
+++ b/bin/.travis/install_mysql8.sh
@@ -5,9 +5,8 @@ set -ex
 sudo mkdir /mnt/ramdisk
 sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
 sudo stop mysql
-sudo start mysql
 
-echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password\nskip-log-bin" > /tmp/mysql-auth.cnf
+echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password\nskip-log-bin\nssl=0" > /tmp/mysql-auth.cnf
 
 docker pull mysql:8.0
 docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=testdb -v /tmp/mysql-auth.cnf:/etc/mysql/conf.d/auth.cnf:ro -v /mnt/ramdisk:/var/lib/mysql -p 33306:3306 --name mysql80 mysql:8.0

--- a/bin/.travis/install_mysql8.sh
+++ b/bin/.travis/install_mysql8.sh
@@ -7,7 +7,7 @@ sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
 sudo stop mysql
 sudo start mysql
 
-echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password" > /tmp/mysql-auth.cnf
+echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password\nskip-log-bin" > /tmp/mysql-auth.cnf
 
 docker pull mysql:8.0
 docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=testdb -v /tmp/mysql-auth.cnf:/etc/mysql/conf.d/auth.cnf:ro -v /mnt/ramdisk:/var/lib/mysql -p 33306:3306 --name mysql80 mysql:8.0


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29740](https://jira.ez.no/browse/EZP-29740)
| **Bug/Improvement**| Improvement
| **New feature**    | no
| **Target version** | 7.3, master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Adds a job running Legacy integration tests on mysql 8.0. This PR is experimental so far:
- first commit is trying to install mysql8.0 with apt addons. Somehow it doesn't work - mysql is unable to start
- second commit is using mysql 8.0 on a Docker image. It works, but the performance is terrible - build is longer than 50 minutes and does not finish.
- third commit improves the second approach - this brings the build time below 50 minutes.
- 4&5 commits are a further improvement, trying to reduce the time of insert on mysql8.0

This approach is based is partially based on:
https://github.com/doctrine/dbal/pull/3183

with potential speedups taken from:
https://github.com/ezsystems/ezpublish-kernel/blob/master/bin/.travis/prepare_unittest.sh#L30
https://dba.stackexchange.com/questions/216352/inserts-in-mysql-8-are-slower-than-inserts-in-mysql-5-7

One issue is already visible: one test is always failing and requires deeper investigation (it passes on mysql 5.6).