### PR TITLE
EZP-29324: Limited ezcontentobject_tree_contentobject_id_path_string index column length

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -769,7 +769,7 @@ CREATE TABLE `ezcontentobject_tree` (
   KEY `ezcontentobject_tree_path` (`path_string` (191)),
   KEY `ezcontentobject_tree_path_ident` (`path_identification_string`(50)),
   KEY `modified_subnode` (`modified_subnode`),
-  KEY `ezcontentobject_tree_contentobject_id_path_string` (`path_string`, `contentobject_id`)
+  KEY `ezcontentobject_tree_contentobject_id_path_string` (`path_string` (191), `contentobject_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/data/update/mysql/dbupdate-7.4.4-to-7.4.5.sql
+++ b/data/update/mysql/dbupdate-7.4.4-to-7.4.5.sql
@@ -1,0 +1,11 @@
+SET default_storage_engine=InnoDB;
+-- Set storage engine schema version number
+UPDATE ezsite_data SET value='7.4.5' WHERE name='ezpublish-version';
+
+--
+-- EZP-29324: ezcontentobject_tree_contentobject_id_path_string index column size is too large
+-- This shortens indexes so that 4-byte content can fit.
+--
+
+ALTER TABLE `ezcontentobject_tree` DROP KEY `ezcontentobject_tree_contentobject_id_path_string`;
+ALTER TABLE `ezcontentobject_tree` ADD UNIQUE KEY `ezcontentobject_tree_contentobject_id_path_string` (`path_string` (191), `contentobject_id`);


### PR DESCRIPTION

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29324](https://jira.ez.no/browse/EZP-29324)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.4` and up
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

From https://github.com/ezsystems/ezpublish-kernel/pull/2495
> Without this fix, `composer ezplatform-install` leads to
```
SQLSTATE[HY000]: General error: 1709 Index column size too large. The maximum column size is 767 bytes. 
```

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
