### PR TITLE
EZP-30149: Unified eznotification table definition for MySQL and PostgreSQL

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -2567,7 +2567,7 @@ CREATE TABLE `eznotification` (
   `is_pending` tinyint(1) NOT NULL DEFAULT '1',
   `type` varchar(128) NOT NULL DEFAULT '',
   `created` int(11) NOT NULL DEFAULT 0,
-  `data` blob,
+  `data` text,
   PRIMARY KEY (`id`),
   KEY `eznotification_owner` (`owner_id`),
   KEY `eznotification_owner_is_pending` (`owner_id`, `is_pending`)

--- a/data/update/mysql/dbupdate-7.4.0-to-7.5.0.sql
+++ b/data/update/mysql/dbupdate-7.4.0-to-7.5.0.sql
@@ -24,3 +24,9 @@ ADD CONSTRAINT `ezcontentclass_attribute_ml_lang_fk`
   REFERENCES `ezcontent_language` (`id`)
   ON DELETE CASCADE
   ON UPDATE CASCADE;
+
+--
+-- EZP-30149: As a Developer I want uniform eznotification DB table definition across all DBMS-es
+--
+
+ALTER TABLE `eznotification` MODIFY COLUMN `data` TEXT;

--- a/data/update/postgres/dbupdate-7.4.0-to-7.5.0.sql
+++ b/data/update/postgres/dbupdate-7.4.0-to-7.5.0.sql
@@ -2,7 +2,7 @@
 UPDATE ezsite_data SET value='7.5.0' WHERE name='ezpublish-version';
 
 --
--- EZP-29990 - Add table for multilingual FieldDefinitions
+-- EZP-29990: Add table for multilingual FieldDefinitions
 --
 
 DROP TABLE IF EXISTS ezcontentclass_attribute_ml;
@@ -24,3 +24,10 @@ ADD CONSTRAINT ezcontentclass_attribute_ml_lang_fk
   REFERENCES ezcontent_language (id)
   ON DELETE CASCADE
   ON UPDATE CASCADE;
+
+--
+-- EZP-30149: As a Developer I want uniform eznotification DB table definition across all DBMS-es
+--
+
+ALTER TABLE eznotification ALTER COLUMN is_pending TYPE BOOLEAN;
+ALTER TABLE eznotification ALTER COLUMN is_pending SET DEFAULT true;

--- a/eZ/Publish/Core/Persistence/Legacy/Notification/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Notification/Gateway/DoctrineDatabase.php
@@ -51,7 +51,7 @@ class DoctrineDatabase extends Gateway
                 self::COLUMN_TYPE => ':type',
                 self::COLUMN_DATA => ':data',
             ])
-            ->setParameter(':is_pending', $createStruct->isPending, PDO::PARAM_INT)
+            ->setParameter(':is_pending', $createStruct->isPending, PDO::PARAM_BOOL)
             ->setParameter(':user_id', $createStruct->ownerId, PDO::PARAM_INT)
             ->setParameter(':created', $createStruct->created, PDO::PARAM_INT)
             ->setParameter(':type', $createStruct->type, PDO::PARAM_STR)
@@ -93,7 +93,7 @@ class DoctrineDatabase extends Gateway
             ->update(self::TABLE_NOTIFICATION)
             ->set(self::COLUMN_IS_PENDING, ':is_pending')
             ->where($query->expr()->eq(self::COLUMN_ID, ':id'))
-            ->setParameter(':is_pending', $notification->isPending, PDO::PARAM_INT)
+            ->setParameter(':is_pending', $notification->isPending, PDO::PARAM_BOOL)
             ->setParameter(':id', $notification->id, PDO::PARAM_INT);
 
         $query->execute();
@@ -120,11 +120,13 @@ class DoctrineDatabase extends Gateway
     public function countUserPendingNotifications(int $userId): int
     {
         $query = $this->connection->createQueryBuilder();
+        $expr = $query->expr();
         $query
             ->select('COUNT(' . self::COLUMN_ID . ')')
             ->from(self::TABLE_NOTIFICATION)
-            ->where($query->expr()->eq(self::COLUMN_OWNER_ID, ':user_id'))
-            ->andWhere($query->expr()->eq(self::COLUMN_IS_PENDING, true))
+            ->where($expr->eq(self::COLUMN_OWNER_ID, ':user_id'))
+            ->andWhere($expr->eq(self::COLUMN_IS_PENDING, ':is_pending'))
+            ->setParameter(':is_pending', true, PDO::PARAM_BOOL)
             ->setParameter(':user_id', $userId, PDO::PARAM_INT);
 
         return (int)$query->execute()->fetchColumn();

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
@@ -487,7 +487,7 @@ DROP TABLE IF EXISTS eznotification;
 CREATE TABLE eznotification (
     id SERIAL,
     owner_id integer DEFAULT 0 NOT NULL ,
-    is_pending integer DEFAULT 1 NOT NULL,
+    is_pending boolean DEFAULT true NOT NULL,
     type character varying(128) NOT NULL,
     created integer DEFAULT 0 NOT NULL,
     data text

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -559,7 +559,7 @@ CREATE TABLE eznotification (
   is_pending integer NOT NULL DEFAULT 1,
   type text(255) NOT NULL DEFAULT '',
   created integer NOT NULL DEFAULT 0,
-  data blob
+  data text
 );
 
 CREATE INDEX eznotification_owner ON eznotification(owner_id);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30149](https://jira.ez.no/browse/EZP-30149)
| **Needed for** | [EZP-29938](https://jira.ez.no/browse/EZP-29938)
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `7.5 for eZ Platform 2.5 LTS`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR unifies `eznotification` database table definition between PostgreSQL and MySQL databases.

> 1. The `is_pending` column has `tinyint(1)` and `integer` data types for MySQL and PostgreSQL respectively. Doctrine Schema Tool transforms `tinyint(1)` to `boolean`, therefore this should be uniform data type. It's important for PostgreSQL because of strict type comparison in queries, which means Gateway code needs to be adjusted.
> 2. The `data` column has `blob` and `text` data types for MySQL and PostgreSQL respectively. The internal stored format is JSON, so the correct data type for this column should be `text` (also easier to fix, because PostgreSQL Doctrine driver returns blobs as data streams).

**TODO**:
- [x] PostgreSQL: change `eznotification.is_pending` db column data type to bool,
- [x] MySQL: change `eznotification.data` db column data type to TEXT.
- [x] Adjust Notification Gateway query for change to `is_pending`.
- [x] Align SQLite integration test schema with the changes.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
