### PR TITLE
EZP-29724: Parametrized base default templates to ease overriding

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -21,6 +21,11 @@ parameters:
     ezplatform.default_view_templates.content.asset_image: 'EzPublishCoreBundle:default:content/asset_image.html.twig'
     ezplatform.default_view_templates.block: 'EzPublishCoreBundle:default:block/block.html.twig'
 
+    # Default templates
+    ezplatform.default_templates.pagelayout: 'EzPublishCoreBundle::pagelayout.html.twig'
+    ezplatform.default_templates.field_templates: 'EzPublishCoreBundle::content_fields.html.twig'
+    ezplatform.default_templates.fielddefinition_settings_templates: 'EzPublishCoreBundle::fielddefinition_settings.html.twig'
+
     # Rich Text Custom Tags global configuration
     ezplatform.ezrichtext.custom_tags: {}
     # Rich Text Custom Tags default scope (for SiteAccess) configuration
@@ -38,7 +43,7 @@ parameters:
         name_field_identifier: name
         parent_location_id: 51
 
-    ezsettings.default.pagelayout: 'EzPublishCoreBundle::pagelayout.html.twig'
+    ezsettings.default.pagelayout: '%ezplatform.default_templates.pagelayout%'
 
     # List of content type identifiers to display as image when embedded
     ezplatform.content_view.image_embed_content_types_identifiers: ['image']
@@ -169,14 +174,14 @@ parameters:
 
     # Templates to use while rendering fields
     ezsettings.default.field_templates:
-        - {template: EzPublishCoreBundle::content_fields.html.twig, priority: 0}
+        - {template: '%ezplatform.default_templates.field_templates%', priority: 0}
 
     # Templates for Field edition. Follows the same structure than for field_templates
     ezsettings.default.field_edit_templates: []
 
     # Templates to use while rendering field definition settings
     ezsettings.default.fielddefinition_settings_templates:
-        - {template: EzPublishCoreBundle::fielddefinition_settings.html.twig, priority: 0}
+        - {template: '%ezplatform.default_templates.fielddefinition_settings_templates%', priority: 0}
 
     # Templates for FieldDefinition edition. Follows the same structure than for field_templates
     ezsettings.default.fielddefinition_edit_templates: []

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/TemplatesTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/TemplatesTest.php
@@ -11,6 +11,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\FieldDefinitionSettingsTemplates;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\FieldTemplates;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
+use function eZ\Publish\API\Repository\Tests\writeFixtureFile;
 use Symfony\Component\Yaml\Yaml;
 
 class TemplatesTest extends AbstractParserTestCase
@@ -41,7 +42,7 @@ class TemplatesTest extends AbstractParserTestCase
             'field_templates',
             array_merge(
                 // Adding default kernel value.
-                array(array('template' => 'EzPublishCoreBundle::content_fields.html.twig', 'priority' => 0)),
+                array(array('template' => '%ezplatform.default_templates.field_templates%', 'priority' => 0)),
                 $groupFieldTemplates,
                 $demoSiteFieldTemplates
             ),
@@ -52,7 +53,7 @@ class TemplatesTest extends AbstractParserTestCase
             'field_templates',
             array_merge(
                 // Adding default kernel value.
-                array(array('template' => 'EzPublishCoreBundle::content_fields.html.twig', 'priority' => 0)),
+                array(array('template' => '%ezplatform.default_templates.field_templates%', 'priority' => 0)),
                 $groupFieldTemplates
             ),
             'fre',
@@ -60,7 +61,7 @@ class TemplatesTest extends AbstractParserTestCase
         );
         $this->assertConfigResolverParameterValue(
             'field_templates',
-            array(array('template' => 'EzPublishCoreBundle::content_fields.html.twig', 'priority' => 0)),
+            array(array('template' => '%ezplatform.default_templates.field_templates%', 'priority' => 0)),
             'ezdemo_site_admin',
             false
         );
@@ -95,7 +96,7 @@ class TemplatesTest extends AbstractParserTestCase
             'fielddefinition_settings_templates',
             array_merge(
                 // Adding default kernel value.
-                array(array('template' => 'EzPublishCoreBundle::fielddefinition_settings.html.twig', 'priority' => 0)),
+                array(array('template' => '%ezplatform.default_templates.fielddefinition_settings_templates%', 'priority' => 0)),
                 $groupFieldTemplates,
                 $demoSiteFieldTemplates
             ),
@@ -106,7 +107,7 @@ class TemplatesTest extends AbstractParserTestCase
             'fielddefinition_settings_templates',
             array_merge(
                 // Adding default kernel value.
-                array(array('template' => 'EzPublishCoreBundle::fielddefinition_settings.html.twig', 'priority' => 0)),
+                array(array('template' => '%ezplatform.default_templates.fielddefinition_settings_templates%', 'priority' => 0)),
                 $groupFieldTemplates
             ),
             'fre',
@@ -114,7 +115,7 @@ class TemplatesTest extends AbstractParserTestCase
         );
         $this->assertConfigResolverParameterValue(
             'fielddefinition_settings_templates',
-            array(array('template' => 'EzPublishCoreBundle::fielddefinition_settings.html.twig', 'priority' => 0)),
+            array(array('template' => '%ezplatform.default_templates.fielddefinition_settings_templates%', 'priority' => 0)),
             'ezdemo_site_admin',
             false
         );

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/TemplatesTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/TemplatesTest.php
@@ -11,7 +11,6 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\FieldDefinitionSettingsTemplates;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\FieldTemplates;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
-use function eZ\Publish\API\Repository\Tests\writeFixtureFile;
 use Symfony\Component\Yaml\Yaml;
 
 class TemplatesTest extends AbstractParserTestCase


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29724](https://jira.ez.no/browse/EZP-29724)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 7.3
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Default values are hardcoded and it is hard to override them in a clean way, and it is crucial for Standard Design to do so.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] ~Implement tests.~
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
