### PR TITLE
EZP-29545: Fix value displayed by the DateTime Field Type being affected by server time zone

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -71,9 +71,9 @@
 {% spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
         {% if fieldSettings.useSeconds %}
-            {% set field_value = field.value.value|localizeddate( 'short', 'medium', parameters.locale ) %}
+            {% set field_value = field.value.value|localizeddate( 'short', 'medium', parameters.locale, false ) %}
         {% else %}
-            {% set field_value = field.value.value|localizeddate( 'short', 'short', parameters.locale ) %}
+            {% set field_value = field.value.value|localizeddate( 'short', 'short', parameters.locale, false ) %}
         {% endif %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29545](https://jira.ez.no/browse/EZP-29545)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | minor
| **Tests pass**     | yes
| **Doc needed**     | no

Currently, the timestamp for ezdatetime is stored in UTC but displayed using `php.ini` timezone which may lead to unexpected results.

This PR is basically ezdatetime adaptation from the same solution for ezdate:
https://github.com/ezsystems/ezpublish-kernel/pull/2422

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests (skipped).
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
