### PR TITLE
EZP-29865: Removed spaceless Twig tag from ezpage_field block

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -444,13 +444,11 @@
 
 {# pageService is exposed under parameters.pageService thanks to Page\ParameterProvider #}
 {% block ezpage_field %}
-{% spaceless %}
-{% if not ez_is_field_empty( content, field ) %}
-    {% set layout = field.value.page.layout %}
-    {% set template = parameters.pageService.getLayoutTemplate( layout ) %}
-    {% include template with { 'zones': field.value.page.zones, 'zone_layout': layout, 'pageService': parameters.pageService } %}
-{% endif %}
-{% endspaceless %}
+{%- if not ez_is_field_empty( content, field ) -%}
+    {%- set layout = field.value.page.layout -%}
+    {%- set template = parameters.pageService.getLayoutTemplate( layout ) -%}
+    {%- include template with { 'zones': field.value.page.zones, 'zone_layout': layout, 'pageService': parameters.pageService } -%}
+{%- endif -%}
 {% endblock %}
 
 


### PR DESCRIPTION
See https://jira.ez.no/browse/EZP-29865

If we are trying to output an ezxml field from an object within an ezpage block template override and the ezxml content is something like:

```
<emphasize>second</emphasize> <strong>paragraph</strong>
```

And then we define a template like this:

```
        block_view:
                BannerCarouselBlock:
                    controller: "MarigoldBaseBundle:EzFlowBlocks:bannerCarousel"
                    template: "@ezdesign/blocks/banner_carousel.html.twig"
                    match:
                        Type: banner_carousel
```

And try to output the ezxml content, the {% spaceless %} twig operator in content_fields.html.twig will make the output become secondparagraph instead of second paragraph.

It is necessary to remove that operator and the developer should specify it by himself.