### PR TITLE
EZP-29887: Added default view template for embed-inline View type

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -17,6 +17,7 @@ parameters:
     ezplatform.default_view_templates.content.line: 'EzPublishCoreBundle:default:content/line.html.twig'
     ezplatform.default_view_templates.content.text_linked: 'EzPublishCoreBundle:default:content/text_linked.html.twig'
     ezplatform.default_view_templates.content.embed: 'EzPublishCoreBundle:default:content/embed.html.twig'
+    ezplatform.default_view_templates.content.embed_inline: 'EzPublishCoreBundle:default:content/embed_inline.html.twig'
     ezplatform.default_view_templates.content.embed_image: 'EzPublishCoreBundle:default:content/embed_image.html.twig'
     ezplatform.default_view_templates.content.asset_image: 'EzPublishCoreBundle:default:content/asset_image.html.twig'
     ezplatform.default_view_templates.block: 'EzPublishCoreBundle:default:block/block.html.twig'
@@ -53,6 +54,10 @@ parameters:
                     Identifier\ContentType: '%ezplatform.content_view.image_embed_content_types_identifiers%'
             default:
                 template: "%ezplatform.default_view_templates.content.embed%"
+                match: []
+        embed-inline:
+            default:
+                template: "%ezplatform.default_view_templates.content.embed_inline%"
                 match: []
         asset_image:
             default:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed_inline.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed_inline.html.twig
@@ -1,0 +1,5 @@
+{% if location is defined %}
+    <a href="{{ path(location) }}">{{ content.name }}</a>
+{% else %}
+    <a href="{{ path( "ez_urlalias", {"contentId": content.id} ) }}">{{ content.name }}</a>
+{% endif %}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29887](https://jira.ez.no/browse/EZP-29887)
| **Requires** | ezsystems/ezplatform-richtext#24
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.4 for eZ Platform 2.4`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR introduces default view template for `embed-inline` View type.

Due to order of merging of arrays with SA-aware configuration, it's impossible to set this default template via `content_view` setting like it was done in ezsystems/ezplatform-richtext#23.

**TODO**:
- [x] Fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
