### PR TITLE
EZP-30300: Methods buildLocationWithContent and buildLocation should behave exactly the same in case of tree root 

### DIFF
--- a/eZ/Publish/Core/Repository/Helper/DomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/DomainMapper.php
@@ -44,7 +44,7 @@ use DateTime;
  */
 class DomainMapper
 {
-    const ROOT_LOCATION_ID = 1;
+    private const ROOT_LOCATION_ID = 1;
 
     const MAX_LOCATION_PRIORITY = 2147483647;
     const MIN_LOCATION_PRIORITY = -2147483648;

--- a/eZ/Publish/Core/Repository/Helper/DomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/DomainMapper.php
@@ -44,6 +44,8 @@ use DateTime;
  */
 class DomainMapper
 {
+    const ROOT_LOCATION_ID = 1;
+
     const MAX_LOCATION_PRIORITY = 2147483647;
     const MIN_LOCATION_PRIORITY = -2147483648;
 
@@ -452,28 +454,8 @@ class DomainMapper
         array $prioritizedLanguages = [],
         bool $useAlwaysAvailable = true
     ): APILocation {
-        if ($spiLocation->id == 1) {
-            $legacyDateTime = $this->getDateTime(1030968000); //  first known commit of eZ Publish 3.x
-            // NOTE: this is hardcoded workaround for missing ContentInfo on root location
-            return $this->mapLocation(
-                $spiLocation,
-                new ContentInfo([
-                    'id' => 0,
-                    'name' => 'Top Level Nodes',
-                    'sectionId' => 1,
-                    'mainLocationId' => 1,
-                    'contentTypeId' => 1,
-                    'currentVersionNo' => 1,
-                    'published' => 1,
-                    'ownerId' => 14, // admin user
-                    'modificationDate' => $legacyDateTime,
-                    'publishedDate' => $legacyDateTime,
-                    'alwaysAvailable' => 1,
-                    'remoteId' => null,
-                    'mainLanguageCode' => 'eng-GB',
-                ]),
-                new Content([])
-            );
+        if ($this->isRootLocation($spiLocation)) {
+            return $this->buildRootLocation($spiLocation);
         }
 
         $spiContentInfo = $this->contentHandler->loadContentInfo($spiLocation->contentId);
@@ -485,11 +467,28 @@ class DomainMapper
         );
     }
 
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $spiLocation
+     * @param \eZ\Publish\API\Repository\Values\Content\Content|null $content
+     * @param \eZ\Publish\SPI\Persistence\Content\ContentInfo|null $spiContentInfo
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
     public function buildLocationWithContent(
         SPILocation $spiLocation,
-        APIContent $content,
-        SPIContentInfo $spiContentInfo = null
+        ?APIContent $content,
+        ?SPIContentInfo $spiContentInfo = null
     ): APILocation {
+        if ($this->isRootLocation($spiLocation)) {
+            return $this->buildRootLocation($spiLocation);
+        }
+
+        if ($content === null) {
+            throw new InvalidArgumentException('$content', "Location {$spiLocation->id} has missing Content");
+        }
+
         if ($spiContentInfo !== null) {
             $contentInfo = $this->buildContentInfoDomainObject($spiContentInfo);
         } else {
@@ -497,6 +496,40 @@ class DomainMapper
         }
 
         return $this->mapLocation($spiLocation, $contentInfo, $content);
+    }
+
+    /**
+     * Builds API Location object for tree root.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $spiLocation
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     */
+    private function buildRootLocation(SPILocation $spiLocation): APILocation
+    {
+        //  first known commit of eZ Publish 3.x
+        $legacyDateTime = $this->getDateTime(1030968000);
+
+        // NOTE: this is hardcoded workaround for missing ContentInfo on root location
+        return $this->mapLocation(
+            $spiLocation,
+            new ContentInfo([
+                'id' => 0,
+                'name' => 'Top Level Nodes',
+                'sectionId' => 1,
+                'mainLocationId' => 1,
+                'contentTypeId' => 1,
+                'currentVersionNo' => 1,
+                'published' => 1,
+                'ownerId' => 14, // admin user
+                'modificationDate' => $legacyDateTime,
+                'publishedDate' => $legacyDateTime,
+                'alwaysAvailable' => 1,
+                'remoteId' => null,
+                'mainLanguageCode' => 'eng-GB',
+            ]),
+            new Content([])
+        );
     }
 
     private function mapLocation(SPILocation $spiLocation, ContentInfo $contentInfo, APIContent $content): APILocation
@@ -804,5 +837,17 @@ class DomainMapper
     public function getUniqueHash($object)
     {
         return md5(uniqid(get_class($object), true));
+    }
+
+    /**
+     * Returns true if given location is a tree root.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $spiLocation
+     *
+     * @return bool
+     */
+    private function isRootLocation(SPILocation $spiLocation): bool
+    {
+        return self::ROOT_LOCATION_ID === (int)$spiLocation->id;
     }
 }

--- a/eZ/Publish/Core/Repository/Helper/DomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/DomainMapper.php
@@ -44,8 +44,6 @@ use DateTime;
  */
 class DomainMapper
 {
-    private const ROOT_LOCATION_ID = 1;
-
     const MAX_LOCATION_PRIORITY = 2147483647;
     const MIN_LOCATION_PRIORITY = -2147483648;
 
@@ -848,6 +846,6 @@ class DomainMapper
      */
     private function isRootLocation(SPILocation $spiLocation): bool
     {
-        return self::ROOT_LOCATION_ID === (int)$spiLocation->id;
+        return $spiLocation->id === $spiLocation->parentId;
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
@@ -52,7 +52,7 @@ class DomainMapperTest extends BaseServiceMockTest
      */
     public function testBuildLocationWithContentForRootLocation()
     {
-        $spiRootLocation = new Location(['id' => 1]);
+        $spiRootLocation = new Location(['id' => 1, 'parentId' => 1]);
         $apiRootLocation = $this->getDomainMapper()->buildLocationWithContent($spiRootLocation, null);
 
         $expectedContentInfo = new ContentInfo([
@@ -74,14 +74,14 @@ class DomainMapperTest extends BaseServiceMockTest
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Argument \'$content\' is invalid: Location 2 has missing Content');
 
-        $nonRootLocation = new Location(['id' => 2]);
+        $nonRootLocation = new Location(['id' => 2, 'parentId' => 1]);
 
         $this->getDomainMapper()->buildLocationWithContent($nonRootLocation, null);
     }
 
     public function testBuildLocationWithContentIsAlignedWithBuildLocation()
     {
-        $spiRootLocation = new Location(['id' => 1]);
+        $spiRootLocation = new Location(['id' => 1, 'parentId' => 1]);
 
         $this->assertEquals(
             $this->getDomainMapper()->buildLocationWithContent($spiRootLocation, null),


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30300](https://jira.ez.no/browse/EZP-30300)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** |`7.x` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Methods `\eZ\Publish\Core\Repository\Helper\DomainMapper::buildLocationWithContent` and `\eZ\Publish\Core\Repository\Helper\DomainMapper::buildLocation` should behave exactly the same way in case of tree root (location with id == 1).



**TODO**:
- [X] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
