### PR TITLE
Remove dot from Content Type identifier

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/FieldTypeContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/FieldTypeContext.php
@@ -335,7 +335,7 @@ class FieldTypeContext implements Context
     {
         $name = $this->fieldConstructionObject['fieldType']->identifier;
         $name = uniqid($name . '#', true);
-        $identifier = strtolower($name);
+        $identifier = str_replace('.', '', strtolower($name));
         $contentTypeCreateStruct = $this->contentTypeService->newContentTypeCreateStruct($identifier);
         $contentTypeCreateStruct->mainLanguageCode = self::DEFAULT_LANGUAGE;
         $contentTypeCreateStruct->names = array(self::DEFAULT_LANGUAGE => $name);


### PR DESCRIPTION
Similar as in https://github.com/ezsystems/repository-forms/pull/275 - the dot cannot be used in Content Type identifier.

Regression from https://github.com/ezsystems/ezpublish-kernel/pull/2523