### PR TITLE
Implemented EZP-30270: Dedicated policy for swap locations

### DIFF
--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -575,11 +575,8 @@ class LocationService implements LocationServiceInterface
         $loadedLocation1 = $this->loadLocation($location1->id);
         $loadedLocation2 = $this->loadLocation($location2->id);
 
-        if (!$this->repository->canUser('content', 'edit', $loadedLocation1->getContentInfo(), $loadedLocation1)) {
-            throw new UnauthorizedException('content', 'edit', ['locationId' => $loadedLocation1->id]);
-        }
-        if (!$this->repository->canUser('content', 'edit', $loadedLocation2->getContentInfo(), $loadedLocation2)) {
-            throw new UnauthorizedException('content', 'edit', ['locationId' => $loadedLocation2->id]);
+        if (!$this->repository->canUser('content', 'swap', $loadedLocation1->getContentInfo())) {
+            throw new UnauthorizedException('content', 'swap');
         }
 
         $this->repository->beginTransaction();

--- a/eZ/Publish/Core/settings/policies.yml
+++ b/eZ/Publish/Core/settings/policies.yml
@@ -19,6 +19,7 @@ parameters:
             pendinglist: ~
             restore: ~
             cleantrash: ~
+            swap: ~
 
         class:
             update: ~


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30270](https://jira.ez.no/browse/EZP-30270)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | master
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | no

Adds a new policy to add more granularity to the swap operation. While edit is a policy that users normally need, swap is another feautre not that used. Furthermore, if not used carefully it can have undesired effects. 

I guess thir ps is enough for kernel but that i need another pr for the translation part. maybe the swap functionality can be not showed in the admin ui if the user does not have permission to do that. 

I marked this a BC change, as long as it changes the permission needed to do a swap operation. 

ping @glye 