### PR TITLE
[DX] Provided autoconfiguration for API/Repository integration tests

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\API\Repository\Tests;
 use Doctrine\DBAL\Connection;
 use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
 use eZ\Publish\API\Repository\Tests\PHPUnitConstraint\ValidationErrorOccurs as PHPUnitConstraintValidationErrorOccurs;
+use eZ\Publish\API\Repository\Tests\SetupFactory\Legacy;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use PHPUnit\Framework\TestCase;
@@ -162,12 +163,13 @@ abstract class BaseTest extends TestCase
     protected function getSetupFactory()
     {
         if (null === $this->setupFactory) {
-            $setupClass = getenv('setupFactory');
+            if (false === ($setupClass = getenv('setupFactory'))) {
+                $setupClass = Legacy::class;
+                putenv("setupFactory=${setupClass}");
+            }
 
-            if (false === $setupClass) {
-                throw new \ErrorException(
-                    'Missing mandatory environment variable "setupFactory", this should normally be set in the relevant phpunit-integration-*.xml file and refer to a setupFactory for the given StorageEngine/SearchEngine in use'
-                );
+            if (false === ($fixtureDir = getenv('fixtureDir'))) {
+                putenv('fixtureDir=Legacy');
             }
 
             if (false === class_exists($setupClass)) {


### PR DESCRIPTION
This PR adds autoconfiguration for Repository integration tests, so running them (by default as Legacy Storage tests on SQLite in-memory database and Legacy Search Engine) does not require providing dedicated `phpunit-integration-legacy.xml` configuration file.

This improves DX, because each time we'd like to run and/or debug a test from an IDE, we needed to configure this file, which is very annoying. Integration test knows everything to be executed as integration test. Configuration file should provide only:
- explicit list of test suite classes when executing all tests,
- alternative search engine.
- alternative DBMS (SQLite in-memory by default for performance and simple config).

For most of the day-to-day development tasks, especially working with IDE, all of this is not needed (unless you're debugging e.g. Solr ;) ).

What we need is quick testing/debugging (by clicking play/debug button in IDE).

This does not mean that configuration files are obsolete. To run full test suites, especially for CI, they're still needed.

**TODO**:
- [x] Provide fallback for missing setup factory settings
- [x] Confirm Travis agrees
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
