### PR TITLE
EZP-30340: Add in-memory cache for User Preferences

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
@@ -139,7 +139,7 @@ abstract class AbstractInMemoryHandler
      * @param callable $listTags Optional, global tags for the list cache.
      * @param array $arguments Optional, arguments when parnt method takes arguments that key varies on.
      *
-     * @return object
+     * @return array
      */
     final protected function getListCacheValue(
         string $key,

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
@@ -92,7 +92,7 @@ abstract class AbstractBaseHandlerTest extends TestCase
             new CacheUrlHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
             new CacheBookmarkHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
             new CacheNotificationHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
-            new CacheUserPreferenceHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
+            new CacheUserPreferenceHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock, $this->inMemoryMock),
             $this->loggerMock
         );
 

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractInMemoryCacheHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractInMemoryCacheHandlerTest.php
@@ -67,7 +67,9 @@ abstract class AbstractInMemoryCacheHandlerTest extends AbstractBaseHandlerTest
         }
 
         $handler = $this->persistenceCacheHandler->$handlerMethodName();
-        call_user_func_array(array($handler, $method), $arguments);
+        $actualReturnValue = call_user_func_array(array($handler, $method), $arguments);
+
+        $this->assertEquals($returnValue, $actualReturnValue);
     }
 
     abstract public function providerForCachedLoadMethods(): array;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserPreferenceHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserPreferenceHandlerTest.php
@@ -54,7 +54,6 @@ class UserPreferenceHandlerTest extends AbstractInMemoryCacheHandlerTest
                 ],
                 null,
                 [
-                    'ez-user-preference-count-' . $userId,
                     'ez-user-preference-' . $userId . '-' . $name,
                 ],
                 new SPIUserPreference(),

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserPreferenceHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserPreferenceHandlerTest.php
@@ -6,9 +6,8 @@
  */
 declare(strict_types=1);
 
-namespace eZ\Publish\Tests\Core\Persistence\Cache;
+namespace eZ\Publish\Core\Persistence\Cache\Tests;
 
-use eZ\Publish\Core\Persistence\Cache\Tests\AbstractCacheHandlerTest;
 use eZ\Publish\SPI\Persistence\UserPreference\UserPreferenceSetStruct;
 use eZ\Publish\SPI\Persistence\UserPreference\Handler as SPIUserPreferenceHandler;
 use eZ\Publish\SPI\Persistence\UserPreference\UserPreference as SPIUserPreference;
@@ -16,7 +15,7 @@ use eZ\Publish\SPI\Persistence\UserPreference\UserPreference as SPIUserPreferenc
 /**
  * Test case for Persistence\Cache\UserPreferenceHandler.
  */
-class UserPreferenceHandlerTest extends AbstractCacheHandlerTest
+class UserPreferenceHandlerTest extends AbstractInMemoryCacheHandlerTest
 {
     /**
      * {@inheritdoc}
@@ -41,6 +40,7 @@ class UserPreferenceHandlerTest extends AbstractCacheHandlerTest
     {
         $userId = 7;
         $name = 'setting';
+        $userPreferenceCount = 10;
 
         // string $method, array $arguments, array? $tags, string? $key, mixed? $returnValue
         return [
@@ -52,15 +52,24 @@ class UserPreferenceHandlerTest extends AbstractCacheHandlerTest
                         'name' => $name,
                     ]),
                 ],
-                [
-                    'user-preference-count-' . $userId,
-                    'user-preference-' . $userId . '-' . $name,
-                ],
                 null,
+                [
+                    'ez-user-preference-count-' . $userId,
+                    'ez-user-preference-' . $userId . '-' . $name,
+                ],
                 new SPIUserPreference(),
             ],
             [
                 'loadUserPreferences', [$userId, 0, 25], null, null, [],
+            ],
+            [
+                'countUserPreferences',
+                [
+                    $userId,
+                ],
+                null,
+                null,
+                $userPreferenceCount,
             ],
         ];
     }
@@ -72,18 +81,9 @@ class UserPreferenceHandlerTest extends AbstractCacheHandlerTest
     {
         $userId = 7;
         $name = 'setting';
-        $userPreferenceCount = 10;
 
         // string $method, array $arguments, string $key, mixed? $data
         return [
-            [
-                'countUserPreferences',
-                [
-                    $userId,
-                ],
-                'ez-user-preference-count-' . $userId,
-                $userPreferenceCount,
-            ],
             [
                 'getUserPreferenceByUserIdAndName',
                 [

--- a/eZ/Publish/Core/Persistence/Cache/UserPreferenceHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserPreferenceHandler.php
@@ -35,10 +35,7 @@ class UserPreferenceHandler extends AbstractInMemoryHandler implements Handler
             'setStruct' => $setStruct,
         ]);
 
-        $this->deleteCache([
-            'ez-user-preference-count-' . $setStruct->userId,
-            'ez-user-preference-' . $setStruct->userId . '-' . $setStruct->name,
-        ]);
+        $this->deleteCache(['ez-user-preference-' . $setStruct->userId . '-' . $setStruct->name]);
 
         return $this->persistenceHandler->userPreferenceHandler()->setUserPreference($setStruct);
     }

--- a/eZ/Publish/Core/Persistence/Cache/UserPreferenceHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserPreferenceHandler.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Persistence\Cache;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\SPI\Persistence\UserPreference\UserPreferenceSetStruct;
 use eZ\Publish\SPI\Persistence\UserPreference\Handler;
 use eZ\Publish\SPI\Persistence\UserPreference\UserPreference;
@@ -20,6 +22,11 @@ use eZ\Publish\SPI\Persistence\UserPreference\UserPreference;
 class UserPreferenceHandler extends AbstractHandler implements Handler
 {
     /**
+     * Constant used for storing not found results for getUserPreferenceByUserIdAndName().
+     */
+    private const NOT_FOUND = 'NotFoundException';
+
+    /**
      * {@inheritdoc}
      */
     public function setUserPreference(UserPreferenceSetStruct $setStruct): UserPreference
@@ -28,9 +35,9 @@ class UserPreferenceHandler extends AbstractHandler implements Handler
             'setStruct' => $setStruct,
         ]);
 
-        $this->cache->invalidateTags([
-            'user-preference-count-' . $setStruct->userId,
-            'user-preference-' . $setStruct->userId . '-' . $setStruct->name,
+        $this->cache->deleteItems([
+            'ez-user-preference-count-' . $setStruct->userId,
+            'ez-user-preference-' . $setStruct->userId . '-' . $setStruct->name,
         ]);
 
         return $this->persistenceHandler->userPreferenceHandler()->setUserPreference($setStruct);
@@ -42,10 +49,8 @@ class UserPreferenceHandler extends AbstractHandler implements Handler
     public function countUserPreferences(int $userId): int
     {
         $cacheItem = $this->cache->getItem('ez-user-preference-count-' . $userId);
-
-        $count = $cacheItem->get();
         if ($cacheItem->isHit()) {
-            return $count;
+            return $cacheItem->get();
         }
 
         $this->logger->logCall(__METHOD__, [
@@ -54,7 +59,7 @@ class UserPreferenceHandler extends AbstractHandler implements Handler
 
         $count = $this->persistenceHandler->userPreferenceHandler()->countUserPreferences($userId);
         $cacheItem->set($count);
-        $cacheItem->tag(['user-preference-count-' . $userId]);
+        $cacheItem->tag(['user-preference-' . $userId]);
         $this->cache->save($cacheItem);
 
         return $count;
@@ -62,13 +67,18 @@ class UserPreferenceHandler extends AbstractHandler implements Handler
 
     /**
      * {@inheritdoc}
+     *
+     * Needs to store NotFoundExceptions as UserPreference feature heavily uses this in valid lookups.
      */
     public function getUserPreferenceByUserIdAndName(int $userId, string $name): UserPreference
     {
         $cacheItem = $this->cache->getItem('ez-user-preference-' . $userId . '-' . $name);
-
-        $userPreference = $cacheItem->get();
         if ($cacheItem->isHit()) {
+            $userPreference = $cacheItem->get();
+            if ($userPreference === self::NOT_FOUND) {
+                throw new NotFoundException('User Preference', $userId . ',' . $name);
+            }
+
             return $userPreference;
         }
 
@@ -76,13 +86,20 @@ class UserPreferenceHandler extends AbstractHandler implements Handler
             'userId' => $userId,
             'name' => $name,
         ]);
+        $cacheItem->tag(['user-preference-' . $userId]);
 
-        $userPreference = $this->persistenceHandler->userPreferenceHandler()->getUserPreferenceByUserIdAndName($userId, $name);
+        try {
+            $userPreference = $this->persistenceHandler->userPreferenceHandler()->getUserPreferenceByUserIdAndName(
+                $userId,
+                $name
+            );
+        } catch (APINotFoundException $e) {
+            $cacheItem->set(self::NOT_FOUND);
+            $this->cache->save($cacheItem);
+            throw new NotFoundException('User Preference', $userId . ',' . $name, $e);
+        }
 
         $cacheItem->set($userPreference);
-        $cacheItem->tag([
-            'user-preference-' . $userId . '-' . $name,
-        ]);
         $this->cache->save($cacheItem);
 
         return $userPreference;

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -124,7 +124,7 @@ services:
 
     ezpublish.spi.persistence.cache.userPreferenceHandler:
         class: "%ezpublish.spi.persistence.cache.userPreferenceHandler.class%"
-        parent: ezpublish.spi.persistence.cache.abstractHandler
+        parent: ezpublish.spi.persistence.cache.abstractInMemoryCacheHandler
 
     ezpublish.spi.persistence.cache:
         class: "%ezpublish.spi.persistence.cache.class%"

--- a/eZ/Publish/SPI/Persistence/UserPreference/Handler.php
+++ b/eZ/Publish/SPI/Persistence/UserPreference/Handler.php
@@ -25,6 +25,8 @@ interface Handler
      * @param int $userId
      * @param string $name
      *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If no value is found for given preference name.
+     *
      * @return \eZ\Publish\SPI\Persistence\UserPreference\UserPreference
      */
     public function getUserPreferenceByUserIdAndName(int $userId, string $name): UserPreference;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30340](https://jira.ez.no/browse/EZP-30340)
| **Improvement**| yes
| **Target version** | `7.5.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Does:
- Add cache for lookups of missing preferences (NotFound)
- Makes all preferences lookups also cached in-memory
- Drops cache of preferences count as it does not seem to be used that many places
     - _Defintly open for debate, but could not find any heavy use of this _(aka if it's used, it's probably only used on specific page where you list up all preferences only, not on every admin page)_ so felt like we can rather drop it._

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
