### PR TITLE
EZP-30139: Fixed testRevealContent randomly failing on PostgreSQL

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -6241,9 +6241,13 @@ XML
     }
 
     /**
-     * @param \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct[] $locationsToHide
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct[] $locationsToReveal
      *
      * @dataProvider provideLocationsToHideAndReveal
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
     public function testRevealContent(array $locationsToReveal)
     {
@@ -6268,6 +6272,13 @@ XML
 
         $publishedContent = $contentService->publishVersion($content->versionInfo);
         $locations = $locationService->loadLocations($publishedContent->contentInfo);
+        // sort the Locations putting hidden one on top, as the order in which they're returned is not deterministic
+        usort(
+            $locations,
+            function (Location $location) {
+                return $location->hidden ? -1 : 1;
+            }
+        );
 
         // Sanity check
         $this->assertCount(3, $locations);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Follow-up for [EZP-30139](https://jira.ez.no/browse/EZP-30139) and #2549 
| **Blocks** | [EZP-30061](https://jira.ez.no/browse/EZP-30061)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5 (master)` for `eZ Platform 2.5 LTS`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This is a follow-up for #2549 and randomly failing Repository integration test `testRevealContent` on PostgreSQL, which also blocks [EZP-30061](https://jira.ez.no/browse/EZP-30061).

The list of loaded Locations is not ordered by anything (and there's nothing relevant to order by), so the result of `loadLocations` is not deterministic. There's no relevant Location id yet at the time of hiding, as these are create structs. The solution is to sort Locations, so the hidden one is always on top for sanity check.

**TODO**:
- [x] Wait for Travis
- [x] Fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
