### PR TITLE
[RFC] EZP-29916: As a developer, I want to validate passwords against blacklist

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -2579,7 +2579,7 @@ CREATE TABLE `eznotification` (
 DROP TABLE IF EXISTS `ezpasswordblacklist`;
 CREATE TABLE `ezpasswordblacklist` (
    `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-   `password` varchar(255) NOT NULL DEFAULT '',
+   `password` varchar(64) NOT NULL DEFAULT '',
    PRIMARY KEY (`id`),
    UNIQUE KEY `ezpasswordblacklist_password` (`password`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -2573,6 +2573,17 @@ CREATE TABLE `eznotification` (
   KEY `eznotification_owner_is_pending` (`owner_id`, `is_pending`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+--
+-- Table structure for table `ezpasswordblacklist`
+--
+DROP TABLE IF EXISTS `ezpasswordblacklist`;
+CREATE TABLE `ezpasswordblacklist` (
+   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+   `password` varchar(255) NOT NULL DEFAULT '',
+   PRIMARY KEY (`id`),
+   UNIQUE KEY `ezpasswordblacklist_password` (`password`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/data/update/mysql/dbupdate-7.4.0-to-7.5.0.sql
+++ b/data/update/mysql/dbupdate-7.4.0-to-7.5.0.sql
@@ -1,0 +1,15 @@
+SET default_storage_engine=InnoDB;
+
+-- Set storage engine schema version number
+UPDATE ezsite_data SET value='7.5.0' WHERE name='ezpublish-version';
+
+--
+-- Table structure for table `ezpasswordblacklist`
+--
+DROP TABLE IF EXISTS `ezpasswordblacklist`;
+CREATE TABLE `ezpasswordblacklist` (
+   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+   `password` varchar(255) NOT NULL DEFAULT '',
+   PRIMARY KEY (`id`),
+   UNIQUE KEY `ezpasswordblacklist_password` (`password`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/data/update/mysql/dbupdate-7.4.0-to-7.5.0.sql
+++ b/data/update/mysql/dbupdate-7.4.0-to-7.5.0.sql
@@ -9,7 +9,7 @@ UPDATE ezsite_data SET value='7.5.0' WHERE name='ezpublish-version';
 DROP TABLE IF EXISTS `ezpasswordblacklist`;
 CREATE TABLE `ezpasswordblacklist` (
    `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-   `password` varchar(255) NOT NULL DEFAULT '',
+   `password` varchar(64) NOT NULL DEFAULT '',
    PRIMARY KEY (`id`),
    UNIQUE KEY `ezpasswordblacklist_password` (`password`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/data/update/postgres/dbupdate-7.4.0-to-7.5.0.sql
+++ b/data/update/postgres/dbupdate-7.4.0-to-7.5.0.sql
@@ -5,7 +5,7 @@ UPDATE ezsite_data SET value='7.5.0' WHERE name='ezpublish-version';
 
 CREATE TABLE IF NOT EXISTS ezpasswordblacklist (
   id SERIAL,
-  password character varying(255) NOT NULL,
+  password character varying(64) NOT NULL,
   CONSTRAINT ezpasswordblacklist_pkey PRIMARY KEY (id)
 );
 

--- a/data/update/postgres/dbupdate-7.4.0-to-7.5.0.sql
+++ b/data/update/postgres/dbupdate-7.4.0-to-7.5.0.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+-- Set storage engine schema version number
+UPDATE ezsite_data SET value='7.5.0' WHERE name='ezpublish-version';
+
+CREATE TABLE IF NOT EXISTS ezpasswordblacklist (
+  id SERIAL,
+  password character varying(255) NOT NULL,
+  CONSTRAINT ezpasswordblacklist_pkey PRIMARY KEY (id)
+);
+
+DROP INDEX IF EXISTS ezpasswordblacklist_password;
+CREATE INDEX ezpasswordblacklist_password ON ezpasswordblacklist USING btree (password);
+
+COMMIT;

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ImportPasswordBlacklistCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ImportPasswordBlacklistCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\Command;
+
+use eZ\Publish\SPI\Persistence\TransactionHandler;
+use eZ\Publish\SPI\Persistence\User\PasswordBlacklist\Handler as PasswordBlacklistHandler;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use InvalidArgumentException;
+use Throwable;
+
+class ImportPasswordBlacklistCommand extends Command
+{
+    /** @var \eZ\Publish\SPI\Persistence\TransactionHandler */
+    private $transactionHandler;
+
+    /** @var \eZ\Publish\SPI\Persistence\User\PasswordBlacklist\Handler */
+    private $blacklistHandler;
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\TransactionHandler $transactionHandler
+     * @param \eZ\Publish\SPI\Persistence\User\PasswordBlacklist\Handler $blacklistHandler
+     * @param string|null $name
+     */
+    public function __construct(
+        TransactionHandler $transactionHandler,
+        PasswordBlacklistHandler $blacklistHandler,
+        ?string $name = null
+    ) {
+        parent::__construct($name);
+
+        $this->transactionHandler = $transactionHandler;
+        $this->blacklistHandler = $blacklistHandler;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(): void
+    {
+        $this->setName('ezplatform:password:import-blacklist');
+        $this->setDescription('Imports password blacklist');
+        $this->addArgument('filepath', InputArgument::REQUIRED);
+        $this->addOption('truncate', null, InputOption::VALUE_OPTIONAL, 'Truncates blacklist before import');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $passwords = $this->loadPasswordsFile($input->getArgument('filepath'));
+        $passwords = array_map('trim', $passwords);
+        $passwords = array_filter($passwords, 'mb_strlen');
+        $passwords = array_unique($passwords);
+
+        $this->transactionHandler->beginTransaction();
+        try {
+            if ($input->getOption('truncate') === 'true') {
+                $this->blacklistHandler->removeAll();
+            }
+
+            $this->blacklistHandler->insert($passwords);
+            $this->transactionHandler->commit();
+        } catch (Throwable $e) {
+            $this->transactionHandler->rollback();
+        }
+
+        $output->writeln('<info>Passwords has been imported.</info>');
+    }
+
+    /**
+     * Loads list of password from given filepath.
+     *
+     * @param string $filepath
+     *
+     * @return string[]
+     */
+    private function loadPasswordsFile(string $filepath): array
+    {
+        if (!file_exists($filepath)) {
+            throw new InvalidArgumentException("File $filepath not found.");
+        }
+
+        if (!is_readable($filepath)) {
+            throw new InvalidArgumentException("File $filepath is not readable.");
+        }
+
+        return explode(PHP_EOL, file_get_contents($filepath));
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml
@@ -7,3 +7,11 @@ services:
             - '@?logger'
         tags:
             - { name: console.command }
+
+    ezpublish.console.command.import_password_blaclist:
+        class: eZ\Bundle\EzPublishCoreBundle\Command\ImportPasswordBlacklistCommand
+        arguments:
+            - '@ezpublish.spi.persistence.legacy.transactionhandler'
+            - '@ezpublish.spi.persistence.legacy.password_blacklist.handler'
+        tags:
+            - { name: console.command }

--- a/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
@@ -91,6 +91,10 @@ class UserIntegrationTest extends BaseIntegrationTest
                     'type' => 'int',
                     'default' => null,
                 ),
+                'isNotBlacklisted' => array(
+                    'type' => 'int',
+                    'default' => null,
+                ),
             ),
         );
     }
@@ -108,6 +112,7 @@ class UserIntegrationTest extends BaseIntegrationTest
                 'requireAtLeastOneLowerCaseCharacter' => false,
                 'requireAtLeastOneNumericCharacter' => false,
                 'requireAtLeastOneNonAlphanumericCharacter' => false,
+                'isNotBlacklisted' => false,
                 'minLength' => null,
             ),
         );

--- a/eZ/Publish/Core/FieldType/Tests/UserTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/UserTest.php
@@ -65,6 +65,10 @@ class UserTest extends FieldTypeTest
                     'type' => 'int',
                     'default' => null,
                 ],
+                'isNotBlacklisted' => [
+                    'type' => 'int',
+                    'default' => null,
+                ],
                 'minLength' => [
                     'type' => 'int',
                     'default' => null,

--- a/eZ/Publish/Core/FieldType/User/Type.php
+++ b/eZ/Publish/Core/FieldType/User/Type.php
@@ -46,6 +46,10 @@ class Type extends FieldType
                 'type' => 'int',
                 'default' => null,
             ],
+            'isNotBlacklisted' => [
+                'type' => 'int',
+                'default' => null,
+            ],
             'minLength' => [
                 'type' => 'int',
                 'default' => null,

--- a/eZ/Publish/Core/Persistence/Cache/Handler.php
+++ b/eZ/Publish/Core/Persistence/Cache/Handler.php
@@ -23,6 +23,7 @@ use eZ\Publish\Core\Persistence\Cache\URLHandler as CacheUrlHandler;
 use eZ\Publish\Core\Persistence\Cache\BookmarkHandler as CacheBookmarkHandler;
 use eZ\Publish\Core\Persistence\Cache\NotificationHandler as CacheNotificationHandler;
 use eZ\Publish\Core\Persistence\Cache\UserPreferenceHandler as CacheUserPreferenceHandler;
+use eZ\Publish\Core\Persistence\Cache\PasswordBlacklistHandler as CachePasswordBlacklistHandler;
 
 /**
  * Persistence Cache Handler class.
@@ -74,6 +75,9 @@ class Handler implements PersistenceHandlerInterface
     /** @var \eZ\Publish\Core\Persistence\Cache\UserPreferenceHandler */
     protected $userPreferenceHandler;
 
+    /** @var \eZ\Publish\Core\Persistence\Cache\PasswordBlacklistHandler */
+    protected $passwordBlacklistHandler;
+
     /** @var \eZ\Publish\Core\Persistence\Cache\PersistenceLogger */
     protected $logger;
 
@@ -93,6 +97,7 @@ class Handler implements PersistenceHandlerInterface
      * @param \eZ\Publish\Core\Persistence\Cache\BookmarkHandler $bookmarkHandler
      * @param \eZ\Publish\Core\Persistence\Cache\NotificationHandler $notificationHandler
      * @param \eZ\Publish\Core\Persistence\Cache\UserPreferenceHandler $userPreferenceHandler
+     * @param \eZ\Publish\Core\Persistence\Cache\PasswordBlacklistHandler $passwordBlacklistHandler
      * @param \eZ\Publish\Core\Persistence\Cache\PersistenceLogger $logger
      */
     public function __construct(
@@ -111,6 +116,7 @@ class Handler implements PersistenceHandlerInterface
         CacheBookmarkHandler $bookmarkHandler,
         CacheNotificationHandler $notificationHandler,
         CacheUserPreferenceHandler $userPreferenceHandler,
+        CachePasswordBlacklistHandler $passwordBlacklistHandler,
         PersistenceLogger $logger
     ) {
         $this->persistenceHandler = $persistenceHandler;
@@ -128,6 +134,7 @@ class Handler implements PersistenceHandlerInterface
         $this->bookmarkHandler = $bookmarkHandler;
         $this->notificationHandler = $notificationHandler;
         $this->userPreferenceHandler = $userPreferenceHandler;
+        $this->passwordBlacklistHandler = $passwordBlacklistHandler;
         $this->logger = $logger;
     }
 
@@ -253,6 +260,14 @@ class Handler implements PersistenceHandlerInterface
     public function userPreferenceHandler()
     {
         return $this->userPreferenceHandler;
+    }
+
+    /**
+     * @return \eZ\Publish\SPI\Persistence\User\PasswordBlacklist\Handler
+     */
+    public function passwordBlacklistHandler()
+    {
+        return $this->passwordBlacklistHandler;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/PasswordBlacklistHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/PasswordBlacklistHandler.php
@@ -15,6 +15,16 @@ class PasswordBlacklistHandler extends AbstractHandler implements PasswordBlackl
     /**
      * {@inheritdoc}
      */
+    public function removeAll(): void
+    {
+        $this->logger->logCall(__METHOD__);
+
+        $this->persistenceHandler->passwordBlacklistHandler()->removeAll();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isBlacklisted(string $password): bool
     {
         $this->logger->logCall(__METHOD__, [
@@ -22,5 +32,15 @@ class PasswordBlacklistHandler extends AbstractHandler implements PasswordBlackl
         ]);
 
         return $this->persistenceHandler->passwordBlacklistHandler()->isBlacklisted($password);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function insert(iterable $passwords): void
+    {
+        $this->logger->logCall(__METHOD__);
+
+        $this->persistenceHandler->passwordBlacklistHandler()->insert($passwords);
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/PasswordBlacklistHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/PasswordBlacklistHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Cache;
+
+use eZ\Publish\SPI\Persistence\User\PasswordBlacklist\Handler as PasswordBlacklistHandlerInterface;
+
+class PasswordBlacklistHandler extends AbstractHandler implements PasswordBlacklistHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isBlacklisted(string $password): bool
+    {
+        $this->logger->logCall(__METHOD__, [
+            'password' => $password,
+        ]);
+
+        return $this->persistenceHandler->passwordBlacklistHandler()->isBlacklisted($password);
+    }
+}

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
@@ -23,6 +23,7 @@ use eZ\Publish\Core\Persistence\Cache\URLHandler as CacheUrlHandler;
 use eZ\Publish\Core\Persistence\Cache\BookmarkHandler as CacheBookmarkHandler;
 use eZ\Publish\Core\Persistence\Cache\NotificationHandler as CacheNotificationHandler;
 use eZ\Publish\Core\Persistence\Cache\UserPreferenceHandler as CacheUserPreferenceHandler;
+use eZ\Publish\Core\Persistence\Cache\PasswordBlacklistHandler as CachePasswordBlacklistHandler;
 use eZ\Publish\SPI\Persistence\Handler;
 use eZ\Publish\Core\Persistence\Cache\PersistenceLogger;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
@@ -86,6 +87,7 @@ abstract class AbstractBaseHandlerTest extends TestCase
             new CacheBookmarkHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
             new CacheNotificationHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
             new CacheUserPreferenceHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
+            new CachePasswordBlacklistHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
             $this->loggerMock
         );
 

--- a/eZ/Publish/Core/Persistence/Cache/Tests/PasswordBlacklistHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/PasswordBlacklistHandlerTest.php
@@ -28,6 +28,8 @@ class PasswordBlacklistHandlerTest extends AbstractCacheHandlerTest
         // string $method, array $arguments, array? $tags, string? $key, mixed $returnValue
         return [
             ['isBlacklisted', ['pass'], [], null, false],
+            ['removeAll', [], [], null, null],
+            ['insert', [['123456', 'qwerty', 'password']], [], null, null],
         ];
     }
 

--- a/eZ/Publish/Core/Persistence/Cache/Tests/PasswordBlacklistHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/PasswordBlacklistHandlerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Tests\Core\Persistence\Cache;
+
+use eZ\Publish\SPI\Persistence\User\PasswordBlacklist\Handler as SPIPasswordBlacklistHandler;
+use eZ\Publish\Core\Persistence\Cache\Tests\AbstractCacheHandlerTest;
+
+class PasswordBlacklistHandlerTest extends AbstractCacheHandlerTest
+{
+    public function getHandlerMethodName(): string
+    {
+        return 'passwordBlacklistHandler';
+    }
+
+    public function getHandlerClassName(): string
+    {
+        return SPIPasswordBlacklistHandler::class;
+    }
+
+    public function providerForUnCachedMethods(): array
+    {
+        // string $method, array $arguments, array? $tags, string? $key, mixed $returnValue
+        return [
+            ['isBlacklisted', ['pass'], [], null, false],
+        ];
+    }
+
+    public function providerForCachedLoadMethods(): array
+    {
+        return [];
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/UserConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/UserConverter.php
@@ -22,6 +22,7 @@ class UserConverter implements Converter
     private const REQUIRE_AT_LEAST_ONE_LOWER_CASE_CHAR = 2;
     private const REQUIRE_AT_LEAST_ONE_NUMERIC_CHAR = 4;
     private const REQUIRE_AT_LEAST_ONE_NON_ALPHANUMERIC_CHAR = 8;
+    private const PASSWORD_IS_NOT_BLACKLISTED = 16;
 
     /**
      * {@inheritdoc}
@@ -54,6 +55,7 @@ class UserConverter implements Converter
             'requireAtLeastOneLowerCaseCharacter' => self::REQUIRE_AT_LEAST_ONE_LOWER_CASE_CHAR,
             'requireAtLeastOneNumericCharacter' => self::REQUIRE_AT_LEAST_ONE_NUMERIC_CHAR,
             'requireAtLeastOneNonAlphanumericCharacter' => self::REQUIRE_AT_LEAST_ONE_NON_ALPHANUMERIC_CHAR,
+            'isNotBlacklisted' => self::PASSWORD_IS_NOT_BLACKLISTED,
         ];
 
         $storageDef->dataInt1 = 0;
@@ -81,6 +83,7 @@ class UserConverter implements Converter
             self::REQUIRE_AT_LEAST_ONE_LOWER_CASE_CHAR => 'requireAtLeastOneLowerCaseCharacter',
             self::REQUIRE_AT_LEAST_ONE_NUMERIC_CHAR => 'requireAtLeastOneNumericCharacter',
             self::REQUIRE_AT_LEAST_ONE_NON_ALPHANUMERIC_CHAR => 'requireAtLeastOneNonAlphanumericCharacter',
+            self::PASSWORD_IS_NOT_BLACKLISTED => 'isNotBlacklisted',
         ];
 
         foreach ($rules as $flag => $rule) {

--- a/eZ/Publish/Core/Persistence/Legacy/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Handler.php
@@ -24,6 +24,7 @@ use eZ\Publish\Core\Persistence\Legacy\URL\Handler as UrlHandler;
 use eZ\Publish\SPI\Persistence\Bookmark\Handler as BookmarkHandler;
 use eZ\Publish\SPI\Persistence\Notification\Handler as NotificationHandler;
 use eZ\Publish\SPI\Persistence\UserPreference\Handler as UserPreferenceHandler;
+use eZ\Publish\SPI\Persistence\User\PasswordBlacklist\Handler as PasswordBlacklistHandler;
 
 /**
  * The main handler for Legacy Storage Engine.
@@ -75,6 +76,9 @@ class Handler implements HandlerInterface
     /** @var \eZ\Publish\SPI\Persistence\UserPreference\Handler */
     protected $userPreferenceHandler;
 
+    /** @var \eZ\Publish\SPI\Persistence\User\PasswordBlacklist\Handler */
+    protected $passwordBlacklistHandler;
+
     /**
      * @param \eZ\Publish\SPI\Persistence\Content\Handler $contentHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
@@ -91,6 +95,7 @@ class Handler implements HandlerInterface
      * @param \eZ\Publish\SPI\Persistence\Bookmark\Handler $bookmarkHandler
      * @param \eZ\Publish\SPI\Persistence\Notification\Handler $notificationHandler
      * @param \eZ\Publish\SPI\Persistence\UserPreference\Handler $userPreferenceHandler
+     * @param \eZ\Publish\SPI\Persistence\User\PasswordBlacklist\Handler $passwordBlacklistHandler
      */
     public function __construct(
         ContentHandler $contentHandler,
@@ -107,7 +112,8 @@ class Handler implements HandlerInterface
         UrlHandler $urlHandler,
         BookmarkHandler $bookmarkHandler,
         NotificationHandler $notificationHandler,
-        UserPreferenceHandler $userPreferenceHandler
+        UserPreferenceHandler $userPreferenceHandler,
+        PasswordBlacklistHandler $passwordBlacklistHandler
     ) {
         $this->contentHandler = $contentHandler;
         $this->contentTypeHandler = $contentTypeHandler;
@@ -124,6 +130,7 @@ class Handler implements HandlerInterface
         $this->bookmarkHandler = $bookmarkHandler;
         $this->notificationHandler = $notificationHandler;
         $this->userPreferenceHandler = $userPreferenceHandler;
+        $this->passwordBlacklistHandler = $passwordBlacklistHandler;
     }
 
     public function contentHandler()
@@ -200,6 +207,14 @@ class Handler implements HandlerInterface
     public function userPreferenceHandler(): UserPreferenceHandler
     {
         return $this->userPreferenceHandler;
+    }
+
+    /**
+     * @return \eZ\Publish\SPI\Persistence\User\PasswordBlacklist\Handler
+     */
+    public function passwordBlacklistHandler(): PasswordBlacklistHandler
+    {
+        return $this->passwordBlacklistHandler;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/PasswordBlacklist/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/PasswordBlacklist/Gateway/DoctrineDatabaseTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\Tests\User\PasswordBlacklist\Gateway;
+
+use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
+use eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway\DoctrineDatabase;
+
+class DoctrineDatabaseTest extends TestCase
+{
+    /**
+     * Inserts DB fixture.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->insertDatabaseFixture(
+            __DIR__ . '/../_fixtures/passwordblacklist.php'
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway\DoctrineDatabase::isBlacklisted
+     */
+    public function testIsBookmarked()
+    {
+        $this->assertTrue($this->getGateway()->isBlacklisted('publish'));
+        $this->assertFalse($this->getGateway()->isBlacklisted('H@xi0R!'));
+    }
+
+    /**
+     * Return a ready to test DoctrineStorage gateway.
+     *
+     * @return \eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway\DoctrineDatabase
+     */
+    protected function getGateway(): DoctrineDatabase
+    {
+        return new DoctrineDatabase(
+            $this->getDatabaseHandler()->getConnection()
+        );
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/PasswordBlacklist/HandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/PasswordBlacklist/HandlerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\Tests\User\PasswordBlacklist;
+
+use eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway;
+use eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Handler;
+use PHPUnit\Framework\TestCase;
+
+class HandlerTest extends TestCase
+{
+    /** @var \eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway|\PHPUnit\Framework\MockObject\MockObject */
+    private $gateway;
+
+    /** @var \eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Handler */
+    private $handler;
+
+    protected function setUp()
+    {
+        $this->gateway = $this->createMock(Gateway::class);
+        $this->handler = new Handler($this->gateway);
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Handler::isBlacklisted
+     */
+    public function testIsBlacklisted()
+    {
+        $password = 'password';
+
+        $this->gateway
+            ->expects($this->once())
+            ->method('isBlacklisted')
+            ->with($password)
+            ->willReturn(true);
+
+        $this->assertTrue($this->handler->isBlacklisted($password));
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/PasswordBlacklist/HandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/PasswordBlacklist/HandlerTest.php
@@ -41,4 +41,31 @@ class HandlerTest extends TestCase
 
         $this->assertTrue($this->handler->isBlacklisted($password));
     }
+
+    /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Handler::removeAll
+     */
+    public function testRemoveAll()
+    {
+        $this->gateway
+            ->expects($this->once())
+            ->method('removeAll');
+
+        $this->handler->removeAll();
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Handler::insert
+     */
+    public function testInsert()
+    {
+        $passwords = ['123456', 'qwerty', 'password'];
+
+        $this->gateway
+            ->expects($this->once())
+            ->method('insert')
+            ->with($passwords);
+
+        $this->handler->insert($passwords);
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/PasswordBlacklist/_fixtures/passwordblacklist.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/PasswordBlacklist/_fixtures/passwordblacklist.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'ezpasswordblacklist' => [
+        0 => [
+            'id' => 1,
+            'password' => 'publish',
+        ],
+        1 => [
+            'id' => 2,
+            'password' => 'qwerty',
+        ],
+        2 => [
+            'id' => 3,
+            'password' => '123456',
+        ],
+    ],
+];

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -654,3 +654,11 @@ CREATE TABLE `ezpreferences` (
   KEY `ezpreferences_name` (`name`),
   KEY `ezpreferences_user_id_idx` (`user_id`,`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=21 DEFAULT CHARSET=utf8mb4;
+
+DROP TABLE IF EXISTS `ezpasswordblacklist`;
+CREATE TABLE `ezpasswordblacklist` (
+   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+   `password` varchar(255) NOT NULL DEFAULT '',
+   PRIMARY KEY (`id`),
+   UNIQUE KEY `ezpasswordblacklist_password` (`password`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -658,7 +658,7 @@ CREATE TABLE `ezpreferences` (
 DROP TABLE IF EXISTS `ezpasswordblacklist`;
 CREATE TABLE `ezpasswordblacklist` (
    `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-   `password` varchar(255) NOT NULL DEFAULT '',
+   `password` varchar(64) NOT NULL DEFAULT '',
    PRIMARY KEY (`id`),
    UNIQUE KEY `ezpasswordblacklist_password` (`password`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
@@ -503,7 +503,7 @@ CREATE TABLE ezpreferences (
 
 CREATE TABLE IF NOT EXISTS ezpasswordblacklist (
    id SERIAL,
-   password character varying(255) NOT NULL
+   password character varying(64) NOT NULL
 );
 
 CREATE INDEX ezimagefile_coid ON ezimagefile USING btree (contentobject_attribute_id);
@@ -838,7 +838,7 @@ ALTER TABLE ONLY ezpreferences
   ADD CONSTRAINT ezpreferences_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY ezpasswordblacklist
-  ADD CONSTRAINT ezpasswordblacklist_pkey PRIMARY KEY (id)
+  ADD CONSTRAINT ezpasswordblacklist_pkey PRIMARY KEY (id);
 
 ALTER TABLE ezcontentbrowsebookmark
 ADD CONSTRAINT ezcontentbrowsebookmark_location_fk

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
@@ -501,6 +501,11 @@ CREATE TABLE ezpreferences (
     value text DEFAULT NULL
 );
 
+CREATE TABLE IF NOT EXISTS ezpasswordblacklist (
+   id SERIAL,
+   password character varying(255) NOT NULL
+);
+
 CREATE INDEX ezimagefile_coid ON ezimagefile USING btree (contentobject_attribute_id);
 
 CREATE INDEX ezimagefile_file ON ezimagefile USING btree (filepath);
@@ -695,6 +700,8 @@ CREATE INDEX ezpreferences_name ON ezpreferences USING btree (name);
 
 CREATE INDEX ezpreferences_user_id_idx ON ezpreferences USING btree (user_id,name);
 
+CREATE INDEX ezpasswordblacklist_password ON ezpasswordblacklist USING btree (password);
+
 ALTER TABLE ONLY ezcobj_state
     ADD CONSTRAINT ezcobj_state_pkey PRIMARY KEY (id);
 
@@ -829,6 +836,9 @@ ALTER TABLE ONLY eznotification
 
 ALTER TABLE ONLY ezpreferences
   ADD CONSTRAINT ezpreferences_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY ezpasswordblacklist
+  ADD CONSTRAINT ezpasswordblacklist_pkey PRIMARY KEY (id)
 
 ALTER TABLE ezcontentbrowsebookmark
 ADD CONSTRAINT ezcontentbrowsebookmark_location_fk

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -574,3 +574,10 @@ CREATE TABLE ezpreferences (
 
 CREATE INDEX ezpreferences_name ON ezpreferences (name);
 CREATE INDEX ezpreferences_user_id_idx ON ezpreferences (user_id, name);
+
+CREATE TABLE ezpasswordblacklist (
+ id integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+ password text(255) DEFAULT NULL
+);
+
+CREATE UNIQUE INDEX ezpasswordblacklist_password ON ezpasswordblacklist (password);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -577,7 +577,7 @@ CREATE INDEX ezpreferences_user_id_idx ON ezpreferences (user_id, name);
 
 CREATE TABLE ezpasswordblacklist (
  id integer NOT NULL PRIMARY KEY AUTOINCREMENT,
- password text(255) DEFAULT NULL
+ password text(64) DEFAULT NULL
 );
 
 CREATE UNIQUE INDEX ezpasswordblacklist_password ON ezpasswordblacklist (password);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/setval.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/setval.pgsql.sql
@@ -28,3 +28,4 @@ SELECT setval('ezuser_role_id_seq',max(id)) FROM ezuser_role;
 SELECT setval('ezcontentbrowsebookmark_id_seq',max(id)) FROM ezcontentbrowsebookmark;
 SELECT setval('eznotification_id_seq',max(id)) FROM eznotification;
 SELECT setval('ezpreferences_id_seq',max(id)) FROM ezpreferences;
+SELECT setval('ezpasswordblacklist_id_seq',max(id)) FROM ezpasswordblacklist;

--- a/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Gateway.php
@@ -20,4 +20,18 @@ abstract class Gateway
      * @return bool
      */
     abstract public function isBlacklisted(string $password): bool;
+
+    /**
+     * Add given passwords to the blacklist.
+     *
+     * For performance reasons should be executed as single transaction.
+     *
+     * @param iterable $passwords
+     */
+    abstract public function insert(iterable $passwords): void;
+
+    /**
+     * Removes all entries from the password blacklist.
+     */
+    abstract public function removeAll(): void;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Gateway.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist;
+
+/**
+ * Base class for password blacklist gateways.
+ */
+abstract class Gateway
+{
+    /**
+     * Returns true if blacklist contains given password.
+     *
+     * @param string $password
+     * @return bool
+     */
+    abstract public function isBlacklisted(string $password): bool;
+}

--- a/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Gateway/DoctrineDatabase.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway;
+
+use Doctrine\DBAL\Connection;
+use eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway;
+
+/**
+ * Password Blacklist gateway implementation using the Doctrine database.
+ */
+class DoctrineDatabase extends Gateway
+{
+    const TABLE_NAME = 'ezpasswordblacklist';
+
+    const COLUMN_ID = 'id';
+    const COLUMN_PASSWORD = 'password';
+
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    private $connection;
+
+    /**
+     * @param \Doctrine\DBAL\Connection $connection
+     */
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isBlacklisted(string $password): bool
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
+            ->select('COUNT(' . self::COLUMN_ID . ')')
+            ->from(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    self::COLUMN_PASSWORD,
+                    $queryBuilder->createNamedParameter($password)
+                )
+            );
+
+        return (int)$queryBuilder->execute()->fetchColumn() > 0;
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Gateway/ExceptionConversion.php
@@ -41,4 +41,28 @@ class ExceptionConversion extends Gateway
             throw new RuntimeException('Database error', 0, $e);
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function insert(iterable $passwords): void
+    {
+        try {
+            $this->innerGateway->insert($passwords);
+        } catch (DBALException | PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeAll(): void
+    {
+        try {
+            $this->innerGateway->removeAll();
+        } catch (DBALException | PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Gateway/ExceptionConversion.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway;
+
+use Doctrine\DBAL\DBALException;
+use eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway;
+use PDOException;
+use RuntimeException;
+
+class ExceptionConversion extends Gateway
+{
+    /**
+     * The wrapped gateway.
+     *
+     * @var \eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway
+     */
+    private $innerGateway;
+
+    /**
+     * @param \eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway $innerGateway
+     */
+    public function __construct(Gateway $innerGateway)
+    {
+        $this->innerGateway = $innerGateway;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isBlacklisted(string $password): bool
+    {
+        try {
+            return $this->innerGateway->isBlacklisted($password);
+        } catch (DBALException | PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Handler.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist;
+
+use eZ\Publish\SPI\Persistence\User\PasswordBlacklist\Handler as HandlerInterface;
+
+/**
+ * Storage Engine handler for password blacklist.
+ */
+class Handler implements HandlerInterface
+{
+    /**
+     * @var \eZ\Publish\Core\Persistence\Legacy\User\PasswordBlackList\Gateway
+     */
+    private $gateway;
+
+    /**
+     * @param \eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway $gateway
+     */
+    public function __construct(Gateway $gateway)
+    {
+        $this->gateway = $gateway;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isBlacklisted(string $password): bool
+    {
+        return $this->gateway->isBlacklisted($password);
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/PasswordBlacklist/Handler.php
@@ -31,8 +31,24 @@ class Handler implements HandlerInterface
     /**
      * {@inheritdoc}
      */
+    public function removeAll(): void
+    {
+        $this->gateway->removeAll();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isBlacklisted(string $password): bool
     {
         return $this->gateway->isBlacklisted($password);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function insert(iterable $passwords): void
+    {
+        $this->gateway->insert($passwords);
     }
 }

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -627,6 +627,7 @@ class Repository implements RepositoryInterface
         $this->userService = new UserService(
             $this,
             $this->persistenceHandler->userHandler(),
+            $this->persistenceHandler->passwordBlacklistHandler(),
             $this->serviceSettings['user']
         );
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -203,6 +203,10 @@ abstract class Base extends TestCase
             $this->persistenceMock->expects($this->any())
                 ->method('urlWildcardHandler')
                 ->will($this->returnValue($this->getPersistenceMockHandler('URL\\Handler')));
+
+            $this->persistenceMock->expects($this->any())
+                ->method('passwordBlacklistHandler')
+                ->will($this->returnValue($this->getPersistenceMockHandler('User\\PasswordBlacklist\\Handler')));
         }
 
         return $this->persistenceMock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UserTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UserTest.php
@@ -150,6 +150,7 @@ class UserTest extends BaseServiceMockTest
                 array(
                     $this->getRepositoryMock(),
                     $this->getPersistenceMock()->userHandler(),
+                    $this->getPersistenceMock()->passwordBlacklistHandler(),
                 )
             )
             ->getMock();

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -20,6 +20,7 @@ parameters:
     ezpublish.spi.persistence.cache.bookmarkHandler.class: eZ\Publish\Core\Persistence\Cache\BookmarkHandler
     ezpublish.spi.persistence.cache.notificationHandler.class: eZ\Publish\Core\Persistence\Cache\NotificationHandler
     ezpublish.spi.persistence.cache.userPreferenceHandler.class: eZ\Publish\Core\Persistence\Cache\UserPreferenceHandler
+    ezpublish.spi.persistence.cache.passwordBlacklistHandler.class: eZ\Publish\Core\Persistence\Cache\PasswordBlacklistHandler
     ezpublish.spi.persistence.cache.persistenceLogger.class: eZ\Publish\Core\Persistence\Cache\PersistenceLogger
     # Make sure logging is only enabled for debug by default
     ezpublish.spi.persistence.cache.persistenceLogger.enableCallLogging: "%kernel.debug%"
@@ -104,6 +105,10 @@ services:
         class: "%ezpublish.spi.persistence.cache.userPreferenceHandler.class%"
         parent: ezpublish.spi.persistence.cache.abstractHandler
 
+    ezpublish.spi.persistence.cache.passwordBlacklistHandler:
+        class: "%ezpublish.spi.persistence.cache.passwordBlacklistHandler.class%"
+        parent: ezpublish.spi.persistence.cache.abstractHandler
+
     ezpublish.spi.persistence.cache:
         class: "%ezpublish.spi.persistence.cache.class%"
         arguments:
@@ -122,4 +127,5 @@ services:
             - "@ezpublish.spi.persistence.cache.bookmarkHandler"
             - '@ezpublish.spi.persistence.cache.notificationHandler'
             - '@ezpublish.spi.persistence.cache.userPreferenceHandler'
+            - '@ezpublish.spi.persistence.cache.passwordBlacklistHandler'
             - "@ezpublish.spi.persistence.cache.persistenceLogger"

--- a/eZ/Publish/Core/settings/storage_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy.yml
@@ -16,6 +16,7 @@ imports:
     - {resource: storage_engines/legacy/user.yml}
     - {resource: storage_engines/legacy/notification.yml}
     - {resource: storage_engines/legacy/user_preference.yml}
+    - {resource: storage_engines/legacy/password_blacklist.yml}
 
 parameters:
     ezpublish.spi.search.legacy.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\MainHandler
@@ -43,6 +44,7 @@ services:
             - "@ezpublish.spi.persistence.legacy.bookmark.handler"
             - "@ezpublish.spi.persistence.legacy.notification.handler"
             - "@ezpublish.spi.persistence.legacy.user_preference.handler"
+            - "@ezpublish.spi.persistence.legacy.password_blacklist.handler"
         tags:
             - {name: ezpublish.storageEngine, alias: legacy}
         lazy: true

--- a/eZ/Publish/Core/settings/storage_engines/legacy/password_blacklist.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/password_blacklist.yml
@@ -1,0 +1,16 @@
+services:
+    eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway\DoctrineDatabase:
+        arguments:
+            $connection: '@ezpublish.persistence.connection'
+
+    eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway\ExceptionConversion:
+        arguments:
+            $innerGateway: '@eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway\DoctrineDatabase'
+
+    eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Handler:
+        arguments:
+            $gateway: '@eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Gateway\ExceptionConversion'
+        lazy: true
+
+    ezpublish.spi.persistence.legacy.password_blacklist.handler:
+        alias: 'eZ\Publish\Core\Persistence\Legacy\User\PasswordBlacklist\Handler'

--- a/eZ/Publish/Core/settings/storage_engines/shortcuts.yml
+++ b/eZ/Publish/Core/settings/storage_engines/shortcuts.yml
@@ -11,6 +11,7 @@ parameters:
     ezpublish.spi.persistence.user_handler.class: eZ\Publish\SPI\Persistence\User\Handler
     ezpublish.spi.persistence.bookmark_handler.class: eZ\Publish\SPI\Persistence\Bookmark\Handler
     ezpublish.spi.persistence.user_preference_handler.class: eZ\Publish\SPI\Persistence\UserPreference\Handler
+    ezpublish.spi.persistence.password_blacklist_handler.class: eZ\Publish\SPI\Persistence\User\Handler
 
 services:
     ezpublish.spi.persistence.content_handler:
@@ -60,3 +61,7 @@ services:
     ezpublish.spi.persistence.user_preference_handler:
         class: "%ezpublish.spi.persistence.user_preference_handler.class%"
         factory: ["@ezpublish.api.persistence_handler", userPreferenceHandler]
+
+    ezpublish.spi.persistence.password_blacklist_handler:
+        class: "%ezpublish.spi.persistence.password_blacklist_handler.class%"
+        factory: ["@ezpublish.api.persistence_handler", passwordBlacklistHandler]

--- a/eZ/Publish/SPI/Persistence/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Handler.php
@@ -84,6 +84,11 @@ interface Handler
     public function userPreferenceHandler();
 
     /**
+     * @return \eZ\Publish\SPI\Persistence\User\PasswordBlacklist\Handler
+     */
+    public function passwordBlacklistHandler();
+
+    /**
      * @return \eZ\Publish\SPI\Persistence\TransactionHandler
      */
     public function transactionHandler();

--- a/eZ/Publish/SPI/Persistence/User/PasswordBlacklist/Handler.php
+++ b/eZ/Publish/SPI/Persistence/User/PasswordBlacklist/Handler.php
@@ -11,10 +11,22 @@ namespace eZ\Publish\SPI\Persistence\User\PasswordBlacklist;
 interface Handler
 {
     /**
+     * Removes all entries from the password blacklist.
+     */
+    public function removeAll(): void;
+
+    /**
      * Returns true if blacklist contains given password.
      *
      * @param string $password
      * @return bool
      */
     public function isBlacklisted(string $password): bool;
+
+    /**
+     * Add given passwords to the blacklist.
+     *
+     * @param iterable $passwords
+     */
+    public function insert(iterable $passwords): void;
 }

--- a/eZ/Publish/SPI/Persistence/User/PasswordBlacklist/Handler.php
+++ b/eZ/Publish/SPI/Persistence/User/PasswordBlacklist/Handler.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Persistence\User\PasswordBlacklist;
+
+interface Handler
+{
+    /**
+     * Returns true if blacklist contains given password.
+     *
+     * @param string $password
+     * @return bool
+     */
+    public function isBlacklisted(string $password): bool;
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29916](https://jira.ez.no/browse/EZP-29916)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Follow up for the https://github.com/ezsystems/ezpublish-kernel/pull/2482 which adds into the product a password validation against blacklist. 

## Important technical details

### Database schema changes 

Added `ezpasswordblacklist` table for storing blacklist. https://github.com/ezsystems/ezpublish-kernel/blob/59748d9ca9cb61d442c8689698eb68e377a0bfa7/data/update/mysql/dbupdate-7.4.0-to-7.5.0.sql#L10-L15

### `ezplatform:password:import-blacklist` command

Usually lists of most common passwords are published as a raw text files. Those lists could be imported using `ezplatform:password:import-blacklist` command. For example:

Append passwords from given file to the blacklist:

```bash
php bin/console ezplatform:password:import-blacklist ~/10-million-password-list-top-10000.txt
```

Clear the blacklist and import passwords from given file:

```bash
php bin/console ezplatform:password:import-blacklist ~/10-million-password-list-top-10000.txt --truncate=true
```

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
