### PR TITLE
EZP-30335: In-memory cache to clear cache using LFU approach

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/Tests/InMemory/InMemoryCacheTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/InMemory/InMemoryCacheTest.php
@@ -164,6 +164,36 @@ class InMemoryCacheTest extends TestCase
         $this->assertSame($obj, $this->cache->get('seventh'));
         $this->assertSame($obj, $this->cache->get('eight'));
     }
+
+    /**
+     * Tests logic behind access counts, making sure least frequently used items are deleted first.
+     */
+    public function testAccessCountsWhenReachingTotalLimit(): void
+    {
+        $obj = new \stdClass();
+        $this->cache->setMulti([$obj], static function ($o) { return ['first']; });
+        $this->cache->setMulti([$obj], static function ($o) { return ['second']; });
+        $this->cache->setMulti([$obj], static function ($o) { return ['third']; });
+        $this->cache->setMulti([$obj], static function ($o) { return ['fourth']; });
+
+        // Make sure these are read before we set further objects.
+        $this->cache->get('first');
+        $this->cache->get('third');
+
+        $this->cache->setMulti([$obj], static function ($o) { return ['fifth']; });
+        $this->cache->setMulti([$obj], static function ($o) { return ['sixth']; });
+        $this->cache->setMulti([$obj], static function ($o) { return ['seventh']; });
+        $this->cache->setMulti([$obj], static function ($o) { return ['eight']; });
+
+        $this->assertSame($obj, $this->cache->get('first'));
+        $this->assertNull($this->cache->get('second'));
+        $this->assertSame($obj, $this->cache->get('third'));
+        $this->assertNull($this->cache->get('fourth'));
+        $this->assertSame($obj, $this->cache->get('fifth'));
+        $this->assertSame($obj, $this->cache->get('sixth'));
+        $this->assertSame($obj, $this->cache->get('seventh'));
+        $this->assertSame($obj, $this->cache->get('eight'));
+    }
 }
 
 namespace eZ\Publish\Core\Persistence\Cache\InMemory;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30335](https://jira.ez.no/browse/EZP-30335)
| **Improvement**| yes
| **Target version** | 7.5.x
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR changes in-memory cache eviction / vacuumin to LFU approach.

Rationale for doing this in story, but main part of it:
> .. as cache will be added for more objects, and/o for larger installs the default limit of 100 items will be reached rather fast. Effect will be that cache items that are very often requested (especially languages and content types) will be evicted from the cache and will be needed to be re-fetched much more often then needed.
> 
> (...)
> 
> NOTE: The reason why LFU and not LRU is proposed is that in-memory cache by design is meant to be short lived, so we don't risk that the LFU tracking need to take into account if cache items where for a short while in great demand but no longer needed, expiry will take care of that.

In sum this aims to make the in-memory cache as efficient as possible.

For further reading:
- https://jira.ez.no/browse/EZP-30335
- https://en.wikipedia.org/wiki/Cache_replacement_policies

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
