### PR TITLE
EZP-29959: Token not found exception in ContentViewBuilder when used to build own exception page

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -223,7 +223,6 @@ services:
         class: "%ezpublish.view_builder.content.class%"
         arguments:
             - "@ezpublish.api.repository"
-            - "@security.authorization_checker"
             - "@ezpublish.view.configurator"
             - "@ezpublish.view.view_parameters.injector.dispatcher"
             - "@ezpublish.content_info_location_loader.main"

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -15,12 +15,10 @@ use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\Core\Helper\ContentInfoLocationLoader;
 use eZ\Publish\Core\MVC\Symfony\View\Configurator;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
-use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 use eZ\Publish\Core\MVC\Symfony\View\EmbedView;
 use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * Builds ContentView objects.
@@ -30,8 +28,8 @@ class ContentViewBuilder implements ViewBuilder
     /** @var \eZ\Publish\API\Repository\Repository */
     private $repository;
 
-    /** @var AuthorizationCheckerInterface */
-    private $authorizationChecker;
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    private $permissionResolver;
 
     /** @var \eZ\Publish\Core\MVC\Symfony\View\Configurator */
     private $viewConfigurator;
@@ -52,16 +50,15 @@ class ContentViewBuilder implements ViewBuilder
 
     public function __construct(
         Repository $repository,
-        AuthorizationCheckerInterface $authorizationChecker,
         Configurator $viewConfigurator,
         ParametersInjector $viewParametersInjector,
         ContentInfoLocationLoader $locationLoader = null
     ) {
         $this->repository = $repository;
-        $this->authorizationChecker = $authorizationChecker;
         $this->viewConfigurator = $viewConfigurator;
         $this->viewParametersInjector = $viewParametersInjector;
         $this->locationLoader = $locationLoader;
+        $this->permissionResolver = $this->repository->getPermissionResolver();
     }
 
     public function matches($argument)
@@ -185,9 +182,7 @@ class ContentViewBuilder implements ViewBuilder
         // Check that Content is published, since sudo allows loading unpublished content.
         if (
             $content->getVersionInfo()->status !== VersionInfo::STATUS_PUBLISHED
-            && !$this->authorizationChecker->isGranted(
-                new AuthorizationAttribute('content', 'versionread', array('valueObject' => $content))
-            )
+            && !$this->permissionResolver->canUser('content', 'versionread', $content)
         ) {
             throw new UnauthorizedException('content', 'versionread', ['contentId' => $contentId]);
         }
@@ -227,17 +222,11 @@ class ContentViewBuilder implements ViewBuilder
      */
     private function canRead(Content $content, Location $location = null)
     {
-        $limitations = ['valueObject' => $content->contentInfo];
-        if (isset($location)) {
-            $limitations['targets'] = $location;
-        }
-
-        $readAttribute = new AuthorizationAttribute('content', 'read', $limitations);
-        $viewEmbedAttribute = new AuthorizationAttribute('content', 'view_embed', $limitations);
+        $targets = isset($location) ? [$location] : [];
 
         return
-            $this->authorizationChecker->isGranted($readAttribute) ||
-            $this->authorizationChecker->isGranted($viewEmbedAttribute);
+            $this->permissionResolver->canUser('content', 'read', $content->contentInfo, $targets) ||
+            $this->permissionResolver->canUser('content', 'read_embed', $content->contentInfo, $targets);
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29959](https://jira.ez.no/browse/EZP-29959)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`/`6.13`/`7.3`/`master` 
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | no

During merge-up (into 7.3 and higher) it might be a good idea to inject `PermissionResolver` instead of getting it from `Repository`. 

Tests for `ContentViewBuilder` were introduced in `7.3` therefore some additional changes are necessary. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
