### PR TITLE
EZP-30230: Fixed issue revealing content with hidden children/parent

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -506,11 +506,18 @@ class DoctrineDatabase extends Gateway
         $query
             ->select($this->handler->quoteColumn('path_string'))
             ->from($this->handler->quoteTable('ezcontentobject_tree'))
+            ->leftJoin('ezcontentobject', 'ezcontentobject_tree.contentobject_id', 'ezcontentobject.id')
             ->where(
                 $query->expr->lAnd(
-                    $query->expr->eq(
-                        $this->handler->quoteColumn('is_hidden'),
-                        $query->bindValue(1)
+                    $query->expr->lOr(
+                        $query->expr->eq(
+                            $this->handler->quoteColumn('is_hidden', 'ezcontentobject_tree'),
+                            $query->bindValue(1)
+                        ),
+                        $query->expr->eq(
+                            $this->handler->quoteColumn('is_hidden', 'ezcontentobject'),
+                            $query->bindValue(1)
+                        )
                     ),
                     $query->expr->in(
                         $this->handler->quoteColumn('node_id'),
@@ -533,11 +540,18 @@ class DoctrineDatabase extends Gateway
         $query
             ->select($this->handler->quoteColumn('path_string'))
             ->from($this->handler->quoteTable('ezcontentobject_tree'))
+            ->leftJoin('ezcontentobject', 'ezcontentobject_tree.contentobject_id', 'ezcontentobject.id')
             ->where(
                 $query->expr->lAnd(
-                    $query->expr->eq(
-                        $this->handler->quoteColumn('is_hidden'),
-                        $query->bindValue(1)
+                    $query->expr->lOr(
+                        $query->expr->eq(
+                            $this->handler->quoteColumn('is_hidden', 'ezcontentobject_tree'),
+                            $query->bindValue(1)
+                        ),
+                        $query->expr->eq(
+                            $this->handler->quoteColumn('is_hidden', 'ezcontentobject'),
+                            $query->bindValue(1)
+                        )
                     ),
                     $query->expr->like(
                         $this->handler->quoteColumn('path_string'),


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30230](https://jira.ez.no/browse/EZP-30230)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no


Contents location should not be revealed when you reveal parent locations content, but contents location should remain hidden if any parent locations content is still hidden.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
