### PR TITLE
Command UpdateTimestampsToUTCCommand will fail on php 5.6

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/UpdateTimestampsToUTCCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/UpdateTimestampsToUTCCommand.php
@@ -162,7 +162,7 @@ EOT
         $this->dryRun = $input->getOption('dry-run');
         $this->mode = $input->getOption('mode');
 
-        if (!isset(self::MODES[$this->mode])) {
+        if (!array_key_exists($this->mode, self::MODES)) {
             $output->writeln(
                 sprintf('Selected mode is not supported, please use one of: %s', implode(', ', array_keys(self::MODES)))
             );


### PR DESCRIPTION
This PR fixes Command UpdateTimestampsToUTCCommand failing on php 5.6 due to `self::MODES[$this->mode]` is treated as expression.
