### PR TITLE
EZP-30107: Name of Content Item is not updated after changing the main language

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -6378,4 +6378,29 @@ XML
         $this->assertFalse($childLocations[0]->hidden);
         $this->assertTrue($childLocations[0]->invisible);
     }
+
+    public function testChangeContentName()
+    {
+        $repository = $this->getRepository();
+
+        $contentService = $repository->getContentService();
+        $contentDraft = $this->createContentDraft(
+            'folder',
+            $this->generateId('location', 2),
+            [
+                'name' => 'Marco'
+            ]
+        );
+
+        $publishedContent = $contentService->publishVersion($contentDraft->versionInfo);
+        $contentMetadataUpdateStruct = new ContentMetadataUpdateStruct([
+            'name' => 'Polo'
+        ]);
+        $contentService->updateContentMetadata($publishedContent->contentInfo, $contentMetadataUpdateStruct);
+
+        $updatedContent = $contentService->loadContent($publishedContent->id);
+
+        $this->assertEquals('Marco', $publishedContent->contentInfo->name);
+        $this->assertEquals('Polo', $updatedContent->contentInfo->name);
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -6388,13 +6388,13 @@ XML
             'folder',
             $this->generateId('location', 2),
             [
-                'name' => 'Marco'
+                'name' => 'Marco',
             ]
         );
 
         $publishedContent = $contentService->publishVersion($contentDraft->versionInfo);
         $contentMetadataUpdateStruct = new ContentMetadataUpdateStruct([
-            'name' => 'Polo'
+            'name' => 'Polo',
         ]);
         $contentService->updateContentMetadata($publishedContent->contentInfo, $contentMetadataUpdateStruct);
 

--- a/eZ/Publish/API/Repository/Values/Content/ContentMetadataUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentMetadataUpdateStruct.php
@@ -69,4 +69,11 @@ class ContentMetadataUpdateStruct extends ValueObject
      * @var mixed|null
      */
     public $mainLocationId;
+
+    /**
+     * If set, will change the content's "always-available" name.
+     *
+     * @var string
+     */
+    public $name;
 }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -965,6 +965,7 @@ class ContentService implements ContentServiceInterface
                                 null,
                             'alwaysAvailable' => $contentMetadataUpdateStruct->alwaysAvailable,
                             'remoteId' => $contentMetadataUpdateStruct->remoteId,
+                            'name' => $contentMetadataUpdateStruct->name,
                         )
                     )
                 );


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30107](https://jira.ez.no/browse/EZP-30107)
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** |  `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

part of https://github.com/ezsystems/ezplatform-admin-ui/pull/897

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
