### PR TITLE
[Tests] Refactored Twig runtime error checking to be less strict

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
@@ -88,7 +88,7 @@ abstract class FileSystemTwigIntegrationTestCase extends Twig_Test_IntegrationTe
                 $output = trim($template->render(eval($match[1] . ';')), "\n ");
             } catch (Exception $e) {
                 if (false !== $exception) {
-                    $this->assertEquals(
+                    $this->assertContains(
                         trim($exception),
                         trim(
                             sprintf('%s: %s', get_class($e), $e->getMessage())

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/field_rendering_functions/ez_render_field_exception.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/field_rendering_functions/ez_render_field_exception.test
@@ -20,4 +20,4 @@ return array(
     )
 )
 --EXCEPTION--
-Twig_Error_Runtime: An exception has been thrown during the rendering of a template ("Cannot find 'notexisting_field' template block.") in "index.twig" at line 4.
+An exception has been thrown during the rendering of a template ("Cannot find 'notexisting_field' template block.") in "index.twig" at line 4.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`, `7.3`, `7.4`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Most recently Twig introduced forced switch to PSR-4 namespaces.
This affects our test fixture which checks Twig exception message.
`Twig_Error_Runtime` became `Twig\Error\RuntimeError`

The mentioned fixture is present since `6.10`, so I fixed it in `6.13` LTS.

Applies to Twig versions:
- `v1.38.1` (surprisingly, tbh).
- `v2.7.1`.

**TODO**:
- [x] Fix a bug.
- [x] Confirm Travis agrees.
- [x] Ask for Code Review.
