### PR TITLE
[WIP][Travis] Add testing with Mysql 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-# Use trusty for better performance (and avoiding mysql/postgres/solr gone issues on precise and container infra)
-dist: trusty
-sudo: required
+dist: xenial
 
 language: php
 
@@ -8,14 +6,6 @@ services:
   - mysql
   - postgresql
   - redis-server
-
-# Mysql isn't installed on trusty (only client is), so we need to specifically install it
-addons:
-  apt:
-    packages:
-    - mysql-server-5.6
-    - mysql-client-core-5.6
-    - mysql-client-5.6
 
 cache:
   directories:
@@ -48,8 +38,13 @@ matrix:
 #    - php: 7.1
 #      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" REPOSITORY_SERVICE_ID="ezpublish.siteaccessaware.repository"
 # 7.2
-    - php: 7.2
-      env: TEST_CONFIG="phpunit.xml"
+    - name: Legacy Storage engine tests with MySQL 8.0
+      php: 7.2
+      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
+      addons:
+        snaps:
+        - name: mysql
+          channel: 8.0/beta
     - php: 7.2
       env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
 # 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: xenial
+# Use trusty by default, as xenial has issues with integration due to java (uses openjdk), mysql & postgress
+dist: trusty
 
 language: php
 
@@ -23,17 +24,18 @@ matrix:
   include:
 # 7.1
     - php: 7.1
+      dist: xenial
       env: TEST_CONFIG="phpunit.xml"
     - php: 7.1
+      dist: xenial
       env: REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
     - php: 7.1
+      dist: xenial
       env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat
     - php: 7.1
       env: SOLR_VERSION="6.6.5" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
-      addons:
-        postgresql: "10"
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
 # Disabled as it currently fails, integration tests are not written for language config awareness in Repo, should probably be opt in by test
@@ -42,16 +44,13 @@ matrix:
 # 7.2
     - name: Legacy Storage engine tests with MySQL 8.0
       php: 7.2
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
-      addons:
-        snaps:
-        - name: mysql
-          channel: 8.0/beta
+      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" MYSQL8="true"
     - php: 7.2
       env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
 # 7.3
     # Temp: Need to use --ignore-platform-reqs due to: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3697
     - php: 7.3
+      dist: xenial
       env: TEST_CONFIG="phpunit.xml" COMPOSER_FLAGS="--ignore-platform-reqs"
     - name: Legacy Storage engine tests with MariaDB 10.3
       php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,11 @@ matrix:
     - php: 7.1
       env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat
     - php: 7.1
-      env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
+      env: SOLR_VERSION="6.6.5" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
+      addons:
+        postgresql: "10"
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
 # Disabled as it currently fails, integration tests are not written for language config awareness in Repo, should probably be opt in by test

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ matrix:
 # 7.2
     - name: Legacy Storage engine tests with MySQL 8.0
       php: 7.2
+      # Mysql8 package only exists for 16.04 (xenial) and up
+      dist: xenial
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" MYSQL8="true"
     - php: 7.2
       env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"

--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -35,22 +35,23 @@ if [ "$DB" = "mysql" ] || [ "$DB" = "mariadb" ] ; then
         sudo systemctl restart mysql
         sudo mysql_upgrade
         mysql --version
-        mysql -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;" -uroot
-    else
-        # https://github.com/travis-ci/travis-ci/issues/3049
-        # make sure we don't run out of entropy apparently (see link above)
-        sudo apt-get -y install haveged
-        sudo service haveged start
-        # make tmpfs and run MySQL on it for reasonable performance
-        sudo mkdir /mnt/ramdisk
-        sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
-        sudo stop mysql
-        sudo mv /var/lib/mysql /mnt/ramdisk
-        sudo ln -s /mnt/ramdisk/mysql /var/lib/mysql
-        sudo start mysql
-        # Install test db
-        mysql -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;" -uroot
     fi
+
+    # https://github.com/travis-ci/travis-ci/issues/3049
+    # make sure we don't run out of entropy apparently (see link above)
+    sudo apt-get -y install haveged
+    sudo service haveged start
+
+    # make tmpfs and run MySQL on it for reasonable performance
+    sudo mkdir /mnt/ramdisk
+    sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
+    sudo systemctl stop mysql
+    sudo mv /var/lib/mysql /mnt/ramdisk
+    sudo ln -s /mnt/ramdisk/mysql /var/lib/mysql
+    sudo systemctl start mysql
+
+    # Install test db
+    mysql -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;" -uroot
 fi
 if [ "$DB" = "postgresql" ] ; then psql -c "CREATE DATABASE testdb;" -U postgres ; psql -c "CREATE EXTENSION pgcrypto;" -U postgres testdb ; fi
 

--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -25,6 +25,9 @@ fi
 if [ "$DB" = "mysql" ] || [ "$DB" = "mariadb" ] ; then
     if [ "$MYSQL8" = "true" ]; then
         echo "Install Mysql8"
+        # docker run -ti ubuntu:xenial bash
+        # apt-get update
+        # apt-get install wget lsb-release
         wget https://repo.mysql.com//mysql-apt-config_0.8.12-1_all.deb
         sudo dpkg -i mysql-apt-config_0.8.12-1_all.deb
         sudo apt-get update -q
@@ -32,20 +35,22 @@ if [ "$DB" = "mysql" ] || [ "$DB" = "mariadb" ] ; then
         sudo systemctl restart mysql
         sudo mysql_upgrade
         mysql --version
+        mysql -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;" -uroot
+    else
+        # https://github.com/travis-ci/travis-ci/issues/3049
+        # make sure we don't run out of entropy apparently (see link above)
+        sudo apt-get -y install haveged
+        sudo service haveged start
+        # make tmpfs and run MySQL on it for reasonable performance
+        sudo mkdir /mnt/ramdisk
+        sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
+        sudo stop mysql
+        sudo mv /var/lib/mysql /mnt/ramdisk
+        sudo ln -s /mnt/ramdisk/mysql /var/lib/mysql
+        sudo start mysql
+        # Install test db
+        mysql -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;" -uroot
     fi
-    # https://github.com/travis-ci/travis-ci/issues/3049
-    # make sure we don't run out of entropy apparently (see link above)
-    sudo apt-get -y install haveged
-    sudo service haveged start
-    # make tmpfs and run MySQL on it for reasonable performance
-    sudo mkdir /mnt/ramdisk
-    sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
-    sudo stop mysql
-    sudo mv /var/lib/mysql /mnt/ramdisk
-    sudo ln -s /mnt/ramdisk/mysql /var/lib/mysql
-    sudo start mysql
-    # Install test db
-    mysql -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;" -uroot
 fi
 if [ "$DB" = "postgresql" ] ; then psql -c "CREATE DATABASE testdb;" -U postgres ; psql -c "CREATE EXTENSION pgcrypto;" -U postgres testdb ; fi
 

--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -23,6 +23,16 @@ fi
 
 # Setup DB
 if [ "$DB" = "mysql" ] || [ "$DB" = "mariadb" ] ; then
+    if [ "$MYSQL8" = "true" ]; then
+        echo "Install Mysql8"
+        wget https://repo.mysql.com//mysql-apt-config_0.8.12-1_all.deb
+        sudo dpkg -i mysql-apt-config_0.8.12-1_all.deb
+        sudo apt-get update -q
+        sudo apt-get install -q -y --allow-unauthenticated -o Dpkg::Options::=--force-confnew mysql-server
+        sudo systemctl restart mysql
+        sudo mysql_upgrade
+        mysql --version
+    fi
     # https://github.com/travis-ci/travis-ci/issues/3049
     # make sure we don't run out of entropy apparently (see link above)
     sudo apt-get -y install haveged


### PR DESCRIPTION
Source: https://travis-ci.community/t/how-can-i-use-mysql-8-0-on-xenial-distribution-currently-it-says-5-7/2728

WIP, need to get mysql8 to use tempfs or otherwise tune it for ci use.