### PR TITLE
EZP-29990: As an Administrator I want to translate ezselection Field Definition options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
         "friendsofsymfony/http-cache-bundle": "^1.3.13 | ^2.5.1",
         "sensio/framework-extra-bundle": "^5.2",
         "jms/translation-bundle": "^1.4",
-        "twig/twig": "^2.5",
-        "ezsystems/ezplatform-solr-search-engine": "~1.0"
+        "twig/twig": "^2.5"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.7.5",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "friendsofsymfony/http-cache-bundle": "^1.3.13 | ^2.5.1",
         "sensio/framework-extra-bundle": "^5.2",
         "jms/translation-bundle": "^1.4",
-        "twig/twig": "^2.5"
+        "twig/twig": "^2.5",
+        "ezsystems/ezplatform-solr-search-engine": "~1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.7.5",

--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -2578,14 +2578,14 @@ CREATE TABLE `eznotification` (
 --
 DROP TABLE IF EXISTS `ezcontentclass_attribute_ml`;
 CREATE TABLE `ezcontentclass_attribute_ml` (
-	`contentclass_attribute_id` INT NOT NULL,
-	`version` INT NOT NULL,
-	`language_id` BIGINT NOT NULL,
-	`name` VARCHAR(255) NOT NULL,
-	`description` TEXT NULL,
-	`data_text` TEXT NULL,
-	`data_json` TEXT NULL,
-	PRIMARY KEY (`contentclass_attribute_id`, `version`, `language_id`)
+  `contentclass_attribute_id` INT NOT NULL,
+  `version` INT NOT NULL,
+  `language_id` BIGINT NOT NULL,
+  `name` VARCHAR(255) NOT NULL,
+  `description` TEXT NULL,
+  `data_text` TEXT NULL,
+  `data_json` TEXT NULL,
+  PRIMARY KEY (`contentclass_attribute_id`, `version`, `language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 ALTER TABLE `ezcontentclass_attribute_ml`
@@ -2607,4 +2607,3 @@ ADD CONSTRAINT `ezcontentclass_attribute_ml_lang_fk`
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
 -- Dump completed on 2012-08-14 15:46:37
-

--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -2585,3 +2585,20 @@ CREATE TABLE `eznotification` (
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
 -- Dump completed on 2012-08-14 15:46:37
+
+DROP TABLE IF EXISTS `ezcontentclass_attribute_ml`;
+create table `ezcontentclass_attribute_ml`
+(
+	contentclass_attribute_id int not null,
+	version int not null,
+	language_id bigint not null,
+	name varchar(255) not null,
+	description text null,
+	data_text text null,
+	data_json text null,
+	primary key (contentclass_attribute_id, version, language_id),
+	constraint ezcontentclass_attribute_ml_lang_fk
+		foreign key (language_id) references ezcontent_language (id)
+			on update cascade on delete cascade
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+

--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -2573,6 +2573,28 @@ CREATE TABLE `eznotification` (
   KEY `eznotification_owner_is_pending` (`owner_id`, `is_pending`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+--
+-- Table structure for table `ezcontentclass_attribute_ml`
+--
+DROP TABLE IF EXISTS `ezcontentclass_attribute_ml`;
+CREATE TABLE `ezcontentclass_attribute_ml` (
+	`contentclass_attribute_id` INT NOT NULL,
+	`version` INT NOT NULL,
+	`language_id` BIGINT NOT NULL,
+	`name` VARCHAR(255) NOT NULL,
+	`description` TEXT NULL,
+	`data_text` TEXT NULL,
+	`data_json` TEXT NULL,
+	PRIMARY KEY (`contentclass_attribute_id`, `version`, `language_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE `ezcontentclass_attribute_ml`
+ADD CONSTRAINT `ezcontentclass_attribute_ml_lang_fk`
+  FOREIGN KEY (`language_id`)
+  REFERENCES `ezcontent_language` (`id`)
+  ON DELETE CASCADE
+  ON UPDATE CASCADE;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -2585,20 +2607,4 @@ CREATE TABLE `eznotification` (
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
 -- Dump completed on 2012-08-14 15:46:37
-
-DROP TABLE IF EXISTS `ezcontentclass_attribute_ml`;
-create table `ezcontentclass_attribute_ml`
-(
-	contentclass_attribute_id int not null,
-	version int not null,
-	language_id bigint not null,
-	name varchar(255) not null,
-	description text null,
-	data_text text null,
-	data_json text null,
-	primary key (contentclass_attribute_id, version, language_id),
-	constraint ezcontentclass_attribute_ml_lang_fk
-		foreign key (language_id) references ezcontent_language (id)
-			on update cascade on delete cascade
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/data/update/mysql/dbupdate-7.4.0-to-7.5.0.sql
+++ b/data/update/mysql/dbupdate-7.4.0-to-7.5.0.sql
@@ -1,0 +1,26 @@
+SET default_storage_engine=InnoDB;
+-- Set storage engine schema version number
+UPDATE ezsite_data SET value='7.5.0' WHERE name='ezpublish-version';
+
+--
+-- EZP-29990 - Add table for multilingual FieldDefinitions
+--
+
+DROP TABLE IF EXISTS `ezcontentclass_attribute_ml`;
+CREATE TABLE `ezcontentclass_attribute_ml` (
+  `contentclass_attribute_id` INT NOT NULL,
+  `version` INT NOT NULL,
+  `language_id` BIGINT NOT NULL,
+  `name` VARCHAR(255) NOT NULL,
+  `description` TEXT NULL,
+  `data_text` TEXT NULL,
+  `data_json` TEXT NULL,
+  PRIMARY KEY (`contentclass_attribute_id`, `version`, `language_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE `ezcontentclass_attribute_ml`
+ADD CONSTRAINT `ezcontentclass_attribute_ml_lang_fk`
+  FOREIGN KEY (`language_id`)
+  REFERENCES `ezcontent_language` (`id`)
+  ON DELETE CASCADE
+  ON UPDATE CASCADE;

--- a/data/update/postgres/dbupdate-7.4.0-to-7.5.0.sql
+++ b/data/update/postgres/dbupdate-7.4.0-to-7.5.0.sql
@@ -1,0 +1,26 @@
+-- Set storage engine schema version number
+UPDATE ezsite_data SET value='7.5.0' WHERE name='ezpublish-version';
+
+--
+-- EZP-29990 - Add table for multilingual FieldDefinitions
+--
+
+DROP TABLE IF EXISTS ezcontentclass_attribute_ml;
+CREATE TABLE ezcontentclass_attribute_ml (
+    contentclass_attribute_id INT NOT NULL,
+    version integer NOT NULL,
+    language_id SERIAL NOT NULL,
+    name character varying(255) NOT NULL,
+    description text DEFAULT NULL,
+    data_text text DEFAULT NULL,
+    data_json text DEFAULT NULL
+);
+
+CREATE INDEX contentclass_attribute_id ON ezcontentclass_attribute_ml USING btree (contentclass_attribute_id, version, language_id);
+
+ALTER TABLE ezcontentclass_attribute_ml
+ADD CONSTRAINT ezcontentclass_attribute_ml_lang_fk
+  FOREIGN KEY (language_id)
+  REFERENCES ezcontent_language (id)
+  ON DELETE CASCADE
+  ON UPDATE CASCADE;

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -162,15 +162,24 @@
 
 {% block ezselection_field %}
 {% spaceless %}
+
+    {% set options = fieldSettings.options %}
+
+    {% if fieldSettings.multilingualOptions[field.languageCode] is defined %}
+        {% set options = fieldSettings.multilingualOptions[field.languageCode] %}
+    {% elseif fieldSettings.multilingualOptions[contentInfo.mainLanguageCode] is defined %}
+        {% set options = fieldSettings.multilingualOptions[contentInfo.mainLanguageCode] %}
+    {% endif %}
+
     {% if field.value.selection|length() <= 0 %}
     {% elseif fieldSettings.isMultiple %}
         <ul {{ block( 'field_attributes' ) }}>
         {% for selectedIndex in field.value.selection %}
-            <li>{{ fieldSettings.options[selectedIndex] }}</li>
+            <li>{{ options[selectedIndex] }}</li>
         {% endfor %}
         </ul>
     {% else %}
-        {% set field_value = fieldSettings.options[field.value.selection.0] %}
+        {% set field_value = options[field.value.selection.0] %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
 {% endspaceless %}

--- a/eZ/Publish/API/Repository/Tests/BaseContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseContentTypeServiceTest.php
@@ -18,9 +18,15 @@ abstract class BaseContentTypeServiceTest extends BaseTest
     /**
      * Creates a fully functional ContentTypeDraft and returns it.
      *
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct[] $additionalFieldDefinitionsCreateStruct
+     *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    protected function createContentTypeDraft()
+    protected function createContentTypeDraft(array $additionalFieldDefinitionsCreateStruct = [])
     {
         $repository = $this->getRepository();
 
@@ -96,6 +102,10 @@ abstract class BaseContentTypeServiceTest extends BaseTest
         $bodyFieldCreate->isSearchable = false;
 
         $typeCreate->addFieldDefinition($bodyFieldCreate);
+
+        foreach ($additionalFieldDefinitionsCreateStruct as $fieldDefinitionCreateStruct) {
+            $typeCreate->addFieldDefinition($fieldDefinitionCreateStruct);
+        }
 
         $contentTypeDraft = $contentTypeService->createContentType(
             $typeCreate,

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -1493,7 +1493,6 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $fieldDefCreate->fieldSettings = array();
         $fieldDefCreate->isSearchable = true;
         $fieldDefCreate->defaultValue = 'default tags';
-        $fieldDefCreate->mainLanguageCode = $contentTypeDraft->mainLanguageCode;
 
         $contentTypeService->addFieldDefinition($contentTypeDraft, $fieldDefCreate);
         /* END: Use Case */

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -1493,6 +1493,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $fieldDefCreate->fieldSettings = array();
         $fieldDefCreate->isSearchable = true;
         $fieldDefCreate->defaultValue = 'default tags';
+        $fieldDefCreate->mainLanguageCode = $contentTypeDraft->mainLanguageCode;
 
         $contentTypeService->addFieldDefinition($contentTypeDraft, $fieldDefCreate);
         /* END: Use Case */

--- a/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
@@ -1012,6 +1012,8 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
             'data',
             $this->getTypeName()
         );
+
+        $fieldDefinitionCreateStruct->names[$contentType->mainLanguageCode] = $this->getTypeName();
         $fieldDefinitionCreateStruct->validatorConfiguration = $this->getValidValidatorConfiguration();
         $fieldDefinitionCreateStruct->fieldSettings = $this->getValidFieldSettings();
         $fieldDefinitionCreateStruct->defaultValue = null;

--- a/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
@@ -265,6 +265,16 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
         // Do nothing by default
     }
 
+    public function getValidContentTypeConfiguration(): array
+    {
+        return [];
+    }
+
+    public function getValidFieldConfiguration(): array
+    {
+        return [];
+    }
+
     /**
      * @dep_ends eZ\Publish\API\Repository\Tests\ContentTypeServiceTest::testCreateContentType
      */
@@ -272,7 +282,9 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     {
         $contentType = $this->createContentType(
             $this->getValidFieldSettings(),
-            $this->getValidValidatorConfiguration()
+            $this->getValidValidatorConfiguration(),
+            $this->getValidContentTypeConfiguration(),
+            $this->getValidFieldConfiguration()
         );
 
         $this->assertNotNull($contentType->id);
@@ -563,8 +575,11 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
         $contentType = $this->createContentType(
             $this->getValidFieldSettings(),
             $this->getValidValidatorConfiguration(),
-            [],
-            ['isTranslatable' => true]
+            $this->getValidContentTypeConfiguration(),
+            array_merge(
+                $this->getValidFieldConfiguration(),
+                ['isTranslatable' => true]
+            )
         );
 
         $repository = $this->getRepository();
@@ -1013,7 +1028,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
             $this->getTypeName()
         );
 
-        $fieldDefinitionCreateStruct->names[$contentType->mainLanguageCode] = $this->getTypeName();
+        $fieldDefinitionCreateStruct->names = $this->getOverride('names', $this->getValidFieldConfiguration(), [$contentType->mainLanguageCode => $this->getTypeName()]);
         $fieldDefinitionCreateStruct->validatorConfiguration = $this->getValidValidatorConfiguration();
         $fieldDefinitionCreateStruct->fieldSettings = $this->getValidFieldSettings();
         $fieldDefinitionCreateStruct->defaultValue = null;

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
@@ -76,7 +76,7 @@ class SelectionIntegrationTest extends SearchMultivaluedBaseIntegrationTest
                     2 => 'Sindelfingen',
                     3 => 'Turtles',
                     4 => 'Zombies',
-                ]
+                ],
             ],
         ];
     }

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
@@ -67,16 +67,18 @@ class SelectionIntegrationTest extends SearchMultivaluedBaseIntegrationTest
      */
     public function getValidFieldSettings()
     {
-        return array(
+        return [
             'isMultiple' => true,
-            'options' => array(
-                0 => 'A first',
-                1 => 'Bielefeld',
-                2 => 'Sindelfingen',
-                3 => 'Turtles',
-                4 => 'Zombies',
-            ),
-        );
+            'options' => [
+                'eng-GB' => [
+                    0 => 'A first',
+                    1 => 'Bielefeld',
+                    2 => 'Sindelfingen',
+                    3 => 'Turtles',
+                    4 => 'Zombies',
+                ]
+            ],
+        ];
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
@@ -57,6 +57,10 @@ class SelectionIntegrationTest extends SearchMultivaluedBaseIntegrationTest
                 'type' => 'hash',
                 'default' => array(),
             ),
+            'multilingualOptions' => array(
+                'type' => 'hash',
+                'default' => array(),
+            ),
         );
     }
 
@@ -70,6 +74,13 @@ class SelectionIntegrationTest extends SearchMultivaluedBaseIntegrationTest
         return [
             'isMultiple' => true,
             'options' => [
+                0 => 'A first',
+                1 => 'Bielefeld',
+                2 => 'Sindelfingen',
+                3 => 'Turtles',
+                4 => 'Zombies',
+            ],
+            'multilingualOptions' => [
                 'eng-GB' => [
                     0 => 'A first',
                     1 => 'Bielefeld',

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionMultilingualIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionMultilingualIntegrationTest.php
@@ -60,11 +60,11 @@ class SelectionMultilingualIntegrationTest extends SelectionIntegrationTest
                         4 => 'Zombies',
                     ],
                     'eng-US' => [
-                        0 => 'Missouri',
-                        1 => 'Mississippi',
-                        2 => 'Yukon',
-                        3 => 'Rio Grande',
-                        4 => 'Arkansas',
+                        0 => 'Arkansas',
+                        1 => 'Hudson',
+                        2 => 'Mississippi',
+                        3 => 'RioGrande',
+                        4 => 'Yukon',
                     ],
                     'ger-DE' => [
                         0 => 'Zuerst',
@@ -88,7 +88,7 @@ class SelectionMultilingualIntegrationTest extends SelectionIntegrationTest
 
     public function getFieldName()
     {
-        return 'Missouri' . ' ' . 'Yukon';
+        return 'Arkansas' . ' ' . 'Mississippi';
     }
 
     protected function getAdditionallyIndexedFieldData()
@@ -96,8 +96,8 @@ class SelectionMultilingualIntegrationTest extends SelectionIntegrationTest
         return [
             [
                 'selected_option_value',
+                'Hudson',
                 'Mississippi',
-                'Yukon',
             ],
             [
                 'sort_value',
@@ -112,8 +112,8 @@ class SelectionMultilingualIntegrationTest extends SelectionIntegrationTest
         return [
             [
                 'selected_option_value',
-                ['Missouri', 'Mississippi'],
-                ['Yukon', 'Rio Grande', 'Arkansas'],
+                ['Arkansas', 'Hudson'],
+                ['Mississippi', 'RioGrande', 'Yukon2'],
             ],
         ];
     }
@@ -121,7 +121,7 @@ class SelectionMultilingualIntegrationTest extends SelectionIntegrationTest
     protected function getFullTextIndexedFieldData()
     {
         return [
-            ['Mississippi', 'Yukon'],
+            ['Hudson', 'Mississippi'],
         ];
     }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionMultilingualIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionMultilingualIntegrationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * File contains: eZ\Publish\API\Repository\Tests\FieldType\SelectionIntegrationTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Tests\FieldType;
+
+/**
+ * Integration test for use field type.
+ *
+ * @group integration
+ * @group field-type
+ */
+class SelectionMultilingualIntegrationTest extends SelectionIntegrationTest
+{
+    /**
+     * Get expected settings schema.
+     *
+     * @return array
+     */
+    public function getSettingsSchema()
+    {
+        return array_merge(
+            parent::getSettingsSchema(),
+            [
+                'multilingualOptions' => [
+                    'type' => 'hash',
+                    'default' => [],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Get a valid $fieldSettings value.
+     *
+     * @return mixed
+     */
+    public function getValidFieldSettings()
+    {
+        return
+            [
+                'isMultiple' => true,
+                'options' => [
+                    0 => 'A first',
+                    1 => 'Bielefeld',
+                    2 => 'Sindelfingen',
+                    3 => 'Turtles',
+                    4 => 'Zombies',
+                ],
+                'multilingualOptions' => [
+                    'eng-GB' => [
+                        0 => 'A first',
+                        1 => 'Bielefeld',
+                        2 => 'Sindelfingen',
+                        3 => 'Turtles',
+                        4 => 'Zombies',
+                    ],
+                    'eng-US' => [
+                        0 => 'Missouri',
+                        1 => 'Mississippi',
+                        2 => 'Yukon',
+                    ],
+                    'ger-DE' => [
+                        0 => 'Zuerst',
+                        1 => 'Zweite',
+                        2 => 'Dritte',
+                    ],
+                ],
+            ];
+    }
+
+    public function getValidFieldConfiguration(): array
+    {
+        return [
+            'names' => [
+                'eng-GB' => 'Test',
+                'eng-US' => 'US TEST',
+                'ger-DE' => 'GER Test'
+            ]
+        ];
+    }
+
+    public function getFieldName()
+    {
+        return 'Missouri' . ' ' . 'Yukon';
+    }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return [
+            ['Bielefeld', 'Dritte'],
+        ];
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionMultilingualIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionMultilingualIntegrationTest.php
@@ -91,7 +91,6 @@ class SelectionMultilingualIntegrationTest extends SelectionIntegrationTest
         return 'Missouri' . ' ' . 'Yukon';
     }
 
-
     protected function getAdditionallyIndexedFieldData()
     {
         return [

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionMultilingualIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionMultilingualIntegrationTest.php
@@ -63,6 +63,8 @@ class SelectionMultilingualIntegrationTest extends SelectionIntegrationTest
                         0 => 'Missouri',
                         1 => 'Mississippi',
                         2 => 'Yukon',
+                        3 => 'Rio Grande',
+                        4 => 'Arkansas',
                     ],
                     'ger-DE' => [
                         0 => 'Zuerst',
@@ -89,10 +91,38 @@ class SelectionMultilingualIntegrationTest extends SelectionIntegrationTest
         return 'Missouri' . ' ' . 'Yukon';
     }
 
+
+    protected function getAdditionallyIndexedFieldData()
+    {
+        return [
+            [
+                'selected_option_value',
+                'Mississippi',
+                'Yukon',
+            ],
+            [
+                'sort_value',
+                '1',
+                '2',
+            ],
+        ];
+    }
+
+    protected function getAdditionallyIndexedMultivaluedFieldData()
+    {
+        return [
+            [
+                'selected_option_value',
+                ['Missouri', 'Mississippi'],
+                ['Yukon', 'Rio Grande', 'Arkansas'],
+            ],
+        ];
+    }
+
     protected function getFullTextIndexedFieldData()
     {
         return [
-            ['Bielefeld', 'Dritte'],
+            ['Mississippi', 'Yukon'],
         ];
     }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionMultilingualIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionMultilingualIntegrationTest.php
@@ -79,8 +79,8 @@ class SelectionMultilingualIntegrationTest extends SelectionIntegrationTest
             'names' => [
                 'eng-GB' => 'Test',
                 'eng-US' => 'US TEST',
-                'ger-DE' => 'GER Test'
-            ]
+                'ger-DE' => 'GER Test',
+            ],
         ];
     }
 

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
@@ -115,7 +115,7 @@ abstract class FieldDefinition extends ValueObject implements MultiLanguageName,
     protected $isSearchable;
 
     /**
-     * Based on mainLanguageCode of contentType
+     * Based on mainLanguageCode of contentType.
      * @var string
      */
     protected $mainLanguageCode;

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
@@ -116,6 +116,7 @@ abstract class FieldDefinition extends ValueObject implements MultiLanguageName,
 
     /**
      * Based on mainLanguageCode of contentType.
+     *
      * @var string
      */
     protected $mainLanguageCode;

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
@@ -27,6 +27,7 @@ use eZ\Publish\SPI\Repository\Values\MultiLanguageDescription;
  * @property-read bool $isSearchable indicates if the field is searchable
  * @property-read bool $isInfoCollector indicates if this field is used for information collection
  * @property-read $defaultValue the default value of the field
+ * @property-read string $mainLanguageCode main Translation (language code) of a multilingual Field Definition
  */
 abstract class FieldDefinition extends ValueObject implements MultiLanguageName, MultiLanguageDescription
 {

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
@@ -113,4 +113,10 @@ abstract class FieldDefinition extends ValueObject implements MultiLanguageName,
      * @var bool
      */
     protected $isSearchable;
+
+    /**
+     * Based on mainLanguageCode of contentType
+     * @var string
+     */
+    protected $mainLanguageCode;
 }

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
@@ -112,4 +112,6 @@ class FieldDefinitionCreateStruct extends ValueObject
      * @var bool
      */
     public $isSearchable;
+
+    public $mainLanguageCode;
 }

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
@@ -112,6 +112,4 @@ class FieldDefinitionCreateStruct extends ValueObject
      * @var bool
      */
     public $isSearchable;
-
-    public $mainLanguageCode;
 }

--- a/eZ/Publish/Core/FieldType/Selection/NameableField.php
+++ b/eZ/Publish/Core/FieldType/Selection/NameableField.php
@@ -42,8 +42,8 @@ class NameableField implements Nameable
                 $names[] = $fieldSettings['multilingualOptions'][$fieldDefinition->mainLanguageCode][$optionIndex];
                 continue;
             }
-            if (isset($fieldSettings['multilingualOptions'][$optionIndex])) {
-                $names[] = $fieldSettings['multilingualOptions'][$optionIndex];
+            if (isset($fieldSettings['options'][$optionIndex])) {
+                $names[] = $fieldSettings['options'][$optionIndex];
             }
         }
 

--- a/eZ/Publish/Core/FieldType/Selection/NameableField.php
+++ b/eZ/Publish/Core/FieldType/Selection/NameableField.php
@@ -34,6 +34,14 @@ class NameableField implements Nameable
         $fieldSettings = $fieldDefinition->getFieldSettings();
 
         foreach ($value->selection as $optionIndex) {
+            if (isset($fieldSettings['options'][$languageCode][$optionIndex])) {
+                $names[] = $fieldSettings['options'][$languageCode][$optionIndex];
+                continue;
+            }
+            if (isset($fieldSettings['options'][$fieldDefinition->mainLanguageCode][$optionIndex])) {
+                $names[] = $fieldSettings['options'][$fieldDefinition->mainLanguageCode][$optionIndex];
+                continue;
+            }
             if (isset($fieldSettings['options'][$optionIndex])) {
                 $names[] = $fieldSettings['options'][$optionIndex];
             }

--- a/eZ/Publish/Core/FieldType/Selection/NameableField.php
+++ b/eZ/Publish/Core/FieldType/Selection/NameableField.php
@@ -34,16 +34,16 @@ class NameableField implements Nameable
         $fieldSettings = $fieldDefinition->getFieldSettings();
 
         foreach ($value->selection as $optionIndex) {
+            if (isset($fieldSettings['multilingualOptions'][$optionIndex])) {
+                $names[] = $fieldSettings['multilingualOptions'][$optionIndex];
+            }
+            if (isset($fieldSettings['multilingualOptions'][$fieldDefinition->mainLanguageCode][$optionIndex])) {
+                $names[] = $fieldSettings['multilingualOptions'][$fieldDefinition->mainLanguageCode][$optionIndex];
+                continue;
+            }
             if (isset($fieldSettings['options'][$languageCode][$optionIndex])) {
                 $names[] = $fieldSettings['options'][$languageCode][$optionIndex];
                 continue;
-            }
-            if (isset($fieldSettings['options'][$fieldDefinition->mainLanguageCode][$optionIndex])) {
-                $names[] = $fieldSettings['options'][$fieldDefinition->mainLanguageCode][$optionIndex];
-                continue;
-            }
-            if (isset($fieldSettings['options'][$optionIndex])) {
-                $names[] = $fieldSettings['options'][$optionIndex];
             }
         }
 

--- a/eZ/Publish/Core/FieldType/Selection/NameableField.php
+++ b/eZ/Publish/Core/FieldType/Selection/NameableField.php
@@ -34,16 +34,16 @@ class NameableField implements Nameable
         $fieldSettings = $fieldDefinition->getFieldSettings();
 
         foreach ($value->selection as $optionIndex) {
-            if (isset($fieldSettings['multilingualOptions'][$optionIndex])) {
-                $names[] = $fieldSettings['multilingualOptions'][$optionIndex];
+            if (isset($fieldSettings['multilingualOptions'][$languageCode][$optionIndex])) {
+                $names[] = $fieldSettings['multilingualOptions'][$languageCode][$optionIndex];
+                continue;
             }
             if (isset($fieldSettings['multilingualOptions'][$fieldDefinition->mainLanguageCode][$optionIndex])) {
                 $names[] = $fieldSettings['multilingualOptions'][$fieldDefinition->mainLanguageCode][$optionIndex];
                 continue;
             }
-            if (isset($fieldSettings['options'][$languageCode][$optionIndex])) {
-                $names[] = $fieldSettings['options'][$languageCode][$optionIndex];
-                continue;
+            if (isset($fieldSettings['multilingualOptions'][$optionIndex])) {
+                $names[] = $fieldSettings['multilingualOptions'][$optionIndex];
             }
         }
 

--- a/eZ/Publish/Core/FieldType/Selection/NameableField.php
+++ b/eZ/Publish/Core/FieldType/Selection/NameableField.php
@@ -36,13 +36,9 @@ class NameableField implements Nameable
         foreach ($value->selection as $optionIndex) {
             if (isset($fieldSettings['multilingualOptions'][$languageCode][$optionIndex])) {
                 $names[] = $fieldSettings['multilingualOptions'][$languageCode][$optionIndex];
-                continue;
-            }
-            if (isset($fieldSettings['multilingualOptions'][$fieldDefinition->mainLanguageCode][$optionIndex])) {
+            } elseif (isset($fieldSettings['multilingualOptions'][$fieldDefinition->mainLanguageCode][$optionIndex])) {
                 $names[] = $fieldSettings['multilingualOptions'][$fieldDefinition->mainLanguageCode][$optionIndex];
-                continue;
-            }
-            if (isset($fieldSettings['options'][$optionIndex])) {
+            } elseif (isset($fieldSettings['options'][$optionIndex])) {
                 $names[] = $fieldSettings['options'][$optionIndex];
             }
         }

--- a/eZ/Publish/Core/FieldType/Selection/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Selection/SearchField.php
@@ -33,21 +33,12 @@ class SearchField implements Indexable
         $fieldSettings = $fieldDefinition->fieldTypeConstraints->fieldSettings;
         $positionSet = array_flip($field->value->data);
 
-        if (isset($fieldSettings['multilingualOptions'])) {
-            foreach ($fieldSettings['multilingualOptions'] as $languageCode => $multilingualOption) {
-                foreach ($multilingualOption as $index => $value) {
-                    if (isset($positionSet[$index])) {
-                        $values[] = $value;
-                        $indexes[] = $index;
-                    }
-                }
-            }
-        } else {
-            foreach ($fieldSettings['options'] as $index => $value) {
-                if (isset($positionSet[$index])) {
-                    $values[] = $value;
-                    $indexes[] = $index;
-                }
+        $options = $fieldSettings['multilingualOptions'][$field->languageCode] ?? $fieldSettings['options'];
+
+        foreach ($options as $index => $value) {
+            if (isset($positionSet[$index])) {
+                $values[] = $value;
+                $indexes[] = $index;
             }
         }
 

--- a/eZ/Publish/Core/FieldType/Selection/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Selection/SearchField.php
@@ -34,10 +34,12 @@ class SearchField implements Indexable
         $options = $fieldSettings['options'];
         $positionSet = array_flip($field->value->data);
 
-        foreach ($options as $index => $value) {
-            if (isset($positionSet[$index])) {
-                $values[] = $value;
-                $indexes[] = $index;
+        foreach ($options as $languageCode => $mlOption) {
+            foreach ($mlOption as $index => $value) {
+                if (isset($positionSet[$index])) {
+                    $values[] = $value;
+                    $indexes[] = $index;
+                }
             }
         }
 

--- a/eZ/Publish/Core/FieldType/Selection/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Selection/SearchField.php
@@ -31,11 +31,19 @@ class SearchField implements Indexable
         $indexes = array();
         $values = array();
         $fieldSettings = $fieldDefinition->fieldTypeConstraints->fieldSettings;
-        $options = $fieldSettings['options'];
         $positionSet = array_flip($field->value->data);
 
-        foreach ($options as $languageCode => $mlOption) {
-            foreach ($mlOption as $index => $value) {
+        if (isset($fieldSettings['multilingualOptions'])) {
+            foreach ($fieldSettings['multilingualOptions'] as $languageCode => $multilingualOption) {
+                foreach ($multilingualOption as $index => $value) {
+                    if (isset($positionSet[$index])) {
+                        $values[] = $value;
+                        $indexes[] = $index;
+                    }
+                }
+            }
+        } else {
+            foreach ($fieldSettings['options'] as $index => $value) {
                 if (isset($positionSet[$index])) {
                     $values[] = $value;
                     $indexes[] = $index;

--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -232,7 +232,6 @@ class Type extends FieldType
 
         //@todo: find a way to include selection language
         if (isset($fieldSettings['multilingualOptions'])) {
-
             $possibleOptionIndexesByLanguage = array_map(function ($languageOptionIndexes) {
                 return array_keys($languageOptionIndexes);
             }, $fieldSettings['multilingualOptions']);

--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -39,6 +39,10 @@ class Type extends FieldType
             'type' => 'hash',
             'default' => array(),
         ),
+        'multilingualOptions' => [
+            'type' => 'hash',
+            'default' => [],
+        ],
     );
 
     /**
@@ -70,6 +74,20 @@ class Type extends FieldType
                     break;
                 case 'options':
                     if (!is_array($settingValue)) {
+                        $validationErrors[] = new ValidationError(
+                            "FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'",
+                            null,
+                            array(
+                                '%fieldType%' => $this->getFieldTypeIdentifier(),
+                                '%setting%' => $settingKey,
+                                '%type%' => 'hash',
+                            ),
+                            "[$settingKey]"
+                        );
+                    }
+                    break;
+                case 'multilingualOptions':
+                    if (!is_array($settingValue) && !is_array(reset($settingValue))) {
                         $validationErrors[] = new ValidationError(
                             "FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'",
                             null,
@@ -200,7 +218,7 @@ class Type extends FieldType
         }
 
         foreach ($fieldValue->selection as $optionIndex) {
-            if (!isset($fieldSettings['options'][$fieldDefinition->mainLanguageCode][$optionIndex])) {
+            if (!isset($fieldSettings['options'][$optionIndex]) && empty($fieldSettings['multilingualOptions'])) {
                 $validationErrors[] = new ValidationError(
                     'Option with index %index% does not exist in the field definition.',
                     null,

--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -200,7 +200,7 @@ class Type extends FieldType
         }
 
         foreach ($fieldValue->selection as $optionIndex) {
-            if (!isset($fieldSettings['options'][$optionIndex])) {
+            if (!isset($fieldSettings['options'][$fieldDefinition->mainLanguageCode][$optionIndex])) {
                 $validationErrors[] = new ValidationError(
                     'Option with index %index% does not exist in the field definition.',
                     null,

--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -230,6 +230,29 @@ class Type extends FieldType
             }
         }
 
+        //@todo: find a way to include selection language
+        if (isset($fieldSettings['multilingualOptions'])) {
+
+            $possibleOptionIndexesByLanguage = array_map(function ($languageOptionIndexes) {
+                return array_keys($languageOptionIndexes);
+            }, $fieldSettings['multilingualOptions']);
+
+            $possibleOptionIndexes = call_user_func_array('array_merge', $possibleOptionIndexesByLanguage);
+
+            foreach ($fieldValue->selection as $optionIndex) {
+                if (!in_array($optionIndex, $possibleOptionIndexes)) {
+                    $validationErrors[] = new ValidationError(
+                        'Option with index %index% does not exist in the field definition.',
+                        null,
+                        array(
+                            '%index%' => $optionIndex,
+                        ),
+                        'selection'
+                    );
+                }
+            }
+        }
+
         return $validationErrors;
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
@@ -65,6 +65,10 @@ class SelectionTest extends FieldTypeTest
                 'type' => 'hash',
                 'default' => array(),
             ),
+            'multilingualOptions' => array(
+                'type' => 'hash',
+                'default' => array(),
+            ),
         );
     }
 

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -184,9 +184,9 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
     public function load($typeId, $status = Type::STATUS_DEFINED)
     {
         $cacheItem = $this->cache->getItem('ez-content-type-' . $typeId . '-' . $status);
-//        if ($cacheItem->isHit()) {
-//            return $cacheItem->get();
-//        }
+        if ($cacheItem->isHit()) {
+            return $cacheItem->get();
+        }
 
         $this->logger->logCall(__METHOD__, array('type' => $typeId, 'status' => $status));
         $type = $this->persistenceHandler->contentTypeHandler()->load($typeId, $status);

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -275,7 +275,7 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
     /**
      * {@inheritdoc}
      */
-    public function delete($typeId, $status, $fieldDefinitions = [])
+    public function delete($typeId, $status)
     {
         $this->logger->logCall(__METHOD__, array('type' => $typeId, 'status' => $status));
         $return = $this->persistenceHandler->contentTypeHandler()->delete($typeId, $status);

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -184,9 +184,9 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
     public function load($typeId, $status = Type::STATUS_DEFINED)
     {
         $cacheItem = $this->cache->getItem('ez-content-type-' . $typeId . '-' . $status);
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
+//        if ($cacheItem->isHit()) {
+//            return $cacheItem->get();
+//        }
 
         $this->logger->logCall(__METHOD__, array('type' => $typeId, 'status' => $status));
         $type = $this->persistenceHandler->contentTypeHandler()->load($typeId, $status);
@@ -275,7 +275,7 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
     /**
      * {@inheritdoc}
      */
-    public function delete($typeId, $status)
+    public function delete($typeId, $status, $fieldDefinitions = [])
     {
         $this->logger->logCall(__METHOD__, array('type' => $typeId, 'status' => $status));
         $return = $this->persistenceHandler->contentTypeHandler()->delete($typeId, $status);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
@@ -126,7 +126,7 @@ class SelectionConverter implements Converter
     public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef)
     {
         $options = [];
-        $multiLingualOptions = [];
+        $multiLingualOptions = array_fill_keys(array_keys($fieldDef->name), []);
 
         if (isset($storageDef->dataText5)) {
             $optionsXml = simplexml_load_string($storageDef->dataText5);
@@ -149,7 +149,6 @@ class SelectionConverter implements Converter
                 }
             }
         }
-
 
         $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings([
                 'isMultiple' => !empty($storageDef->dataInt1) ? (bool)$storageDef->dataInt1 : false,

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
@@ -11,7 +11,6 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\API\Repository\LanguageService;
 use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
-use eZ\Publish\Core\Persistence\Legacy\Content\MultilingualStorageFieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
@@ -88,9 +88,7 @@ class SelectionConverter implements Converter
         if (isset($fieldSettings['isMultiple'])) {
             $storageDef->dataInt1 = (int)$fieldSettings['isMultiple'];
         }
-        if (isset($fieldSettings['isMultiple'])) {
-            $storageDef->dataInt1 = (int)$fieldSettings['isMultiple'];
-        }
+
         $isAssocArray = array_keys($fieldSettings['options']) === range(0, count($fieldSettings['options']) - 1);
 
         if ($isAssocArray) {
@@ -126,12 +124,12 @@ class SelectionConverter implements Converter
         $options = array_fill_keys(array_keys($fieldDef->name), []);
         $simpleXmlList = [];
 
-        if (!isset($storageDef->multilingualData[$fieldDef->mainLanguageCode])) {
-            $simpleXmlList[$fieldDef->mainLanguageCode] = simplexml_load_string($storageDef->dataText5);
-        }
-
         foreach ($storageDef->multilingualData as $languageCode => $mlData) {
             $simpleXmlList[$languageCode] = simplexml_load_string($mlData->dataText);
+        }
+
+        if (isset($storageDef->dataText5)) {
+            $simpleXmlList[$fieldDef->mainLanguageCode] = simplexml_load_string($storageDef->dataText5);
         }
 
         foreach ($simpleXmlList as $optionLanguageCode => $simpleXml) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
@@ -94,6 +94,7 @@ class SelectionConverter implements Converter
         if ($isAssocArray) {
             $xml = $this->buildOptionsXml($fieldSettings['options']);
             $storageDef->dataText5 = $xml->saveXML();
+
             return;
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
@@ -103,13 +103,8 @@ class SelectionConverter implements Converter
 
         foreach ($fieldSettings['multilingualOptions'] as $languageCode => $option) {
             $xml = $this->buildOptionsXml($option);
-            $multilingualData = new MultilingualStorageFieldDefinition();
-            $multilingualData->dataText = $xml->saveXML();
-            $multilingualData->name = $fieldDef->name[$languageCode];
-            $multilingualData->description = $fieldDef->description[$languageCode] ?? null;
-            $multilingualData->languageId = $this->languageService->loadLanguage($languageCode)->id;
 
-            $storageDef->multilingualData[$languageCode] = $multilingualData;
+            $storageDef->multilingualData[$languageCode]->dataText = $xml->saveXML();
 
             if ($fieldDef->mainLanguageCode === $languageCode) {
                 $storageDef->dataText5 = $xml->saveXML();
@@ -126,7 +121,7 @@ class SelectionConverter implements Converter
     public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef)
     {
         $options = [];
-        $multiLingualOptions = array_fill_keys(array_keys($fieldDef->name), []);
+        $multiLingualOptions = [$fieldDef->mainLanguageCode => []];
 
         if (isset($storageDef->dataText5)) {
             $optionsXml = simplexml_load_string($storageDef->dataText5);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/MultilingualStorageFieldDefinition.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/MultilingualStorageFieldDefinition.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\Content;
+
+class MultilingualStorageFieldDefinition
+{
+    public $name;
+
+    public $description;
+
+    public $dataText;
+
+    public $dataJson;
+
+    public $languageId;
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Content/MultilingualStorageFieldDefinition.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/MultilingualStorageFieldDefinition.php
@@ -8,15 +8,32 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Persistence\Legacy\Content;
 
-class MultilingualStorageFieldDefinition
+use eZ\Publish\SPI\Persistence\ValueObject;
+
+class MultilingualStorageFieldDefinition extends ValueObject
 {
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var string
+     */
     public $description;
 
+    /**
+     * @var string
+     */
     public $dataText;
 
+    /**
+     * @var string
+     */
     public $dataJson;
 
+    /**
+     * @var int
+     */
     public $languageId;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/StorageFieldDefinition.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/StorageFieldDefinition.php
@@ -111,9 +111,9 @@ class StorageFieldDefinition extends ValueObject
     public $serializedDataText;
 
     /**
-     * associative array with language codes keys.
+     * Associative array with language codes keys.
      *
-     * @var MultilingualStorageFieldDefinition[]
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\MultilingualStorageFieldDefinition[]
      */
     public $multilingualData = [];
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/StorageFieldDefinition.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/StorageFieldDefinition.php
@@ -109,4 +109,11 @@ class StorageFieldDefinition extends ValueObject
      * @var string[]
      */
     public $serializedDataText;
+
+    /**
+     * associative array with language codes keys.
+     *
+     * @var MultilingualStorageFieldDefinition[]
+     */
+    public $multilingualData = [];
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
@@ -284,4 +284,19 @@ abstract class Gateway
      * @return array
      */
     abstract public function getSearchableFieldMapData();
+
+    /**
+     * Removes fieldDefinition data from multilingual table.
+     *
+     * @param int $fieldDefinitionId
+     * @param string $languageCode
+     * @param int $status
+     *
+     * @return void
+     */
+    abstract public function removeFieldDefinitionTranslation(
+        int $fieldDefinitionId,
+        string $languageCode,
+        int $status
+    ): void;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
@@ -291,8 +291,6 @@ abstract class Gateway
      * @param int $fieldDefinitionId
      * @param string $languageCode
      * @param int $status
-     *
-     * @return void
      */
     abstract public function removeFieldDefinitionTranslation(
         int $fieldDefinitionId,

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -1410,16 +1410,16 @@ class DoctrineDatabase extends Gateway
             ->select('attr.id as ezcontentclass_attribute_id')
             ->from('ezcontentclass_attribute', 'attr')
             ->where('attr.contentclass_id = :typeId')
-            ->andWhere('attr.id = attr_ml.contentclass_attribute_id');
+            ->andWhere('attr.id = ezcontentclass_attribute_ml.contentclass_attribute_id');
 
         $mlDataPublishQuery = $this->connection->createQueryBuilder();
         $mlDataPublishQuery
-            ->update('ezcontentclass_attribute_ml', 'attr_ml')
-            ->set('attr_ml.version', ':newVersion')
+            ->update('ezcontentclass_attribute_ml')
+            ->set('version', ':newVersion')
             ->where(
                 sprintf('EXISTS (%s)', $subQuery->getSQL())
             )
-            ->andWhere('attr_ml.version = :sourceVersion')
+            ->andWhere('ezcontentclass_attribute_ml.version = :sourceVersion')
             ->setParameter('typeId', $typeId, ParameterType::INTEGER)
             ->setParameter('newVersion', $targetVersion, ParameterType::INTEGER)
             ->setParameter('sourceVersion', $sourceVersion, ParameterType::INTEGER);
@@ -1497,8 +1497,6 @@ class DoctrineDatabase extends Gateway
      * @param int $fieldDefinitionId
      * @param string $languageCode
      * @param int $status
-     *
-     * @return void
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -897,7 +897,6 @@ class DoctrineDatabase extends Gateway
         array $multilingualData,
         int $status
     ): void {
-
         $newData = [];
         foreach ($multilingualData as $languageCode => $data) {
             $query = $this->connection->createQueryBuilder();

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -611,9 +611,9 @@ class DoctrineDatabase extends Gateway
         $this->setCommonFieldColumns($q, $fieldDefinition, $storageFieldDef);
 
         $q->prepare()->execute();
-        
+
         if (!isset($fieldDefinition->id)) {
-            $fieldDefinitionId =  $this->dbHandler->lastInsertId(
+            $fieldDefinitionId = $this->dbHandler->lastInsertId(
                 $this->dbHandler->getSequenceName('ezcontentclass_attribute', 'id')
             );
             $this->insertMultilingualFieldDefinition($fieldDefinitionId, $storageFieldDef->multilingualData, $status);
@@ -637,8 +637,7 @@ class DoctrineDatabase extends Gateway
         int $fieldDefinitionId,
         array $multilingualData,
         int $status
-    ):void {
-
+    ): void {
         foreach ($multilingualData as $languageCode => $data) {
             $query = $this->connection->createQueryBuilder();
             $query
@@ -650,7 +649,7 @@ class DoctrineDatabase extends Gateway
                     'description' => ':description',
                     'contentclass_attribute_id' => ':fieldDefinitionId',
                     'version' => ':status',
-                    'language_id' => ':languageId'
+                    'language_id' => ':languageId',
                 ])
                 ->setParameter('data_text', $data->dataText)
                 ->setParameter('data_json', $data->dataJson)
@@ -874,7 +873,7 @@ class DoctrineDatabase extends Gateway
         FieldDefinition $fieldDefinition,
         array $multilingualData,
         int $status
-    ):void {
+    ): void {
         foreach ($multilingualData as $languageCode => $data) {
             $query = $this->connection->createQueryBuilder();
             $query

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -441,10 +441,10 @@ class ExceptionConversion extends Gateway
      * @param mixed $typeId
      * @param int $status
      */
-    public function delete($typeId, $status)
+    public function delete($typeId, $status, array $fieldDefinitions = [])
     {
         try {
-            return $this->innerGateway->delete($typeId, $status);
+            return $this->innerGateway->delete($typeId, $status, $fieldDefinitions);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -458,10 +458,10 @@ class ExceptionConversion extends Gateway
      * @param mixed $typeId
      * @param int $status
      */
-    public function deleteFieldDefinitionsForType($typeId, $status)
+    public function deleteFieldDefinitionsForType($typeId, $status, array $fieldDefinitions = [])
     {
         try {
-            return $this->innerGateway->deleteFieldDefinitionsForType($typeId, $status);
+            return $this->innerGateway->deleteFieldDefinitionsForType($typeId, $status, $fieldDefinitions);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -513,10 +513,10 @@ class ExceptionConversion extends Gateway
      * @param int $sourceStatus
      * @param int $targetStatus
      */
-    public function publishTypeAndFields($typeId, $sourceStatus, $targetStatus)
+    public function publishTypeAndFields($typeId, $sourceStatus, $targetStatus, array $fieldDefinitions = [])
     {
         try {
-            return $this->innerGateway->publishTypeAndFields($typeId, $sourceStatus, $targetStatus);
+            return $this->innerGateway->publishTypeAndFields($typeId, $sourceStatus, $targetStatus, $fieldDefinitions);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -539,4 +539,31 @@ class ExceptionConversion extends Gateway
             throw new RuntimeException('Database error', 0, $e);
         }
     }
+
+    /**
+     * Removes fieldDefinition data from multilingual table.
+     *
+     * @param int $fieldDefinitionId
+     * @param string $languageCode
+     * @param int $status
+     *
+     * @return void
+     */
+    public function removeFieldDefinitionTranslation(
+        int $fieldDefinitionId,
+        string $languageCode,
+        int $status
+    ): void {
+        try {
+            $this->innerGateway->removeFieldDefinitionTranslation(
+                $fieldDefinitionId,
+                $languageCode,
+                $status
+            );
+        } catch (DBALException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        } catch (PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -441,10 +441,10 @@ class ExceptionConversion extends Gateway
      * @param mixed $typeId
      * @param int $status
      */
-    public function delete($typeId, $status, array $fieldDefinitions = [])
+    public function delete($typeId, $status)
     {
         try {
-            return $this->innerGateway->delete($typeId, $status, $fieldDefinitions);
+            return $this->innerGateway->delete($typeId, $status);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -458,10 +458,10 @@ class ExceptionConversion extends Gateway
      * @param mixed $typeId
      * @param int $status
      */
-    public function deleteFieldDefinitionsForType($typeId, $status, array $fieldDefinitions = [])
+    public function deleteFieldDefinitionsForType($typeId, $status)
     {
         try {
-            return $this->innerGateway->deleteFieldDefinitionsForType($typeId, $status, $fieldDefinitions);
+            return $this->innerGateway->deleteFieldDefinitionsForType($typeId, $status);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -513,10 +513,10 @@ class ExceptionConversion extends Gateway
      * @param int $sourceStatus
      * @param int $targetStatus
      */
-    public function publishTypeAndFields($typeId, $sourceStatus, $targetStatus, array $fieldDefinitions = [])
+    public function publishTypeAndFields($typeId, $sourceStatus, $targetStatus)
     {
         try {
-            return $this->innerGateway->publishTypeAndFields($typeId, $sourceStatus, $targetStatus, $fieldDefinitions);
+            return $this->innerGateway->publishTypeAndFields($typeId, $sourceStatus, $targetStatus);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -546,8 +546,6 @@ class ExceptionConversion extends Gateway
      * @param int $fieldDefinitionId
      * @param string $languageCode
      * @param int $status
-     *
-     * @return void
      */
     public function removeFieldDefinitionTranslation(
         int $fieldDefinitionId,

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -360,7 +360,7 @@ class Handler implements BaseContentTypeHandler
      *
      * @return bool
      */
-    public function delete($contentTypeId, $status, array $fieldDefinitions = [])
+    public function delete($contentTypeId, $status)
     {
         if (Type::STATUS_DEFINED === $status && $this->contentTypeGateway->countInstancesOfType($contentTypeId)) {
             throw new BadStateException(
@@ -369,7 +369,7 @@ class Handler implements BaseContentTypeHandler
             );
         }
 
-        $this->contentTypeGateway->delete($contentTypeId, $status, $fieldDefinitions);
+        $this->contentTypeGateway->delete($contentTypeId, $status);
 
         // @todo FIXME: Return true only if deletion happened
         return true;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -501,19 +501,9 @@ class Handler implements BaseContentTypeHandler
             );
         }
 
-        $multilingualData = array_map(function (array $fieldData) use ($rows) {
-            return [
-                'ezcontentclass_attribute_multilingual_name' => $fieldData['ezcontentclass_attribute_multilingual_name'],
-                'ezcontentclass_attribute_multilingual_description' => $fieldData['ezcontentclass_attribute_multilingual_description'],
-                'ezcontentclass_attribute_multilingual_language_id' => $fieldData['ezcontentclass_attribute_multilingual_language_id'],
-                'ezcontentclass_attribute_multilingual_data_text' => $fieldData['ezcontentclass_attribute_multilingual_data_text'],
-                'ezcontentclass_attribute_multilingual_data_json' => $fieldData['ezcontentclass_attribute_multilingual_data_json'],
-            ];
-        }, $rows);
+        $multilingualData = $this->mapper->extractMultilingualData($rows);
 
-        reset($rows);
-
-        return $this->mapper->extractFieldFromRow($rows, $multilingualData);
+        return $this->mapper->extractFieldFromRow(reset($rows), $multilingualData);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -637,6 +637,17 @@ class Handler implements BaseContentTypeHandler
         unset($type->description[$languageCode]);
 
         foreach ($type->fieldDefinitions as $fieldDefinition) {
+            $this->contentTypeGateway->removeFieldDefinitionTranslation(
+                $fieldDefinition->id,
+                $languageCode,
+                Type::STATUS_DRAFT
+            );
+
+            //Refresh FieldDefinition object after removing translation data.
+            $fieldDefinition = $this->getFieldDefinition(
+                $fieldDefinition->id,
+                Type::STATUS_DRAFT
+            );
             unset($fieldDefinition->name[$languageCode]);
             unset($fieldDefinition->description[$languageCode]);
             $storageFieldDefinition = new StorageFieldDefinition();

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -489,9 +489,9 @@ class Handler implements BaseContentTypeHandler
      */
     public function getFieldDefinition($id, $status)
     {
-        $row = $this->contentTypeGateway->loadFieldDefinition($id, $status);
+        $rows = $this->contentTypeGateway->loadFieldDefinition($id, $status);
 
-        if ($row === false) {
+        if ($rows === false) {
             throw new NotFoundException(
                 'FieldDefinition',
                 array(
@@ -501,7 +501,18 @@ class Handler implements BaseContentTypeHandler
             );
         }
 
-        return $this->mapper->extractFieldFromRow($row);
+        $multilingualData = array_map(function (array $fieldData) use ($rows) {
+            return [
+                'ezcontentclass_attribute_multilingual_name' => $fieldData['ezcontentclass_attribute_multilingual_name'],
+                'ezcontentclass_attribute_multilingual_description' => $fieldData['ezcontentclass_attribute_multilingual_description'],
+                'ezcontentclass_attribute_multilingual_language_id' => $fieldData['ezcontentclass_attribute_multilingual_language_id'],
+                'ezcontentclass_attribute_multilingual_data_text' => $fieldData['ezcontentclass_attribute_multilingual_data_text'],
+                'ezcontentclass_attribute_multilingual_data_json' => $fieldData['ezcontentclass_attribute_multilingual_data_json'],
+            ];
+        }, $rows);
+
+        reset($rows);
+        return $this->mapper->extractFieldFromRow($rows, $multilingualData);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -512,6 +512,7 @@ class Handler implements BaseContentTypeHandler
         }, $rows);
 
         reset($rows);
+
         return $this->mapper->extractFieldFromRow($rows, $multilingualData);
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -360,7 +360,7 @@ class Handler implements BaseContentTypeHandler
      *
      * @return bool
      */
-    public function delete($contentTypeId, $status)
+    public function delete($contentTypeId, $status, array $fieldDefinitions = [])
     {
         if (Type::STATUS_DEFINED === $status && $this->contentTypeGateway->countInstancesOfType($contentTypeId)) {
             throw new BadStateException(
@@ -369,7 +369,7 @@ class Handler implements BaseContentTypeHandler
             );
         }
 
-        $this->contentTypeGateway->delete($contentTypeId, $status);
+        $this->contentTypeGateway->delete($contentTypeId, $status, $fieldDefinitions);
 
         // @todo FIXME: Return true only if deletion happened
         return true;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
@@ -124,7 +124,7 @@ class Mapper
             $fieldId = (int)$row['ezcontentclass_attribute_id'];
 
             if ($fieldId && !isset($fields[$fieldId])) {
-                $multilingualData = array_map(function ($fieldData) use ($row) {
+                $multilingualData = array_map(function (array $fieldData) use ($row) {
                     return [
                         'ezcontentclass_attribute_multilingual_name' => $fieldData['ezcontentclass_attribute_multilingual_name'] ?? $this->unserialize($row['ezcontentclass_serialized_name_list']),
                         'ezcontentclass_attribute_multilingual_description' => $fieldData['ezcontentclass_attribute_multilingual_description'] ?? $this->unserialize($row['ezcontentclass_serialized_description_list']),
@@ -132,7 +132,7 @@ class Mapper
                         'ezcontentclass_attribute_multilingual_data_text' => $fieldData['ezcontentclass_attribute_multilingual_data_text'] ?? '',
                         'ezcontentclass_attribute_multilingual_data_json' => $fieldData['ezcontentclass_attribute_multilingual_data_json'] ?? '',
                     ];
-                }, array_filter($rows, function ($row) use ($fieldId) {
+                }, array_filter($rows, function (array $row) use ($fieldId) {
                     return $row['ezcontentclass_attribute_id'] === (string) $fieldId;
                 }));
 
@@ -281,18 +281,16 @@ class Mapper
         $storageFieldDef->dataText5 = $row['ezcontentclass_attribute_data_text5'];
         $storageFieldDef->serializedDataText = $row['ezcontentclass_attribute_serialized_data_text'];
 
-        if (!empty($multilingualDataRow)) {
-            foreach ($multilingualDataRow as $languageDataRow) {
-                $multilingualData = new MultilingualStorageFieldDefinition();
-                $multilingualData->name = $languageDataRow['ezcontentclass_attribute_multilingual_name'];
-                $multilingualData->description = $languageDataRow['ezcontentclass_attribute_multilingual_description'];
-                $multilingualData->dataText = $languageDataRow['ezcontentclass_attribute_multilingual_data_text'];
-                $multilingualData->dataJson = $languageDataRow['ezcontentclass_attribute_multilingual_data_json'];
-                $multilingualData->languageId = (int)$languageDataRow['ezcontentclass_attribute_multilingual_language_id'];
+        foreach ($multilingualDataRow as $languageDataRow) {
+            $multilingualData = new MultilingualStorageFieldDefinition();
+            $multilingualData->name = $languageDataRow['ezcontentclass_attribute_multilingual_name'];
+            $multilingualData->description = $languageDataRow['ezcontentclass_attribute_multilingual_description'];
+            $multilingualData->dataText = $languageDataRow['ezcontentclass_attribute_multilingual_data_text'];
+            $multilingualData->dataJson = $languageDataRow['ezcontentclass_attribute_multilingual_data_json'];
+            $multilingualData->languageId = (int)$languageDataRow['ezcontentclass_attribute_multilingual_language_id'];
 
-                $languageCode = $this->maskGenerator->extractLanguageCodesFromMask((int)$languageDataRow['ezcontentclass_attribute_multilingual_language_id']);
-                $storageFieldDef->multilingualData[reset($languageCode)] = $multilingualData;
-            }
+            $languageCode = $this->maskGenerator->extractLanguageCodesFromMask((int)$languageDataRow['ezcontentclass_attribute_multilingual_language_id']);
+            $storageFieldDef->multilingualData[reset($languageCode)] = $multilingualData;
         }
 
         return $storageFieldDef;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
@@ -419,9 +419,20 @@ class Mapper
         FieldDefinition $fieldDef,
         StorageFieldDefinition $storageFieldDef
     ) {
+        foreach (array_keys($fieldDef->name) as $languageCode) {
+            $multilingualData = new MultilingualStorageFieldDefinition();
+            $multilingualData->name = $fieldDef->name[$languageCode];
+            $multilingualData->description = $fieldDef->description[$languageCode] ?? null;
+            $multilingualData->languageId =
+                $this->maskGenerator->generateLanguageMaskFromLanguageCodes([$languageCode]);
+
+            $storageFieldDef->multilingualData[$languageCode] = $multilingualData;
+        }
+
         $converter = $this->converterRegistry->getConverter(
             $fieldDef->fieldType
         );
+
         $converter->toStorageFieldDefinition(
             $fieldDef,
             $storageFieldDef

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
@@ -125,7 +125,7 @@ class Mapper
 
             if ($fieldId && !isset($fields[$fieldId])) {
                 $fieldDataRows = array_filter($rows, function (array $row) use ($fieldId) {
-                    return $row['ezcontentclass_attribute_id'] === (string) $fieldId;
+                    return (int) $row['ezcontentclass_attribute_id'] === (int) $fieldId;
                 });
 
                 $multilingualData = $this->extractMultilingualData($fieldDataRows);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
@@ -241,7 +241,9 @@ class Mapper
 
         $field->isSearchable = (bool)$row['ezcontentclass_attribute_is_searchable'];
         $field->position = (int)$row['ezcontentclass_attribute_placement'];
-        $field->mainLanguageCode = $this->maskGenerator->extractLanguageCodesFromMask((int)$row['ezcontentclass_initial_language_id'])[0];
+
+        $mainLanguageCode = $this->maskGenerator->extractLanguageCodesFromMask((int)$row['ezcontentclass_initial_language_id']);
+        $field->mainLanguageCode = array_shift($mainLanguageCode);
 
         $this->toFieldDefinition($storageFieldDef, $field);
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
@@ -298,7 +298,6 @@ class Mapper
         return $storageFieldDef;
     }
 
-
     /**
      * Maps properties from $struct to $type.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
@@ -124,17 +124,11 @@ class Mapper
             $fieldId = (int)$row['ezcontentclass_attribute_id'];
 
             if ($fieldId && !isset($fields[$fieldId])) {
-                $multilingualData = array_map(function (array $fieldData) use ($row) {
-                    return [
-                        'ezcontentclass_attribute_multilingual_name' => $fieldData['ezcontentclass_attribute_multilingual_name'] ?? $this->unserialize($row['ezcontentclass_serialized_name_list']),
-                        'ezcontentclass_attribute_multilingual_description' => $fieldData['ezcontentclass_attribute_multilingual_description'] ?? $this->unserialize($row['ezcontentclass_serialized_description_list']),
-                        'ezcontentclass_attribute_multilingual_language_id' => $fieldData['ezcontentclass_attribute_multilingual_language_id'] ?? (int)$row['ezcontentclass_initial_language_id'],
-                        'ezcontentclass_attribute_multilingual_data_text' => $fieldData['ezcontentclass_attribute_multilingual_data_text'] ?? '',
-                        'ezcontentclass_attribute_multilingual_data_json' => $fieldData['ezcontentclass_attribute_multilingual_data_json'] ?? '',
-                    ];
-                }, array_filter($rows, function (array $row) use ($fieldId) {
+                $fieldDataRows = array_filter($rows, function (array $row) use ($fieldId) {
                     return $row['ezcontentclass_attribute_id'] === (string) $fieldId;
-                }));
+                });
+
+                $multilingualData = $this->extractMultilingualData($fieldDataRows);
 
                 $types[$typeId]->fieldDefinitions[] = $fields[$fieldId] = $this->extractFieldFromRow($row, $multilingualData);
             }
@@ -151,6 +145,19 @@ class Mapper
 
         // Re-index $types to avoid people relying on ID keys
         return array_values($types);
+    }
+
+    public function extractMultilingualData(array $fieldDefinitionRows): array
+    {
+        return array_map(function (array $fieldData) {
+            return [
+                'ezcontentclass_attribute_multilingual_name' => $fieldData['ezcontentclass_attribute_multilingual_name'] ?? $this->unserialize($fieldData['ezcontentclass_attribute_serialized_name_list']),
+                'ezcontentclass_attribute_multilingual_description' => $fieldData['ezcontentclass_attribute_multilingual_description'] ?? $this->unserialize($fieldData['ezcontentclass_attribute_serialized_description_list']),
+                'ezcontentclass_attribute_multilingual_language_id' => $fieldData['ezcontentclass_attribute_multilingual_language_id'] ?? (int)$fieldData['ezcontentclass_initial_language_id'],
+                'ezcontentclass_attribute_multilingual_data_text' => $fieldData['ezcontentclass_attribute_multilingual_data_text'] ?? '',
+                'ezcontentclass_attribute_multilingual_data_json' => $fieldData['ezcontentclass_attribute_multilingual_data_json'] ?? '',
+            ];
+        }, $fieldDefinitionRows);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
@@ -290,6 +290,9 @@ class Mapper
             $multilingualData->languageId = (int)$languageDataRow['ezcontentclass_attribute_multilingual_language_id'];
 
             $languageCode = $this->maskGenerator->extractLanguageCodesFromMask((int)$languageDataRow['ezcontentclass_attribute_multilingual_language_id']);
+            if (null === $languageCode) {
+                continue;
+            }
             $storageFieldDef->multilingualData[reset($languageCode)] = $multilingualData;
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
@@ -139,6 +139,10 @@ class Mapper
             }
         }
 
+        foreach ($types as $type) {
+            sort($type->groupIds);
+        }
+
         if ($keepTypeIdAsKey) {
             return $types;
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Update/Handler/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Update/Handler/DoctrineDatabase.php
@@ -77,8 +77,7 @@ class DoctrineDatabase extends Handler
         $this->contentTypeGateway->publishTypeAndFields(
             $toType->id,
             $toType->status,
-            $newStatus,
-            $toType->fieldDefinitions
+            $newStatus
         );
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Update/Handler/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Update/Handler/DoctrineDatabase.php
@@ -63,7 +63,7 @@ class DoctrineDatabase extends Handler
      */
     public function deleteOldType(Type $fromType)
     {
-        $this->contentTypeGateway->delete($fromType->id, $fromType->status);
+        $this->contentTypeGateway->delete($fromType->id, $fromType->status, $fromType->fieldDefinitions);
     }
 
     /**
@@ -77,7 +77,8 @@ class DoctrineDatabase extends Handler
         $this->contentTypeGateway->publishTypeAndFields(
             $toType->id,
             $toType->status,
-            $newStatus
+            $newStatus,
+            $toType->fieldDefinitions
         );
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
@@ -33,9 +33,6 @@ class SelectionTest extends TestCase
         parent::setUp();
         $languageServiceMock = $this->createMock(LanguageService::class);
 
-//        $languageServiceMock
-//            ->method('getPrioritizedLanguageCodeList')
-//            ->will($this->returnValue(array('prioritizedLanguageList')));
         $this->converter = new SelectionConverter($languageServiceMock);
     }
 
@@ -241,6 +238,9 @@ EOT;
 
         $expectedFieldDefinition = new PersistenceFieldDefinition(
             array(
+                'name' => array(
+                    'eng-GB' => 'test name',
+                ),
                 'fieldTypeConstraints' => new FieldTypeConstraints(
                     array(
                         'fieldSettings' => new FieldSettings(
@@ -251,7 +251,9 @@ EOT;
                                     1 => 'Second',
                                     2 => 'Third',
                                 ),
-                                'multilingualOptions' => array ()
+                                'multilingualOptions' => array(
+                                    'eng-GB' => array(),
+                                ),
                             )
                         ),
                     )
@@ -265,7 +267,13 @@ EOT;
             )
         );
 
-        $actualFieldDefinition = new PersistenceFieldDefinition();
+        $actualFieldDefinition = new PersistenceFieldDefinition(
+            array(
+                'name' => array(
+                    'eng-GB' => 'test name',
+                ),
+            )
+        );
 
         $this->converter->toFieldDefinition($storageFieldDefinition, $actualFieldDefinition);
 
@@ -291,13 +299,18 @@ EOT;
 
         $expectedFieldDefinition = new PersistenceFieldDefinition(
             array(
+                'name' => array(
+                    'eng-GB' => 'test name',
+                ),
                 'fieldTypeConstraints' => new FieldTypeConstraints(
                     array(
                         'fieldSettings' => new FieldSettings(
                             array(
                                 'isMultiple' => false,
                                 'options' => array(),
-                                'multilingualOptions' => array(),
+                                'multilingualOptions' => array(
+                                    'eng-GB' => array(),
+                                ),
                             )
                         ),
                     )
@@ -306,7 +319,13 @@ EOT;
             )
         );
 
-        $actualFieldDefinition = new PersistenceFieldDefinition();
+        $actualFieldDefinition = new PersistenceFieldDefinition(
+            array(
+                'name' => array(
+                    'eng-GB' => 'test name',
+                ),
+            )
+        );
 
         $this->converter->toFieldDefinition($storageFieldDefinition, $actualFieldDefinition);
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;
 
+use eZ\Publish\API\Repository\LanguageService;
 use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
@@ -30,7 +31,12 @@ class SelectionTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->converter = new SelectionConverter();
+        $languageServiceMock = $this->createMock(LanguageService::class);
+
+//        $languageServiceMock
+//            ->method('getPrioritizedLanguageCodeList')
+//            ->will($this->returnValue(array('prioritizedLanguageList')));
+        $this->converter = new SelectionConverter($languageServiceMock);
     }
 
     /**
@@ -245,6 +251,7 @@ EOT;
                                     1 => 'Second',
                                     2 => 'Third',
                                 ),
+                                'multilingualOptions' => array ()
                             )
                         ),
                     )
@@ -290,6 +297,7 @@ EOT;
                             array(
                                 'isMultiple' => false,
                                 'options' => array(),
+                                'multilingualOptions' => array(),
                             )
                         ),
                     )

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
@@ -241,6 +241,7 @@ EOT;
                 'name' => array(
                     'eng-GB' => 'test name',
                 ),
+                'mainLanguageCode' => 'eng-GB',
                 'fieldTypeConstraints' => new FieldTypeConstraints(
                     array(
                         'fieldSettings' => new FieldSettings(
@@ -252,7 +253,11 @@ EOT;
                                     2 => 'Third',
                                 ),
                                 'multilingualOptions' => array(
-                                    'eng-GB' => array(),
+                                    'eng-GB' => array(
+                                        0 => 'First',
+                                        1 => 'Second',
+                                        2 => 'Third',
+                                    ),
                                 ),
                             )
                         ),
@@ -272,6 +277,7 @@ EOT;
                 'name' => array(
                     'eng-GB' => 'test name',
                 ),
+                'mainLanguageCode' => 'eng-GB'
             )
         );
 
@@ -302,6 +308,7 @@ EOT;
                 'name' => array(
                     'eng-GB' => 'test name',
                 ),
+                'mainLanguageCode' => 'eng-GB',
                 'fieldTypeConstraints' => new FieldTypeConstraints(
                     array(
                         'fieldSettings' => new FieldSettings(
@@ -324,6 +331,7 @@ EOT;
                 'name' => array(
                     'eng-GB' => 'test name',
                 ),
+                'mainLanguageCode' => 'eng-GB',
             )
         );
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
@@ -277,7 +277,7 @@ EOT;
                 'name' => array(
                     'eng-GB' => 'test name',
                 ),
-                'mainLanguageCode' => 'eng-GB'
+                'mainLanguageCode' => 'eng-GB',
             )
         );
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
@@ -900,7 +900,10 @@ class ContentTypeHandlerTest extends TestCase
     public function testGetFieldDefinition()
     {
         $mapperMock = $this->getMapperMock(
-            array('extractFieldFromRow')
+            array(
+                'extractFieldFromRow',
+                'extractMultilingualData',
+            )
         );
         $mapperMock->expects($this->once())
             ->method('extractFieldFromRow')
@@ -910,6 +913,16 @@ class ContentTypeHandlerTest extends TestCase
                 $this->returnValue(new FieldDefinition())
             );
 
+        $mapperMock->expects($this->once())
+            ->method('extractMultilingualData')
+            ->with(
+                $this->equalTo(array(
+                    array(),
+                ))
+            )->will(
+                $this->returnValue(array())
+            );
+
         $gatewayMock = $this->getGatewayMock();
         $gatewayMock->expects($this->once())
             ->method('loadFieldDefinition')
@@ -917,7 +930,9 @@ class ContentTypeHandlerTest extends TestCase
                 $this->equalTo(42),
                 $this->equalTo(Type::STATUS_DEFINED)
             )->will(
-                $this->returnValue(array())
+                $this->returnValue(array(
+                    array(),
+                ))
             );
 
         $handler = $this->getHandler();

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
@@ -398,7 +398,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
             count($rows)
         );
         $this->assertEquals(
-            44,
+            49,
             count($rows[0])
         );
 
@@ -431,7 +431,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
             count($rows)
         );
         $this->assertEquals(
-            44,
+            49,
             count($rows[0])
         );
     }
@@ -455,7 +455,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
             count($rows)
         );
         $this->assertEquals(
-            44,
+            49,
             count($rows[0])
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/MapperTest.php
@@ -390,6 +390,9 @@ class MapperTest extends TestCase
 
         $fieldDef = new FieldDefinition();
         $fieldDef->fieldType = 'some_type';
+        $fieldDef->name = [
+            'eng-GB' => 'some name',
+        ];
 
         $storageFieldDef = new StorageFieldDefinition();
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -656,17 +656,20 @@ CREATE TABLE `ezpreferences` (
 ) ENGINE=InnoDB AUTO_INCREMENT=21 DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `ezcontentclass_attribute_ml`;
-create table `ezcontentclass_attribute_ml`
-(
-	contentclass_attribute_id int not null,
-	version int not null,
-	language_id bigint not null,
-	name varchar(255) not null,
-	description text null,
-	data_text text null,
-	data_json text null,
-	primary key (contentclass_attribute_id, version, language_id),
-	constraint ezcontentclass_attribute_ml_lang_fk
-		foreign key (language_id) references ezcontent_language (id)
-			on update cascade on delete cascade
+CREATE TABLE `ezcontentclass_attribute_ml` (
+	`contentclass_attribute_id` INT NOT NULL,
+	`version` INT NOT NULL,
+	`language_id` BIGINT NOT NULL,
+	`name` VARCHAR(255) NOT NULL,
+	`description` TEXT NULL,
+	`data_text` TEXT NULL,
+	`data_json` TEXT NULL,
+	PRIMARY KEY (`contentclass_attribute_id`, `version`, `language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE `ezcontentclass_attribute_ml`
+ADD CONSTRAINT `ezcontentclass_attribute_ml_lang_fk`
+  FOREIGN KEY (`language_id`)
+  REFERENCES `ezcontent_language` (`id`)
+  ON DELETE CASCADE
+  ON UPDATE CASCADE;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -654,3 +654,19 @@ CREATE TABLE `ezpreferences` (
   KEY `ezpreferences_name` (`name`),
   KEY `ezpreferences_user_id_idx` (`user_id`,`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=21 DEFAULT CHARSET=utf8mb4;
+
+DROP TABLE IF EXISTS `ezcontentclass_attribute_ml`;
+create table `ezcontentclass_attribute_ml`
+(
+	contentclass_attribute_id int not null,
+	version int not null,
+	language_id bigint not null,
+	name varchar(255) not null,
+	description text null,
+	data_text text null,
+	data_json text null,
+	primary key (contentclass_attribute_id, version, language_id),
+	constraint ezcontentclass_attribute_ml_lang_fk
+		foreign key (language_id) references ezcontent_language (id)
+			on update cascade on delete cascade
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -657,14 +657,14 @@ CREATE TABLE `ezpreferences` (
 
 DROP TABLE IF EXISTS `ezcontentclass_attribute_ml`;
 CREATE TABLE `ezcontentclass_attribute_ml` (
-	`contentclass_attribute_id` INT NOT NULL,
-	`version` INT NOT NULL,
-	`language_id` BIGINT NOT NULL,
-	`name` VARCHAR(255) NOT NULL,
-	`description` TEXT NULL,
-	`data_text` TEXT NULL,
-	`data_json` TEXT NULL,
-	PRIMARY KEY (`contentclass_attribute_id`, `version`, `language_id`)
+  `contentclass_attribute_id` INT NOT NULL,
+  `version` INT NOT NULL,
+  `language_id` BIGINT NOT NULL,
+  `name` VARCHAR(255) NOT NULL,
+  `description` TEXT NULL,
+  `data_text` TEXT NULL,
+  `data_json` TEXT NULL,
+  PRIMARY KEY (`contentclass_attribute_id`, `version`, `language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 ALTER TABLE `ezcontentclass_attribute_ml`

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
@@ -501,6 +501,17 @@ CREATE TABLE ezpreferences (
     value text DEFAULT NULL
 );
 
+DROP TABLE IF EXISTS ezcontentclass_attribute_ml;
+CREATE TABLE ezcontentclass_attribute_ml (
+	contentclass_attribute_id INT NOT NULL,
+	version integer NOT NULL,
+	language_id SERIAL NOT NULL,
+	name character varying(255) NOT NULL,
+	description text DEFAULT NULL,
+	data_text text DEFAULT NULL,
+	data_json text DEFAULT NULL
+);
+
 CREATE INDEX ezimagefile_coid ON ezimagefile USING btree (contentobject_attribute_id);
 
 CREATE INDEX ezimagefile_file ON ezimagefile USING btree (filepath);
@@ -695,6 +706,8 @@ CREATE INDEX ezpreferences_name ON ezpreferences USING btree (name);
 
 CREATE INDEX ezpreferences_user_id_idx ON ezpreferences USING btree (user_id,name);
 
+CREATE INDEX contentclass_attribute_id ON ezcontentclass_attribute_ml USING btree (contentclass_attribute_id, version, language_id);
+
 ALTER TABLE ONLY ezcobj_state
     ADD CONSTRAINT ezcobj_state_pkey PRIMARY KEY (id);
 
@@ -843,3 +856,10 @@ ADD CONSTRAINT ezcontentbrowsebookmark_user_fk
   REFERENCES ezuser (contentobject_id)
   ON DELETE CASCADE
   ON UPDATE NO ACTION;
+
+ALTER TABLE ezcontentclass_attribute_ml
+ADD CONSTRAINT ezcontentclass_attribute_ml_lang_fk
+  FOREIGN KEY (language_id)
+  REFERENCES ezcontent_language (id)
+  ON DELETE CASCADE
+  ON UPDATE CASCADE;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
@@ -503,13 +503,13 @@ CREATE TABLE ezpreferences (
 
 DROP TABLE IF EXISTS ezcontentclass_attribute_ml;
 CREATE TABLE ezcontentclass_attribute_ml (
-	contentclass_attribute_id INT NOT NULL,
-	version integer NOT NULL,
-	language_id SERIAL NOT NULL,
-	name character varying(255) NOT NULL,
-	description text DEFAULT NULL,
-	data_text text DEFAULT NULL,
-	data_json text DEFAULT NULL
+    contentclass_attribute_id INT NOT NULL,
+    version integer NOT NULL,
+    language_id SERIAL NOT NULL,
+    name character varying(255) NOT NULL,
+    description text DEFAULT NULL,
+    data_text text DEFAULT NULL,
+    data_json text DEFAULT NULL
 );
 
 CREATE INDEX ezimagefile_coid ON ezimagefile USING btree (contentobject_attribute_id);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -575,20 +575,16 @@ CREATE TABLE ezpreferences (
 CREATE INDEX ezpreferences_name ON ezpreferences (name);
 CREATE INDEX ezpreferences_user_id_idx ON ezpreferences (user_id, name);
 
-create table `ezcontentclass_attribute_ml`
+create table ezcontentclass_attribute_ml
 (
-	contentclass_attribute_id int not null,
-	version int not null,
-	language_id bigint not null,
-	name varchar(255) not null,
-	description text null,
-	data_text text null,
-	data_json text null,
-	primary key (contentclass_attribute_id, version, language_id),
-	constraint ezcontentclass_attribute_ml_lang_fk
-		foreign key (language_id) references ezcontent_language (id)
-			on update cascade on delete cascade
-)
+	contentclass_attribute_id integer not null,
+	version integer not null,
+	language_id integer not null,
+	name text(255) not null,
+	description text DEFAULT null,
+	data_text text DEFAULT null,
+	data_json text DEFAULT null
+);
 
 CREATE INDEX ezcontentclass_attribute_ml_language_id ON ezcontentclass_attribute_ml (language_id);
 CREATE INDEX ezcontentclass_attribute_ml_id ON ezcontentclass_attribute_ml (contentclass_attribute_id, version, language_id);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -575,14 +575,14 @@ CREATE TABLE ezpreferences (
 CREATE INDEX ezpreferences_name ON ezpreferences (name);
 CREATE INDEX ezpreferences_user_id_idx ON ezpreferences (user_id, name);
 
-create table ezcontentclass_attribute_ml (
-	contentclass_attribute_id integer NOT NULL,
-	version integer NOT NULL,
-	language_id integer NOT NULL,
-	name text(255) NOT NULL,
-	description text DEFAULT NULL,
-	data_text text DEFAULT NULL,
-	data_json text DEFAULT NULL
+CREATE TABLE ezcontentclass_attribute_ml (
+  contentclass_attribute_id integer NOT NULL,
+  version integer NOT NULL,
+  language_id integer NOT NULL,
+  name text(255) NOT NULL,
+  description text DEFAULT NULL,
+  data_text text DEFAULT NULL,
+  data_json text DEFAULT NULL
 );
 
 CREATE INDEX ezcontentclass_attribute_ml_language_id ON ezcontentclass_attribute_ml (language_id);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -575,15 +575,14 @@ CREATE TABLE ezpreferences (
 CREATE INDEX ezpreferences_name ON ezpreferences (name);
 CREATE INDEX ezpreferences_user_id_idx ON ezpreferences (user_id, name);
 
-create table ezcontentclass_attribute_ml
-(
-	contentclass_attribute_id integer not null,
-	version integer not null,
-	language_id integer not null,
-	name text(255) not null,
-	description text DEFAULT null,
-	data_text text DEFAULT null,
-	data_json text DEFAULT null
+create table ezcontentclass_attribute_ml (
+	contentclass_attribute_id integer NOT NULL,
+	version integer NOT NULL,
+	language_id integer NOT NULL,
+	name text(255) NOT NULL,
+	description text DEFAULT NULL,
+	data_text text DEFAULT NULL,
+	data_json text DEFAULT NULL
 );
 
 CREATE INDEX ezcontentclass_attribute_ml_language_id ON ezcontentclass_attribute_ml (language_id);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -574,3 +574,21 @@ CREATE TABLE ezpreferences (
 
 CREATE INDEX ezpreferences_name ON ezpreferences (name);
 CREATE INDEX ezpreferences_user_id_idx ON ezpreferences (user_id, name);
+
+create table `ezcontentclass_attribute_ml`
+(
+	contentclass_attribute_id int not null,
+	version int not null,
+	language_id bigint not null,
+	name varchar(255) not null,
+	description text null,
+	data_text text null,
+	data_json text null,
+	primary key (contentclass_attribute_id, version, language_id),
+	constraint ezcontentclass_attribute_ml_lang_fk
+		foreign key (language_id) references ezcontent_language (id)
+			on update cascade on delete cascade
+)
+
+CREATE INDEX ezcontentclass_attribute_ml_language_id ON ezcontentclass_attribute_ml (language_id);
+CREATE INDEX ezcontentclass_attribute_ml_id ON ezcontentclass_attribute_ml (contentclass_attribute_id, version, language_id);

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -704,6 +704,8 @@ class ContentTypeService implements ContentTypeServiceInterface
                     "Argument contains duplicate field definition position '{$fieldDefinitionCreateStruct->position}'"
                 );
             }
+
+            $fieldDefinitionCreateStruct->mainLanguageCode = $contentTypeCreateStruct->mainLanguageCode;
         }
 
         $allValidationErrors = array();

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -1101,13 +1101,15 @@ class ContentTypeService implements ContentTypeServiceInterface
             if (!$contentType instanceof APIContentTypeDraft) {
                 $this->contentTypeHandler->delete(
                     $contentType->id,
-                    APIContentTypeDraft::STATUS_DEFINED
+                    APIContentTypeDraft::STATUS_DEFINED,
+                    $contentType->fieldDefinitions
                 );
             }
 
             $this->contentTypeHandler->delete(
                 $contentType->id,
-                APIContentTypeDraft::STATUS_DRAFT
+                APIContentTypeDraft::STATUS_DRAFT,
+                $contentType->fieldDefinitions
             );
 
             $this->repository->commit();

--- a/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
@@ -407,7 +407,7 @@ class ContentTypeDomainMapper
                 'isSearchable' => $fieldDefinitionCreateStruct->isSearchable === null ?
                     $fieldType->isSearchable() :
                     $fieldDefinitionCreateStruct->isSearchable,
-                'mainLanguageCode' => $fieldDefinitionCreateStruct->mainLanguageCode
+                'mainLanguageCode' => $fieldDefinitionCreateStruct->mainLanguageCode,
                 // These properties are precreated in constructor
                 //"fieldTypeConstraints"
                 //"defaultValue"

--- a/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
@@ -282,6 +282,8 @@ class ContentTypeDomainMapper
      * Builds SPIFieldDefinition object using API FieldDefinitionUpdateStruct
      * and API FieldDefinition.
      *
+     * @deprecated use \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper::buildSPIFieldDefinitionFromUpdateStruct()
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException if validator configuration or
      *         field setting do not validate
      *
@@ -351,7 +353,6 @@ class ContentTypeDomainMapper
                 'isSearchable' => $fieldDefinitionUpdateStruct->isSearchable === null ?
                     $fieldDefinition->isSearchable :
                     $fieldDefinitionUpdateStruct->isSearchable,
-                'mainLanguageCode' => $fieldDefinition->mainLanguageCode,
                 // These properties are precreated in constructor
                 //"fieldTypeConstraints"
                 //"defaultValue"
@@ -368,7 +369,99 @@ class ContentTypeDomainMapper
     }
 
     /**
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
+     * @param string $mainLanguageCode
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\Core\Base\Exceptions\ContentTypeFieldDefinitionValidationException
+     */
+    public function buildSPIFieldDefinitionFromUpdateStruct(
+        APIFieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct,
+        APIFieldDefinition $fieldDefinition,
+        string $mainLanguageCode
+    ): SPIFieldDefinition {
+        /** @var $fieldType \eZ\Publish\SPI\FieldType\FieldType */
+        $fieldType = $this->fieldTypeRegistry->getFieldType(
+            $fieldDefinition->fieldTypeIdentifier
+        );
+
+        $validatorConfiguration = $fieldDefinitionUpdateStruct->validatorConfiguration === null
+            ? $fieldDefinition->validatorConfiguration
+            : $fieldDefinitionUpdateStruct->validatorConfiguration;
+        $fieldSettings = $fieldDefinitionUpdateStruct->fieldSettings === null
+            ? $fieldDefinition->fieldSettings
+            : $fieldDefinitionUpdateStruct->fieldSettings;
+
+        $validationErrors = [];
+        if ($fieldDefinitionUpdateStruct->isSearchable && !$fieldType->isSearchable()) {
+            $validationErrors[] = new ValidationError(
+                "FieldType '{$fieldDefinition->fieldTypeIdentifier}' is not searchable"
+            );
+        }
+        $validationErrors = array_merge(
+            $validationErrors,
+            $fieldType->validateValidatorConfiguration($validatorConfiguration),
+            $fieldType->validateFieldSettings($fieldSettings)
+        );
+
+        if (!empty($validationErrors)) {
+            throw new ContentTypeFieldDefinitionValidationException($validationErrors);
+        }
+
+        $spiFieldDefinition = new SPIFieldDefinition(
+            [
+                'id' => $fieldDefinition->id,
+                'fieldType' => $fieldDefinition->fieldTypeIdentifier,
+                'name' => $fieldDefinitionUpdateStruct->names === null ?
+                    $fieldDefinition->getNames() :
+                    array_merge($fieldDefinition->getNames(), $fieldDefinitionUpdateStruct->names),
+                'description' => $fieldDefinitionUpdateStruct->descriptions === null ?
+                    $fieldDefinition->getDescriptions() :
+                    array_merge($fieldDefinition->getDescriptions(), $fieldDefinitionUpdateStruct->descriptions),
+                'identifier' => $fieldDefinitionUpdateStruct->identifier === null ?
+                    $fieldDefinition->identifier :
+                    $fieldDefinitionUpdateStruct->identifier,
+                'fieldGroup' => $fieldDefinitionUpdateStruct->fieldGroup === null ?
+                    $fieldDefinition->fieldGroup :
+                    $fieldDefinitionUpdateStruct->fieldGroup,
+                'position' => $fieldDefinitionUpdateStruct->position === null ?
+                    $fieldDefinition->position :
+                    $fieldDefinitionUpdateStruct->position,
+                'isTranslatable' => $fieldDefinitionUpdateStruct->isTranslatable === null ?
+                    $fieldDefinition->isTranslatable :
+                    $fieldDefinitionUpdateStruct->isTranslatable,
+                'isRequired' => $fieldDefinitionUpdateStruct->isRequired === null ?
+                    $fieldDefinition->isRequired :
+                    $fieldDefinitionUpdateStruct->isRequired,
+                'isInfoCollector' => $fieldDefinitionUpdateStruct->isInfoCollector === null ?
+                    $fieldDefinition->isInfoCollector :
+                    $fieldDefinitionUpdateStruct->isInfoCollector,
+                'isSearchable' => $fieldDefinitionUpdateStruct->isSearchable === null ?
+                    $fieldDefinition->isSearchable :
+                    $fieldDefinitionUpdateStruct->isSearchable,
+                'mainLanguageCode' => $mainLanguageCode,
+                // These properties are precreated in constructor
+                //"fieldTypeConstraints"
+                //"defaultValue"
+            ]
+        );
+
+        $spiFieldDefinition->fieldTypeConstraints->validators = $validatorConfiguration;
+        $spiFieldDefinition->fieldTypeConstraints->fieldSettings = $fieldSettings;
+        $spiFieldDefinition->defaultValue = $fieldType->toPersistenceValue(
+            $fieldType->acceptValue($fieldDefinitionUpdateStruct->defaultValue)
+        );
+
+        return $spiFieldDefinition;
+    }
+
+    /**
      * Builds SPIFieldDefinition object using API FieldDefinitionCreateStruct.
+     *
+     * @deprecated use \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper::buildSPIFieldDefinitionFromCreateStruct()
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException if validator configuration or
      *         field setting do not validate
@@ -407,11 +500,67 @@ class ContentTypeDomainMapper
                 'isSearchable' => $fieldDefinitionCreateStruct->isSearchable === null ?
                     $fieldType->isSearchable() :
                     $fieldDefinitionCreateStruct->isSearchable,
-                'mainLanguageCode' => $fieldDefinitionCreateStruct->mainLanguageCode,
                 // These properties are precreated in constructor
                 //"fieldTypeConstraints"
                 //"defaultValue"
             )
+        );
+
+        $spiFieldDefinition->fieldTypeConstraints->validators = $fieldDefinitionCreateStruct->validatorConfiguration;
+        $spiFieldDefinition->fieldTypeConstraints->fieldSettings = $fieldDefinitionCreateStruct->fieldSettings;
+        $spiFieldDefinition->defaultValue = $fieldType->toPersistenceValue(
+            $fieldType->acceptValue($fieldDefinitionCreateStruct->defaultValue)
+        );
+
+        return $spiFieldDefinition;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct $fieldDefinitionCreateStruct
+     * @param \eZ\Publish\SPI\FieldType\FieldType $fieldType
+     * @param string $mainLanguageCode
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function buildSPIFieldDefinitionFromCreateStruct(
+        APIFieldDefinitionCreateStruct $fieldDefinitionCreateStruct,
+        SPIFieldType $fieldType,
+        string $mainLanguageCode
+    ): SPIFieldDefinition {
+        $spiFieldDefinition = new SPIFieldDefinition(
+            [
+                'id' => null,
+                'identifier' => $fieldDefinitionCreateStruct->identifier,
+                'fieldType' => $fieldDefinitionCreateStruct->fieldTypeIdentifier,
+                'name' => $fieldDefinitionCreateStruct->names === null ?
+                    [] :
+                    $fieldDefinitionCreateStruct->names,
+                'description' => $fieldDefinitionCreateStruct->descriptions === null ?
+                    [] :
+                    $fieldDefinitionCreateStruct->descriptions,
+                'fieldGroup' => $fieldDefinitionCreateStruct->fieldGroup === null ?
+                    '' :
+                    $fieldDefinitionCreateStruct->fieldGroup,
+                'position' => (int)$fieldDefinitionCreateStruct->position,
+                'isTranslatable' => $fieldDefinitionCreateStruct->isTranslatable === null ?
+                    true :
+                    $fieldDefinitionCreateStruct->isTranslatable,
+                'isRequired' => $fieldDefinitionCreateStruct->isRequired === null ?
+                    false :
+                    $fieldDefinitionCreateStruct->isRequired,
+                'isInfoCollector' => $fieldDefinitionCreateStruct->isInfoCollector === null ?
+                    false :
+                    $fieldDefinitionCreateStruct->isInfoCollector,
+                'isSearchable' => $fieldDefinitionCreateStruct->isSearchable === null ?
+                    $fieldType->isSearchable() :
+                    $fieldDefinitionCreateStruct->isSearchable,
+                'mainLanguageCode' => $mainLanguageCode,
+                // These properties are precreated in constructor
+                //"fieldTypeConstraints"
+                //"defaultValue"
+            ]
         );
 
         $spiFieldDefinition->fieldTypeConstraints->validators = $fieldDefinitionCreateStruct->validatorConfiguration;

--- a/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
@@ -351,6 +351,7 @@ class ContentTypeDomainMapper
                 'isSearchable' => $fieldDefinitionUpdateStruct->isSearchable === null ?
                     $fieldDefinition->isSearchable :
                     $fieldDefinitionUpdateStruct->isSearchable,
+                'mainLanguageCode' => $fieldDefinition->mainLanguageCode,
                 // These properties are precreated in constructor
                 //"fieldTypeConstraints"
                 //"defaultValue"

--- a/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
@@ -407,6 +407,7 @@ class ContentTypeDomainMapper
                 'isSearchable' => $fieldDefinitionCreateStruct->isSearchable === null ?
                     $fieldType->isSearchable() :
                     $fieldDefinitionCreateStruct->isSearchable,
+                'mainLanguageCode' => $fieldDefinitionCreateStruct->mainLanguageCode
                 // These properties are precreated in constructor
                 //"fieldTypeConstraints"
                 //"defaultValue"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/field_value_converters.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/field_value_converters.yml
@@ -81,6 +81,8 @@ services:
 
     ezpublish.fieldType.ezselection.converter:
         class: "%ezpublish.fieldType.ezselection.converter.class%"
+        arguments:
+            - '@ezpublish.api.service.language'
         tags:
             - {name: ezpublish.storageEngine.legacy.converter, alias: ezselection}
 

--- a/eZ/Publish/SPI/Persistence/Content/Type/FieldDefinition.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/FieldDefinition.php
@@ -114,8 +114,6 @@ class FieldDefinition extends ValueObject
 
     public $mainLanguageCode;
 
-    public $languageCode;
-
     /**
      * Constructor.
      */

--- a/eZ/Publish/SPI/Persistence/Content/Type/FieldDefinition.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/FieldDefinition.php
@@ -113,7 +113,7 @@ class FieldDefinition extends ValueObject
     public $isSearchable;
 
     /**
-     * Based on mainLanguageCode of contentType
+     * Based on mainLanguageCode of contentType.
      * @var string
      */
     public $mainLanguageCode;

--- a/eZ/Publish/SPI/Persistence/Content/Type/FieldDefinition.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/FieldDefinition.php
@@ -112,6 +112,10 @@ class FieldDefinition extends ValueObject
      */
     public $isSearchable;
 
+    /**
+     * Based on mainLanguageCode of contentType
+     * @var string
+     */
     public $mainLanguageCode;
 
     /**

--- a/eZ/Publish/SPI/Persistence/Content/Type/FieldDefinition.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/FieldDefinition.php
@@ -114,6 +114,7 @@ class FieldDefinition extends ValueObject
 
     /**
      * Based on mainLanguageCode of contentType.
+     *
      * @var string
      */
     public $mainLanguageCode;

--- a/eZ/Publish/SPI/Persistence/Content/Type/FieldDefinition.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/FieldDefinition.php
@@ -112,6 +112,10 @@ class FieldDefinition extends ValueObject
      */
     public $isSearchable;
 
+    public $mainLanguageCode;
+
+    public $languageCode;
+
     /**
      * Constructor.
      */

--- a/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
@@ -68,6 +68,17 @@ class SelectionIntegrationTest extends BaseIntegrationTest
                             2 => 'Second',
                             3 => 'Sindelfingen',
                         ),
+                        'multilingualOptions' => array(
+                            'ger-DE' => array(
+                                1 => 'Zuerst',
+                                2 => 'Zweite',
+                            ),
+                            'eng-US' => array(
+                                1 => 'ML First',
+                                2 => 'ML Second',
+                                3 => 'ML Sindelfingen',
+                            ),
+                        ),
                     )
                 ),
             )
@@ -94,18 +105,20 @@ class SelectionIntegrationTest extends BaseIntegrationTest
                             array(
                                 'isMultiple' => true,
                                 'options' => array(
-                                    1 => 'First',
-                                    2 => 'Second',
-                                    3 => 'Sindelfingen',
+                                    1 => 'ML First',
+                                    2 => 'ML Second',
+                                    3 => 'ML Sindelfingen',
                                 ),
                                 'multilingualOptions' => array(
-                                    // mainLanguageCode of contentType is not consistent with names provided for FieldDefinition
-                                    'eng-US' => array(
-                                        1 => 'First',
-                                        2 => 'Second',
-                                        3 => 'Sindelfingen',
+                                    'ger-DE' => array(
+                                        1 => 'Zuerst',
+                                        2 => 'Zweite',
                                     ),
-                                    'eng-GB' => array(),
+                                    'eng-US' => array(
+                                        1 => 'ML First',
+                                        2 => 'ML Second',
+                                        3 => 'ML Sindelfingen',
+                                    ),
                                 ),
                             )
                         ),
@@ -147,5 +160,70 @@ class SelectionIntegrationTest extends BaseIntegrationTest
                 'sortKey' => '2',
             )
         );
+    }
+
+    /**
+     * Performs the creation of the content type with a field of the field type
+     * under test.
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\Type
+     */
+    protected function createContentType()
+    {
+        $createStruct = new Content\Type\CreateStruct(
+            [
+                'name' => [
+                    'eng-US' => 'Test',
+                    'ger-DE' => 'Test NOR'
+                ],
+                'identifier' => 'test-' . $this->getTypeName(),
+                'status' => 0,
+                'creatorId' => 14,
+                'created' => time(),
+                'modifierId' => 14,
+                'modified' => time(),
+                'initialLanguageId' => 2,
+                'remoteId' => 'abcdef',
+            ]
+        );
+
+        $createStruct->fieldDefinitions = array(
+            new Content\Type\FieldDefinition(
+                [
+                    'name' => [
+                        'eng-US' => 'Name',
+                        'ger-DE' => 'Name NOR'
+                    ],
+                    'identifier' => 'name',
+                    'fieldGroup' => 'main',
+                    'position' => 1,
+                    'fieldType' => 'ezstring',
+                    'isTranslatable' => false,
+                    'isRequired' => true,
+                    'mainLanguageCode' => 'eng-US',
+                ]
+            ),
+            new Content\Type\FieldDefinition(
+                [
+                    'name' => [
+                        'eng-US' => 'Data',
+                        'ger-DE' => 'Data NOR'
+                    ],
+                    'identifier' => 'data',
+                    'fieldGroup' => 'main',
+                    'position' => 2,
+                    'fieldType' => $this->getTypeName(),
+                    'isTranslatable' => false,
+                    'isRequired' => true,
+                    'fieldTypeConstraints' => $this->getTypeConstraints(),
+                    'mainLanguageCode' => 'eng-US',
+                ]
+            ),
+        );
+
+        $handler = $this->getCustomHandler();
+        $contentTypeHandler = $handler->contentTypeHandler();
+
+        return $contentTypeHandler->create($createStruct);
     }
 }

--- a/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
@@ -99,11 +99,13 @@ class SelectionIntegrationTest extends BaseIntegrationTest
                                     3 => 'Sindelfingen',
                                 ),
                                 'multilingualOptions' => array(
+                                    // mainLanguageCode of contentType is not consistent with names provided for FieldDefinition
                                     'eng-US' => array(
                                         1 => 'First',
                                         2 => 'Second',
                                         3 => 'Sindelfingen',
                                     ),
+                                    'eng-GB' => array(),
                                 ),
                             )
                         ),

--- a/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
@@ -174,7 +174,7 @@ class SelectionIntegrationTest extends BaseIntegrationTest
             [
                 'name' => [
                     'eng-US' => 'Test',
-                    'ger-DE' => 'Test NOR'
+                    'ger-DE' => 'Test NOR',
                 ],
                 'identifier' => 'test-' . $this->getTypeName(),
                 'status' => 0,
@@ -192,7 +192,7 @@ class SelectionIntegrationTest extends BaseIntegrationTest
                 [
                     'name' => [
                         'eng-US' => 'Name',
-                        'ger-DE' => 'Name NOR'
+                        'ger-DE' => 'Name NOR',
                     ],
                     'identifier' => 'name',
                     'fieldGroup' => 'main',
@@ -207,7 +207,7 @@ class SelectionIntegrationTest extends BaseIntegrationTest
                 [
                     'name' => [
                         'eng-US' => 'Data',
-                        'ger-DE' => 'Data NOR'
+                        'ger-DE' => 'Data NOR',
                     ],
                     'identifier' => 'data',
                     'fieldGroup' => 'main',

--- a/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
@@ -39,11 +39,12 @@ class SelectionIntegrationTest extends BaseIntegrationTest
     {
         $fieldType = new FieldType\Selection\Type();
         $fieldType->setTransformationProcessor($this->getTransformationProcessor());
+        $languageService = self::$container->get('ezpublish.api.service.language');
 
         return $this->getHandler(
             'ezselection',
             $fieldType,
-            new Legacy\Content\FieldValue\Converter\SelectionConverter(),
+            new Legacy\Content\FieldValue\Converter\SelectionConverter($languageService),
             new FieldType\NullStorage()
         );
     }
@@ -96,6 +97,13 @@ class SelectionIntegrationTest extends BaseIntegrationTest
                                     1 => 'First',
                                     2 => 'Second',
                                     3 => 'Sindelfingen',
+                                ),
+                                'multilingualOptions' => array(
+                                    'eng-US' => array(
+                                        1 => 'First',
+                                        2 => 'Second',
+                                        3 => 'Sindelfingen',
+                                    ),
                                 ),
                             )
                         ),


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29990](https://jira.ez.no/browse/EZP-29990)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

main concerns:

- bc breaks:
options for ezselections are now in shape of array with language key.
    - solutions:
    move translatable options under new key in settings?

- additional parameters into some gateway methods
- mainLanguageCode for fieldtype based on contentType main language
- validation for multiple languages https://github.com/ezsystems/ezpublish-kernel/pull/2532/files#diff-ed1b5f7a81f509bc03b439eb89907acbR203

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Add docblocks
- [x] Fix all possible BC breaks
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
