### PR TITLE
EZP-30111: [REST] Added Content status to RestContent output

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -291,6 +291,7 @@ XML Example
                         <mainLanguageCode>eng-GB</mainLanguageCode>
                         <currentVersionNo>9</currentVersionNo>
                         <alwaysAvailable>true</alwaysAvailable>
+                        <status>PUBLISHED</status>
                         <ObjectStates media-type="application/vnd.ez.api.ContentObjectStates+xml" href="/api/ezp/v2/content/objects/1/objectstates"/>
                     </Content>
                 </ContentInfo>
@@ -379,6 +380,7 @@ JSON Example
                                 "mainLanguageCode": "eng-GB",
                                 "currentVersionNo": 9,
                                 "alwaysAvailable": true,
+                                "status": "PUBLISHED",
                                 "ObjectStates": {
                                     "_media-type": "application/vnd.ez.api.ContentObjectStates+json",
                                     "_href": "/api/ezp/v2/content/objects/1/objectstates"
@@ -859,6 +861,7 @@ XML Example
       <mainLanguageCode>eng-US</mainLanguageCode>
       <currentVersionNo>1</currentVersionNo>
       <alwaysAvailable>true</alwaysAvailable>
+      <status>PUBLISHED</status>
     </Content>
 
 JSON Example
@@ -1025,7 +1028,8 @@ JSON Example
         "lastModificationDate": "2012-02-12T12:30:00",
         "mainLanguageCode": "eng-US",
         "currentVersionNo": "1",
-        "alwaysAvailable": true
+        "alwaysAvailable": true,
+        "status": "PUBLISHED"
       }
     }
 
@@ -1120,6 +1124,7 @@ XML Example
       <mainLanguageCode>eng-US</mainLanguageCode>
       <currentVersionNo>1</currentVersionNo>
       <alwaysAvailable>true</alwaysAvailable>
+      <status>PUBLISHED</status>
     </Content>
 
 
@@ -1216,6 +1221,7 @@ In this example
       <mainLanguageCode>ger-DE</mainLanguageCode>
       <currentVersionNo>1</currentVersionNo>
       <alwaysAvailable>false</alwaysAvailable>
+      <status>PUBLISHED</status>
     </Content>
 
 Delete Content
@@ -7045,6 +7051,7 @@ Content XML Schema
               <xsd:element name="mainLanguageCode" type="xsd:string" />
               <xsd:element name="currentVersionNo" type="xsd:int" />
               <xsd:element name="alwaysAvailable" type="xsd:boolean" />
+              <xsd:element name="status" type="xsd:string" />
             </xsd:all>
             <xsd:attribute name="id" type="xsd:int" />
             <xsd:attribute name="remoteId" type="xsd:string" />

--- a/doc/specifications/rest/xsd/Content.xsd
+++ b/doc/specifications/rest/xsd/Content.xsd
@@ -29,6 +29,7 @@
           <xsd:element name="mainLanguageCode" type="xsd:string" />
           <xsd:element name="currentVersionNo" type="xsd:int" />
           <xsd:element name="alwaysAvailable" type="xsd:boolean" />
+          <xsd:element name="status" type="xsd:string" />
           <xsd:element name="ObjectStates" type="ref" />
         </xsd:all>
         <xsd:attribute name="id" type="xsd:int" />

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
@@ -9,7 +9,7 @@
 namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\Core\Base\Exceptions\BadStateException;
+use eZ\Publish\Core\Base\Exceptions\BadStateException as CoreBadStateException;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
@@ -221,6 +221,6 @@ class RestContent extends ValueObjectVisitor
                 return 'TRASHED';
         }
 
-        throw new BadStateException('status', $status);
+        throw new CoreBadStateException('status', $status);
     }
 }

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\Base\Exceptions\BadStateException;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
@@ -177,6 +179,12 @@ class RestContent extends ValueObjectVisitor
         );
         $generator->endValueElement('alwaysAvailable');
 
+        $generator->startValueElement(
+            'status',
+            $this->getStatusString($contentInfo->status)
+        );
+        $generator->endValueElement('status');
+
         $generator->startObjectElement('ObjectStates', 'ContentObjectStates');
         $generator->startAttribute(
             'href',
@@ -189,5 +197,30 @@ class RestContent extends ValueObjectVisitor
         $generator->endObjectElement('ObjectStates');
 
         $generator->endObjectElement('Content');
+    }
+
+    /**
+     * Maps the given content $status to a representative string.
+     *
+     * @param int $status
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\BadStateException
+     *
+     * @return string
+     */
+    protected function getStatusString($status)
+    {
+        switch ($status) {
+            case ContentInfo::STATUS_DRAFT:
+                return 'DRAFT';
+
+            case ContentInfo::STATUS_PUBLISHED:
+                return 'PUBLISHED';
+
+            case ContentInfo::STATUS_TRASHED:
+                return 'TRASHED';
+        }
+
+        throw new BadStateException('status', $status);
     }
 }

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTest.php
@@ -109,6 +109,7 @@ class RestContentTest extends ValueObjectVisitorBaseTest
                     'modificationDate' => new \DateTime('2012-09-05 15:27 Europe/Berlin'),
                     'publishedDate' => null,
                     'alwaysAvailable' => true,
+                    'status' => ContentInfo::STATUS_PUBLISHED,
                     'remoteId' => 'abc123',
                     'mainLanguageCode' => 'eng-US',
                     'mainLocationId' => 'location23',
@@ -352,6 +353,16 @@ class RestContentTest extends ValueObjectVisitorBaseTest
     public function testAlwaysAvailableCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/Content/alwaysAvailable[text()="true"]');
+    }
+
+    /**
+     * @param \DOMDocument $dom
+     *
+     * @depends testVisitWithoutEmbeddedVersion
+     */
+    public function testStatusCorrect(\DOMDocument $dom)
+    {
+        $this->assertXPath($dom, '/Content/status[text()="PUBLISHED"]');
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30111](https://jira.ez.no/browse/EZP-30111)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Currently I do not have the opportunity to know if the content is in the trash, right?
The code is similar to the VersionInfo output visitor

**TODO**:
- [x] Implement feature.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
