### PR TITLE
EZP-30144: Add paths option for translator service instead of injecting files into the translator service paths

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/TranslationCollectorPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/TranslationCollectorPass.php
@@ -43,7 +43,6 @@ class TranslationCollectorPass implements CompilerPassInterface
             return;
         }
 
-        $definition = $container->getDefinition('translator.default');
         $collector = new GlobCollector($container->getParameterBag()->get('kernel.root_dir'));
 
         $availableTranslations = [self::ORIGINAL_TRANSLATION];
@@ -53,11 +52,6 @@ class TranslationCollectorPass implements CompilerPassInterface
                 $file['locale'] = self::LOCALES_MAP[$file['locale']];
             }
             $availableTranslations[] = $file['locale'];
-
-            $definition->addMethodCall(
-                'addResource',
-                array($file['format'], $file['file'], $file['locale'], $file['domain'])
-            );
         }
 
         $container->setParameter('available_translations', array_values(array_unique($availableTranslations)));

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/TranslationCollectorPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/TranslationCollectorPassTest.php
@@ -27,28 +27,6 @@ class TranslationCollectorPassTest extends AbstractCompilerPassTestCase
 
         $this->compile();
 
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'translator.default',
-            'addResource',
-            [
-                'xlf',
-                __DIR__ . $this->normalizePath('/../Fixtures/vendor/../vendor/ezplatform-i18n/ezplatform-i18n-hi_in/ezpublish-kernel/messages.hi_IN.xlf'),
-                'hi',
-                'messages',
-            ]
-        );
-
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'translator.default',
-            'addResource',
-            [
-                'xlf',
-                __DIR__ . $this->normalizePath('/../Fixtures/vendor/../vendor/ezplatform-i18n/ezplatform-i18n-nb_no/ezpublish-kernel/messages.nb_NO.xlf'),
-                'nb',
-                'messages',
-            ]
-        );
-
         $this->assertContainerBuilderHasParameter('available_translations', ['en', 'hi', 'nb']);
     }
 


### PR DESCRIPTION
This PR should be merged only when new translation files, with names which follow Symfony a strict convention, will be generated and available to download.


| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30144](https://jira.ez.no/browse/EZP-30144)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**   | no

Now we use compiler pass to map and add translation files. Files comes from non-standard location and has names which not follow Symfony convention. The problem occurs when we generate translation files for javascript components. For example for translation file which holds locale 'fr', generated file is with 'fr_FR' keys. To avoid those problems we can set for the translator service option called `paths`. It holds an array of paths where the component will look for translation files.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
