### PR TITLE
EZP-30087: Move LimitationService from Helpers to public API

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -376,6 +376,7 @@ class EzPublishCoreExtension extends Extension
         $coreLoader->load('policies.yml');
         $coreLoader->load('notification.yml');
         $coreLoader->load('user_preference.yml');
+        $coreLoader->load('limitation.yml');
 
         // Load Core RichText settings
         if (!$this->isRichTextBundleEnabled($container)) {

--- a/eZ/Publish/API/Repository/Exceptions/NotFound/LimitationNotFoundException.php
+++ b/eZ/Publish/API/Repository/Exceptions/NotFound/LimitationNotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Exceptions\NotFound;
+
+use RuntimeException;
+
+/**
+ * Limitation Not Found Exception implementation.
+ */
+abstract class LimitationNotFoundException extends RuntimeException
+{
+}

--- a/eZ/Publish/API/Repository/LimitationService.php
+++ b/eZ/Publish/API/Repository/LimitationService.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * File containing the eZ\Publish\API\Repository\LimitationService class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace  eZ\Publish\API\Repository;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\SPI\Limitation\Type;
+
+/**
+ * This service provides methods for managing Limitations.
+ */
+interface LimitationService
+{
+    /**
+     * Returns the LimitationType registered with the given identifier.
+     *
+     * Returns the correct implementation of API Limitation value object
+     * based on provided identifier
+     *
+     * @param string $identifier
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\NotFound\LimitationNotFoundException
+     *
+     * @return \eZ\Publish\SPI\Limitation\Type
+     */
+    public function getLimitationType($identifier): Type;
+
+    /**
+     * Validates an array of Limitations.
+     *
+     * @uses ::validateLimitation()
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\BadStateException If the Role settings is in a bad state
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[][]
+     */
+    public function validateLimitations(array $limitations): array;
+
+    /**
+     * Validates single Limitation.
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitation
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\BadStateException If the Role settings is in a bad state
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If the Role settings is in a bad state
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateLimitation(Limitation $limitation): array;
+}

--- a/eZ/Publish/API/Repository/Repository.php
+++ b/eZ/Publish/API/Repository/Repository.php
@@ -185,6 +185,13 @@ interface Repository
     public function getRoleService();
 
     /**
+     * Get LimitationService.
+     *
+     * @return \eZ\Publish\API\Repository\LimitationService
+     */
+    public function getLimitationService();
+
+    /**
      * Get FieldTypeService.
      *
      * @return \eZ\Publish\API\Repository\FieldTypeService

--- a/eZ/Publish/API/Repository/Tests/LimitationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LimitationServiceTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests;
+
+use eZ\Publish\API\Repository\Exceptions\BadStateException;
+use eZ\Publish\API\Repository\Exceptions\NotFound\LimitationNotFoundException;
+use eZ\Publish\API\Repository\Values\Translation\Message;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\SPI\FieldType\ValidationError;
+use eZ\Publish\SPI\Limitation\Type;
+
+/**
+ * Test case for the LimitationService.
+ *
+ * @see \eZ\Publish\API\Repository\LimitationService
+ */
+class LimitationServiceTest extends BaseTest
+{
+    private const VALID_LIMITATION_VALUE = 2;
+    private const INVALID_LIMITATION_VALUE = 9999;
+
+    /**
+     * @covers \eZ\Publish\API\Repository\LimitationService::getLimitationType()
+     */
+    public function testGetLimitationType(): void
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $limitationService = $repository->getLimitationService();
+        $limitationType = $limitationService->getLimitationType(Limitation::CONTENTTYPE);
+        /* END: Use Case */
+
+        $this->assertInstanceOf(Type::class, $limitationType);
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\LimitationService::getLimitationType()
+     */
+    public function testGetLimitationTypeThrowsLimitationNotFoundExceptionOnInvalidIdentifier(): void
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $limitationService = $repository->getLimitationService();
+
+        $this->expectException(LimitationNotFoundException::class);
+        $limitationService->getLimitationType('foo');
+        /* END: Use Case */
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\LimitationService::validateLimitation()
+     */
+    public function testValidateLimitation(): void
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $limitationService = $repository->getLimitationService();
+        // $userPreferenceName is the name of an existing preference
+        $locationLimitation = new Limitation\LocationLimitation(['limitationValues' => [self::VALID_LIMITATION_VALUE]]);
+        $errors = $limitationService->validateLimitation($locationLimitation);
+        /* END: Use Case */
+
+        $this->assertEquals($errors, []);
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\LimitationService::validateLimitation()
+     */
+    public function testValidateLimitationReturnError(): void
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $limitationService = $repository->getLimitationService();
+        // $userPreferenceName is the name of an existing preference
+        $locationLimitation = new Limitation\LocationLimitation(['limitationValues' => [self::INVALID_LIMITATION_VALUE]]);
+        $errors = $limitationService->validateLimitation($locationLimitation);
+        /* END: Use Case */
+
+        $this->assertCount(1, $errors);
+        $this->assertInstanceOf(
+            ValidationError::class,
+            $errors[0]
+        );
+
+        $this->assertEquals(
+            new Message(
+                "limitationValues[%key%] => '%value%' does not exist in the backend",
+                ['value' => self::INVALID_LIMITATION_VALUE, 'key' => 0]
+            ),
+            $errors[0]->getTranslatableMessage()
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\LimitationService::validateLimitation()
+     */
+    public function testValidateLimitationThrowsBadStateExceptionOnInvalidLimitationIdentifier(): void
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $limitationService = $repository->getLimitationService();
+        // $userPreferenceName is the name of an existing preference
+
+        $limitationMock = $this->createMock(Limitation::class);
+        $limitationMock
+            ->method('getIdentifier')
+            ->willReturn('foo');
+
+        $this->expectException(BadStateException::class);
+        $limitationService->validateLimitation($limitationMock);
+        /* END: Use Case */
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\LimitationService::validateLimitations()
+     *
+     * @depends testValidateLimitation
+     * @depends testValidateLimitationReturnError
+     * @depends testValidateLimitationThrowsBadStateExceptionOnInvalidLimitationIdentifier
+     */
+    public function testValidateLimitations(): void
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $limitationService = $repository->getLimitationService();
+        // $userPreferenceName is the name of an existing preference
+        $locationLimitation = new Limitation\LocationLimitation(['limitationValues' => [self::VALID_LIMITATION_VALUE]]);
+        $sectionLimitation = new Limitation\SectionLimitation(['limitationValues' => [self::VALID_LIMITATION_VALUE]]);
+        $errors = $limitationService->validateLimitations([$locationLimitation, $sectionLimitation]);
+        /* END: Use Case */
+
+        $this->assertEquals($errors, []);
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\LimitationService::validateLimitations()
+     *
+     * @depends testValidateLimitation
+     * @depends testValidateLimitationReturnError
+     * @depends testValidateLimitationThrowsBadStateExceptionOnInvalidLimitationIdentifier
+     */
+    public function testValidateLimitationsReturnError(): void
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $limitationService = $repository->getLimitationService();
+        // $userPreferenceName is the name of an existing preference
+        $locationLimitation = new Limitation\LocationLimitation(['limitationValues' => [self::VALID_LIMITATION_VALUE]]);
+        $sectionLimitation = new Limitation\SectionLimitation(['limitationValues' => [self::INVALID_LIMITATION_VALUE]]);
+        $errors = $limitationService->validateLimitations([$locationLimitation, $sectionLimitation]);
+        /* END: Use Case */
+
+        $this->assertCount(1, $errors['Section']);
+        $this->assertInstanceOf(
+            ValidationError::class,
+            $errors['Section'][0]
+        );
+
+        $this->assertEquals(
+            new Message(
+                "limitationValues[%key%] => '%value%' does not exist in the backend",
+                ['value' => self::INVALID_LIMITATION_VALUE, 'key' => 0]
+            ),
+            $errors['Section'][0]->getTranslatableMessage()
+        );
+    }
+}

--- a/eZ/Publish/Core/Base/Exceptions/NotFound/LimitationNotFoundException.php
+++ b/eZ/Publish/Core/Base/Exceptions/NotFound/LimitationNotFoundException.php
@@ -12,12 +12,12 @@ use eZ\Publish\Core\Base\Exceptions\Httpable;
 use Exception;
 use eZ\Publish\Core\Base\TranslatableBase;
 use eZ\Publish\Core\Base\Translatable;
-use RuntimeException;
+use eZ\Publish\API\Repository\Exceptions\NotFound\LimitationNotFoundException as APILimitationNotFoundException;
 
 /**
  * Limitation Not Found Exception implementation.
  */
-class LimitationNotFoundException extends RuntimeException implements Httpable, Translatable
+class LimitationNotFoundException extends APILimitationNotFoundException implements Httpable, Translatable
 {
     use TranslatableBase;
 

--- a/eZ/Publish/Core/Helper/Tests/ContentInfoLocationLoader/SudoMainLocationLoaderTest.php
+++ b/eZ/Publish/Core/Helper/Tests/ContentInfoLocationLoader/SudoMainLocationLoaderTest.php
@@ -13,7 +13,7 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\Repository\Repository;
 use eZ\Publish\Core\Repository\Permission\PermissionResolver;
 use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
-use eZ\Publish\Core\Repository\Helper\LimitationService;
+use eZ\Publish\API\Repository\LimitationService;
 use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
 use eZ\Publish\API\Repository\Values\User\UserReference;
 use PHPUnit\Framework\TestCase;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/BaseTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/BaseTest.php
@@ -14,7 +14,7 @@ use eZ\Publish\Core\Repository\Permission\PermissionResolver;
 use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
 use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
-use eZ\Publish\Core\Repository\Helper\LimitationService;
+use eZ\Publish\API\Repository\LimitationService;
 use eZ\Publish\Core\MVC\Symfony\View\Provider\Location\Configured;
 use eZ\Publish\Core\Repository\Repository;
 use PHPUnit\Framework\TestCase;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Tests;
 
+use eZ\Publish\API\Repository\LimitationService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -18,7 +19,6 @@ use eZ\Publish\Core\Repository\Permission\PermissionResolver;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use eZ\Publish\Core\Repository\Helper\LimitationService;
 use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
 use eZ\Publish\Core\Repository\Repository;
 use eZ\Publish\Core\Repository\Values\Content\Location;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
@@ -8,12 +8,12 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;
 
+use eZ\Publish\API\Repository\LimitationService;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\User\User as ApiUser;
 use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\Core\MVC\Symfony\Security\Authentication\RememberMeRepositoryAuthenticationProvider;
 use eZ\Publish\Core\MVC\Symfony\Security\User;
-use eZ\Publish\Core\Repository\Helper\LimitationService;
 use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
 use eZ\Publish\Core\Repository\Permission\PermissionResolver;
 use eZ\Publish\SPI\Persistence\User\Handler as UserHandler;

--- a/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
@@ -11,12 +11,12 @@ namespace eZ\Publish\Core\Repository\Helper;
 use eZ\Publish\Core\Repository\Values\User\Policy;
 use eZ\Publish\Core\Repository\Values\User\PolicyDraft;
 use eZ\Publish\Core\Repository\Values\User\Role;
+use eZ\Publish\API\Repository\LimitationService;
 use eZ\Publish\API\Repository\Values\User\Role as APIRole;
 use eZ\Publish\Core\Repository\Values\User\RoleDraft;
 use eZ\Publish\API\Repository\Values\User\RoleCreateStruct as APIRoleCreateStruct;
 use eZ\Publish\Core\Repository\Values\User\UserRoleAssignment;
 use eZ\Publish\Core\Repository\Values\User\UserGroupRoleAssignment;
-use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
 use eZ\Publish\SPI\Persistence\User\Policy as SPIPolicy;
@@ -32,12 +32,12 @@ use eZ\Publish\SPI\Persistence\User\RoleCreateStruct as SPIRoleCreateStruct;
 class RoleDomainMapper
 {
     /**
-     * @var \eZ\Publish\Core\Repository\Helper\LimitationService
+     * @var \eZ\Publish\API\Repository\LimitationService
      */
     protected $limitationService;
 
     /**
-     * @param \eZ\Publish\Core\Repository\Helper\LimitationService $limitationService
+     * @param \eZ\Publish\API\Repository\LimitationService $limitationService
      */
     public function __construct(LimitationService $limitationService)
     {

--- a/eZ/Publish/Core/Repository/LimitationService.php
+++ b/eZ/Publish/Core/Repository/LimitationService.php
@@ -6,18 +6,18 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\Repository\Helper;
+namespace eZ\Publish\Core\Repository;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\Core\Base\Exceptions\NotFound\LimitationNotFoundException;
 use eZ\Publish\Core\Base\Exceptions\BadStateException;
+use eZ\Publish\API\Repository\LimitationService as LimitationServiceInterface;
+use eZ\Publish\SPI\Limitation\Type;
 
 /**
- * Internal service to deal with limitations and limitation types.
- *
- * @internal Meant for internal use by Repository.
+ * This service provides methods for managing Limitations.
  */
-class LimitationService
+class LimitationService implements LimitationServiceInterface
 {
     /**
      * @var array
@@ -34,18 +34,9 @@ class LimitationService
     }
 
     /**
-     * Returns the LimitationType registered with the given identifier.
-     *
-     * Returns the correct implementation of API Limitation value object
-     * based on provided identifier
-     *
-     * @param string $identifier
-     *
-     * @throws \eZ\Publish\Core\Base\Exceptions\NotFound\LimitationNotFoundException
-     *
-     * @return \eZ\Publish\SPI\Limitation\Type
+     * {@inheritdoc}
      */
-    public function getLimitationType($identifier)
+    public function getLimitationType($identifier): Type
     {
         if (!isset($this->settings['limitationTypes'][$identifier])) {
             throw new LimitationNotFoundException($identifier);
@@ -55,15 +46,9 @@ class LimitationService
     }
 
     /**
-     * Validates an array of Limitations.
-     *
-     * @uses ::validateLimitation()
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
-     *
-     * @return \eZ\Publish\Core\FieldType\ValidationError[][]
+     * {@inheritdoc}
      */
-    public function validateLimitations(array $limitations)
+    public function validateLimitations(array $limitations): array
     {
         $allErrors = array();
         foreach ($limitations as $limitation) {
@@ -77,15 +62,9 @@ class LimitationService
     }
 
     /**
-     * Validates single Limitation.
-     *
-     * @throws \eZ\Publish\Core\Base\Exceptions\BadStateException If the Role settings is in a bad state
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitation
-     *
-     * @return \eZ\Publish\Core\FieldType\ValidationError[]
+     * {@inheritdoc}
      */
-    public function validateLimitation(Limitation $limitation)
+    public function validateLimitation(Limitation $limitation): array
     {
         $identifier = $limitation->getIdentifier();
         if (!isset($this->settings['limitationTypes'][$identifier])) {
@@ -95,9 +74,7 @@ class LimitationService
             );
         }
 
-        /**
-         * @var \eZ\Publish\SPI\Limitation\Type
-         */
+        /** @var \eZ\Publish\SPI\Limitation\Type $type */
         $type = $this->settings['limitationTypes'][$identifier];
 
         // This will throw if it does not pass

--- a/eZ/Publish/Core/Repository/Permission/PermissionCriterionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionCriterionResolver.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\Repository\Permission;
 
+use eZ\Publish\API\Repository\LimitationService;
 use eZ\Publish\API\Repository\PermissionCriterionResolver as APIPermissionCriterionResolver;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOr;
@@ -13,7 +14,6 @@ use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\PermissionResolver as PermissionResolverInterface;
 use eZ\Publish\API\Repository\Values\User\UserReference;
-use eZ\Publish\Core\Repository\Helper\LimitationService;
 use eZ\Publish\Core\Limitation\TargetOnlyLimitationType;
 use RuntimeException;
 
@@ -28,7 +28,7 @@ class PermissionCriterionResolver implements APIPermissionCriterionResolver
     private $permissionResolver;
 
     /**
-     * @var \eZ\Publish\Core\Repository\Helper\LimitationService
+     * @var \eZ\Publish\API\Repository\LimitationService
      */
     private $limitationService;
 
@@ -36,7 +36,7 @@ class PermissionCriterionResolver implements APIPermissionCriterionResolver
      * Constructor.
      *
      * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
-     * @param \eZ\Publish\Core\Repository\Helper\LimitationService $limitationService
+     * @param \eZ\Publish\API\Repository\LimitationService $limitationService
      */
     public function __construct(
         PermissionResolverInterface $permissionResolver,

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -11,8 +11,8 @@ use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\API\Repository\LimitationService;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
-use eZ\Publish\Core\Repository\Helper\LimitationService;
 use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
 use eZ\Publish\SPI\Limitation\Type as LimitationType;
 use eZ\Publish\SPI\Persistence\User\Handler as UserHandler;
@@ -37,7 +37,7 @@ class PermissionResolver implements PermissionResolverInterface
     private $roleDomainMapper;
 
     /**
-     * @var \eZ\Publish\Core\Repository\Helper\LimitationService
+     * @var \eZ\Publish\API\Repository\LimitationService
      */
     private $limitationService;
 
@@ -62,7 +62,7 @@ class PermissionResolver implements PermissionResolverInterface
 
     /**
      * @param \eZ\Publish\Core\Repository\Helper\RoleDomainMapper $roleDomainMapper
-     * @param \eZ\Publish\Core\Repository\Helper\LimitationService $limitationService
+     * @param \eZ\Publish\API\Repository\LimitationService $limitationService
      * @param \eZ\Publish\SPI\Persistence\User\Handler $userHandler
      * @param \eZ\Publish\API\Repository\Values\User\UserReference $userReference
      * @param array $policyMap Map of system configured policies, for validation usage.

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -220,7 +220,7 @@ class Repository implements RepositoryInterface
     /**
      * Instance of role service.
      *
-     * @var \eZ\Publish\Core\Repository\Helper\LimitationService
+     * @var \eZ\Publish\API\Repository\LimitationService
      */
     protected $limitationService;
 
@@ -774,15 +774,15 @@ class Repository implements RepositoryInterface
     /**
      * Get LimitationService.
      *
-     * @return \eZ\Publish\Core\Repository\Helper\LimitationService
+     * @return \eZ\Publish\API\Repository\LimitationService
      */
-    protected function getLimitationService()
+    public function getLimitationService()
     {
         if ($this->limitationService !== null) {
             return $this->limitationService;
         }
 
-        $this->limitationService = new Helper\LimitationService($this->serviceSettings['role']);
+        $this->limitationService = new LimitationService($this->serviceSettings['role']);
 
         return $this->limitationService;
     }

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -9,9 +9,9 @@
 namespace eZ\Publish\Core\Repository;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
+use eZ\Publish\API\Repository\LimitationService;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\RoleService as RoleServiceInterface;
-use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\Policy as APIPolicy;
 use eZ\Publish\API\Repository\Values\User\PolicyCreateStruct as APIPolicyCreateStruct;
@@ -28,15 +28,12 @@ use eZ\Publish\Core\Base\Exceptions\BadStateException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 use eZ\Publish\Core\Base\Exceptions\LimitationValidationException;
-use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\NotFound\LimitationNotFoundException;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
-use eZ\Publish\Core\Repository\Values\User\Policy;
 use eZ\Publish\Core\Repository\Values\User\PolicyCreateStruct;
 use eZ\Publish\Core\Repository\Values\User\PolicyUpdateStruct;
 use eZ\Publish\Core\Repository\Values\User\Role;
 use eZ\Publish\Core\Repository\Values\User\RoleCreateStruct;
-use eZ\Publish\Core\Repository\Values\User\RoleDraft;
 use eZ\Publish\SPI\Persistence\User\Handler;
 use eZ\Publish\SPI\Persistence\User\Role as SPIRole;
 use eZ\Publish\SPI\Persistence\User\RoleUpdateStruct as SPIRoleUpdateStruct;
@@ -58,7 +55,7 @@ class RoleService implements RoleServiceInterface
     protected $userHandler;
 
     /**
-     * @var \eZ\Publish\Core\Repository\Helper\LimitationService
+     * @var \eZ\Publish\API\Repository\LimitationService
      */
     protected $limitationService;
 
@@ -77,14 +74,14 @@ class RoleService implements RoleServiceInterface
      *
      * @param \eZ\Publish\API\Repository\Repository $repository
      * @param \eZ\Publish\SPI\Persistence\User\Handler $userHandler
-     * @param \eZ\Publish\Core\Repository\Helper\LimitationService $limitationService
+     * @param \eZ\Publish\API\Repository\LimitationService $limitationService
      * @param \eZ\Publish\Core\Repository\Helper\RoleDomainMapper $roleDomainMapper
      * @param array $settings
      */
     public function __construct(
         RepositoryInterface $repository,
         Handler $userHandler,
-        Helper\LimitationService $limitationService,
+        LimitationService $limitationService,
         Helper\RoleDomainMapper $roleDomainMapper,
         array $settings = array()
     ) {

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Repository.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Repository.php
@@ -170,6 +170,11 @@ class Repository implements RepositoryInterface
         return $this->repository->getRoleService();
     }
 
+    public function getLimitationService()
+    {
+        return $this->repository->getLimitationService();
+    }
+
     public function getSearchService()
     {
         return $this->searchService;

--- a/eZ/Publish/Core/Repository/Tests/Permission/PermissionCriterionResolverTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Permission/PermissionCriterionResolverTest.php
@@ -13,9 +13,9 @@ use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\Core\Limitation\TargetOnlyLimitationType;
+use eZ\Publish\API\Repository\LimitationService;
 use eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver;
 use eZ\Publish\Core\Repository\Values\User\Policy;
-use eZ\Publish\Core\Repository\Helper\LimitationService;
 use eZ\Publish\SPI\Limitation\Type;
 use PHPUnit\Framework\TestCase;
 
@@ -412,10 +412,6 @@ class PermissionCriterionResolverTest extends TestCase
             return $this->limitationServiceMock;
         }
 
-        return $this->limitationServiceMock = $this
-            ->getMockBuilder(LimitationService::class)
-            ->setMethods($methods)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->limitationServiceMock = $this->createMock(LimitationService::class);
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionTest.php
@@ -9,7 +9,7 @@ namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\Core\Repository\Helper\LimitationService;
+use eZ\Publish\API\Repository\LimitationService;
 use eZ\Publish\Core\Repository\Permission\PermissionResolver;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
 use eZ\Publish\Core\Repository\Repository as CoreRepository;
@@ -130,7 +130,7 @@ class PermissionTest extends BaseServiceMockTest
 
         $result = $mockedService->hasAccess('dummy-module', 'dummy-function');
 
-        self::assertEquals(true, $result);
+        self::assertTrue($result);
     }
 
     public function providerForTestHasAccessReturnsFalse()
@@ -207,7 +207,7 @@ class PermissionTest extends BaseServiceMockTest
 
         $result = $service->hasAccess('dummy-module2', 'dummy-function2');
 
-        self::assertEquals(false, $result);
+        self::assertFalse($result);
     }
 
     /**
@@ -235,7 +235,7 @@ class PermissionTest extends BaseServiceMockTest
             $repositoryMock
         );
 
-        self::assertEquals(true, $result);
+        self::assertTrue($result);
     }
 
     /**
@@ -1108,7 +1108,7 @@ class PermissionTest extends BaseServiceMockTest
     protected $limitationServiceMock;
 
     /**
-     * @return \eZ\Publish\Core\Repository\Helper\LimitationService|\PHPUnit\Framework\MockObject\MockObject
+     * @return \eZ\Publish\API\Repository\LimitationService|\PHPUnit\Framework\MockObject\MockObject
      */
     protected function getLimitationServiceMock($methods = [])
     {

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
@@ -13,8 +13,8 @@ use eZ\Publish\Core\Repository\PermissionsCriterionHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Values\User\Limitation as APILimitation;
+use eZ\Publish\API\Repository\LimitationService;
 use eZ\Publish\Core\Repository\Values\User\Policy;
-use eZ\Publish\Core\Repository\Helper\LimitationService;
 
 /**
  * Mock test case for PermissionCriterionHandler.
@@ -434,11 +434,7 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
     protected function getLimitationServiceMock($methods = [])
     {
         if ($this->limitationServiceMock === null) {
-            $this->limitationServiceMock = $this
-                ->getMockBuilder(LimitationService::class)
-                ->setMethods($methods)
-                ->disableOriginalConstructor()
-                ->getMock();
+            $this->limitationServiceMock = $this->createMock(LimitationService::class);
         }
 
         return $this->limitationServiceMock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RoleTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RoleTest.php
@@ -18,6 +18,7 @@ use eZ\Publish\API\Repository\Values\User\RoleCreateStruct;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
 use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
+use eZ\Publish\Core\Repository\LimitationService;
 use eZ\Publish\Core\Repository\RoleService;
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
@@ -35,8 +36,8 @@ class RoleTest extends BaseServiceMockTest
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::createRole
      * @covers \eZ\Publish\Core\Repository\RoleService::validateRoleCreateStruct
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitations
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitations
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\LimitationValidationException
      */
     public function testCreateRoleThrowsLimitationValidationException()
@@ -102,8 +103,8 @@ class RoleTest extends BaseServiceMockTest
      * Test for the addPolicy() method.
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::addPolicy
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitations
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitations
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\LimitationValidationException
      */
     public function testAddPolicyThrowsLimitationValidationException()
@@ -168,8 +169,8 @@ class RoleTest extends BaseServiceMockTest
      * Test for the updatePolicy() method.
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::updatePolicy
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitations
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitations
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\LimitationValidationException
      */
     public function testUpdatePolicyThrowsLimitationValidationException()
@@ -265,7 +266,7 @@ class RoleTest extends BaseServiceMockTest
      * Test for the assignRoleToUser() method.
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::assignRoleToUser
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\LimitationValidationException
      */
     public function testAssignRoleToUserThrowsLimitationValidationException()
@@ -314,7 +315,7 @@ class RoleTest extends BaseServiceMockTest
      * Test for the assignRoleToUser() method.
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::assignRoleToUser
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\BadStateException
      */
     public function testAssignRoleToUserThrowsBadStateException()
@@ -348,7 +349,7 @@ class RoleTest extends BaseServiceMockTest
      * Test for the assignRoleToUser() method.
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::assignRoleToUser
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      */
     public function testAssignRoleToUser()
     {
@@ -433,7 +434,7 @@ class RoleTest extends BaseServiceMockTest
      * Test for the assignRoleToUser() method.
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::assignRoleToUser
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      */
     public function testAssignRoleToUserWithNullLimitation()
     {
@@ -497,7 +498,7 @@ class RoleTest extends BaseServiceMockTest
      * Test for the assignRoleToUser() method.
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::assignRoleToUser
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      * @expectedException \Exception
      */
     public function testAssignRoleToUserWithRollback()
@@ -589,7 +590,7 @@ class RoleTest extends BaseServiceMockTest
      * Test for the assignRoleToUserGroup() method.
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::assignRoleToUserGroup
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\LimitationValidationException
      */
     public function testAssignRoleToUserGroupThrowsLimitationValidationException()
@@ -638,7 +639,7 @@ class RoleTest extends BaseServiceMockTest
      * Test for the assignRoleToUserGroup() method.
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::assignRoleToUserGroup
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\BadStateException
      */
     public function testAssignRoleGroupToUserThrowsBadStateException()
@@ -672,7 +673,7 @@ class RoleTest extends BaseServiceMockTest
      * Test for the assignRoleToUserGroup() method.
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::assignRoleToUserGroup
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      */
     public function testAssignRoleToUserGroup()
     {
@@ -761,7 +762,7 @@ class RoleTest extends BaseServiceMockTest
      * Test for the assignRoleToUserGroup() method.
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::assignRoleToUserGroup
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      */
     public function testAssignRoleToUserGroupWithNullLimitation()
     {
@@ -829,7 +830,7 @@ class RoleTest extends BaseServiceMockTest
      * Test for the assignRoleToUserGroup() method.
      *
      * @covers \eZ\Publish\Core\Repository\RoleService::assignRoleToUserGroup
-     * @covers \eZ\Publish\Core\Repository\Helper\LimitationService::validateLimitation
+     * @covers \eZ\Publish\Core\Repository\LimitationService::validateLimitation
      * @expectedException \Exception
      */
     public function testAssignRoleToUserGroupWithRollback()
@@ -1056,12 +1057,12 @@ class RoleTest extends BaseServiceMockTest
      * @param string[] $methods
      * @param array $settings
      *
-     * @return \eZ\Publish\Core\Repository\Helper\LimitationService|\PHPUnit\Framework\MockObject\MockObject
+     * @return \eZ\Publish\Core\Repository\LimitationService|\PHPUnit\Framework\MockObject\MockObject
      */
     protected function getPartlyMockedLimitationService(array $methods = null, array $settings = array())
     {
         if (!isset($this->partlyMockedLimitationService) || !empty($settings)) {
-            $this->partlyMockedLimitationService = $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\Helper\\LimitationService')
+            $this->partlyMockedLimitationService = $this->getMockBuilder(LimitationService::class)
                 ->setMethods($methods)
                 ->setConstructorArgs(
                     array(

--- a/eZ/Publish/Core/SignalSlot/LimitationService.php
+++ b/eZ/Publish/Core/SignalSlot/LimitationService.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * LimitationService class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\SignalSlot;
+
+use eZ\Publish\API\Repository\LimitationService as LimitationServiceInterface;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\SPI\Limitation\Type;
+
+class LimitationService implements LimitationServiceInterface
+{
+    /**
+     * Aggregated service.
+     *
+     * @var \eZ\Publish\API\Repository\LimitationService
+     */
+    protected $service;
+
+    /**
+     * SignalDispatcher.
+     *
+     * @var \eZ\Publish\Core\SignalSlot\SignalDispatcher
+     */
+    protected $signalDispatcher;
+
+    /**
+     * Construct service object from aggregated service and signal dispatcher.
+     *
+     * @param \eZ\Publish\API\Repository\LimitationService $service
+     * @param \eZ\Publish\Core\SignalSlot\SignalDispatcher $signalDispatcher
+     */
+    public function __construct(LimitationServiceInterface $service, SignalDispatcher $signalDispatcher)
+    {
+        $this->service = $service;
+        $this->signalDispatcher = $signalDispatcher;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLimitationType($identifier): Type
+    {
+        return $this->service->getLimitationType($identifier);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateLimitations(array $limitations): array
+    {
+        return $this->service->validateLimitations($limitations);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateLimitation(Limitation $limitation): array
+    {
+        return $this->service->validateLimitation($limitation);
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/Repository.php
+++ b/eZ/Publish/Core/SignalSlot/Repository.php
@@ -54,6 +54,13 @@ class Repository implements RepositoryInterface
     protected $roleService;
 
     /**
+     * Instance of limitation service.
+     *
+     * @var \eZ\Publish\API\Repository\LimitationService
+     */
+    protected $limitationService;
+
+    /**
      * Instance of search service.
      *
      * @var \eZ\Publish\API\Repository\SearchService
@@ -173,6 +180,7 @@ class Repository implements RepositoryInterface
      * @param \eZ\Publish\Core\SignalSlot\BookmarkService $bookmarkService
      * @param \eZ\Publish\API\Repository\NotificationService $notificationService
      * @param \eZ\Publish\Core\SignalSlot\UserPreferenceService $userPreferenceService
+     * @param \eZ\Publish\Core\SignalSlot\LimitationService $limitationService
      */
     public function __construct(
         RepositoryInterface $repository,
@@ -193,7 +201,8 @@ class Repository implements RepositoryInterface
         URLService $urlService,
         BookmarkService $bookmarkService,
         NotificationService $notificationService,
-        UserPreferenceService $userPreferenceService
+        UserPreferenceService $userPreferenceService,
+        LimitationService $limitationService
     ) {
         $this->signalDispatcher = $signalDispatcher;
         $this->repository = $repository;
@@ -214,6 +223,7 @@ class Repository implements RepositoryInterface
         $this->bookmarkService = $bookmarkService;
         $this->notificationService = $notificationService;
         $this->userPreferenceService = $userPreferenceService;
+        $this->limitationService = $limitationService;
     }
 
     /**
@@ -485,6 +495,16 @@ class Repository implements RepositoryInterface
     public function getRoleService()
     {
         return $this->roleService;
+    }
+
+    /**
+     * Get LimitationService.
+     *
+     * @return \eZ\Publish\API\Repository\LimitationService
+     */
+    public function getLimitationService()
+    {
+        return $this->limitationService;
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/Tests/LimitationServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/LimitationServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\SignalSlot\Tests;
+
+use eZ\Publish\API\Repository\LimitationService as APILimitationService;
+use eZ\Publish\Core\SignalSlot\LimitationService;
+use eZ\Publish\Core\SignalSlot\SignalDispatcher;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\SPI\Limitation\Type as LimitationInterface;
+
+class LimitationServiceTest extends ServiceTest
+{
+    /**
+     * This method is a dataProvider for \eZ\Publish\Core\SignalSlot\Tests\ServiceTest::testService.
+     *
+     * Should return array in following format:
+     *
+     *```php
+     * [
+     *     [
+     *         $originalServiceMethodName,
+     *         $methodArguments
+     *         $returnedValueFromServiceMethod
+     *         $numberOfSignalsEmitted,
+     *         $signalClass = '',
+     *         array $signalArguments = null
+     *     ],
+     *     ...
+     * ]
+     *
+     * ```
+     *
+     * @return array
+     */
+    public function serviceProvider(): array
+    {
+        return [
+            [
+                'getLimitationType',
+                [Limitation::LOCATION],
+                $this->createMock(LimitationInterface::class),
+                0,
+            ],
+            [
+                'validateLimitations',
+                [[new Limitation\LocationLimitation(['limitationValues' => [2]])]],
+                [],
+                0,
+            ],
+            [
+                'validateLimitation',
+                [new Limitation\LocationLimitation(['limitationValues' => [2]])],
+                [],
+                0,
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getServiceMock()
+    {
+        return $this->createMock(APILimitationService::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getSignalSlotService($innerService, SignalDispatcher $dispatcher)
+    {
+        return new LimitationService($innerService, $dispatcher);
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/Tests/RepositoryTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/RepositoryTest.php
@@ -7,6 +7,7 @@
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
 use eZ\Publish\API\Repository\BookmarkService;
+use eZ\Publish\Core\SignalSlot\LimitationService;
 use eZ\Publish\Core\SignalSlot\NotificationService;
 use eZ\Publish\Core\SignalSlot\UserPreferenceService;
 use eZ\Publish\Core\SignalSlot\Repository;
@@ -57,6 +58,7 @@ class RepositoryTest extends TestCase
         $bookmarkServiceMock = $this->getMockBuilder(BookmarkService::class)->disableOriginalConstructor()->getMock();
         $notificationServiceMock = $this->getMockBuilder(NotificationService::class)->disableOriginalConstructor()->getMock();
         $userPreferenceServiceMock = $this->getMockBuilder(UserPreferenceService::class)->disableOriginalConstructor()->getMock();
+        $limitationServiceMock = $this->getMockBuilder(LimitationService::class)->disableOriginalConstructor()->getMock();
 
         $repository = new Repository(
             $innerRepositoryMock,
@@ -77,7 +79,8 @@ class RepositoryTest extends TestCase
             $urlServiceMock,
             $bookmarkServiceMock,
             $notificationServiceMock,
-            $userPreferenceServiceMock
+            $userPreferenceServiceMock,
+            $limitationServiceMock
         );
 
         $service = $repository->{$method}();
@@ -130,6 +133,7 @@ class RepositoryTest extends TestCase
         $urlServiceMock = $this->getMockBuilder(URLService::class)->disableOriginalConstructor()->getMock();
         $notificationServiceMock = $this->getMockBuilder(NotificationService::class)->disableOriginalConstructor()->getMock();
         $userPreferenceServiceMock = $this->getMockBuilder(UserPreferenceService::class)->disableOriginalConstructor()->getMock();
+        $limitationServiceMock = $this->getMockBuilder(LimitationService::class)->disableOriginalConstructor()->getMock();
 
         $innerRepositoryMock->expects($this->once())
             ->method($method)
@@ -158,7 +162,8 @@ class RepositoryTest extends TestCase
             $urlServiceMock,
             $bookmarkServiceMock,
             $notificationServiceMock,
-            $userPreferenceServiceMock
+            $userPreferenceServiceMock,
+            $limitationServiceMock
         );
 
         $result = call_user_func_array([$repository, $method], $parameters);

--- a/eZ/Publish/Core/settings/limitation.yml
+++ b/eZ/Publish/Core/settings/limitation.yml
@@ -1,0 +1,3 @@
+services:
+    eZ\Publish\API\Repository\LimitationService:
+        alias: eZ\Publish\Core\SignalSlot\LimitationService

--- a/eZ/Publish/Core/settings/repository.yml
+++ b/eZ/Publish/Core/settings/repository.yml
@@ -71,3 +71,7 @@ services:
     ezpublish.api.service.user_preference:
         alias: eZ\Publish\Core\SignalSlot\UserPreferenceService
         public: true
+
+    ezpublish.api.service.limitation:
+        alias: eZ\Publish\Core\SignalSlot\LimitationService
+        public: true

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -18,6 +18,7 @@ parameters:
     ezpublish.api.service.bookmark.class: eZ\Publish\Core\Repository\BookmarkService
     ezpublish.api.service.notification.class: eZ\Publish\Core\Repository\NotificationService
     ezpublish.api.service.user_preference.class: eZ\Publish\Core\Repository\UserPreferenceService
+    ezpublish.api.service.limitation.class: eZ\Publish\Core\Repository\LimitationService
 
     ezpublish.field_type_collection.factory.class: eZ\Publish\Core\Base\Container\ApiLoader\FieldTypeCollectionFactory
     ezpublish.field_type_nameable_collection.factory.class: eZ\Publish\Core\Base\Container\ApiLoader\FieldTypeNameableCollectionFactory
@@ -131,6 +132,11 @@ services:
     ezpublish.api.service.inner_user_preference:
         class: '%ezpublish.api.service.user_preference.class%'
         factory: ["@ezpublish.api.inner_repository", getUserPreferenceService]
+        lazy: true
+
+    ezpublish.api.service.inner_limitation:
+        class: '%ezpublish.api.service.limitation.class%'
+        factory: ["@ezpublish.api.inner_repository", getLimitationService]
         lazy: true
 
     # Factories

--- a/eZ/Publish/Core/settings/repository/signalslot.yml
+++ b/eZ/Publish/Core/settings/repository/signalslot.yml
@@ -44,6 +44,7 @@ services:
             - "@ezpublish.signalslot.service.bookmark"
             - '@eZ\Publish\Core\SignalSlot\NotificationService'
             - '@eZ\Publish\Core\SignalSlot\UserPreferenceService'
+            - '@eZ\Publish\Core\SignalSlot\LimitationService'
 
     ezpublish.signalslot.service.content:
         class: "%ezpublish.signalslot.service.content.class%"
@@ -143,6 +144,11 @@ services:
     eZ\Publish\Core\SignalSlot\UserPreferenceService:
         arguments:
             - "@ezpublish.api.service.inner_user_preference"
+            - "@ezpublish.signalslot.signal_dispatcher_transaction_wrapper"
+
+    eZ\Publish\Core\SignalSlot\LimitationService:
+        arguments:
+            - "@ezpublish.api.service.inner_limitation"
             - "@ezpublish.signalslot.signal_dispatcher_transaction_wrapper"
 
     # Single slot internal services


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30087](https://jira.ez.no/browse/EZP-30087)
| **Bug/Improvement**|no
| **New feature**    | yes
| **Target version** | `master` 
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     | yes

This is needed to allow fetching possible languages and CT's for location in which user want to create a content item in ContentOnTheFly. The other thing is to make LimitationService a part of the API, because of clients who extend our Limitation system and maybe wants LimitationService as a part of the API.

Relates to: [https://github.com/ezsystems/ezplatform-admin-ui/pull/818](https://github.com/ezsystems/ezplatform-admin-ui/pull/818)

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
