### PR TITLE
Fixes for the issues causing PHP fatal errors during the static analysis

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/Relation/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/Relation/ParameterProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\RelationList;
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\Relation;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RelationList/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RelationList/ParameterProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\Relation;
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\RelationList;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;

--- a/eZ/Publish/Core/REST/Client/LocationService.php
+++ b/eZ/Publish/Core/REST/Client/LocationService.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\REST\Common\RequestParser;
 use eZ\Publish\Core\REST\Common\Input\Dispatcher;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
@@ -259,6 +260,19 @@ class LocationService implements APILocationService, Sessionable
         );
 
         return $this->inputDispatcher->parse($response);
+    }
+
+    /**
+     * Load parent Locations for Content Draft.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
+     * @param string[]|null $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location[] List of parent Locations
+     */
+    public function loadParentLocationsForDraftContent(VersionInfo $versionInfo, array $prioritizedLanguages = null)
+    {
+        throw new \Exception('@todo: Implement.');
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/LocationService.php
+++ b/eZ/Publish/Core/REST/Client/LocationService.php
@@ -80,7 +80,7 @@ class LocationService implements APILocationService, Sessionable
      * Instantiates a new location create class.
      *
      * @param mixed $parentLocationId the parent under which the new location should be created
-     * @param eZ\Publish\API\Repository\Values\ContentType\ContentType|null $contentType
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType|null $contentType
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct
      */
@@ -132,10 +132,11 @@ class LocationService implements APILocationService, Sessionable
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the specified location is not found
      *
      * @param mixed $locationId
+     * @param string[]|null $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Location
      */
-    public function loadLocation($locationId)
+    public function loadLocation($locationId, array $prioritizedLanguages = null)
     {
         $response = $this->client->request(
             'GET',
@@ -155,10 +156,11 @@ class LocationService implements APILocationService, Sessionable
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the specified location is not found
      *
      * @param string $remoteId
+     * @param string[]|null $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Location
      */
-    public function loadLocationByRemoteId($remoteId)
+    public function loadLocationByRemoteId($remoteId, array $prioritizedLanguages = null)
     {
         $response = $this->client->request(
             'GET',
@@ -217,10 +219,11 @@ class LocationService implements APILocationService, Sessionable
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
      * @param \eZ\Publish\API\Repository\Values\Content\Location $rootLocation
+     * @param string[]|null $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Location[]
      */
-    public function loadLocations(ContentInfo $contentInfo, Location $rootLocation = null)
+    public function loadLocations(ContentInfo $contentInfo, Location $rootLocation = null, array $prioritizedLanguages = null)
     {
         $values = $this->requestParser->parse('object', $contentInfo->id);
         $response = $this->client->request(
@@ -240,10 +243,11 @@ class LocationService implements APILocationService, Sessionable
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
      * @param int $offset the start offset for paging
      * @param int $limit the number of locations returned
+     * @param string[]|null $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationList
      */
-    public function loadLocationChildren(Location $location, $offset = 0, $limit = 25)
+    public function loadLocationChildren(Location $location, $offset = 0, $limit = 25, array $prioritizedLanguages = null)
     {
         $values = $this->requestParser->parse('location', $location->id);
         $response = $this->client->request(

--- a/eZ/Publish/Core/REST/Client/Repository.php
+++ b/eZ/Publish/Core/REST/Client/Repository.php
@@ -512,6 +512,16 @@ class Repository implements APIRepository
     }
 
     /**
+     * Get NotificationService
+     *
+     * @return \eZ\Publish\API\Repository\NotificationService
+     */
+    public function getNotificationService()
+    {
+        throw new \RuntimeException('@todo: Implement');
+    }
+
+    /**
      * Begin transaction.
      *
      * Begins an transaction, make sure you'll call commit or rollback when done,

--- a/eZ/Publish/Core/REST/Client/Tests/Output/ValueObjectVisitor/RestContentMetadataUpdateStruct.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Output/ValueObjectVisitor/RestContentMetadataUpdateStruct.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\REST\Client\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Client\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor;
-use eZ\Publish\Core\REST\Common\Values\RestContentMetadataUpdateStruct;
+use eZ\Publish\Core\REST\Common\Values;
 
 class RestContentMetadataUpdateStruct extends ValueObjectVisitorBaseTest
 {
@@ -27,7 +27,7 @@ class RestContentMetadataUpdateStruct extends ValueObjectVisitorBaseTest
 
         $generator->startDocument(null);
 
-        $sectionCreatestruct = new RestContentMetadataUpdateStruct(
+        $sectionCreatestruct = new Values\RestContentMetadataUpdateStruct(
             $this->getValidValues()
         );
 

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\REST\Client;
 use eZ\Publish\API\Repository\UserService as APIUserService;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserCreateStruct;
+use eZ\Publish\API\Repository\Values\User\UserTokenUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\UserUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
 use eZ\Publish\API\Repository\Values\User\UserGroupCreateStruct;
@@ -227,6 +228,19 @@ class UserService implements APIUserService, Sessionable
     }
 
     /**
+     * Loads a user with user hash key.
+     *
+     * @param string $hash
+     * @param array $prioritizedLanguages
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    public function loadUserByToken($hash, array $prioritizedLanguages = [])
+    {
+        throw new \Exception('@todo: Implement.');
+    }
+
+    /**
      * This method deletes a user.
      *
      * @param \eZ\Publish\API\Repository\Values\User\User $user
@@ -257,6 +271,30 @@ class UserService implements APIUserService, Sessionable
     {
         throw new \Exception('@todo: Implement.');
     }
+
+    /**
+     * Update the user token information specified by the user token struct.
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param \eZ\Publish\API\Repository\Values\User\UserTokenUpdateStruct $userTokenUpdateStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    public function updateUserToken(User $user, UserTokenUpdateStruct $userTokenUpdateStruct)
+    {
+        throw new \Exception('@todo: Implement.');
+    }
+
+    /**
+     * Expires user token with user hash.
+     *
+     * @param string $hash
+     */
+    public function expireUserToken($hash)
+    {
+        throw new \Exception('@todo: Implement.');
+    }
+
 
     /**
      * Assigns a new user group to the user.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | ---
| **Bug/Improvement**| ---
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | ?
| **Doc needed**     | no

I wanted to run PHPStan against `ezpublish-kernel`, but during the static analysis, PHP interpreter complained about a few minor issues like incorrect namespaces or missing implementations of interfaces methods. This PR fixes all of them, therefore it's possible to finish PHPStan execution. 
There is a plan for another PRs in the future, regarding the issues found by the mentioned tool.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
