### PR TITLE
Missing use statement in  eZ/Publish/Core/MVC/Symfony/Controller/Controller

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Controller.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Controller.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Controller;
 
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 


### PR DESCRIPTION
Added Missing use Statement for ContainerInterface to \eZ\Publish\Core\MVC\Symfony\Controller\Controller