### PR TITLE
EZP-29924: Can't save ContentType with RelationList which has selectionMethod from legacy

### DIFF
--- a/eZ/Publish/Core/FieldType/RelationList/Type.php
+++ b/eZ/Publish/Core/FieldType/RelationList/Type.php
@@ -27,11 +27,11 @@ use eZ\Publish\Core\FieldType\Value as BaseValue;
 class Type extends FieldType
 {
     const SELECTION_BROWSE = 0;
-    const SELECTION_DROPDOWN = 1;
     /**
-     * @todo following selection methods needs to be implemented in 8.0.
-     * Please, refer to: https://jira.ez.no/browse/EZP-29924
+     * @todo following selection methods comes from legacy and may be interpreted as SELECTION_BROWSE by UI.
+     * UI support will be evaluated on a case by case basis for future versions.
      */
+    const SELECTION_DROPDOWN = 1;
     const SELECTION_LIST_WITH_RADIO_BUTTONS = 2;
     const SELECTION_LIST_WITH_CHECKBOXES = 3;
     const SELECTION_MULTIPLE_SELECTION_LIST = 4;

--- a/eZ/Publish/Core/FieldType/RelationList/Type.php
+++ b/eZ/Publish/Core/FieldType/RelationList/Type.php
@@ -79,15 +79,7 @@ class Type extends FieldType
 
             switch ($name) {
                 case 'selectionMethod':
-                    if (!in_array($value, [
-                        self::SELECTION_BROWSE,
-                        self::SELECTION_DROPDOWN,
-                        self::SELECTION_LIST_WITH_RADIO_BUTTONS,
-                        self::SELECTION_LIST_WITH_CHECKBOXES,
-                        self::SELECTION_MULTIPLE_SELECTION_LIST,
-                        self::SELECTION_TEMPLATE_BASED_MULTIPLE,
-                        self::SELECTION_TEMPLATE_BASED_SINGLE,
-                    ], true)) {
+                    if (!$this->isValidSelectionMethod($value)) {
                         $validationErrors[] = new ValidationError(
                             "Setting '%setting%' must be one of %selection_browse%, %selection_dropdown%, %selection_list_with_radio_buttons%, %selection_list_with_checkboxes%, %selection_multiple_selection_list%, %selection_template_based_multiple%, %selection_template_based_single%",
                             null,
@@ -300,5 +292,25 @@ class Type extends FieldType
         return array(
             Relation::FIELD => $value->destinationContentIds,
         );
+    }
+
+    /**
+     * Checks whether given selectionMethod is valid.
+     *
+     * @param int $selectionMethod
+     *
+     * @return bool
+     */
+    private function isValidSelectionMethod($selectionMethod)
+    {
+        return in_array($selectionMethod, [
+            self::SELECTION_BROWSE,
+            self::SELECTION_DROPDOWN,
+            self::SELECTION_LIST_WITH_RADIO_BUTTONS,
+            self::SELECTION_LIST_WITH_CHECKBOXES,
+            self::SELECTION_MULTIPLE_SELECTION_LIST,
+            self::SELECTION_TEMPLATE_BASED_MULTIPLE,
+            self::SELECTION_TEMPLATE_BASED_SINGLE,
+        ], true);
     }
 }

--- a/eZ/Publish/Core/FieldType/RelationList/Type.php
+++ b/eZ/Publish/Core/FieldType/RelationList/Type.php
@@ -89,7 +89,7 @@ class Type extends FieldType
                         self::SELECTION_TEMPLATE_BASED_SINGLE,
                     ], true)) {
                         $validationErrors[] = new ValidationError(
-                            "Setting '%setting%' must be either %selection_browse% or %selection_dropdown%",
+                            "Setting '%setting%' must be one of %selection_browse%, %selection_dropdown%, %selection_list_with_radio_buttons%, %selection_list_with_checkboxes%, %selection_multiple_selection_list%, %selection_template_based_multi%, %selection_template_based_single%",
                             null,
                             array(
                                 '%setting%' => $name,

--- a/eZ/Publish/Core/FieldType/RelationList/Type.php
+++ b/eZ/Publish/Core/FieldType/RelationList/Type.php
@@ -35,7 +35,7 @@ class Type extends FieldType
     const SELECTION_LIST_WITH_RADIO_BUTTONS = 2;
     const SELECTION_LIST_WITH_CHECKBOXES = 3;
     const SELECTION_MULTIPLE_SELECTION_LIST = 4;
-    const SELECTION_TEMPLATE_BASED_MULTI = 5;
+    const SELECTION_TEMPLATE_BASED_MULTIPLE = 5;
     const SELECTION_TEMPLATE_BASED_SINGLE = 6;
 
     protected $settingsSchema = array(
@@ -85,11 +85,11 @@ class Type extends FieldType
                         self::SELECTION_LIST_WITH_RADIO_BUTTONS,
                         self::SELECTION_LIST_WITH_CHECKBOXES,
                         self::SELECTION_MULTIPLE_SELECTION_LIST,
-                        self::SELECTION_TEMPLATE_BASED_MULTI,
+                        self::SELECTION_TEMPLATE_BASED_MULTIPLE,
                         self::SELECTION_TEMPLATE_BASED_SINGLE,
                     ], true)) {
                         $validationErrors[] = new ValidationError(
-                            "Setting '%setting%' must be one of %selection_browse%, %selection_dropdown%, %selection_list_with_radio_buttons%, %selection_list_with_checkboxes%, %selection_multiple_selection_list%, %selection_template_based_multi%, %selection_template_based_single%",
+                            "Setting '%setting%' must be one of %selection_browse%, %selection_dropdown%, %selection_list_with_radio_buttons%, %selection_list_with_checkboxes%, %selection_multiple_selection_list%, %selection_template_based_multiple%, %selection_template_based_single%",
                             null,
                             array(
                                 '%setting%' => $name,
@@ -98,7 +98,7 @@ class Type extends FieldType
                                 '%selection_list_with_radio_buttons%' => self::SELECTION_LIST_WITH_RADIO_BUTTONS,
                                 '%selection_list_with_checkboxes%' => self::SELECTION_LIST_WITH_CHECKBOXES,
                                 '%selection_multiple_selection_list%' => self::SELECTION_MULTIPLE_SELECTION_LIST,
-                                '%selection_template_based_multi%' => self::SELECTION_TEMPLATE_BASED_MULTI,
+                                '%selection_template_based_multiple%' => self::SELECTION_TEMPLATE_BASED_MULTIPLE,
                                 '%selection_template_based_single%' => self::SELECTION_TEMPLATE_BASED_SINGLE,
                             ),
                             "[$name]"

--- a/eZ/Publish/Core/FieldType/RelationList/Type.php
+++ b/eZ/Publish/Core/FieldType/RelationList/Type.php
@@ -26,11 +26,17 @@ use eZ\Publish\Core\FieldType\Value as BaseValue;
  */
 class Type extends FieldType
 {
-    /**
-     * @todo Consider to add all 6 selection options
-     */
     const SELECTION_BROWSE = 0;
     const SELECTION_DROPDOWN = 1;
+    /**
+     * @todo following selection methods needs to be implemented in 8.0.
+     * Please, refer to: https://jira.ez.no/browse/EZP-29924
+     */
+    const SELECTION_LIST_WITH_RADIO_BUTTONS = 2;
+    const SELECTION_LIST_WITH_CHECKBOXES = 3;
+    const SELECTION_MULTIPLE_SELECTION_LIST = 4;
+    const SELECTION_TEMPLATE_BASED_MULTI = 5;
+    const SELECTION_TEMPLATE_BASED_SINGLE = 6;
 
     protected $settingsSchema = array(
         'selectionMethod' => array(
@@ -73,7 +79,15 @@ class Type extends FieldType
 
             switch ($name) {
                 case 'selectionMethod':
-                    if ($value !== self::SELECTION_BROWSE && $value !== self::SELECTION_DROPDOWN) {
+                    if (!in_array($value, [
+                        self::SELECTION_BROWSE,
+                        self::SELECTION_DROPDOWN,
+                        self::SELECTION_LIST_WITH_RADIO_BUTTONS,
+                        self::SELECTION_LIST_WITH_CHECKBOXES,
+                        self::SELECTION_MULTIPLE_SELECTION_LIST,
+                        self::SELECTION_TEMPLATE_BASED_MULTI,
+                        self::SELECTION_TEMPLATE_BASED_SINGLE,
+                    ], true)) {
                         $validationErrors[] = new ValidationError(
                             "Setting '%setting%' must be either %selection_browse% or %selection_dropdown%",
                             null,
@@ -81,6 +95,11 @@ class Type extends FieldType
                                 '%setting%' => $name,
                                 '%selection_browse%' => self::SELECTION_BROWSE,
                                 '%selection_dropdown%' => self::SELECTION_DROPDOWN,
+                                '%selection_list_with_radio_buttons%' => self::SELECTION_LIST_WITH_RADIO_BUTTONS,
+                                '%selection_list_with_checkboxes%' => self::SELECTION_LIST_WITH_CHECKBOXES,
+                                '%selection_multiple_selection_list%' => self::SELECTION_MULTIPLE_SELECTION_LIST,
+                                '%selection_template_based_multi%' => self::SELECTION_TEMPLATE_BASED_MULTI,
+                                '%selection_template_based_single%' => self::SELECTION_TEMPLATE_BASED_SINGLE,
                             ),
                             "[$name]"
                         );

--- a/eZ/Publish/Core/FieldType/Tests/RelationListTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RelationListTest.php
@@ -305,6 +305,41 @@ class RelationListTest extends FieldTypeTest
                     'selectionContentTypes' => array(1, 2, 3),
                 ),
             ),
+            array(
+                array(
+                    'selectionMethod' => RelationList::SELECTION_LIST_WITH_RADIO_BUTTONS,
+                    'selectionDefaultLocation' => 'foo',
+                    'selectionContentTypes' => array(1, 2, 3),
+                ),
+            ),
+            array(
+                array(
+                    'selectionMethod' => RelationList::SELECTION_LIST_WITH_CHECKBOXES,
+                    'selectionDefaultLocation' => 'foo',
+                    'selectionContentTypes' => array(1, 2, 3),
+                ),
+            ),
+            array(
+                array(
+                    'selectionMethod' => RelationList::SELECTION_MULTIPLE_SELECTION_LIST,
+                    'selectionDefaultLocation' => 'foo',
+                    'selectionContentTypes' => array(1, 2, 3),
+                ),
+            ),
+            array(
+                array(
+                    'selectionMethod' => RelationList::SELECTION_TEMPLATE_BASED_MULTI,
+                    'selectionDefaultLocation' => 'foo',
+                    'selectionContentTypes' => array(1, 2, 3),
+                ),
+            ),
+            array(
+                array(
+                    'selectionMethod' => RelationList::SELECTION_TEMPLATE_BASED_SINGLE,
+                    'selectionDefaultLocation' => 'foo',
+                    'selectionContentTypes' => array(1, 2, 3),
+                ),
+            ),
         );
     }
 
@@ -355,6 +390,14 @@ class RelationListTest extends FieldTypeTest
                 // Invalid value for 'selectionContentTypes'
                 array(
                     'selectionMethod' => RelationList::SELECTION_DROPDOWN,
+                    'selectionDefaultLocation' => 23,
+                    'selectionContentTypes' => true,
+                ),
+            ),
+            array(
+                // Invalid value for 'selectionMethod'
+                array(
+                    'selectionMethod' => 9,
                     'selectionDefaultLocation' => 23,
                     'selectionContentTypes' => true,
                 ),

--- a/eZ/Publish/Core/FieldType/Tests/RelationListTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RelationListTest.php
@@ -328,7 +328,7 @@ class RelationListTest extends FieldTypeTest
             ),
             array(
                 array(
-                    'selectionMethod' => RelationList::SELECTION_TEMPLATE_BASED_MULTI,
+                    'selectionMethod' => RelationList::SELECTION_TEMPLATE_BASED_MULTIPLE,
                     'selectionDefaultLocation' => 'foo',
                     'selectionContentTypes' => array(1, 2, 3),
                 ),


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29924](https://jira.ez.no/browse/EZP-29924)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `6.7`/`6.13`/`7.3`/`7.4`/`master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Please refer to the JIRA ticket for more information. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
