### PR TITLE
 [AbstractInMemoryHandler] Add a init() method to avoid overloading __construct()

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
@@ -65,9 +65,12 @@ abstract class AbstractInMemoryHandler
     }
 
     /**
-     * Function to initialize handler without having to overload __construct().
+     * Optional dunction to initialize handler without having to overload __construct().
      */
-    abstract protected function init(): void;
+    protected function init(): void
+    {
+        // overload to add init logic if needed in handler
+    }
 
     /**
      * Load one cache item from cache and loggs the hits / misses.

--- a/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
@@ -60,7 +60,14 @@ abstract class AbstractInMemoryHandler
         $this->persistenceHandler = $persistenceHandler;
         $this->logger = $logger;
         $this->inMemory = $inMemory;
+
+        $this->init();
     }
+
+    /**
+     * Function to initialize handler without having to overload __construct().
+     */
+    abstract protected function init(): void;
 
     /**
      * Load one cache item from cache and loggs the hits / misses.

--- a/eZ/Publish/Core/Persistence/Cache/ContentLanguageHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentLanguageHandler.php
@@ -8,12 +8,9 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache;
 
-use eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache;
-use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Persistence\Content\Language\Handler as ContentLanguageHandlerInterface;
 use eZ\Publish\SPI\Persistence\Content\Language;
 use eZ\Publish\SPI\Persistence\Content\Language\CreateStruct;
-use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
 /**
  * @see \eZ\Publish\SPI\Persistence\Content\Language\Handler
@@ -26,14 +23,11 @@ class ContentLanguageHandler extends AbstractInMemoryHandler implements ContentL
     /** @var callable */
     private $getKeys;
 
-    public function __construct(
-        TagAwareAdapterInterface $cache,
-        PersistenceHandler $persistenceHandler,
-        PersistenceLogger $logger,
-        InMemoryCache $inMemory
-    ) {
-        parent::__construct($cache, $persistenceHandler, $logger, $inMemory);
-
+    /**
+     * Set callback functions for use in cache retrival.
+     */
+    protected function init(): void
+    {
         $this->getTags = static function (Language $language) { return ['language-' . $language->id]; };
         $this->getKeys = static function (Language $language) {
             return [

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -8,8 +8,6 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache;
 
-use eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache;
-use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandlerInterface;
 use eZ\Publish\SPI\Persistence\Content\Type;
 use eZ\Publish\SPI\Persistence\Content\Type\CreateStruct;
@@ -17,7 +15,6 @@ use eZ\Publish\SPI\Persistence\Content\Type\UpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\Type\Group\CreateStruct as GroupCreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Type\Group\UpdateStruct as GroupUpdateStruct;
-use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
 /**
  * ContentType cache.
@@ -40,14 +37,11 @@ class ContentTypeHandler extends AbstractInMemoryHandler implements ContentTypeH
     /** @var callable */
     private $getTypeKeys;
 
-    public function __construct(
-        TagAwareAdapterInterface $cache,
-        PersistenceHandler $persistenceHandler,
-        PersistenceLogger $logger,
-        InMemoryCache $inMemory
-    ) {
-        parent::__construct($cache, $persistenceHandler, $logger, $inMemory);
-
+    /**
+     * Set callback functions for use in cache retrival.
+     */
+    protected function init(): void
+    {
         $this->getGroupTags = static function (Type\Group $group) { return ['type-group-' . $group->id]; };
         $this->getGroupKeys = static function (Type\Group $group) {
             return [

--- a/eZ/Publish/Core/Persistence/Cache/TransactionHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TransactionHandler.php
@@ -15,6 +15,11 @@ use eZ\Publish\SPI\Persistence\TransactionHandler as TransactionHandlerInterface
  */
 class TransactionHandler extends AbstractInMemoryHandler implements TransactionHandlerInterface
 {
+    protected function init(): void
+    {
+        // do nothing yet here.
+    }
+
     /**
      * @todo Maybe this can be solved by contributing to Symfony, as in for instance using a layered cache with memory
      * cache first and use saveDefered so cache is not persisted before commit is made, and omitted on rollback.

--- a/eZ/Publish/Core/Persistence/Cache/TransactionHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TransactionHandler.php
@@ -15,11 +15,6 @@ use eZ\Publish\SPI\Persistence\TransactionHandler as TransactionHandlerInterface
  */
 class TransactionHandler extends AbstractInMemoryHandler implements TransactionHandlerInterface
 {
-    protected function init(): void
-    {
-        // do nothing yet here.
-    }
-
     /**
      * @todo Maybe this can be solved by contributing to Symfony, as in for instance using a layered cache with memory
      * cache first and use saveDefered so cache is not persisted before commit is made, and omitted on rollback.

--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -8,8 +8,6 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache;
 
-use eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache;
-use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct;
 use eZ\Publish\SPI\Persistence\User\Handler as UserHandlerInterface;
 use eZ\Publish\SPI\Persistence\User;
@@ -18,7 +16,6 @@ use eZ\Publish\SPI\Persistence\User\RoleAssignment;
 use eZ\Publish\SPI\Persistence\User\RoleCreateStruct;
 use eZ\Publish\SPI\Persistence\User\RoleUpdateStruct;
 use eZ\Publish\SPI\Persistence\User\Policy;
-use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
 /**
  * Cache handler for user module.
@@ -43,14 +40,11 @@ class UserHandler extends AbstractInMemoryHandler implements UserHandlerInterfac
     /** @var callable */
     private $getRoleAssignmentKeys;
 
-    public function __construct(
-        TagAwareAdapterInterface $cache,
-        PersistenceHandler $persistenceHandler,
-        PersistenceLogger $logger,
-        InMemoryCache $inMemory
-    ) {
-        parent::__construct($cache, $persistenceHandler, $logger, $inMemory);
-
+    /**
+     * Set callback functions for use in cache retrival.
+     */
+    public function init(): void
+    {
         $this->getUserTags = static function (User $user) {
             return ['content-' . $user->id, 'user-' . $user->id];
         };


### PR DESCRIPTION
In the end made it optional, but avoid hardcoding __construct() signature in handlers.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
