### PR TITLE
EZP-30028: As a Developer I'd like sudo() to be exposed on API

### DIFF
--- a/eZ/Publish/API/Repository/Repository.php
+++ b/eZ/Publish/API/Repository/Repository.php
@@ -103,7 +103,7 @@ interface Repository
      *
      * @return mixed
      */
-    public function sudo(callable $callback, Repository $outerRepository = null);
+    public function sudo(callable $callback, self $outerRepository = null);
 
     /**
      * Get Content Service.

--- a/eZ/Publish/API/Repository/Repository.php
+++ b/eZ/Publish/API/Repository/Repository.php
@@ -83,6 +83,29 @@ interface Repository
     public function canUser($module, $function, ValueObject $object, $targets = null);
 
     /**
+     * Allows API execution to be performed with full access, sand-boxed.
+     *
+     * The closure sandbox will do a catch all on exceptions and rethrow after
+     * re-setting the sudo flag.
+     *
+     * Example use:
+     *     $location = $repository->sudo(function (Repository $repo) use ($locationId) {
+     *             return $repo->getLocationService()->loadLocation($locationId)
+     *         }
+     *     );
+     *
+     *
+     * @param callable $callback
+     * @param \eZ\Publish\API\Repository\Repository|null $outerRepository Optional, mostly for internal use but allows to
+     *                                                   specify Repository to pass to closure.
+     *
+     * @throws \Exception Re-throws exceptions thrown inside $callback
+     *
+     * @return mixed
+     */
+    public function sudo(callable $callback, Repository $outerRepository = null);
+
+    /**
      * Get Content Service.
      *
      * Get service object to perform operations on Content objects and it's aggregate members.

--- a/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\User\Limitation\LocationLimitation;
 
@@ -112,6 +114,29 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
         // $contentId contains a content object ID not accessible for anonymous
         $contentService->loadContentInfo($contentId);
         /* END: Use Case */
+    }
+
+    /**
+     * Test for the sudo() method.
+     *
+     * @see \eZ\Publish\API\Repository\Repository::sudo()
+     * @depends testLoadContentInfoThrowsUnauthorizedException
+     */
+    public function testSudo()
+    {
+        $repository = $this->getRepository();
+        $contentId = $this->generateId('object', 10);
+        // Set restricted editor user
+        $repository->setCurrentUser($this->createAnonymousWithEditorRole());
+
+        $contentInfo = $repository->sudo(function (Repository $repository) use ($contentId) {
+            return $repository->getContentService()->loadContentInfo($contentId);
+        });
+
+        $this->assertInstanceOf(
+            ContentInfo::class,
+            $contentInfo
+        );
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Repository.php
+++ b/eZ/Publish/Core/REST/Client/Repository.php
@@ -555,4 +555,12 @@ class Repository implements APIRepository
     {
         // @todo: Implement / discuss
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sudo(callable $callback, APIRepository $outerRepository = null)
+    {
+        // TODO: Implement sudo() method.
+    }
 }

--- a/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
+++ b/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
@@ -128,7 +128,7 @@ class CachedPermissionService implements APIPermissionResolver, APIPermissionCri
     /**
      * @internal For internal use only, do not depend on this method.
      */
-    public function sudo(Closure $callback, RepositoryInterface $outerRepository)
+    public function sudo(callable $callback, RepositoryInterface $outerRepository)
     {
         ++$this->sudoNestingLevel;
         try {

--- a/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
+++ b/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
@@ -11,7 +11,6 @@ use eZ\Publish\API\Repository\PermissionCriterionResolver as APIPermissionCriter
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use Closure;
 use Exception;
 
 /**

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -266,7 +266,7 @@ class PermissionResolver implements PermissionResolverInterface
      *
      * @return mixed
      */
-    public function sudo(Closure $callback, RepositoryInterface $outerRepository)
+    public function sudo(callable $callback, RepositoryInterface $outerRepository)
     {
         ++$this->sudoNestingLevel;
         try {

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -19,7 +19,6 @@ use eZ\Publish\Core\Repository\Values\User\UserReference;
 use eZ\Publish\Core\Search\Common\BackgroundIndexer;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Search\Handler as SearchHandler;
-use Closure;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -385,29 +385,9 @@ class Repository implements RepositoryInterface
     }
 
     /**
-     * Allows API execution to be performed with full access sand-boxed.
-     *
-     * The closure sandbox will do a catch all on exceptions and rethrow after
-     * re-setting the sudo flag.
-     *
-     * Example use:
-     *     $location = $repository->sudo(
-     *         function ( Repository $repo ) use ( $locationId )
-     *         {
-     *             return $repo->getLocationService()->loadLocation( $locationId )
-     *         }
-     *     );
-     *
-     *
-     * @param \Closure $callback
-     * @param \eZ\Publish\API\Repository\Repository|null $outerRepository
-     *
-     * @throws \RuntimeException Thrown on recursive sudo() use.
-     * @throws \Exception Re throws exceptions thrown inside $callback
-     *
-     * @return mixed
+     * {@inheritdoc}
      */
-    public function sudo(Closure $callback, RepositoryInterface $outerRepository = null)
+    public function sudo(callable $callback, RepositoryInterface $outerRepository = null)
     {
         return $this->getPermissionResolver()->sudo($callback, $outerRepository ?? $this);
     }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Repository.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Repository.php
@@ -100,7 +100,7 @@ class Repository implements RepositoryInterface
         return $this->repository->setCurrentUser($user);
     }
 
-    public function sudo(Closure $callback, RepositoryInterface $outerRepository = null)
+    public function sudo(callable $callback, RepositoryInterface $outerRepository = null)
     {
         return $this->repository->sudo($callback, $outerRepository ?? $this);
     }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Repository.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Repository.php
@@ -11,7 +11,6 @@ namespace eZ\Publish\Core\Repository\SiteAccessAware;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\User\UserReference;
-use Closure;
 
 /**
  * Repository class.

--- a/eZ/Publish/Core/SignalSlot/Repository.php
+++ b/eZ/Publish/Core/SignalSlot/Repository.php
@@ -253,29 +253,9 @@ class Repository implements RepositoryInterface
     }
 
     /**
-     * Allows API execution to be performed with full access sand-boxed.
-     *
-     * The closure sandbox will do a catch all on exceptions and rethrow after
-     * re-setting the sudo flag.
-     *
-     * Example use:
-     *     $location = $repository->sudo(
-     *         function ( Repository $repo ) use ( $locationId )
-     *         {
-     *             return $repo->getLocationService()->loadLocation( $locationId )
-     *         }
-     *     );
-     *
-     *
-     * @param \Closure $callback
-     * @param \eZ\Publish\API\Repository\Repository|null $outerRepository
-     *
-     * @throws \RuntimeException Thrown on recursive sudo() use.
-     * @throws \Exception Re throws exceptions thrown inside $callback
-     *
-     * @return mixed
+     * {@inheritdoc}
      */
-    public function sudo(Closure $callback, RepositoryInterface $outerRepository = null)
+    public function sudo(callable $callback, RepositoryInterface $outerRepository = null)
     {
         return $this->repository->sudo($callback, $outerRepository ?? $this);
     }

--- a/eZ/Publish/Core/SignalSlot/Repository.php
+++ b/eZ/Publish/Core/SignalSlot/Repository.php
@@ -11,7 +11,6 @@ use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\SPI\Persistence\TransactionHandler;
-use Closure;
 
 /**
  * Repository class.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30028](https://jira.ez.no/browse/EZP-30028)
| **New feature**    | _API Interface wise yes, otherwise no_
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

A bit overdue change perhaps.

Needed so:
- It can be found easier by developers, and so we can document it as part of how to get content current user does not have access to.
- So it can become official so Developers feels safe using it

Note, this does not:
- Remove the need to continue adding bulk loading API's that don't throw but instead just filters on permission
    - Remove the possible future option of adding arguments on these bulk load methods to opt out of permission checking, like is the case on find*()
- Fix the fact that sudo() does not have relevant return type hinting by it's very nature

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
