### PR TITLE
EZP-30029: As a Developer I'd like API for bulk loading Content Info Items

### DIFF
--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -39,6 +39,17 @@ interface ContentService
     public function loadContentInfo($contentId);
 
     /**
+     * Bulk-load ContentInfo items by id's.
+     *
+     * Note: It does not throw exceptions on load, just skips erroneous (NotFound or Unauthorized) ContentInfo items.
+     *
+     * @param int[] $contentIds
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo[] list of ContentInfo with Content Ids as keys
+     */
+    public function loadContentInfoList(array $contentIds): iterable;
+
+    /**
      * Loads a content info object for the given remoteId.
      *
      * To load fields use loadContent

--- a/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
@@ -140,6 +140,24 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
     }
 
     /**
+     * Test for the loadContentInfoList() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentService::loadContentInfoList()
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadContentInfoList
+     */
+    public function testLoadContentInfoListSkipsUnauthorizedItems()
+    {
+        $repository = $this->getRepository();
+        $contentId = $this->generateId('object', 10);
+        $contentService = $repository->getContentService();
+        $repository->setCurrentUser($this->createAnonymousWithEditorRole());
+
+        $list = $contentService->loadContentInfoList([$contentId]);
+
+        $this->assertCount(0, $list);
+    }
+
+    /**
      * Test for the loadContentInfoByRemoteId() method.
      *
      * @see \eZ\Publish\API\Repository\ContentService::loadContentInfoByRemoteId()

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -572,6 +572,44 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
+     * Test for the loadContentInfoList() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentService::loadContentInfoList()
+     */
+    public function testLoadContentInfoList()
+    {
+        $repository = $this->getRepository();
+
+        $mediaFolderId = $this->generateId('object', 41);
+        $contentService = $repository->getContentService();
+        $list = $contentService->loadContentInfoList([$mediaFolderId]);
+
+        $this->assertCount(1, $list);
+        $this->assertEquals([$mediaFolderId], array_keys($list), 'Array key was not content id');
+        $this->assertInstanceOf(
+            ContentInfo::class,
+            $list[$mediaFolderId]
+        );
+    }
+
+    /**
+     * Test for the loadContentInfoList() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentService::loadContentInfoList()
+     * @depends testLoadContentInfoList
+     */
+    public function testLoadContentInfoListSkipsNotFoundItems()
+    {
+        $repository = $this->getRepository();
+
+        $nonExistentContentId = $this->generateId('object', self::DB_INT_MAX);
+        $contentService = $repository->getContentService();
+        $list = $contentService->loadContentInfoList([$nonExistentContentId]);
+
+        $this->assertCount(0, $list);
+    }
+
+    /**
      * Test for the loadContentInfoByRemoteId() method.
      *
      * @see \eZ\Publish\API\Repository\ContentService::loadContentInfoByRemoteId()

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/RelationList/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/RelationList/ParameterProvider.php
@@ -3,8 +3,6 @@
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\RelationList;
 
 use eZ\Publish\API\Repository\ContentService;
-use eZ\Publish\API\Repository\Exceptions\NotFoundException;
-use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderInterface;
 
@@ -34,18 +32,18 @@ class ParameterProvider implements ParameterProviderInterface
      */
     public function getViewParameters(Field $field)
     {
-        $available = [];
+        $ids = $field->value->destinationContentIds;
+        $list = $this->contentService->loadContentInfoList($ids);
 
-        foreach ($field->value->destinationContentIds as $contentId) {
-            try {
-                $contentInfo = $this->contentService->loadContentInfo($contentId);
+        // Start by setting missing ids as false on $available
+        $available = array_fill_keys(
+            array_diff($ids, array_keys($list)),
+            false
+        );
 
-                $available[$contentId] = !$contentInfo->isTrashed();
-            } catch (NotFoundException $exception) {
-                $available[$contentId] = false;
-            } catch (UnauthorizedException $exception) {
-                $available[$contentId] = false;
-            }
+        // Check if loaded items are in trash or not, for availability
+        foreach ($list as $contentId => $contentInfo) {
+            $available[$contentId] = !$contentInfo->isTrashed();
         }
 
         return [

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -114,6 +114,14 @@ class ContentService implements APIContentService, Sessionable
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function loadContentInfoList(array $contentIds): iterable
+    {
+        throw new \Exception('@todo: Implement.');
+    }
+
+    /**
      * Loads a content info object for the given remoteId.
      *
      * To load fields use loadContent

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -140,6 +140,23 @@ class ContentService implements ContentServiceInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function loadContentInfoList(array $contentIds): iterable
+    {
+        $contentInfoList = [];
+        $spiInfoList = $this->persistenceHandler->contentHandler()->loadContentInfoList($contentIds);
+        foreach ($spiInfoList as $id => $spiInfo) {
+            $contentInfo = $this->domainMapper->buildContentInfoDomainObject($spiInfo);
+            if ($this->repository->canUser('content', 'read', $contentInfo)) {
+                $contentInfoList[$id] = $contentInfo;
+            }
+        }
+
+        return $contentInfoList;
+    }
+
+    /**
      * Loads a content info object.
      *
      * To load fields use loadContent

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -49,6 +49,14 @@ class ContentService implements ContentServiceInterface
         return $this->service->loadContentInfo($contentId);
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function loadContentInfoList(array $contentIds): iterable
+    {
+        return $this->service->loadContentInfoList($contentIds);
+    }
+
     public function loadContentInfoByRemoteId($remoteId)
     {
         return $this->service->loadContentInfoByRemoteId($remoteId);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
@@ -39,6 +39,7 @@ class ContentServiceTest extends AbstractServiceTest
         // string $method, array $arguments, bool $return = true
         return [
             ['loadContentInfo', [42]],
+            ['loadContentInfoList', [[42]], [$contentInfo]],
 
             ['loadContentInfoByRemoteId', ['f348tj4gorgji4']],
 

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -86,6 +86,14 @@ class ContentService implements ContentServiceInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function loadContentInfoList(array $contentIds): iterable
+    {
+        return $this->service->loadContentInfoList($contentIds);
+    }
+
+    /**
      * Loads a content info object for the given remoteId.
      *
      * To load fields use loadContent

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
@@ -86,6 +86,12 @@ class ContentServiceTest extends ServiceTest
                 0,
             ),
             array(
+                'loadContentInfoList',
+                array(array($contentId)),
+                [$contentInfo],
+                0,
+            ),
+            array(
                 'loadContentInfoByRemoteId',
                 array($remoteId),
                 $contentInfo,


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30029](https://jira.ez.no/browse/EZP-30029)
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | maybe

In order to optimize logic in  RelationList/ParameterProvider, and other places eventually.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.

**Design:**
`public function loadContentInfoList(array $contentIds, bool $filterOnUserPermissions = true): iterable;`


**REVIEW NOTE***
- ~I'm not sold on adding `bool $filterOnUserPermissions` param myself, but it aligns with `SearchService`, and it also fits well with `loadContentListByContentInfo` which explicitly does not check permissions as it expects that to already have been done on provided content info.~