### PR TITLE
EZP-29841: The field "password" is missing in User value

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
@@ -303,6 +303,7 @@ class UserIntegrationTest extends BaseIntegrationTest
                     'email' => null,
                     'passwordHash' => null,
                     'passwordHashType' => null,
+                    'password' => null,
                     'enabled' => null,
                     'maxLogin' => null,
                 ),

--- a/eZ/Publish/Core/FieldType/Tests/UserTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/UserTest.php
@@ -225,7 +225,7 @@ class UserTest extends FieldTypeTest
                         'email' => 'sindelfingen@example.com',
                         'passwordHash' => '1234567890abcdef',
                         'passwordHashType' => 'md5',
-                        'password' => null,
+                        'password' => 'e@mc;3*>',
                         'enabled' => true,
                         'maxLogin' => 1000,
                     )

--- a/eZ/Publish/Core/FieldType/Tests/UserTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/UserTest.php
@@ -225,6 +225,7 @@ class UserTest extends FieldTypeTest
                         'email' => 'sindelfingen@example.com',
                         'passwordHash' => '1234567890abcdef',
                         'passwordHashType' => 'md5',
+                        'password' => null,
                         'enabled' => true,
                         'maxLogin' => 1000,
                     )

--- a/eZ/Publish/Core/FieldType/User/Value.php
+++ b/eZ/Publish/Core/FieldType/User/Value.php
@@ -58,6 +58,13 @@ class Value extends BaseValue
     public $passwordHashType;
 
     /**
+     * Password.
+     *
+     * @var mixed
+     */
+    public $password;
+
+    /**
      * Is enabled.
      *
      * @var bool


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29841](https://jira.ez.no/browse/EZP-29841)
| **Bug/Improvement**| Bug
| **New feature**    | no
| **Target version** | `6.x`/`7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

The field `password` is missing in `eZ\Publish\Core\FieldType\User\Value`, leading to `PropertyNotFoundException`.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
