### PR TITLE
EZP-29801: Content View breaks when providing location id as param

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -130,7 +130,7 @@ class ContentViewBuilder implements ViewBuilder
                 throw new InvalidArgumentException('Location', 'Provided location does not belong to selected content');
             }
 
-            if (isset($parameters['contentId']) && $location->contentId != $parameters['contentId']) {
+            if (isset($parameters['contentId']) && $location->contentId !== (int)$parameters['contentId']) {
                 throw new InvalidArgumentException(
                     'Location',
                     'Provided location does not belong to selected content as requested via contentId parameter'

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -130,7 +130,7 @@ class ContentViewBuilder implements ViewBuilder
                 throw new InvalidArgumentException('Location', 'Provided location does not belong to selected content');
             }
 
-            if (isset($parameters['contentId']) && $location->contentId !== $parameters['contentId']) {
+            if (isset($parameters['contentId']) && $location->contentId != $parameters['contentId']) {
                 throw new InvalidArgumentException(
                     'Location',
                     'Provided location does not belong to selected content as requested via contentId parameter'


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29801](https://jira.ez.no/browse/EZP-29801)
| **Bug/Improvement**| yes/no
| **New feature**    | no
| **Target version** | `7.2+`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

If you somehow provide location id to Content View, then it will throw the following now after ContentProxy feature was added in 2.2:
```
Argument 'Location' is invalid: Provided location does not belong to selected content as requested via contentId parameter
```

This for instance break Step 3 in Bike Ride tutorial where you are asked to enter following url, last parameter is optional so removing it makes it work:
`http://<yourdomains>/view/content/<ContentId>/<language>/full/true/<LocationId>`

Culprit is the following code which is wrongly using strict check:
```php
if (isset($parameters['contentId']) && $location->contentId !== $parameters['contentId']) {
```


**TODO**:
- [x] Implement feature / fix a bug.
- [x] ~Implement tests.~
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
