### PR TITLE
EZP-29980 : Anonymous should be able to see images 

### DIFF
--- a/data/mysql/cleandata.sql
+++ b/data/mysql/cleandata.sql
@@ -1351,7 +1351,7 @@ INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `ro
 INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `role_id`) VALUES ('login',331,'user',0,1);
 INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `role_id`) VALUES ('*',332,'*',0,2);
 INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `role_id`) VALUES ('read',333,'content',0,4);
-INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `role_id`) VALUES ('view_embed',334,'content',0,4);
+INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `role_id`) VALUES ('view_embed',334,'content',0,1);
 INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `role_id`) VALUES ('*',340,'url',0,3);
 
 INSERT INTO `ezpolicy_limitation` (`id`, `identifier`, `policy_id`) VALUES (251,'Section',328);

--- a/data/mysql/cleandata.sql
+++ b/data/mysql/cleandata.sql
@@ -1351,6 +1351,7 @@ INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `ro
 INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `role_id`) VALUES ('login',331,'user',0,1);
 INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `role_id`) VALUES ('*',332,'*',0,2);
 INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `role_id`) VALUES ('read',333,'content',0,4);
+INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `role_id`) VALUES ('view_embed',334,'content',0,4);
 INSERT INTO `ezpolicy` (`function_name`, `id`, `module_name`, `original_id`, `role_id`) VALUES ('*',340,'url',0,3);
 
 INSERT INTO `ezpolicy_limitation` (`id`, `identifier`, `policy_id`) VALUES (251,'Section',328);
@@ -1358,12 +1359,15 @@ INSERT INTO `ezpolicy_limitation` (`id`, `identifier`, `policy_id`) VALUES (252,
 INSERT INTO `ezpolicy_limitation` (`id`, `identifier`, `policy_id`) VALUES (253,'SiteAccess',331);
 INSERT INTO `ezpolicy_limitation` (`id`, `identifier`, `policy_id`) VALUES (254,'Class',333);
 INSERT INTO `ezpolicy_limitation` (`id`, `identifier`, `policy_id`) VALUES (255,'Owner',333);
+INSERT INTO `ezpolicy_limitation` (`id`, `identifier`, `policy_id`) VALUES (256,'Class',334);
 
 INSERT INTO `ezpolicy_limitation_value` (`id`, `limitation_id`, `value`) VALUES (477,251,'1');
 INSERT INTO `ezpolicy_limitation_value` (`id`, `limitation_id`, `value`) VALUES (478,252,'1');
 INSERT INTO `ezpolicy_limitation_value` (`id`, `limitation_id`, `value`) VALUES (479,253,'1766001124');
 INSERT INTO `ezpolicy_limitation_value` (`id`, `limitation_id`, `value`) VALUES (480,254,'4');
 INSERT INTO `ezpolicy_limitation_value` (`id`, `limitation_id`, `value`) VALUES (481,255,'1');
+INSERT INTO `ezpolicy_limitation_value` (`id`, `limitation_id`, `value`) VALUES (482,256,'5');
+INSERT INTO `ezpolicy_limitation_value` (`id`, `limitation_id`, `value`) VALUES (483,256,'12');
 
 INSERT INTO `ezrole` (`id`, `is_new`, `name`, `value`, `version`) VALUES (1,0,'Anonymous','',0);
 INSERT INTO `ezrole` (`id`, `is_new`, `name`, `value`, `version`) VALUES (2,0,'Administrator','0',0);

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -64,7 +64,6 @@ services:
         class: \eZ\Publish\Core\MVC\Symfony\FieldType\ImageAsset\ParameterProvider
         arguments:
             - "@ezpublish.siteaccessaware.repository"
-            - "@security.authorization_checker"
         tags:
             - {name: ezpublish.fieldType.parameterProvider, alias: ezimageasset}
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -63,9 +63,8 @@ services:
     ezpublish.fieldType.ezimageasset.parameterProvider:
         class: \eZ\Publish\Core\MVC\Symfony\FieldType\ImageAsset\ParameterProvider
         arguments:
-            - "@ezpublish.api.service.content"
-            - "@ezpublish.api.service.inner_field_type"
-            - "@eZ\\Publish\\Core\\FieldType\\ImageAsset\\AssetMapper"
+            - "@ezpublish.siteaccessaware.repository"
+            - "@security.authorization_checker"
         tags:
             - {name: ezpublish.fieldType.parameterProvider, alias: ezimageasset}
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -448,7 +448,7 @@
         {% if not ez_is_field_empty(content, field) and parameters.available %}
             {{ fos_httpcache_tag('relation-' ~ field.value.destinationContentId) }}
             <div {{ block('field_attributes') }}>
-                {{ render(controller('ez_content:viewAction', {
+                {{ render(controller('ez_content:embedAction', {
                     contentId: field.value.destinationContentId,
                     viewType: 'asset_image',
                     noLayout: true,

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/ImageAsset/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/ImageAsset/ParameterProvider.php
@@ -20,6 +20,7 @@ class ParameterProvider implements ParameterProviderInterface
      * @var \eZ\Publish\API\Repository\Repository
      */
     private $repository;
+
     /**
      * @var \eZ\Publish\API\Repository\PermissionResolver
      */

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/ImageAsset/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/ImageAsset/ParameterProvider.php
@@ -8,23 +8,36 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\ImageAsset;
 
-use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 
 class ParameterProvider implements ParameterProviderInterface
 {
-    /** @var \eZ\Publish\API\Repository\ContentService */
-    private $contentService;
+    /**
+     * @var \eZ\Publish\API\Repository\Repository
+     */
+    private $repository;
+    /**
+     * @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface
+     */
+    private $authorizationChecker;
 
     /**
-     * @param \eZ\Publish\API\Repository\ContentService
+     * @param \eZ\Publish\API\Repository\Repository $repository
+     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface $authorizationChecker
      */
-    public function __construct(ContentService $contentService)
-    {
-        $this->contentService = $contentService;
+    public function __construct(
+        Repository $repository,
+        AuthorizationCheckerInterface $authorizationChecker
+    ) {
+        $this->repository = $repository;
+        $this->authorizationChecker = $authorizationChecker;
     }
 
     /**
@@ -33,17 +46,52 @@ class ParameterProvider implements ParameterProviderInterface
     public function getViewParameters(Field $field): array
     {
         try {
-            $contentInfo = $this->contentService->loadContentInfo(
+            $contentInfo = $this->loadContentInfo(
                 $field->value->destinationContentId
             );
 
-            return [
-                'available' => !$contentInfo->isTrashed(),
-            ];
+            if (!$this->userHasPermissions($contentInfo)) {
+                return [
+                    'available' => false,
+                ];
+            }
+
+            return ['available' => !$contentInfo->isTrashed()];
         } catch (NotFoundException | UnauthorizedException $exception) {
             return [
                 'available' => false,
             ];
         }
+    }
+
+    /**
+     * @param int $id
+     * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo
+     * @throws \Exception
+     */
+    private function loadContentInfo(int $id): ContentInfo
+    {
+        return  $this->repository->sudo(
+            function (Repository $repository) use ($id) {
+                return $repository->getContentService()->loadContentInfo($id);
+            }
+        );
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     * @return bool
+     */
+    private function userHasPermissions(ContentInfo $contentInfo): bool
+    {
+        $readAttribute = new Attribute('content', 'read', [
+            'valueObject' => $contentInfo,
+        ]);
+
+        $viewEmbedAttribute = new Attribute('content', 'view_embed', [
+            'valueObject' => $contentInfo,
+        ]);
+
+        return $this->authorizationChecker->isGranted($readAttribute) || $this->authorizationChecker->isGranted($viewEmbedAttribute);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/ImageAsset/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/ImageAsset/ParameterProvider.php
@@ -51,7 +51,9 @@ class ParameterProvider implements ParameterProviderInterface
                 ];
             }
 
-            return ['available' => !$contentInfo->isTrashed()];
+            return [
+                'available' => !$contentInfo->isTrashed(),
+            ];
         } catch (NotFoundException $exception) {
             return [
                 'available' => false,
@@ -62,11 +64,11 @@ class ParameterProvider implements ParameterProviderInterface
     /**
      * @param int $id
      * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo
-     * @throws \Exception
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     private function loadContentInfo(int $id): ContentInfo
     {
-        return  $this->repository->sudo(
+        return $this->repository->sudo(
             function (Repository $repository) use ($id) {
                 return $repository->getContentService()->loadContentInfo($id);
             }

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/ImageAsset/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/ImageAsset/ParameterProviderTest.php
@@ -20,10 +20,10 @@ use PHPUnit\Framework\TestCase;
 
 class ParameterProviderTest extends TestCase
 {
-    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \eZ\Publish\Core\Repository\SiteAccessAware\Repository|\PHPUnit\Framework\MockObject\MockObject */
     private $repository;
 
-    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \eZ\Publish\API\Repository\PermissionResolver|\PHPUnit\Framework\MockObject\MockObject */
     private $permissionsResolver;
 
     /** @var \eZ\Publish\Core\MVC\Symfony\FieldType\ImageAsset\ParameterProvider */
@@ -36,13 +36,11 @@ class ParameterProviderTest extends TestCase
 
         $this->permissionsResolver
             ->method('canUser')
-            ->willReturn(true)
-        ;
+            ->willReturn(true);
 
         $this->repository
             ->method('getPermissionResolver')
-            ->willReturn($this->permissionsResolver)
-        ;
+            ->willReturn($this->permissionsResolver);
 
         $this->parameterProvider = new ParameterProvider($this->repository);
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29980](https://jira.ez.no/browse/EZP-29980)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 7.4
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Adds permission for Anonymous user to view_embed images and files
Allow users with view_embed permission to see image assets

**TODO**:
- [x]  fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
