### PR TITLE
EZP-30271: Published version table disappears after bulk removing of drafts under edit

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -738,9 +738,8 @@ abstract class BaseTest extends TestCase
         $contentService = $repository->getContentService();
 
         $draft = $contentService->createContentDraft($content->contentInfo);
-        $mainLanguageCode = array_keys($names)[0];
         $struct = $contentService->newContentUpdateStruct();
-        $struct->initialLanguageCode = $mainLanguageCode;
+        $struct->initialLanguageCode = array_keys($names)[0];
 
         foreach ($names as $languageCode => $translatedName) {
             $struct->setField('name', $translatedName, $languageCode);

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\API\Repository\Tests;
 use Doctrine\DBAL\Connection;
 use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
 use eZ\Publish\API\Repository\Tests\PHPUnitConstraint\ValidationErrorOccurs as PHPUnitConstraintValidationErrorOccurs;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use PHPUnit\Framework\TestCase;
@@ -715,6 +716,37 @@ abstract class BaseTest extends TestCase
         );
 
         return $contentService->publishVersion($contentDraft->versionInfo);
+    }
+
+    /**
+     * Update 'folder' Content.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * @param array $names Folder names in the form of <code>['&lt;language_code&gt;' => '&lt;name&gt;']</code>
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    protected function updateFolder(Content $content, array $names)
+    {
+        $repository = $this->getRepository(false);
+        $contentService = $repository->getContentService();
+
+        $draft = $contentService->createContentDraft($content->contentInfo);
+        $mainLanguageCode = array_keys($names)[0];
+        $struct = $contentService->newContentUpdateStruct();
+        $struct->initialLanguageCode = $mainLanguageCode;
+
+        foreach ($names as $languageCode => $translatedName) {
+            $struct->setField('name', $translatedName, $languageCode);
+        }
+
+        return $contentService->updateContent($draft->versionInfo, $struct);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -5884,6 +5884,45 @@ XML
     }
 
     /**
+     * Test loading content versions after removing exactly two drafts.
+     *
+     * Test for the issue EZP-30271:
+     * "Published version table disappears after bulk removing of drafts under edit"
+     *
+     * @covers \eZ\Publish\Core\Repository\ContentService::deleteVersion
+     */
+    public function testLoadVersionsAfterDeletingTwoDrafts()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $content = $this->createFolder(['eng-GB' => 'Foo'], 2);
+
+        // First update and publish
+        $modifiedContent = $this->updateFolder($content, ['eng-GB' => 'Foo1']);
+        $content = $contentService->publishVersion($modifiedContent->versionInfo);
+
+        // Second update and publish
+        $modifiedContent = $this->updateFolder($content, ['eng-GB' => 'Foo2']);
+        $content = $contentService->publishVersion($modifiedContent->versionInfo);
+
+        // Create drafts
+        $this->updateFolder($content, ['eng-GB' => 'Foo3']);
+        $this->updateFolder($content, ['eng-GB' => 'Foo4']);
+
+        $versions = $contentService->loadVersions($content->contentInfo);
+
+        foreach ($versions as $key => $version) {
+            if ($version->isDraft()) {
+                $contentService->deleteVersion($version);
+                unset($versions[$key]);
+            }
+        }
+
+        $this->assertEquals($versions, $contentService->loadVersions($content->contentInfo));
+    }
+
+    /**
      * Asserts that all aliases defined in $expectedAliasProperties with the
      * given properties are available in $actualAliases and not more.
      *

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -5886,8 +5886,7 @@ XML
     /**
      * Test loading content versions after removing exactly two drafts.
      *
-     * Test for the issue EZP-30271:
-     * "Published version table disappears after bulk removing of drafts under edit"
+     * @see https://jira.ez.no/browse/EZP-30271
      *
      * @covers \eZ\Publish\Core\Repository\ContentService::deleteVersion
      */

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -24,6 +24,7 @@ use eZ\Publish\SPI\Persistence\Content\Relation\CreateStruct as RelationCreateSt
 class ContentHandler extends AbstractHandler implements ContentHandlerInterface
 {
     const ALL_TRANSLATIONS_KEY = '0';
+    const DEFAULT_LIST_VERSIONS_LIMIT = -1;
 
     /**
      * {@inheritdoc}
@@ -276,9 +277,9 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function listVersions($contentId, $status = null, $limit = -1)
+    public function listVersions($contentId, $status = null, $limit = self::DEFAULT_LIST_VERSIONS_LIMIT)
     {
-        $cacheItem = $this->cache->getItem("ez-content-${contentId}-version-list" . ($status ? "-byStatus-${status}" : ''));
+        $cacheItem = $this->cache->getItem("ez-content-${contentId}-version-list" . ($status ? "-byStatus-${status}" : '') . "-limit-{$limit}");
         if ($cacheItem->isHit()) {
             return $cacheItem->get();
         }
@@ -286,7 +287,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
         $this->logger->logCall(__METHOD__, array('content' => $contentId, 'status' => $status));
         $versions = $this->persistenceHandler->contentHandler()->listVersions($contentId, $status, $limit);
         $cacheItem->set($versions);
-        $tags = ["content-{$contentId}", "content-{$contentId}-version-list"];
+        $tags = ["content-{$contentId}", "content-{$contentId}-version-list", "content-{$contentId}-version-list-{$limit}"];
         foreach ($versions as $version) {
             $tags = $this->getCacheTagsForVersion($version, $tags);
         }

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -24,7 +24,6 @@ use eZ\Publish\SPI\Persistence\Content\Relation\CreateStruct as RelationCreateSt
 class ContentHandler extends AbstractHandler implements ContentHandlerInterface
 {
     const ALL_TRANSLATIONS_KEY = '0';
-    const DEFAULT_LIST_VERSIONS_LIMIT = -1;
 
     /**
      * {@inheritdoc}
@@ -277,7 +276,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function listVersions($contentId, $status = null, $limit = self::DEFAULT_LIST_VERSIONS_LIMIT)
+    public function listVersions($contentId, $status = null, $limit = -1)
     {
         $cacheItem = $this->cache->getItem("ez-content-${contentId}-version-list" . ($status ? "-byStatus-${status}" : '') . "-limit-{$limit}");
         if ($cacheItem->isHit()) {
@@ -287,7 +286,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
         $this->logger->logCall(__METHOD__, array('content' => $contentId, 'status' => $status));
         $versions = $this->persistenceHandler->contentHandler()->listVersions($contentId, $status, $limit);
         $cacheItem->set($versions);
-        $tags = ["content-{$contentId}", "content-{$contentId}-version-list", "content-{$contentId}-version-list-{$limit}"];
+        $tags = ["content-{$contentId}", "content-{$contentId}-version-list"];
         foreach ($versions as $version) {
             $tags = $this->getCacheTagsForVersion($version, $tags);
         }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -81,8 +81,8 @@ class ContentHandlerTest extends AbstractCacheHandlerTest
             ['loadContentInfoList', [[2]], 'ez-content-info-2', [2 => $info], true],
             ['loadContentInfoByRemoteId', ['3d8jrj'], 'ez-content-info-byRemoteId-3d8jrj', $info],
             ['loadVersionInfo', [2, 1], 'ez-content-version-info-2-1', $version],
-            ['listVersions', [2], 'ez-content-2-version-list', [$version]],
-            ['listVersions', [2, 1], 'ez-content-2-version-list-byStatus-1', [$version]],
+            ['listVersions', [2], 'ez-content-2-version-list-limit--1', [$version]],
+            ['listVersions', [2, 1], 'ez-content-2-version-list-byStatus-1-limit--1', [$version]],
         ];
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30271](https://jira.ez.no/browse/EZP-30271)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.4`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
