### PR TITLE
EZP-29997: Exposed information about removed content items in EmptyTrashSignal and DeleteTrashItemSignal

### DIFF
--- a/eZ/Publish/API/Repository/TrashService.php
+++ b/eZ/Publish/API/Repository/TrashService.php
@@ -66,6 +66,8 @@ interface TrashService
      * if all locations of the content are gone.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to empty the trash
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResultList
      */
     public function emptyTrash();
 
@@ -77,6 +79,8 @@ interface TrashService
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to delete this trash item
      *
      * @param \eZ\Publish\API\Repository\Values\Content\TrashItem $trashItem
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResult
      */
     public function deleteTrashItem(TrashItem $trashItem);
 

--- a/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResult.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace eZ\Publish\API\Repository\Values\Content\Trash;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+class TrashItemDeleteResult extends ValueObject
+{
+    /**
+     * @var mixed
+     */
+    public $trashItemId;
+
+    /**
+     * @var mixed
+     */
+    public $contentId;
+
+    /**
+     * @var bool
+     */
+    public $itemRemoved = true;
+
+    /**
+     * Flag indicating content was removed.
+     *
+     * @var bool
+     */
+    public $contentRemoved = false;
+}

--- a/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResult.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace eZ\Publish\API\Repository\Values\Content\Trash;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -7,19 +11,14 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 class TrashItemDeleteResult extends ValueObject
 {
     /**
-     * @var mixed
+     * @var int
      */
     public $trashItemId;
 
     /**
-     * @var mixed
+     * @var int
      */
     public $contentId;
-
-    /**
-     * @var bool
-     */
-    public $itemRemoved = true;
 
     /**
      * Flag indicating content was removed.

--- a/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResultList.php
+++ b/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResultList.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace eZ\Publish\API\Repository\Values\Content\Trash;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+class TrashItemDeleteResultList extends ValueObject implements \IteratorAggregate
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResult[]
+     */
+    public $items = [];
+
+    /**
+     * @return \ArrayIterator
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->items);
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResultList.php
+++ b/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResultList.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace eZ\Publish\API\Repository\Values\Content\Trash;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
@@ -99,7 +99,8 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
     public function emptyTrash()
     {
         $this->logger->logCall(__METHOD__, array());
-        $this->persistenceHandler->trashHandler()->emptyTrash();
+
+        return $this->persistenceHandler->trashHandler()->emptyTrash();
     }
 
     /**
@@ -108,6 +109,7 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
     public function deleteTrashItem($trashedId)
     {
         $this->logger->logCall(__METHOD__, array('id' => $trashedId));
-        $this->persistenceHandler->trashHandler()->deleteTrashItem($trashedId);
+
+        return $this->persistenceHandler->trashHandler()->deleteTrashItem($trashedId);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
@@ -194,8 +194,7 @@ class Handler implements BaseTrashHandler
     }
 
     /**
-     * Empties the trash
-     * Everything contained in the trash must be removed.
+     * {@inheritdoc}
      */
     public function emptyTrash()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/TrashHandlerTest.php
@@ -407,7 +407,6 @@ class TrashHandlerTest extends TestCase
         foreach ($returnValue->items as $key => $trashItemDeleteResult) {
             $this->assertEquals($trashItemDeleteResult->trashItemId, $trashedItemIds[$key]);
             $this->assertEquals($trashItemDeleteResult->contentId, $trashedContentIds[$key]);
-            $this->assertTrue($trashItemDeleteResult->itemRemoved);
             $this->assertTrue($trashItemDeleteResult->contentRemoved);
         }
     }
@@ -471,7 +470,6 @@ class TrashHandlerTest extends TestCase
         $this->assertInstanceOf(TrashItemDeleteResult::class, $trashItemDeleteResult);
         $this->assertEquals($trashItemId, $trashItemDeleteResult->trashItemId);
         $this->assertEquals($contentId, $trashItemDeleteResult->contentId);
-        $this->assertTrue($trashItemDeleteResult->itemRemoved);
         $this->assertTrue($trashItemDeleteResult->contentRemoved);
     }
 
@@ -533,7 +531,6 @@ class TrashHandlerTest extends TestCase
         $this->assertInstanceOf(TrashItemDeleteResult::class, $trashItemDeleteResult);
         $this->assertEquals($trashItemId, $trashItemDeleteResult->trashItemId);
         $this->assertEquals($contentId, $trashItemDeleteResult->contentId);
-        $this->assertTrue($trashItemDeleteResult->itemRemoved);
         $this->assertFalse($trashItemDeleteResult->contentRemoved);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/TrashHandlerTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Location;
 
+use eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResult;
+use eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResultList;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Trash\Handler;
 use eZ\Publish\SPI\Persistence\Content\Location\Trashed;
@@ -360,6 +362,9 @@ class TrashHandlerTest extends TestCase
                 $this->returnValue($expectedTrashed)
             );
 
+        $trashedItemIds = [];
+        $trashedContentIds = [];
+
         foreach ($expectedTrashed as $trashedElement) {
             $this->locationMapper
                 ->expects($this->at($iLocation++))
@@ -390,9 +395,21 @@ class TrashHandlerTest extends TestCase
                 ->expects($this->at($iContent++))
                 ->method('deleteContent')
                 ->with($trashedElement['contentobject_id']);
+
+            $trashedItemIds[] = $trashedElement['node_id'];
+            $trashedContentIds[] = $trashedElement['contentobject_id'];
         }
 
-        $handler->emptyTrash();
+        $returnValue = $handler->emptyTrash();
+
+        $this->assertInstanceOf(TrashItemDeleteResultList::class, $returnValue);
+
+        foreach ($returnValue->items as $key => $trashItemDeleteResult) {
+            $this->assertEquals($trashItemDeleteResult->trashItemId, $trashedItemIds[$key]);
+            $this->assertEquals($trashItemDeleteResult->contentId, $trashedContentIds[$key]);
+            $this->assertTrue($trashItemDeleteResult->itemRemoved);
+            $this->assertTrue($trashItemDeleteResult->contentRemoved);
+        }
     }
 
     /**
@@ -402,15 +419,17 @@ class TrashHandlerTest extends TestCase
     {
         $handler = $this->getTrashHandler();
 
+        $trashItemId = 69;
+        $contentId = 67;
         $this->locationGateway
             ->expects($this->once())
             ->method('loadTrashByLocation')
-            ->with(69)
+            ->with($trashItemId)
             ->will(
                 $this->returnValue(
                     array(
-                        'node_id' => 69,
-                        'contentobject_id' => 67,
+                        'node_id' => $trashItemId,
+                        'contentobject_id' => $contentId,
                         'path_string' => '/1/2/69',
                     )
                 )
@@ -423,8 +442,8 @@ class TrashHandlerTest extends TestCase
                 $this->returnValue(
                     new Trashed(
                         array(
-                            'id' => 69,
-                            'contentId' => 67,
+                            'id' => $trashItemId,
+                            'contentId' => $contentId,
                             'pathString' => '/1/2/69',
                         )
                     )
@@ -434,20 +453,26 @@ class TrashHandlerTest extends TestCase
         $this->locationGateway
             ->expects($this->once())
             ->method('removeElementFromTrash')
-            ->with(69);
+            ->with($trashItemId);
 
         $this->locationGateway
             ->expects($this->once())
             ->method('countLocationsByContentId')
-            ->with(67)
+            ->with($contentId)
             ->will($this->returnValue(0));
 
         $this->contentHandler
             ->expects($this->once())
             ->method('deleteContent')
-            ->with(67);
+            ->with($contentId);
 
-        $handler->deleteTrashItem(69);
+        $trashItemDeleteResult = $handler->deleteTrashItem($trashItemId);
+
+        $this->assertInstanceOf(TrashItemDeleteResult::class, $trashItemDeleteResult);
+        $this->assertEquals($trashItemId, $trashItemDeleteResult->trashItemId);
+        $this->assertEquals($contentId, $trashItemDeleteResult->contentId);
+        $this->assertTrue($trashItemDeleteResult->itemRemoved);
+        $this->assertTrue($trashItemDeleteResult->contentRemoved);
     }
 
     /**
@@ -457,15 +482,17 @@ class TrashHandlerTest extends TestCase
     {
         $handler = $this->getTrashHandler();
 
+        $trashItemId = 69;
+        $contentId = 67;
         $this->locationGateway
             ->expects($this->once())
             ->method('loadTrashByLocation')
-            ->with(69)
+            ->with($trashItemId)
             ->will(
                 $this->returnValue(
                     array(
-                        'node_id' => 69,
-                        'contentobject_id' => 67,
+                        'node_id' => $trashItemId,
+                        'contentobject_id' => $contentId,
                         'path_string' => '/1/2/69',
                     )
                 )
@@ -478,8 +505,8 @@ class TrashHandlerTest extends TestCase
                 $this->returnValue(
                     new Trashed(
                         array(
-                            'id' => 69,
-                            'contentId' => 67,
+                            'id' => $trashItemId,
+                            'contentId' => $contentId,
                             'pathString' => '/1/2/69',
                         )
                     )
@@ -489,18 +516,24 @@ class TrashHandlerTest extends TestCase
         $this->locationGateway
             ->expects($this->once())
             ->method('removeElementFromTrash')
-            ->with(69);
+            ->with($trashItemId);
 
         $this->locationGateway
             ->expects($this->once())
             ->method('countLocationsByContentId')
-            ->with(67)
+            ->with($contentId)
             ->will($this->returnValue(1));
 
         $this->contentHandler
             ->expects($this->never())
             ->method('deleteContent');
 
-        $handler->deleteTrashItem(69);
+        $trashItemDeleteResult = $handler->deleteTrashItem($trashItemId);
+
+        $this->assertInstanceOf(TrashItemDeleteResult::class, $trashItemDeleteResult);
+        $this->assertEquals($trashItemId, $trashItemDeleteResult->trashItemId);
+        $this->assertEquals($contentId, $trashItemDeleteResult->contentId);
+        $this->assertTrue($trashItemDeleteResult->itemRemoved);
+        $this->assertFalse($trashItemDeleteResult->contentRemoved);
     }
 }

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -235,8 +235,10 @@ class TrashService implements TrashServiceInterface
         $this->repository->beginTransaction();
         try {
             // Persistence layer takes care of deleting content objects
-            $this->persistenceHandler->trashHandler()->emptyTrash();
+            $result = $this->persistenceHandler->trashHandler()->emptyTrash();
             $this->repository->commit();
+
+            return $result;
         } catch (Exception $e) {
             $this->repository->rollback();
             throw $e;
@@ -251,6 +253,8 @@ class TrashService implements TrashServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to delete this trash item
      *
      * @param \eZ\Publish\API\Repository\Values\Content\TrashItem $trashItem
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResult
      */
     public function deleteTrashItem(APITrashItem $trashItem)
     {
@@ -264,8 +268,10 @@ class TrashService implements TrashServiceInterface
 
         $this->repository->beginTransaction();
         try {
-            $this->persistenceHandler->trashHandler()->deleteTrashItem($trashItem->id);
+            $trashItemDeleteResult = $this->persistenceHandler->trashHandler()->deleteTrashItem($trashItem->id);
             $this->repository->commit();
+
+            return $trashItemDeleteResult;
         } catch (Exception $e) {
             $this->repository->rollback();
             throw $e;

--- a/eZ/Publish/Core/SignalSlot/Signal/TrashService/DeleteTrashItemSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/TrashService/DeleteTrashItemSignal.php
@@ -19,20 +19,13 @@ class DeleteTrashItemSignal extends Signal
      * TrashItemId.
      *
      * @var mixed
+     *
+     * @deprecated Use <code>$trashItemDeleteResult->trashItemId</code> instead.
      */
     public $trashItemId;
 
     /**
-     * Identifier of content associated with deleted TrashItem.
-     *
-     * @var mixed
+     * @var \eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResult
      */
-    public $contentId;
-
-    /**
-     * Indicates that content was removed.
-     *
-     * @var bool
-     */
-    public $contentRemoved;
+    public $trashItemDeleteResult;
 }

--- a/eZ/Publish/Core/SignalSlot/Signal/TrashService/DeleteTrashItemSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/TrashService/DeleteTrashItemSignal.php
@@ -21,4 +21,18 @@ class DeleteTrashItemSignal extends Signal
      * @var mixed
      */
     public $trashItemId;
+
+    /**
+     * Identifier of content associated with deleted TrashItem.
+     *
+     * @var mixed
+     */
+    public $contentId;
+
+    /**
+     * Indicates that content was removed.
+     *
+     * @var bool
+     */
+    public $contentRemoved;
 }

--- a/eZ/Publish/Core/SignalSlot/Signal/TrashService/EmptyTrashSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/TrashService/EmptyTrashSignal.php
@@ -15,4 +15,13 @@ use eZ\Publish\Core\SignalSlot\Signal;
  */
 class EmptyTrashSignal extends Signal
 {
+    /**
+     * @var mixed[]
+     */
+    public $deletedTrashItemIds;
+
+    /**
+     * @var mixed[]
+     */
+    public $deletedContentIds;
 }

--- a/eZ/Publish/Core/SignalSlot/Signal/TrashService/EmptyTrashSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/TrashService/EmptyTrashSignal.php
@@ -16,12 +16,7 @@ use eZ\Publish\Core\SignalSlot\Signal;
 class EmptyTrashSignal extends Signal
 {
     /**
-     * @var mixed[]
+     * @var \eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResultList
      */
-    public $deletedTrashItemIds;
-
-    /**
-     * @var mixed[]
-     */
-    public $deletedContentIds;
+    public $trashItemDeleteResultList;
 }

--- a/eZ/Publish/Core/SignalSlot/Tests/TrashServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/TrashServiceTest.php
@@ -70,11 +70,19 @@ class TrashServiceTest extends ServiceTest
             )
         );
 
-        $trashItemDeleteResult = new TrashItemDeleteResult([
-            'trashItemId' => $trashItemId,
-            'contentId' => $contentId,
-            'contentRemoved' => true,
-        ]);
+        $trashItemDeleteResult = new TrashItemDeleteResult(
+            array(
+                'trashItemId' => $trashItemId,
+                'contentId' => $contentId,
+                'contentRemoved' => true,
+            )
+        );
+
+        $trashItemDeleteResultList = new TrashItemDeleteResultList(
+            array(
+                'items' => array($trashItemDeleteResult),
+            )
+        );
 
         return array(
             array(
@@ -118,13 +126,10 @@ class TrashServiceTest extends ServiceTest
             array(
                 'emptyTrash',
                 array(),
-                new TrashItemDeleteResultList(['items' => [$trashItemDeleteResult]]),
+                $trashItemDeleteResultList,
                 1,
                 TrashServiceSignals\EmptyTrashSignal::class,
-                array(
-                    'deletedTrashItemIds' => array($trashItemId),
-                    'deletedContentIds' => array($contentId),
-                ),
+                array('trashItemDeleteResultList' => $trashItemDeleteResultList),
             ),
             array(
                 'deleteTrashItem',
@@ -134,8 +139,7 @@ class TrashServiceTest extends ServiceTest
                 TrashServiceSignals\DeleteTrashItemSignal::class,
                 array(
                     'trashItemId' => $trashItemId,
-                    'contentId' => $contentId,
-                    'contentRemoved' => true,
+                    'trashItemDeleteResult' => $trashItemDeleteResult,
                 ),
             ),
             array(

--- a/eZ/Publish/Core/SignalSlot/TrashService.php
+++ b/eZ/Publish/Core/SignalSlot/TrashService.php
@@ -139,8 +139,7 @@ class TrashService implements TrashServiceInterface
         $returnValue = $this->service->emptyTrash();
 
         $signal = new EmptyTrashSignal();
-        $signal->deletedTrashItemIds = array_column($returnValue->items, 'trashItemId');
-        $signal->deletedContentIds = array_column($returnValue->items, 'contentId');
+        $signal->trashItemDeleteResultList = $returnValue;
 
         $this->signalDispatcher->emit($signal);
 
@@ -163,8 +162,7 @@ class TrashService implements TrashServiceInterface
             new DeleteTrashItemSignal(
                 array(
                     'trashItemId' => $trashItem->id,
-                    'contentId' => $trashItem->contentInfo->id,
-                    'contentRemoved' => $returnValue->contentRemoved,
+                    'trashItemDeleteResult' => $returnValue,
                 )
             )
         );

--- a/eZ/Publish/Core/SignalSlot/TrashService.php
+++ b/eZ/Publish/Core/SignalSlot/TrashService.php
@@ -137,7 +137,12 @@ class TrashService implements TrashServiceInterface
     public function emptyTrash()
     {
         $returnValue = $this->service->emptyTrash();
-        $this->signalDispatcher->emit(new EmptyTrashSignal(array()));
+
+        $signal = new EmptyTrashSignal();
+        $signal->deletedTrashItemIds = array_column($returnValue->items, 'trashItemId');
+        $signal->deletedContentIds = array_column($returnValue->items, 'contentId');
+
+        $this->signalDispatcher->emit($signal);
 
         return $returnValue;
     }
@@ -158,6 +163,8 @@ class TrashService implements TrashServiceInterface
             new DeleteTrashItemSignal(
                 array(
                     'trashItemId' => $trashItem->id,
+                    'contentId' => $trashItem->contentInfo->id,
+                    'contentRemoved' => $returnValue->contentRemoved,
                 )
             )
         );

--- a/eZ/Publish/SPI/Persistence/Content/Location/Trash/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Trash/Handler.php
@@ -75,6 +75,8 @@ interface Handler
     /**
      * Empties the trash
      * Everything contained in the trash must be removed.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResultList
      */
     public function emptyTrash();
 
@@ -83,6 +85,8 @@ interface Handler
      * Associated content has to be deleted.
      *
      * @param int $trashedId
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResult
      */
     public function deleteTrashItem($trashedId);
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29997](https://jira.ez.no/browse/EZP-29997)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | yes/no
| **Tests pass**     | yes/no
| **Doc needed**     | no

I described the problem in the ticket and here is the quick and dirty implementation. I need your validation on the idea.

After discussion I can fix naming (TrashedItem, TrashItem... it's kind of a mess now :P), update tests.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
