### PR TITLE
EZP-29851: As a developer I want to be able to load several Locations at once, fast

### DIFF
--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -52,6 +52,19 @@ interface LocationService
     public function loadLocation($locationId, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null);
 
     /**
+     * Loads several location objects from its $locationIds.
+     *
+     * Returned list of Locations will be filtered by what is found and what current user has access to.
+     *
+     * @param array $locationIds
+     * @param string[]|null $prioritizedLanguages Filter on and use as prioritized language code on translated properties of returned objects.
+     * @param bool|null $useAlwaysAvailable Respect always available flag on content when filtering on $prioritizedLanguages.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location[]|iterable
+     */
+    public function loadLocationList(array $locationIds, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null): iterable;
+
+    /**
      * Loads a location object from its $remoteId.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read this location

--- a/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
@@ -147,6 +147,27 @@ class LocationServiceAuthorizationTest extends BaseTest
     }
 
     /**
+     * Test for the loadLocationList() method.
+     *
+     * @covers \eZ\Publish\API\Repository\LocationService::loadLocationList
+     */
+    public function testLoadLocationListFiltersUnauthorizedLocations(): void
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        // Set current user to newly created user (with no rights)
+        $repository->getPermissionResolver()->setCurrentUserReference(
+            $this->createUserVersion1()
+        );
+
+        $locations = $locationService->loadLocationList([13]);
+
+        self::assertInternalType('iterable', $locations);
+        self::assertCount(0, $locations);
+    }
+
+    /**
      * Test for the loadLocationByRemoteId() method.
      *
      * @see \eZ\Publish\API\Repository\LocationService::loadLocationByRemoteId()

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -549,6 +549,69 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
+     * Test for the loadLocationList() method.
+     *
+     * @covers \eZ\Publish\API\Repository\LocationService::loadLocationList
+     */
+    public function testLoadLocationList(): void
+    {
+        $repository = $this->getRepository();
+
+        // 5 is the ID of an existing location, 442 is a non-existing id
+        $locationService = $repository->getLocationService();
+        $locations = $locationService->loadLocationList([5, 442]);
+
+        self::assertInternalType('iterable', $locations);
+        self::assertCount(1, $locations);
+        self::assertEquals([5], array_keys($locations));
+        self::assertInstanceOf(Location::class, $locations[5]);
+        self::assertEquals(5, $locations[5]->id);
+    }
+
+    /**
+     * Test for the loadLocationList() method.
+     *
+     * @covers \eZ\Publish\API\Repository\LocationService::loadLocationList
+     * @depends testLoadLocationList
+     */
+    public function testLoadLocationListPrioritizedLanguagesFallback(): void
+    {
+        $repository = $this->getRepository();
+
+        $this->createLanguage('pol-PL', 'Polski');
+
+        // 5 is the ID of an existing location, 442 is a non-existing id
+        $locationService = $repository->getLocationService();
+        $locations = $locationService->loadLocationList([5, 442], ['pol-PL'], false);
+
+        self::assertInternalType('iterable', $locations);
+        self::assertCount(0, $locations);
+    }
+
+    /**
+     * Test for the loadLocationList() method.
+     *
+     * @covers \eZ\Publish\API\Repository\LocationService::loadLocationList
+     * @depends testLoadLocationListPrioritizedLanguagesFallback
+     */
+    public function testLoadLocationListPrioritizedLanguagesFallbackAndAlwaysAvailable(): void
+    {
+        $repository = $this->getRepository();
+
+        $this->createLanguage('pol-PL', 'Polski');
+
+        // 5 is the ID of an existing location, 442 is a non-existing id
+        $locationService = $repository->getLocationService();
+        $locations = $locationService->loadLocationList([5, 442], ['pol-PL'], true);
+
+        self::assertInternalType('iterable', $locations);
+        self::assertCount(1, $locations);
+        self::assertEquals([5], array_keys($locations));
+        self::assertInstanceOf(Location::class, $locations[5]);
+        self::assertEquals(5, $locations[5]->id);
+    }
+
+    /**
      * Test for the loadLocationByRemoteId() method.
      *
      * @see \eZ\Publish\API\Repository\LocationService::loadLocationByRemoteId()

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -42,6 +42,26 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
         return $location;
     }
 
+    public function loadList(array $locationIds, array $translations = null, bool $useAlwaysAvailable = true): iterable
+    {
+        return $this->getMultipleCacheItems(
+            $locationIds,
+            'ez-location-',
+            function (array $cacheMissIds) use ($translations, $useAlwaysAvailable) {
+                $this->logger->logCall(
+                    __CLASS__ . '::loadList',
+                    ['location' => $cacheMissIds, 'translations' => $translations, 'always-available' => $useAlwaysAvailable]
+                );
+
+                return $this->persistenceHandler->locationHandler()->loadList($cacheMissIds, $translations, $useAlwaysAvailable);
+            },
+            function (Location $location) {
+                return $this->getCacheTags($location);
+            },
+            array_fill_keys($locationIds, '-' . $this->getCacheTranslationKey($translations, $useAlwaysAvailable))
+        );
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
@@ -55,6 +55,8 @@ class LocationHandlerTest extends AbstractCacheHandlerTest
         return [
             ['load', [12], 'ez-location-12-1', $location],
             ['load', [12, ['eng-GB', 'bra-PG'], false], 'ez-location-12-bra-PG|eng-GB|0', $location],
+            ['loadList', [[12]], 'ez-location-12-1', [12 => $location], true],
+            ['loadList', [[12], ['eng-GB', 'bra-PG'], false], 'ez-location-12-bra-PG|eng-GB|0', [12 => $location], true],
             ['loadSubtreeIds', [12], 'ez-location-subtree-12', [33, 44]],
             ['loadLocationsByContent', [4, 12], 'ez-content-locations-4-root-12', [$location]],
             ['loadLocationsByContent', [4], 'ez-content-locations-4', [$location]],

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -44,6 +44,17 @@ abstract class Gateway
     abstract public function getBasicNodeData($nodeId, array $translations = null, bool $useAlwaysAvailable = true);
 
     /**
+     * Returns an array with node data for several locations.
+     *
+     * @param array $locationIds
+     * @param string[]|null $translations
+     * @param bool $useAlwaysAvailable Respect always available flag on content when filtering on $translations.
+     *
+     * @return array
+     */
+    abstract public function getNodeDataList(array $locationIds, array $translations = null, bool $useAlwaysAvailable = true): iterable;
+
+    /**
      * Returns an array with basic node data for the node with $remoteId.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator;
@@ -83,6 +84,22 @@ class DoctrineDatabase extends Gateway
         }
 
         throw new NotFound('location', $nodeId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNodeDataList(array $locationIds, array $translations = null, bool $useAlwaysAvailable = true): iterable
+    {
+        $q = $this->createNodeQueryBuilder($translations, $useAlwaysAvailable);
+        $q->where(
+            $q->expr()->in(
+                't.node_id',
+                $q->createNamedParameter($locationIds, Connection::PARAM_INT_ARRAY)
+            )
+        );
+
+        return $q->execute()->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -56,6 +56,18 @@ class ExceptionConversion extends Gateway
     /**
      * {@inheritdoc}
      */
+    public function getNodeDataList(array $locationIds, array $translations = null, bool $useAlwaysAvailable = true): iterable
+    {
+        try {
+            return $this->innerGateway->getNodeDataList($locationIds, $translations, $useAlwaysAvailable);
+        } catch (DBALException | PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getBasicNodeDataByRemoteId($remoteId, array $translations = null, bool $useAlwaysAvailable = true)
     {
         try {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -106,6 +106,24 @@ class Handler implements BaseLocationHandler
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function loadList(array $locationIds, array $translations = null, bool $useAlwaysAvailable = true): iterable
+    {
+        $list = $this->locationGateway->getNodeDataList($locationIds, $translations, $useAlwaysAvailable);
+
+        $locations = [];
+        foreach ($list as $row) {
+            $id = (int)$row['node_id'];
+            if (!isset($locations[$id])) {
+                $locations[$id] = $this->locationMapper->createLocationFromRow($row);
+            }
+        }
+
+        return $locations;
+    }
+
+    /**
      * Loads the subtree ids of the location identified by $locationId.
      *
      * @param int $locationId

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
@@ -29,56 +29,66 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         );
     }
 
-    public static function getLoadLocationValues()
+    private static function getLoadLocationValues(): array
     {
-        return array(
-            array('node_id', 77),
-            array('priority', 0),
-            array('is_hidden', 0),
-            array('is_invisible', 0),
-            array('remote_id', 'dbc2f3c8716c12f32c379dbf0b1cb133'),
-            array('contentobject_id', 75),
-            array('parent_node_id', 2),
-            array('path_identification_string', 'solutions'),
-            array('path_string', '/1/2/77/'),
-            array('modified_subnode', 1311065017),
-            array('main_node_id', 77),
-            array('depth', 2),
-            array('sort_field', 2),
-            array('sort_order', 1),
-        );
+        return [
+            'node_id' => 77,
+            'priority' => 0,
+            'is_hidden' => 0,
+            'is_invisible' => 0,
+            'remote_id' => 'dbc2f3c8716c12f32c379dbf0b1cb133',
+            'contentobject_id' => 75,
+            'parent_node_id' => 2,
+            'path_identification_string' => 'solutions',
+            'path_string' => '/1/2/77/',
+            'modified_subnode' => 1311065017,
+            'main_node_id' => 77,
+            'depth' => 2,
+            'sort_field' => 2,
+            'sort_order' => 1,
+        ];
     }
 
-    /**
-     * @dataProvider getLoadLocationValues
-     */
-    public function testLoadLocationByRemoteId($field, $value)
+    private function assertLoadLocationProperties(array $locationData): void
+    {
+        foreach (self::getLoadLocationValues() as $field => $expectedValue) {
+            self::assertEquals(
+                $expectedValue,
+                $locationData[$field],
+                "Value in property $field not as expected."
+            );
+        }
+    }
+
+    public function testLoadLocationByRemoteId()
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
         $handler = $this->getLocationGateway();
         $data = $handler->getBasicNodeDataByRemoteId('dbc2f3c8716c12f32c379dbf0b1cb133');
 
-        $this->assertEquals(
-            $value,
-            $data[$field],
-            "Value in property $field not as expected."
-        );
+        self::assertLoadLocationProperties($data);
     }
 
-    /**
-     * @dataProvider getLoadLocationValues
-     */
-    public function testLoadLocation($field, $value)
+    public function testLoadLocation()
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
         $handler = $this->getLocationGateway();
         $data = $handler->getBasicNodeData(77);
 
-        $this->assertEquals(
-            $value,
-            $data[$field],
-            "Value in property $field not as expected."
-        );
+        self::assertLoadLocationProperties($data);
+    }
+
+    public function testLoadLocationList()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
+        $handler = $this->getLocationGateway();
+        $locationsData = $handler->getNodeDataList([77]);
+
+        self::assertCount(1, $locationsData);
+
+        $locationRow = reset($locationsData);
+
+        self::assertLoadLocationProperties($locationRow);
     }
 
     /**
@@ -88,13 +98,10 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
         $handler = $this->getLocationGateway();
-        $data = $handler->getBasicNodeData(1337);
+        $handler->getBasicNodeData(1337);
     }
 
-    /**
-     * @dataProvider getLoadLocationValues
-     */
-    public function testLoadLocationDataByContent($field, $value)
+    public function testLoadLocationDataByContent()
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
 
@@ -102,17 +109,14 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
 
         $locationsData = $gateway->loadLocationDataByContent(75);
 
-        $this->assertCount(1, $locationsData);
+        self::assertCount(1, $locationsData);
 
         $locationRow = reset($locationsData);
 
-        $this->assertEquals($value, $locationRow[$field]);
+        self::assertLoadLocationProperties($locationRow);
     }
 
-    /**
-     * @dataProvider getLoadLocationValues
-     */
-    public function testLoadParentLocationDataForDraftContentAll($field, $value)
+    public function testLoadParentLocationDataForDraftContentAll()
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
 
@@ -124,7 +128,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
 
         $locationRow = reset($locationsData);
 
-        $this->assertEquals($value, $locationRow[$field]);
+        self::assertLoadLocationProperties($locationRow);
     }
 
     public function testLoadLocationDataByContentLimitSubtree()

--- a/eZ/Publish/Core/REST/Client/LocationService.php
+++ b/eZ/Publish/Core/REST/Client/LocationService.php
@@ -127,17 +127,9 @@ class LocationService implements APILocationService, Sessionable
     }
 
     /**
-     * Loads a location object from its $locationId.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read this location
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the specified location is not found
-     *
-     * @param mixed $locationId
-     * @param string[]|null $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     * {@inheritdoc)
      */
-    public function loadLocation($locationId, array $prioritizedLanguages = null)
+    public function loadLocation($locationId, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null)
     {
         $response = $this->client->request(
             'GET',
@@ -151,17 +143,25 @@ class LocationService implements APILocationService, Sessionable
     }
 
     /**
-     * Loads a location object from its $remoteId.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read this location
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the specified location is not found
-     *
-     * @param string $remoteId
-     * @param string[]|null $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     * {@inheritdoc)
      */
-    public function loadLocationByRemoteId($remoteId, array $prioritizedLanguages = null)
+    public function loadLocationList(array $locationIds, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null): iterable
+    {
+        // @todo Implement server part, ala: https://gist.github.com/andrerom/f2f328029ae7a9d78b363282b3ddf4a4
+
+        $response = $this->client->request(
+            'GET',
+            $this->requestParser->generate('locationsByIds', ['locations' => $locationIds]),
+            new Message(['Accept' => $this->outputVisitor->getMediaType('LocationList')])
+        );
+
+        return $this->inputDispatcher->parse($response);
+    }
+
+    /**
+     * {@inheritdoc)
+     */
+    public function loadLocationByRemoteId($remoteId, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null)
     {
         $response = $this->client->request(
             'GET',

--- a/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
@@ -57,6 +57,15 @@ class LocationService implements LocationServiceInterface
         );
     }
 
+    public function loadLocationList(array $locationIds, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null): iterable
+    {
+        return $this->service->loadLocationList(
+            $locationIds,
+            $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages),
+            $this->languageResolver->getUseAlwaysAvailable($useAlwaysAvailable)
+        );
+    }
+
     public function loadLocationByRemoteId($remoteId, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null)
     {
         return $this->service->loadLocationByRemoteId(

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/AbstractServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/AbstractServiceTest.php
@@ -139,7 +139,7 @@ abstract class AbstractServiceTest extends TestCase
      *
      * @param string $method
      * @param array $arguments
-     * @param bool $return
+     * @param mixed|null $return
      * @param int $languageArgumentIndex From 0 and up, so the array index on $arguments.
      */
     final public function testForLanguagesLookup($method, array $arguments, $return, $languageArgumentIndex, callable $callback = null, int $alwaysAvailableArgumentIndex = null)
@@ -179,7 +179,7 @@ abstract class AbstractServiceTest extends TestCase
         $actualReturn = $this->service->$method(...$arguments);
 
         if ($return) {
-            $this->assertTrue($actualReturn);
+            $this->assertEquals($return, $actualReturn);
         }
     }
 
@@ -206,7 +206,7 @@ abstract class AbstractServiceTest extends TestCase
      *
      * @param string $method
      * @param array $arguments
-     * @param bool $return
+     * @param mixed|null $return
      * @param int $languageArgumentIndex From 0 and up, so the array index on $arguments.
      */
     final public function testForLanguagesPassTrough($method, array $arguments, $return, $languageArgumentIndex, callable $callback = null, int $alwaysAvailableArgumentIndex = null)
@@ -241,7 +241,7 @@ abstract class AbstractServiceTest extends TestCase
         $actualReturn = $this->service->$method(...$arguments);
 
         if ($return) {
-            $this->assertTrue($actualReturn);
+            $this->assertEquals($return, $actualReturn);
         }
     }
 }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LocationServiceTest.php
@@ -61,11 +61,15 @@ class LocationServiceTest extends AbstractServiceTest
         $contentInfo = new ContentInfo();
         $versionInfo = new VersionInfo();
 
-        // string $method, array $arguments, bool $return, int $languageArgumentIndex, ?callable $callback, ?int $alwaysAvailableArgumentIndex
+        // string $method, array $arguments, mixed|null $return, int $languageArgumentIndex, ?callable $callback, ?int $alwaysAvailableArgumentIndex
         return [
             ['loadLocation', [55], true, 1],
             ['loadLocation', [55, self::LANG_ARG], true, 1],
             ['loadLocation', [55, self::LANG_ARG, true], true, 1, null, 2],
+
+            ['loadLocationList', [[55]], ['return'], 1],
+            ['loadLocationList', [[55], self::LANG_ARG], ['return'], 1],
+            ['loadLocationList', [[55], self::LANG_ARG, true], ['return'], 1, null, 2],
 
             ['loadLocationByRemoteId', ['ergemiotregf'], true, 1],
             ['loadLocationByRemoteId', ['ergemiotregf', self::LANG_ARG], true, 1],

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LocationServiceTest.php
@@ -67,9 +67,9 @@ class LocationServiceTest extends AbstractServiceTest
             ['loadLocation', [55, self::LANG_ARG], true, 1],
             ['loadLocation', [55, self::LANG_ARG, true], true, 1, null, 2],
 
-            ['loadLocationList', [[55]], ['return'], 1],
-            ['loadLocationList', [[55], self::LANG_ARG], ['return'], 1],
-            ['loadLocationList', [[55], self::LANG_ARG, true], ['return'], 1, null, 2],
+            ['loadLocationList', [[55]], [55 => $location], 1],
+            ['loadLocationList', [[55], self::LANG_ARG], [55 => $location], 1],
+            ['loadLocationList', [[55], self::LANG_ARG, true], [55 => $location], 1, null, 2],
 
             ['loadLocationByRemoteId', ['ergemiotregf'], true, 1],
             ['loadLocationByRemoteId', ['ergemiotregf', self::LANG_ARG], true, 1],

--- a/eZ/Publish/Core/SignalSlot/LocationService.php
+++ b/eZ/Publish/Core/SignalSlot/LocationService.php
@@ -99,6 +99,14 @@ class LocationService implements LocationServiceInterface
     /**
      * {@inheritdoc}
      */
+    public function loadLocationList(array $locationIds, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null): iterable
+    {
+        return $this->service->loadLocationList($locationIds, $prioritizedLanguages, $useAlwaysAvailable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function loadLocationByRemoteId($remoteId, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null)
     {
         return $this->service->loadLocationByRemoteId($remoteId, $prioritizedLanguages, $useAlwaysAvailable);

--- a/eZ/Publish/Core/SignalSlot/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/LocationServiceTest.php
@@ -92,6 +92,12 @@ class LocationServiceTest extends ServiceTest
                 0,
             ),
             array(
+                'loadLocationList',
+                array([$rootId], [], true),
+                [$root],
+                0,
+            ),
+            array(
                 'loadLocationByRemoteId',
                 array($rootRemoteId, [], true),
                 $root,

--- a/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
@@ -29,6 +29,20 @@ interface Handler
     public function load($locationId, array $translations = null, bool $useAlwaysAvailable = true);
 
     /**
+     * Return list of unique Locations, with location id as key.
+     *
+     * Missing items (NotFound) will be missing from the array and not cause an exception, it's up
+     * to calling logic to determine if this should cause exception or not.
+     *
+     * @param int[] $locationIds
+     * @param string[]|null $translations If set, only locations with content in given translations are returned.
+     * @param bool $useAlwaysAvailable Respect always available flag on content, where main language is valid translation fallback.
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\Location[]|iterable
+     */
+    public function loadList(array $locationIds, array $translations = null, bool $useAlwaysAvailable = true): iterable;
+
+    /**
      * Loads the subtree ids of the location identified by $locationId.
      *
      * @param int $locationId


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29851](https://jira.ez.no/browse/EZP-29851)
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | _maybe_

Motivation
----------
Like the other bulk loading API's added recently this is to optimize usage in:
- Page builder
- Cron Jobs / Commands
- GraphQL
- REST
- Admin UI
- Internally in Repository itself
- ...

Any place where several content / locations might be loaded today.

These changes allows for less PHP code to execute, less SQL lookups, and less cache lookups by taking advantage of Symfony Cache's multi get support.

Biggest benefit will be on setups where cache server is on a different machine, this can save ~5ms
for each and every lookup saved. Which can on complex landing pages mean saving up-to several seconds of load time when HTTPCache is cold or disabled.

_There are a few other follow ups on this coming later in other parts of the system, for instance getting rid of Symfon's tag lookup._

Design
------
Like other multi load API's return iterable list of objects, in this case Locations.
_Iterable as we might want to introduce custom collection in the future to expose more info, hence avoid hardcoding usage of plain PHP array type._

```php
     /**
      * Return list of unique Locations, with location id as key.
      *
      * Missing items (NotFound) & those user does not have access to (Unauthorized), will be missing from the
      * list and not cause any exception. It's up to calling logic to determine if this should cause exception or not.
      *
      * @param array $locationIds
      * @param string[]|null $prioritizedLanguages Filter on and use as prioritized language code on translated properties of returned objects.
      * @param bool|null $useAlwaysAvailable Respect always available flag on content when filtering on $prioritizedLanguages.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Location[]|iterable
      */
     public function loadLocationList(array $locationIds, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null): iterable;
```


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
-  [x] Rebase on master once #2480 is merged up
