### PR TITLE
EZP-30136: Updating content with "ezuser" field will not commit changes to Solr

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -324,6 +324,38 @@ class SearchEngineIndexingTest extends BaseTest
     }
 
     /**
+     * Test that a newly updated user is available for search.
+     */
+    public function testUpdateUser()
+    {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+        $contentService = $repository->getContentService();
+        $searchService = $repository->getSearchService();
+
+        $user = $this->createUserVersion1();
+
+        $newName = 'Drizzt Do\'Urden';
+        $userUpdate = $userService->newUserUpdateStruct();
+        $userUpdate->contentUpdateStruct = $contentService->newContentUpdateStruct();
+        $userUpdate->contentUpdateStruct->setField('first_name', $newName);
+
+        $userService->updateUser($user, $userUpdate);
+
+        $this->refreshSearch($repository);
+
+        // Should be found
+        $query = new Query(
+            [
+                'query' => new Criterion\FullText($newName),
+            ]
+        );
+        $result = $searchService->findContentInfo($query);
+
+        $this->assertEquals(1, $result->totalCount);
+    }
+
+    /**
      * Test that a newly created user group is available for search.
      */
     public function testCreateUserGroup()

--- a/eZ/Publish/Core/Search/Common/Slot/UpdateUser.php
+++ b/eZ/Publish/Core/Search/Common/Slot/UpdateUser.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\Core\Search\Common\Slot;
+
+/**
+ * A Search Engine slot handling UpdateUserSignal.
+ */
+class UpdateUser extends Slot
+{
+    /**
+     * Receive the given $signal and react on it.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     */
+    public function receive(Signal $signal)
+    {
+        if (!$signal instanceof Signal\UserService\UpdateUserSignal) {
+            return;
+        }
+
+        $userContentInfo = $this->persistenceHandler->contentHandler()->loadContentInfo(
+            $signal->userId
+        );
+
+        $this->searchHandler->indexContent(
+            $this->persistenceHandler->contentHandler()->load(
+                $userContentInfo->id,
+                $userContentInfo->currentVersionNo
+            )
+        );
+
+        $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent(
+            $userContentInfo->id
+        );
+        foreach ($locations as $location) {
+            $this->searchHandler->indexLocation($location);
+        }
+    }
+}

--- a/eZ/Publish/Core/settings/search_engines/elasticsearch/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/elasticsearch/slots.yml
@@ -9,6 +9,7 @@ parameters:
     ezpublish.search.elasticsearch.slot.delete_location.class: eZ\Publish\Core\Search\Common\Slot\DeleteLocation
     ezpublish.search.elasticsearch.slot.create_user.class: eZ\Publish\Core\Search\Common\Slot\CreateUser
     ezpublish.search.elasticsearch.slot.delete_user.class: eZ\Publish\Core\Search\Common\Slot\DeleteUser
+    ezpublish.search.elasticsearch.slot.update_user.class: eZ\Publish\Core\Search\Common\Slot\UpdateUser
     ezpublish.search.elasticsearch.slot.create_user_group.class: eZ\Publish\Core\Search\Common\Slot\CreateUserGroup
     ezpublish.search.elasticsearch.slot.move_user_group.class: eZ\Publish\Core\Search\Common\Slot\MoveUserGroup
     ezpublish.search.elasticsearch.slot.delete_user_group.class: eZ\Publish\Core\Search\Common\Slot\DeleteUserGroup
@@ -86,6 +87,12 @@ services:
         class: "%ezpublish.search.elasticsearch.slot.delete_user.class%"
         tags:
             - {name: ezpublish.search.elasticsearch.slot, signal: UserService\DeleteUserSignal}
+
+    ezpublish.search.elasticsearch.slot.update_user:
+        parent: ezpublish.search.elasticsearch.slot
+        class: "%ezpublish.search.elasticsearch.slot.update_user.class%"
+        tags:
+            - {name: ezpublish.search.elasticsearch.slot, signal: UserService\UpdateUserSignal}
 
     ezpublish.search.elasticsearch.slot.create_user_group:
         parent: ezpublish.search.elasticsearch.slot

--- a/eZ/Publish/Core/settings/search_engines/legacy/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/slots.yml
@@ -11,6 +11,7 @@ parameters:
     ezpublish.search.legacy.slot.assign_section.class: eZ\Publish\Core\Search\Common\Slot\AssignSection
     ezpublish.search.legacy.slot.create_user.class: eZ\Publish\Core\Search\Common\Slot\CreateUser
     ezpublish.search.legacy.slot.delete_user.class: eZ\Publish\Core\Search\Common\Slot\DeleteUser
+    ezpublish.search.legacy.slot.update_user.class: eZ\Publish\Core\Search\Common\Slot\UpdateUser
     ezpublish.search.legacy.slot.create_user_group.class: eZ\Publish\Core\Search\Common\Slot\CreateUserGroup
     ezpublish.search.legacy.slot.delete_user_group.class: eZ\Publish\Core\Search\Common\Slot\DeleteUserGroup
 
@@ -88,6 +89,12 @@ services:
         class: "%ezpublish.search.legacy.slot.delete_user.class%"
         tags:
             - {name: ezpublish.search.legacy.slot, signal: UserService\DeleteUserSignal}
+
+    ezpublish.search.legacy.slot.update_user:
+        parent: ezpublish.search.legacy.slot
+        class: "%ezpublish.search.legacy.slot.update_user.class%"
+        tags:
+            - {name: ezpublish.search.legacy.slot, signal: UserService\UpdateUserSignal}
 
     ezpublish.search.legacy.slot.create_user_group:
         parent: ezpublish.search.legacy.slot


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30136](https://jira.ez.no/browse/EZP-30136)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Tests pass**     | [yes](https://travis-ci.org/ezsystems/ezpublish-kernel/builds/496053283), requires ezsystems/ezplatform-solr-search-engine#130
| **Target version** | `6.7, 6.13, 7.3, 7.4`, `master`

Recreated this PR, as the last one got automatically closed after rebase.

This is part one of the fix for changes after updating content with `ezuser` field not being committed.
Part two `ezsystems/ezplatform-solr-search-engine`:
https://github.com/ezsystems/ezplatform-solr-search-engine/pull/130

**TODO**
- [ ] Remove TMP commit