### PR TITLE
 Fix wrongly logging Cache hits as in-memory in getMultipleCacheValues()

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
@@ -245,7 +245,7 @@ abstract class AbstractInMemoryHandler
 
         // No cache pool misses, cache loaded items in-memory and return
         if (empty($cacheMisses)) {
-            $this->logger->logCacheHit($ids, 3, true);
+            $this->logger->logCacheHit($ids, 3);
             $this->inMemory->setMulti($loaded, $cacheIndexes);
 
             return $list;


### PR DESCRIPTION
getListCacheValue and getCacheValue is already doing this correct, but in getMultipleCacheValues() cache hits from symfony cache pool is wrongly logged as in-memory cache hits.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
