### PR TITLE
RFC: Reversed order of merging of SA languages setting

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Languages.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Languages.php
@@ -39,7 +39,7 @@ class Languages extends AbstractParser
 
     public function preMap(array $config, ContextualizerInterface $contextualizer)
     {
-        $contextualizer->mapConfigArray('languages', $config, ContextualizerInterface::UNIQUE);
+        $contextualizer->mapConfigArray('languages', $config, ContextualizerInterface::UNIQUE | ContextualizerInterface::REVERSE_ARRAY_MERGING_ORDER);
         $contextualizer->mapConfigArray('translation_siteaccesses', $config, ContextualizerInterface::UNIQUE);
 
         $container = $contextualizer->getContainer();

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/Contextualizer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/Contextualizer.php
@@ -143,6 +143,13 @@ class Contextualizer implements ContextualizerInterface
                         );
                     }
                 }
+            } elseif ($options & static::REVERSE_ARRAY_MERGING_ORDER) {
+                $mergedSettings = array_merge(
+                    $globalSettings,
+                    $scopeSettings,
+                    $groupsSettings,
+                    $defaultSettings
+                );
             } else {
                 $mergedSettings = array_merge(
                     $defaultSettings,

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ContextualizerInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ContextualizerInterface.php
@@ -27,6 +27,12 @@ interface ContextualizerInterface
     const MERGE_FROM_SECOND_LEVEL = 2;
 
     /**
+     * With this option, mapConfigArray() will merge arrays in reverse order (global, scope, group, default).
+     * Contrary to scalar settings, such merging order provides more natural and expected result for array settings.
+     */
+    const REVERSE_ARRAY_MERGING_ORDER = 4;
+
+    /**
      * Defines a contextual parameter in the container for given scope in current namespace.
      * Resulting parameter will have format <namespace>.<scope>.<parameterName> .
      *


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28895](https://jira.ez.no/browse/EZP-28895)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | ? `7.5 for eZ Platform 2.5 LTS` or `8.0 for 3.0`
| **BC breaks**      | **yes**
| **Tests pass**     | yes
| **Doc needed**     | yes, if accepted

This PR:
- [x] adds to the SA `Contextualizer` a possibility to apply different merging order of SiteAccess array settings when calling `mapConfigArray` by the means of `ContextualizerInterface::REVERSE_ARRAY_MERGING_ORDER` flag,
- [x] applies new flag when merging `languages` settings.

## BC break

This is of course BC break, but honestly, who, when setting this:
```yaml
 system:
        site:
            languages: [nor-NO]
        default:
            languages: [eng-GB]
```

expects his `site.languages` setting to be `[eng-GB, nor-NO]`?

**TODO**:
- [ ] Determine if this is 2.5 LTS or 3.0 candidate.
- [ ] Determine if we should actually check if setting is an array when using the new flag (didn't do it to avoid spaghetti if)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
