### PR TITLE
Improve loadBookmarks() handling on Unauthorized locations

### DIFF
--- a/eZ/Publish/Core/Repository/BookmarkService.php
+++ b/eZ/Publish/Core/Repository/BookmarkService.php
@@ -105,9 +105,17 @@ class BookmarkService implements BookmarkServiceInterface
         if ($list->totalCount > 0) {
             $bookmarks = $this->bookmarkHandler->loadUserBookmarks($currentUserId, $offset, $limit);
 
+            // https://jira.ez.no/browse/EZP-30120 
+            // The bookmark page should not crash if the user has content in his bookmark that he is not allowed to read. 
             $list->items = array_map(function (Bookmark $bookmark) {
                 return $this->repository->getLocationService()->loadLocation($bookmark->locationId);
+                try {
+                } catch (UnauthorizedException $e) {
+                    // TODO Warning
+                    return null;
+                }
             }, $bookmarks);
+            $list->items = array_filter($list->items);
         }
 
         return $list;

--- a/eZ/Publish/Core/Repository/BookmarkService.php
+++ b/eZ/Publish/Core/Repository/BookmarkService.php
@@ -105,17 +105,13 @@ class BookmarkService implements BookmarkServiceInterface
         if ($list->totalCount > 0) {
             $bookmarks = $this->bookmarkHandler->loadUserBookmarks($currentUserId, $offset, $limit);
 
-            // https://jira.ez.no/browse/EZP-30120 
-            // The bookmark page should not crash if the user has content in his bookmark that he is not allowed to read. 
-            $list->items = array_map(function (Bookmark $bookmark) {
-                return $this->repository->getLocationService()->loadLocation($bookmark->locationId);
-                try {
-                } catch (UnauthorizedException $e) {
-                    // TODO Warning
-                    return null;
-                }
+            // https://jira.ez.no/browse/EZP-30120
+            // The bookmark page should not crash if the user has content in his bookmark that he is not allowed to read.
+            // V2 with loadLocationList().
+            $locationIdList = array_map(function (Bookmark $bookmark) {
+                return $bookmark->locationId;
             }, $bookmarks);
-            $list->items = array_filter($list->items);
+            $list->items = $this->repository->getLocationService()->loadLocationList($locationIdList);
         }
 
         return $list;


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-30120 
The bookmark page should not crash if the user has content in his bookmark that he is not allowed to read.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30120](https://jira.ez.no/browse/EZP-30120)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `2.5`



**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
