### PR TITLE
Set dependency to existing testCreateUserGroup test

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UserTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UserTest.php
@@ -276,7 +276,7 @@ XML;
     }
 
     /**
-     * @depends testCreateGroup
+     * @depends testCreateUserGroup
      * Covers GET /user/groups/{groupPath}/subgroups
      */
     public function testLoadSubUserGroups($groupHref)


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| no
| **New feature**    | no
| **Target version** | 6.13 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

The build for 1.13 version is currently failing: https://travis-ci.org/ezsystems/ezplatform/jobs/494621949 with
```
There was 1 warning:
1) eZ\Bundle\EzPublishRestBundle\Tests\Functional\UserTest::testLoadSubUserGroups
This test depends on "eZ\Bundle\EzPublishRestBundle\Tests\Functional\UserTest::testCreateGroup" which does not exist.
--
```

This is a similar failure to the one that happened on Friday (fixed in https://github.com/ezsystems/ezpublish-kernel/commit/7d82ac85be44c66298c687664f8ab0350e1cf020 )

Changed the dependency to `testCreateUserGroup`, as it's a tests that exists and seems closest to the the one that's missing.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.