### PR TITLE
EZP-29962: As a Developer I want API to detect if object is user/group

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -54,6 +54,10 @@ class UserServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup', $userGroup);
+
+        // User group happens to also be a Content; isUserGroup() should be true and isUser() should be false
+        $this->assertTrue($userService->isUserGroup($userGroup), 'isUserGroup() => false on a user group');
+        $this->assertFalse($userService->isUser($userGroup), 'isUser() => true on a user group');
     }
 
     /**
@@ -1123,6 +1127,10 @@ class UserServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertEquals($user, $userReloaded);
+
+        // User happens to also be a Content; isUser() should be true and isUserGroup() should be false
+        $this->assertTrue($userService->isUser($user), 'isUser() => false on a user');
+        $this->assertFalse($userService->isUserGroup($user), 'isUserGroup() => true on a user group');
     }
 
     /**

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\API\Repository;
 
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\User\PasswordValidationContext;
 use eZ\Publish\API\Repository\Values\User\UserTokenUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\UserCreateStruct;
@@ -304,6 +305,20 @@ interface UserService
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
     public function loadUsersOfUserGroup(UserGroup $userGroup, $offset = 0, $limit = 25, array $prioritizedLanguages = []);
+
+    /**
+     * Checks if Content is a user.
+     *
+     *  @since 7.4
+     */
+    public function isUser(Content $content) : bool;
+
+    /**
+     * Checks if Content is a user group.
+     *
+     * @since 7.4
+     */
+    public function isUserGroup(Content $content) : bool;
 
     /**
      * Instantiate a user create class.

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\REST\Client;
 
 use eZ\Publish\API\Repository\UserService as APIUserService;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\User\PasswordValidationContext;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserCreateStruct;
@@ -400,5 +401,21 @@ class UserService implements APIUserService, Sessionable
     public function validatePassword(string $password, PasswordValidationContext $context = null): array
     {
         throw new \Exception('@todo: Implement.');
+    }
+
+    /**
+     * Checks if Content is a user.
+     */
+    public function isUser(Content $content): bool
+    {
+        // TODO: Implement isUser() method.
+    }
+
+    /**
+     * Checks if Content is a user group.
+     */
+    public function isUserGroup(Content $content): bool
+    {
+        // TODO: Implement isUserGroup() method.
     }
 }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/UserServiceTest.php
@@ -61,6 +61,9 @@ class UserServiceTest extends AbstractServiceTest
             ['newUserUpdateStruct', []],
             ['newUserGroupUpdateStruct', []],
 
+            ['isUser', [$userGroup]],
+            ['isUserGroup', [$userGroup]],
+
             ['validatePassword', ['H@xi0r!', $passwordValidationContext], []],
         ];
     }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/UserService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/UserService.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Repository\SiteAccessAware;
 
 use eZ\Publish\API\Repository\UserService as UserServiceInterface;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\User\PasswordValidationContext;
 use eZ\Publish\API\Repository\Values\User\UserGroupCreateStruct;
 use eZ\Publish\API\Repository\Values\User\UserGroupUpdateStruct;
@@ -168,6 +169,16 @@ class UserService implements UserServiceInterface
     public function expireUserToken($hash)
     {
         return $this->service->expireUserToken($hash);
+    }
+
+    public function isUser(Content $content) : bool
+    {
+        return $this->service->isUser($content);
+    }
+
+    public function isUserGroup(Content $content) : bool
+    {
+        return $this->service->isUserGroup($content);
     }
 
     public function newUserCreateStruct($login, $email, $password, $mainLanguageCode, $contentType = null)

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -1149,6 +1149,22 @@ class UserService implements UserServiceInterface
     }
 
     /**
+     * Checks if Content is a user.
+     */
+    public function isUser(APIContent $content) : bool
+    {
+        return $this->settings['userClassID'] == $content->getVersionInfo()->getContentInfo()->contentTypeId;
+    }
+
+    /**
+     * Checks if Content is a user group.
+     */
+    public function isUserGroup(APIContent $content) : bool
+    {
+        return $this->settings['userGroupClassID'] == $content->getVersionInfo()->getContentInfo()->contentTypeId;
+    }
+
+    /**
      * Instantiate a user create class.
      *
      * @param string $login the login of the new user

--- a/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
@@ -267,6 +267,18 @@ class UserServiceTest extends ServiceTest
                 0,
             ),
             array(
+                'isUser',
+                array($userGroup),
+                false,
+                0,
+            ),
+            array(
+                'isUserGroup',
+                array($userGroup),
+                true,
+                0,
+            ),
+            array(
                 'newUserCreateStruct',
                 array(
                     $login, $email, $password, $mainLanguageCode, $contentType,

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\SignalSlot;
 
 use eZ\Publish\API\Repository\UserService as UserServiceInterface;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\User\PasswordValidationContext;
 use eZ\Publish\API\Repository\Values\User\UserTokenUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\UserGroupCreateStruct;
@@ -499,6 +500,22 @@ class UserService implements UserServiceInterface
             $limit,
             $prioritizedLanguages
         );
+    }
+
+    /**
+     * Checks if Content is a user.
+     */
+    public function isUser(Content $content) : bool
+    {
+        return $this->service->isUser($content);
+    }
+
+    /**
+     * Checks if Content is a user group.
+     */
+    public function isUserGroup(Content $content) : bool
+    {
+        return $this->service->isUserGroup($content);
     }
 
     /**


### PR DESCRIPTION


| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29962](https://jira.ez.no/browse/EZP-29962)
| **New feature**    | yes
| **Target version** | `master` / `7.4`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

To be able to avoid expensive uncached API calls in Admin UI to always
have to load to see if a object is User or User Group, simply expose
isUser() and isUserGroup() APIs on UserService to avoid this,
as it can check against config instead.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
