### PR TITLE
EZP-29886: Add loadGroupByIdentifier/loadByIdentifier to objectstate api

### DIFF
--- a/eZ/Publish/API/Repository/ObjectStateService.php
+++ b/eZ/Publish/API/Repository/ObjectStateService.php
@@ -48,6 +48,31 @@ interface ObjectStateService
     public function loadObjectStateGroup($objectStateGroupId, array $prioritizedLanguages = []);
 
     /**
+     * Loads an object state by identifier and group it belongs to.
+     *
+     * @param string $identifier
+     * @param mixed $groupId
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the state was not found
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
+     */
+    public function loadByIdentifier($identifier, $groupId, array $prioritizedLanguages = []);
+
+    /**
+     * Loads a object state group by identifier.
+     *
+     * @param string $identifier
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the group was not found
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
+     */
+    public function loadGroupByIdentifier($identifier, array $prioritizedLanguages = []);
+
+    /**
      * Loads all object state groups.
      *
      * @param int $offset

--- a/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
@@ -376,6 +376,61 @@ class ObjectStateServiceTest extends BaseTest
     }
 
     /**
+     * @covers \eZ\Publish\API\Repository\ObjectStateService::loadGroupByIdentifier
+     */
+    public function testLoadGroupByIdentifier()
+    {
+        $repository = $this->getRepository();
+        $objectStateGroupIdentifier = 'ez_lock';
+        /* BEGIN: Use Case */
+        // $objectStateGroupIdentifier contains the identifier of the standard object state
+        // group ez_lock.
+        $objectStateService = $repository->getObjectStateService();
+
+        $loadedObjectStateGroup = $objectStateService->loadGroupByIdentifier(
+            $objectStateGroupIdentifier
+        );
+        /* END: Use Case */
+
+        $this->assertInstanceOf(
+            ObjectStateGroup::class,
+            $loadedObjectStateGroup
+        );
+
+        $this->assertPropertiesCorrect(
+            [
+                'id' => 2,
+                'identifier' => 'ez_lock',
+                'mainLanguageCode' => 'eng-US',
+                'languageCodes' => ['eng-US'],
+                'names' => ['eng-US' => 'Lock'],
+                'descriptions' => ['eng-US' => ''],
+            ],
+            $loadedObjectStateGroup
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\ObjectStateService::loadGroupByIdentifier
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testLoadGroupByIdentifierThrowsNotFoundException()
+    {
+        $repository = $this->getRepository();
+        $nonExistentObjectStateGroupIdentifier = 'nonexistant';
+        /* BEGIN: Use Case */
+        // $nonExistentObjectStateGroupIdentifier contains an ID for an object state
+        // that does not exist
+        $objectStateService = $repository->getObjectStateService();
+
+        // Throws a not found exception
+        $loadedObjectStateGroup = $objectStateService->loadGroupByIdentifier(
+            $nonExistentObjectStateGroupIdentifier
+        );
+        /* END: Use Case */
+    }
+
+    /**
      * Test for the loadObjectStateGroups() method.
      *
      *
@@ -967,6 +1022,36 @@ class ObjectStateServiceTest extends BaseTest
 
         $loadedObjectState = $objectStateService->loadObjectState(
             $objectStateId
+        );
+        /* END: Use Case */
+
+        $this->assertInstanceOf(
+            'eZ\\Publish\\API\\Repository\\Values\\ObjectState\\ObjectState',
+            $loadedObjectState
+        );
+
+        return $loadedObjectState;
+    }
+
+    /**
+     * Test for the loadObjectState() method.
+     *
+     *
+     * @see \eZ\Publish\API\Repository\ObjectStateService::loadByIdentifier()
+     * @depends testLoadObjectStateGroup
+     */
+    public function testLoadByIdentifier()
+    {
+        $repository = $this->getRepository();
+        $objectStateGroupId = $this->generateId('objectstategroup', 2);
+        $this->generateId('objectstate', 2);
+        $objectStateIdentifier = 'locked';
+        /* BEGIN: Use Case */
+        // $objectStateIdentifier contains the identifier of the "locked" state
+        $objectStateService = $repository->getObjectStateService();
+
+        $loadedObjectState = $objectStateService->loadByIdentifier(
+            $objectStateIdentifier, $objectStateGroupId
         );
         /* END: Use Case */
 

--- a/eZ/Publish/Core/REST/Client/ObjectStateService.php
+++ b/eZ/Publish/Core/REST/Client/ObjectStateService.php
@@ -249,6 +249,22 @@ class ObjectStateService implements APIObjectStateService, Sessionable
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function loadByIdentifier($identifier, $groupId, array $prioritizedLanguages = [])
+    {
+        throw new \Exception('@todo Implement');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadGroupByIdentifier($identifier, array $prioritizedLanguages = [])
+    {
+        throw new \Exception('@todo Implement');
+    }
+
+    /**
      * Updates an object state.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to update an object state

--- a/eZ/Publish/Core/Repository/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/ObjectStateService.php
@@ -125,6 +125,41 @@ class ObjectStateService implements ObjectStateServiceInterface
     }
 
     /**
+     * Loads an object state by identifier and group it belongs to.
+     *
+     * @param string $identifier
+     * @param mixed  $groupId
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the state was not found
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
+     */
+    public function loadByIdentifier($identifier, $groupId, array $prioritizedLanguages = [])
+    {
+        $spiObjectState = $this->objectStateHandler->loadByIdentifier($identifier, $groupId);
+
+        return $this->buildDomainObjectStateObject($spiObjectState, null, $prioritizedLanguages);
+    }
+
+    /**
+     * Loads a object state group by identifier.
+     *
+     * @param string $identifier
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the group was not found
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
+     */
+    public function loadGroupByIdentifier($identifier, array $prioritizedLanguages = [])
+    {
+        $spiObjectStateGroup = $this->objectStateHandler->loadGroupByIdentifier($identifier);
+
+        return $this->buildDomainObjectStateGroupObject($spiObjectStateGroup, $prioritizedLanguages);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function loadObjectStateGroups($offset = 0, $limit = -1, array $prioritizedLanguages = [])

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ObjectStateService.php
@@ -55,6 +55,20 @@ class ObjectStateService implements ObjectStateServiceInterface
         return $this->service->loadObjectStateGroup($objectStateGroupId, $prioritizedLanguages);
     }
 
+    public function loadByIdentifier($identifier, $groupId, array $prioritizedLanguages = [])
+    {
+        $prioritizedLanguages = $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages);
+
+        return $this->service->loadByIdentifier($identifier, $groupId, $prioritizedLanguages);
+    }
+
+    public function loadGroupByIdentifier($identifier, array $prioritizedLanguages = [])
+    {
+        $prioritizedLanguages = $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages);
+
+        return $this->service->loadGroupByIdentifier($identifier, $prioritizedLanguages);
+    }
+
     public function loadObjectStateGroups($offset = 0, $limit = -1, array $prioritizedLanguages = null)
     {
         $prioritizedLanguages = $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages);

--- a/eZ/Publish/Core/SignalSlot/ObjectStateService.php
+++ b/eZ/Publish/Core/SignalSlot/ObjectStateService.php
@@ -94,6 +94,22 @@ class ObjectStateService implements ObjectStateServiceInterface
     /**
      * {@inheritdoc}
      */
+    public function loadByIdentifier($identifier, $groupId, array $prioritizedLanguages = [])
+    {
+        return $this->service->loadByIdentifier($identifier, $groupId, $prioritizedLanguages);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadGroupByIdentifier($identifier, array $prioritizedLanguages = [])
+    {
+        return $this->service->loadGroupByIdentifier($identifier, $prioritizedLanguages);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function loadObjectStateGroups($offset = 0, $limit = -1, array $prioritizedLanguages = [])
     {
         return $this->service->loadObjectStateGroups($offset, $limit, $prioritizedLanguages);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29886](https://jira.ez.no/browse/EZP-29886)
| **Improvement**| yes
| **New feature**    | yes
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Add loadGroupByIdentifier/loadByIdentifier to objectstate api

**TODO**:
- [x] Implement feature
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
