### PR TITLE
EZP-28663: Cannot swap location when viewing item from non-main location

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -933,12 +933,24 @@ class DoctrineDatabase extends Gateway
      *
      * @see loadContentInfo(), loadContentInfoByRemoteId(), loadContentInfoList(), loadContentInfoByLocationId()
      *
+     * @param bool $joinMainLocation
+     *
      * @return \Doctrine\DBAL\Query\QueryBuilder
      */
-    private function createLoadContentInfoQueryBuilder()
+    private function createLoadContentInfoQueryBuilder($joinMainLocation = true)
     {
         $queryBuilder = $this->connection->createQueryBuilder();
         $expr = $queryBuilder->expr();
+
+        $joinCondition = $expr->eq('c.id', 't.contentobject_id');
+        if ($joinMainLocation) {
+            // wrap join condition with AND operator and join by a Main Location
+            $joinCondition = $expr->andX(
+                $joinCondition,
+                $expr->eq('t.node_id', 't.main_node_id')
+            );
+        }
+
         $queryBuilder
             ->select('c.*', 't.main_node_id AS ezcontentobject_tree_main_node_id')
             ->from('ezcontentobject', 'c')
@@ -946,10 +958,7 @@ class DoctrineDatabase extends Gateway
                 'c',
                 'ezcontentobject_tree',
                 't',
-                $expr->andX(
-                    $expr->eq('c.id', 't.contentobject_id'),
-                    $expr->eq('t.node_id', 't.main_node_id')
-                )
+                $joinCondition
             );
 
         return $queryBuilder;
@@ -1031,14 +1040,14 @@ class DoctrineDatabase extends Gateway
      */
     public function loadContentInfoByLocationId($locationId)
     {
-        $queryBuilder = $this->createLoadContentInfoQueryBuilder();
+        $queryBuilder = $this->createLoadContentInfoQueryBuilder(false);
         $queryBuilder
-            ->where('t.main_node_id = :id')
+            ->where('t.node_id = :id')
             ->setParameter('id', $locationId, PDO::PARAM_INT);
 
         $results = $queryBuilder->execute()->fetchAll(PDO::FETCH_ASSOC);
         if (empty($results)) {
-            throw new NotFound('content', "main_node_id: $locationId");
+            throw new NotFound('content', "node_id: $locationId");
         }
 
         return $results[0];

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -1128,27 +1128,19 @@ class DoctrineDatabase extends Gateway
 
     public function getLocationContentMainLanguageId($locationId)
     {
-        $dbHandler = $this->dbHandler;
-        $query = $dbHandler->createSelectQuery();
-        $query
-            ->select($dbHandler->quoteColumn('initial_language_id', 'ezcontentobject'))
-            ->from($dbHandler->quoteTable('ezcontentobject'))
-            ->innerJoin(
-                $dbHandler->quoteTable('ezcontentobject_tree'),
-                $query->expr->lAnd(
-                    $query->expr->eq(
-                        $dbHandler->quoteColumn('contentobject_id', 'ezcontentobject_tree'),
-                        $dbHandler->quoteColumn('id', 'ezcontentobject')
-                    ),
-                    $query->expr->eq(
-                        $dbHandler->quoteColumn('node_id', 'ezcontentobject_tree'),
-                        $query->bindValue($locationId, null, \PDO::PARAM_INT)
-                    )
-                )
-            );
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $expr = $queryBuilder->expr();
+        $queryBuilder
+            ->select('c.initial_language_id')
+            ->from('ezcontentobject', 'c')
+            ->join('c', 'ezcontentobject_tree', 't', $expr->eq('t.contentobject_id', 'c.id'))
+            ->where(
+                $expr->eq('t.node_id', ':locationId')
+            )
+            ->setParameter('locationId', $locationId, \PDO::PARAM_INT)
+        ;
 
-        $statement = $query->prepare();
-        $statement->execute();
+        $statement = $queryBuilder->execute();
         $languageId = $statement->fetchColumn();
 
         if ($languageId === false) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -1142,10 +1142,6 @@ class DoctrineDatabase extends Gateway
                     ),
                     $query->expr->eq(
                         $dbHandler->quoteColumn('node_id', 'ezcontentobject_tree'),
-                        $dbHandler->quoteColumn('main_node_id', 'ezcontentobject_tree')
-                    ),
-                    $query->expr->eq(
-                        $dbHandler->quoteColumn('node_id', 'ezcontentobject_tree'),
                         $query->bindValue($locationId, null, \PDO::PARAM_INT)
                     )
                 )


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28663](https://jira.ez.no/browse/EZP-28663)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`, `6.13`, `7.2`, `7.3`, `7.4`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR fixes the issue with swapping non-main Location of Content items.

The root cause of this issue was forcing joining Content Info data by main Location w/o taking into the account that a Location might not be the main one.

The second issue is the state of Main Location. In the case of swapping of main Location with non-main Location, that state needs to be swapped as well.

## Under the hood
### Simplest case - swapping two main Locations

Note: Content Id is in the square brackets:

#### Before swap:

```
Root
└── [50] Content1
└── [51] Content2
```
content_id | main_node_id | node_id | parent
--- | --- | --- | ---
50 | 60 | 60 | 0
51 | 61 | 61 | 0

#### After swap:

```
Root
└── [51] Content2
└── [50] Content1
```
content_id | main_node_id | node_id | parent
--- | --- | --- | ---
**51** | 60 | 60 | 0
**50** | 61 | 61 | 0

### Complex case 01 - swapping non-main Location with a main one.
#### Before swap:
```
Root
└── [50] MainArticle (main Location)
└── [51] TestFolder
|         └── [50] MainArticle (secondary Location)
└── [52] FolderSecond
|         └── [53] FolderSecond2 (main Location)
```

content_id | main_node_id | node_id | parent
--- | --- | --- | ---
50 | 60 | 60 | 0
51 | 61 | 61 | 0
50 | 60 | 62 | 61
52 | 63 | 63 | 0
53 | 64 | 64 | 63

#### After swap:
```
Root
└── [50] MainArticle (main Location)
└── [51] TestFolder
|         └── [53] FolderSecond2 (main Location)
└── [52] FolderSecond
|         └── [50] MainArticle (secondary Location)
```
content_id | main_node_id | node_id | parent
--- | --- | --- | ---
50 | 60 | 60 | 0
51 | 61 | 61 | 0
**53** | **62** | 62 | 61
52 | 63 | 63 | 0
**50** | **60** | 64 | 63

Please notice that `main_node_id` in this case needs to change as well.

### Complex case 02 - swapping two non-main Locations.
#### Before swap:

```
Root
└── [50] Article01 (main Location)
└── [51] Article02 (main Location)
└── [52] TestFolder
|         └── [50] Article01 (secondary Location)
└── [53] FolderSecond
|         └── [51] Article02 (secondary Location)
```

content_id | main_node_id | node_id | parent
--- | --- | --- | ---
50 | 60 | 60 | 0
51 | 61 | 61 | 0
52 | 62 | 62 | 0
50 | 60 | 63 | 62
53 | 64 | 64 | 0
51 | 61 | 65 | 65

#### After swap:
```
Root
└── [50] Article01 (main Location)
└── [51] Article02 (main Location)
└── [52] TestFolder (main Location)
|         └── [51] Article02 (secondary Location)
└── [53] FolderSecond (main Location)
|         └── [50] Article01 (secondary Location)
```

content_id | main_node_id | node_id | parent
--- | --- | --- | ---
50 | 60 | 60 | 0
51 | 61 | 61 | 0
52 | 62 | 62 | 0
**51** | **61** | 63 | 62
53 | 64 | 64 | 0
**50** | **60** | 65 | 65


**TODO**:
- [x] Drop forcing Main Location when loading Content Info by Location Id (`Content\Gateway::loadContentInfoByLocationId`)
- [x] Drop forcing Main Location when loading Content item Main Language by its Location Id (`Content\UrlAlias\Gateway::getLocationContentMainLanguageId`)
- [x] Refactor `Content\UrlAlias\Gateway\DoctrineDatabase::getLocationContentMainLanguageId` to use Doctrine Query Builder.
- [x] Swap main Location association for non-main Location swap
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
