### PR TITLE
Add location id information to UnauthorizedExceptions when using API LocationService

### DIFF
--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -134,7 +134,7 @@ class LocationService implements LocationServiceInterface
 
         // check create permission on target
         if (!$this->repository->canUser('content', 'create', $loadedSubtree->getContentInfo(), $loadedTargetLocation)) {
-            throw new UnauthorizedException('content', 'create');
+            throw new UnauthorizedException('content', 'create', ['locationId' => $loadedTargetLocation->id]);
         }
 
         /** Check read access to whole source subtree
@@ -212,7 +212,7 @@ class LocationService implements LocationServiceInterface
         $spiLocation = $this->persistenceHandler->locationHandler()->load($locationId);
         $location = $this->domainMapper->buildLocationDomainObject($spiLocation);
         if (!$this->repository->canUser('content', 'read', $location->getContentInfo(), $location)) {
-            throw new UnauthorizedException('content', 'read');
+            throw new UnauthorizedException('content', 'read', ['locationId' => $location->id]);
         }
 
         return $location;
@@ -238,7 +238,7 @@ class LocationService implements LocationServiceInterface
         $spiLocation = $this->persistenceHandler->locationHandler()->loadByRemoteId($remoteId);
         $location = $this->domainMapper->buildLocationDomainObject($spiLocation);
         if (!$this->repository->canUser('content', 'read', $location->getContentInfo(), $location)) {
-            throw new UnauthorizedException('content', 'read');
+            throw new UnauthorizedException('content', 'read', ['locationId' => $location->id]);
         }
 
         return $location;
@@ -364,11 +364,11 @@ class LocationService implements LocationServiceInterface
         $parentLocation = $this->loadLocation($locationCreateStruct->parentLocationId);
 
         if (!$this->repository->canUser('content', 'manage_locations', $content->contentInfo)) {
-            throw new UnauthorizedException('content', 'manage_locations');
+            throw new UnauthorizedException('content', 'manage_locations', ['contentId' => $contentInfo->id]);
         }
 
         if (!$this->repository->canUser('content', 'create', $content->contentInfo, $parentLocation)) {
-            throw new UnauthorizedException('content', 'create');
+            throw new UnauthorizedException('content', 'create', ['locationId' => $parentLocation->id]);
         }
 
         // Check if the parent is a sub location of one of the existing content locations (this also solves the
@@ -468,7 +468,7 @@ class LocationService implements LocationServiceInterface
         }
 
         if (!$this->repository->canUser('content', 'edit', $loadedLocation->getContentInfo(), $loadedLocation)) {
-            throw new UnauthorizedException('content', 'edit');
+            throw new UnauthorizedException('content', 'edit', ['locationId' => $loadedLocation->id]);
         }
 
         $updateStruct = new UpdateStruct();
@@ -503,10 +503,10 @@ class LocationService implements LocationServiceInterface
         $loadedLocation2 = $this->loadLocation($location2->id);
 
         if (!$this->repository->canUser('content', 'edit', $loadedLocation1->getContentInfo(), $loadedLocation1)) {
-            throw new UnauthorizedException('content', 'edit');
+            throw new UnauthorizedException('content', 'edit', ['locationId' => $loadedLocation1->id]);
         }
         if (!$this->repository->canUser('content', 'edit', $loadedLocation2->getContentInfo(), $loadedLocation2)) {
-            throw new UnauthorizedException('content', 'edit');
+            throw new UnauthorizedException('content', 'edit', ['locationId' => $loadedLocation2->id]);
         }
 
         $this->repository->beginTransaction();
@@ -537,7 +537,7 @@ class LocationService implements LocationServiceInterface
     public function hideLocation(APILocation $location)
     {
         if (!$this->repository->canUser('content', 'hide', $location->getContentInfo(), $location)) {
-            throw new UnauthorizedException('content', 'hide');
+            throw new UnauthorizedException('content', 'hide', ['locationId' => $location->id]);
         }
 
         $this->repository->beginTransaction();
@@ -567,7 +567,7 @@ class LocationService implements LocationServiceInterface
     public function unhideLocation(APILocation $location)
     {
         if (!$this->repository->canUser('content', 'hide', $location->getContentInfo(), $location)) {
-            throw new UnauthorizedException('content', 'hide');
+            throw new UnauthorizedException('content', 'hide', ['locationId' => $location->id]);
         }
 
         $this->repository->beginTransaction();
@@ -602,7 +602,7 @@ class LocationService implements LocationServiceInterface
 
         // check create permission on target location
         if (!$this->repository->canUser('content', 'create', $location->getContentInfo(), $newParentLocation)) {
-            throw new UnauthorizedException('content', 'create');
+            throw new UnauthorizedException('content', 'create', ['locationId' => $newParentLocation->id]);
         }
 
         /** Check read access to whole source subtree
@@ -678,10 +678,10 @@ class LocationService implements LocationServiceInterface
         $location = $this->loadLocation($location->id);
 
         if (!$this->repository->canUser('content', 'manage_locations', $location->getContentInfo())) {
-            throw new UnauthorizedException('content', 'manage_locations');
+            throw new UnauthorizedException('content', 'manage_locations', ['locationId' => $location->id]);
         }
         if (!$this->repository->canUser('content', 'remove', $location->getContentInfo(), $location)) {
-            throw new UnauthorizedException('content', 'remove');
+            throw new UnauthorizedException('content', 'remove', ['locationId' => $location->id]);
         }
 
         /** Check remove access to descendants


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | -
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 6.7
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

The ContentService includes information about the content in question when throwing `UnauthorizedException`s (as seen for example in https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Repository/ContentService.php#L136), which helps when inspecting/debugging thrown exceptions.

I'd like to propose a similar approach for `UnauthorizedException`s thrown from the LocationService.

:octocat: 