### PR TITLE
api_keys.google_maps should not be set as null by default

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -71,7 +71,6 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
                 ->children()
                     ->scalarNode('google_maps')
                         ->info('Google Maps API Key, required as of Google Maps v3 to make sure maps show up correctly.')
-                        ->defaultNull()
                     ->end()
                 ->end()
             ->end()


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | none
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR removes `api_keys.google_maps` setting to be automatically set as null. By explicitly setting it to null,  has effect to all configuration scopes like `global` and `default` which makes impossible to set values per siteaccess. The only way to override it is by adding `ezsettings.global.api_keys.google_maps` to parameters.yml.

Fallback is already provided by https://github.com/ezsystems/ezpublish-kernel/blob/36f372c3b7c21adec7970439af8e2ca9e775097e/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml#L95, so removing `null` as default won't break config. 
