### PR TITLE
EZP-30147: Fixed moving a subtree with invisible items

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -2255,6 +2255,47 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
+     * Test moving invisible (hidden by parent) subtree.
+     *
+     * @covers \eZ\Publish\API\Repository\LocationService::moveSubtree
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testMoveInvisibleSubtree()
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $rootLocationId = 2;
+
+        $folder = $this->createFolder(['eng-GB' => 'Folder'], $rootLocationId);
+        $child = $this->createFolder(['eng-GB' => 'Child'], $folder->contentInfo->mainLocationId);
+        $locationService->hideLocation(
+            $locationService->loadLocation($folder->contentInfo->mainLocationId)
+        );
+        // sanity check
+        $childLocation = $locationService->loadLocation($child->contentInfo->mainLocationId);
+        self::assertFalse($childLocation->hidden);
+        self::assertTrue($childLocation->invisible);
+        self::assertEquals($folder->contentInfo->mainLocationId, $childLocation->parentLocationId);
+
+        $destination = $this->createFolder(['eng-GB' => 'Destination'], $rootLocationId);
+        $destinationLocation = $locationService->loadLocation(
+            $destination->contentInfo->mainLocationId
+        );
+
+        $locationService->moveSubtree($childLocation, $destinationLocation);
+
+        $childLocation = $locationService->loadLocation($child->contentInfo->mainLocationId);
+        // Business logic - Location moved to visible parent becomes visible
+        self::assertFalse($childLocation->hidden);
+        self::assertFalse($childLocation->invisible);
+        self::assertEquals($destinationLocation->id, $childLocation->parentLocationId);
+    }
+
+    /**
      * Test for the moveSubtree() method.
      *
      * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testMoveSubtree

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -293,7 +293,8 @@ class DoctrineDatabase extends Gateway
                 $this->handler->quoteColumn('node_id'),
                 $this->handler->quoteColumn('parent_node_id'),
                 $this->handler->quoteColumn('path_string'),
-                $this->handler->quoteColumn('path_identification_string')
+                $this->handler->quoteColumn('path_identification_string'),
+                $this->handler->quoteColumn('is_hidden')
             )
             ->from($this->handler->quoteTable('ezcontentobject_tree'))
             ->where(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
@@ -258,44 +258,6 @@ class DoctrineDatabaseTest extends TestCase
         );
     }
 
-    public function testMoveInvisibleSourceUpdate()
-    {
-        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
-        $handler = $this->getLocationGateway();
-        $handler->hideSubtree('/1/2/69/');
-        $handler->moveSubtreeNodes(
-            array(
-                'path_string' => '/1/2/69/',
-                'path_identification_string' => 'products',
-                'is_hidden' => 0,
-                'is_invisible' => 1,
-            ),
-            array(
-                'path_string' => '/1/2/77/',
-                'path_identification_string' => 'solutions',
-                'is_hidden' => 0,
-                'is_invisible' => 0,
-            )
-        );
-
-        /** @var $query \eZ\Publish\Core\Persistence\Database\SelectQuery */
-        $query = $this->handler->createSelectQuery();
-        $this->assertQueryResult(
-            array(
-                array(65, '/1/2/', '', 1, 1, 0, 0),
-                array(67, '/1/2/77/69/', 'solutions/products', 77, 3, 1, 0),
-                array(69, '/1/2/77/69/70/71/', 'solutions/products/software/os_type_i', 70, 5, 0, 1),
-                array(73, '/1/2/77/69/72/75/', 'solutions/products/boxes/cd_dvd_box_iii', 72, 5, 0, 1),
-                array(75, '/1/2/77/', 'solutions', 2, 2, 0, 0),
-            ),
-            $query
-                ->select('contentobject_id', 'path_string', 'path_identification_string', 'parent_node_id', 'depth', 'is_hidden', 'is_invisible')
-                ->from('ezcontentobject_tree')
-                ->where($query->expr->in('node_id', array(69, 71, 75, 77, 2)))
-                ->orderBy('contentobject_id')
-        );
-    }
-
     public function testMoveHiddenSourceChildUpdate()
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
@@ -258,6 +258,44 @@ class DoctrineDatabaseTest extends TestCase
         );
     }
 
+    public function testMoveInvisibleSourceUpdate()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
+        $handler = $this->getLocationGateway();
+        $handler->hideSubtree('/1/2/69/');
+        $handler->moveSubtreeNodes(
+            array(
+                'path_string' => '/1/2/69/',
+                'path_identification_string' => 'products',
+                'is_hidden' => 0,
+                'is_invisible' => 1,
+            ),
+            array(
+                'path_string' => '/1/2/77/',
+                'path_identification_string' => 'solutions',
+                'is_hidden' => 0,
+                'is_invisible' => 0,
+            )
+        );
+
+        /** @var $query \eZ\Publish\Core\Persistence\Database\SelectQuery */
+        $query = $this->handler->createSelectQuery();
+        $this->assertQueryResult(
+            array(
+                array(65, '/1/2/', '', 1, 1, 0, 0),
+                array(67, '/1/2/77/69/', 'solutions/products', 77, 3, 1, 0),
+                array(69, '/1/2/77/69/70/71/', 'solutions/products/software/os_type_i', 70, 5, 0, 1),
+                array(73, '/1/2/77/69/72/75/', 'solutions/products/boxes/cd_dvd_box_iii', 72, 5, 0, 1),
+                array(75, '/1/2/77/', 'solutions', 2, 2, 0, 0),
+            ),
+            $query
+                ->select('contentobject_id', 'path_string', 'path_identification_string', 'parent_node_id', 'depth', 'is_hidden', 'is_invisible')
+                ->from('ezcontentobject_tree')
+                ->where($query->expr->in('node_id', array(69, 71, 75, 77, 2)))
+                ->orderBy('contentobject_id')
+        );
+    }
+
     public function testMoveHiddenSourceChildUpdate()
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30147](https://jira.ez.no/browse/EZP-30147)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
