### PR TITLE
EZP-30061: Created integration tests schema using Schema Importer

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
@@ -186,12 +186,6 @@ class Legacy extends SetupFactory
         $dbPlatform = $connection->getDatabasePlatform();
         $this->cleanupVarDir($this->getInitialVarDir());
 
-        // @todo FIXME: Needs to be in fixture
-        $data['ezcontentobject_trash'] = array();
-        $data['ezurlwildcard'] = array();
-        $data['ezmedia'] = array();
-        $data['ezkeyword'] = array();
-
         foreach (array_reverse(array_keys($data)) as $table) {
             try {
                 // Cleanup before inserting (using TRUNCATE for speed, however not possible to rollback)
@@ -311,7 +305,6 @@ class Legacy extends SetupFactory
     {
         if (!isset(self::$initialData)) {
             self::$initialData = include __DIR__ . '/../../../../Core/Repository/Tests/Service/Integration/Legacy/_fixtures/clean_ezdemo_47_dump.php';
-            // self::$initialData = include __DIR__ . '/../../../../Core/Repository/Tests/Service/Legacy/_fixtures/full_dump.php';
         }
 
         return self::$initialData;

--- a/eZ/Publish/Core/Persistence/Tests/DatabaseConnectionFactory.php
+++ b/eZ/Publish/Core/Persistence/Tests/DatabaseConnectionFactory.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Tests;
+
+use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+
+/**
+ * Database connection factory for integration tests.
+ */
+class DatabaseConnectionFactory
+{
+    /**
+     * Associative array of <code>[driver => AbstractPlatform]</code>.
+     *
+     * @var array
+     */
+    private $databasePlatforms = [];
+
+    /**
+     * @var \Doctrine\Common\EventManager
+     */
+    private $eventManager;
+
+    /**
+     * @param \EzSystems\DoctrineSchema\Database\DbPlatform\DbPlatform[] $databasePlatforms
+     * @param \Doctrine\Common\EventManager $eventManager
+     */
+    public function __construct(iterable $databasePlatforms, EventManager $eventManager)
+    {
+        $this->databasePlatforms = [];
+        foreach ($databasePlatforms as $databasePlatform) {
+            $this->databasePlatforms[$databasePlatform->getDriverName()] = $databasePlatform;
+        }
+
+        $this->eventManager = $eventManager;
+    }
+
+    /**
+     * Connect to a database described by URL (a.k.a. DSN).
+     *
+     * @param string $databaseURL
+     *
+     * @return \Doctrine\DBAL\Connection
+     *
+     * @throws \Doctrine\DBAL\DBALException if connection failed
+     */
+    public function createConnection(string $databaseURL): Connection
+    {
+        $params = ['url' => $databaseURL];
+
+        // set DbPlatform based on database url scheme
+        $scheme = parse_url($databaseURL, PHP_URL_SCHEME);
+        $driverName = 'pdo_' . $scheme;
+        if (isset($this->databasePlatforms[$driverName])) {
+            $params['platform'] = $this->databasePlatforms[$driverName];
+        }
+
+        return DriverManager::getConnection($params, null, $this->eventManager);
+    }
+}

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/Legacy/_fixtures/clean_ezdemo_47_dump.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/Legacy/_fixtures/clean_ezdemo_47_dump.php
@@ -11776,5 +11776,9 @@ Country�</literallayout></para></section>
         'user_id' => 14,
         'value' => 'value_5'
     ),
-  )
+  ),
+  'ezurlwildcard' => array(),
+  'ezmedia' => array(),
+  'ezkeyword' => array(),
+  'ezcontentclass_attribute_ml' => array(),
 );

--- a/eZ/Publish/Core/settings/tests/integration_legacy.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy.yml
@@ -20,3 +20,24 @@ services:
             $contentTypeService: '@ezpublish.api.service.content_type'
             # Siteaccess aware configuration is not available in the integration tests
             $mappings: '%ezsettings.default.fieldtypes.ezimageasset.mappings%'
+
+    # repeat part of DIC setup to avoid loading DoctrineSchemaBundle
+    _instanceof:
+        EzSystems\DoctrineSchema\Database\DbPlatform\DbPlatform:
+            tags: ['doctrine.dbplatform']
+
+    Doctrine\Common\EventManager: ~
+
+    EzSystems\DoctrineSchema\Database\DbPlatform\SqliteDbPlatform:
+        autowire: true
+
+    eZ\Publish\Core\Persistence\Tests\DatabaseConnectionFactory:
+        autowire: true
+        arguments:
+            $databasePlatforms: !tagged 'doctrine.dbplatform'
+
+    # build ezpublish.api.storage_engine.legacy.connection for test purposes
+    ezpublish.api.storage_engine.legacy.connection:
+        factory: 'eZ\Publish\Core\Persistence\Tests\DatabaseConnectionFactory:createConnection'
+        arguments:
+            $databaseURL: '%legacy_dsn%'

--- a/eZ/Publish/Core/settings/tests/integration_legacy_elasticsearch.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_elasticsearch.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: integration_legacy.yml }
+
 parameters:
     # Redefining default field type classes with the implementation that defines the type
     # as searchable. Needed in order to test searching with Solr and Elasticsearch engines.
@@ -5,22 +8,9 @@ parameters:
     ezpublish.fieldType.ezimage.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableImage
     ezpublish.fieldType.ezmedia.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableMedia
     ezpublish.fieldType.ezurl.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableUrl
-    languages:
-        - eng-US
-        - eng-GB
-    ignored_storage_files:
-        -
-            var/ezdemo_site/storage/images/design/plain-site/172-2-eng-US/eZ-Publish-Demo-Design-without-demo-content1.png
 
     # SignalDispatcher factory
     ezpublish.signalslot.signal_dispatcher.factory.class: eZ\Publish\Core\Base\Container\ApiLoader\SignalSlot\SignalDispatcherFactory
-
-    # Image Asset mappings
-    ezsettings.default.fieldtypes.ezimageasset.mappings:
-        content_type_identifier: image
-        content_field_identifier: image
-        name_field_identifier: name
-        parent_location_id: 51
 
 services:
     ezpublish.spi.search_engine:
@@ -31,11 +21,3 @@ services:
         arguments:
             - "%ezpublish.signalslot.signal_dispatcher.class%"
             - "elasticsearch"
-
-    eZ\Publish\Core\FieldType\ImageAsset\AssetMapper:
-        arguments:
-            $contentService: '@ezpublish.api.service.content'
-            $locationService: '@ezpublish.api.service.location'
-            $contentTypeService: '@ezpublish.api.service.content_type'
-            # Siteaccess aware configuration is not available in the integration tests
-            $mappings: '%ezsettings.default.fieldtypes.ezimageasset.mappings%'


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30061](https://jira.ez.no/browse/EZP-30061)
| **Related to** | [EZP-29938](https://jira.ez.no/browse/EZP-29938)
| **Requires** | ezsystems/doctrine-dbal-schema#1
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `7.5 (master)` for eZ Platform `v2.5 LTS`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR changes the way Repository integration test schema is built to use `SchemaImporter` from [`ezsystems/doctrine-dbal-schema`](https://gitub.com/ezsystems/doctrine-dbal-schema). It re-uses `schema.yaml` used by eZ Platform installer. While disadvantage is it creates more tables (once on all tests startup), we can at least be sure that installer is still going to work.

It also includes some simplifications of test setup like removal of dead code, resolving outstanding "todo", sharing common integration test setup for ES and introducing dedicated test db connection factory to avoid using the deprecated one.

**TODO**:
- [x] Remove TMP commit.
- [x] Provide better description once this is ready for review.
- [x] Drop integration test db schemas for SQLite, MySQL and PostgreSQL.
- [x] Provide `schema.yaml` file common for clean installer and tests.
- [x] Use eZ Systems Doctrine Schema Importer to import schema from Yaml to a db
- [x] Cleanup code after testing.
- [x] Confirm CI passes
- [x] Extract bug fixes to other PRs
- [x] Move SqliteSessionInit to doctrine-dbal-schema
- [x] Try to get db connection from a class that is actually not deprecated ;)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
