### PR TITLE
EZP-30204: Checked if orig URL Alias is correct when repairing arch.

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -1385,7 +1385,8 @@ class DoctrineDatabase extends Gateway
         $originalUrlAliases = array_filter(
             $urlAliasesData,
             function ($urlAliasData) {
-                return (int)$urlAliasData['is_original'] === 1;
+                // filter is_original=true ignoring broken parent records (cleaned up elsewhere)
+                return (bool)$urlAliasData['is_original'] && $urlAliasData['existing_parent'] !== null;
             }
         );
         // return language_mask-indexed array


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30204](https://jira.ez.no/browse/EZP-30204)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`, `6.13`, `7.3`, `7.4` and `7.5 (master)`
| **BC breaks**      | no
| **Tests pass**     | TBD
| **Doc needed**     | no

Sometimes, especially when using PostgreSQL, records returned from a database are ordered randomly.
When repairing broken archived URL Alias entries, when fetch is executed, usually two original entries exist - the just corrected one and a broken one.
To make sure correct entry is using for repairing, this PR adds checking if entry parent exists. If it doesn't it means entry is broken.

**TODO**:
- [x] Fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [x] Confirm Travis CI passes.
