### PR TITLE
EZP-29839: ReindexCommand should allow to use selected user

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -117,6 +117,12 @@ class ReindexCommand extends ContainerAwareCommand
                 InputOption::VALUE_OPTIONAL,
                 'Number of child processes to run in parallel for iterations, if set to "auto" it will set to number of CPU cores -1, set to "1" or "0" to disable',
                 1
+            )->addOption(
+                'user',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'User id to use. (default admin user is 14)',
+                1
             )->setHelp(
                 <<<EOT
 The command <info>%command.name%</info> indexes current configured database in configured search engine index.
@@ -146,6 +152,13 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $userId = (int)$input->getOption('user');
+        if ($userId) {
+            $repository = $this->getContainer()->get('ezpublish.api.repository');
+            $user = $repository->getUserService()->loadUser($userID);
+            $repository->setCurrentUser($user);
+        }
+        
         $commit = !$input->getOption('no-commit');
         $iterationCount = $input->getOption('iteration-count');
         $this->siteaccess = $input->getOption('siteaccess');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29839](https://jira.ez.no/browse/EZP-29839)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`/`6.13` / `7.2` / `7.3` / `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR introduces a new command option for setting proper user for command execution. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
