### PR TITLE
EZP-30344: Allowed limiting Content management to specific translations

### DIFF
--- a/doc/bc/changes-7.5.md
+++ b/doc/bc/changes-7.5.md
@@ -18,3 +18,10 @@ Changes affecting version compatibility with former or future versions.
 
   Similarly, the default password of the Admin user is not changed. But you must of course change it
   before going live with a new project, and when you do, the new rules come into effect.
+
+* Language Limitation supports now properly multilingual Content items allowing to modify translation
+  which is not main for users with limitation to that translation only.
+
+  Creating draft from existing Versions is no longer disallowed, even if a source Version does not
+  contain any of the translations that are within the scope of the Language Limitations.
+  This is due to the fact that when creating a Draft, an intent of translating is not known yet.

--- a/eZ/Publish/API/Repository/PermissionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionResolver.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\API\Repository;
 
+use eZ\Publish\API\Repository\Values\User\LookupLimitationResult;
 use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\API\Repository\Values\ValueObject;
 
@@ -70,4 +71,24 @@ interface PermissionResolver
      * @return bool
      */
     public function canUser($module, $function, ValueObject $object, array $targets = []);
+
+    /**
+     * @param string $module The module, aka controller identifier to check permissions on
+     * @param string $function The function, aka the controller action to check permissions on
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $object The object to check if the user has access to
+     * @param \eZ\Publish\API\Repository\Values\ValueObject[] $targets An array of location, parent or "assignment" value objects
+     * @param string[] $limitationsIdentifiers An array of Limitations identifiers to filter from all which will pass
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\LookupLimitationResult
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     */
+    public function lookupLimitations(
+        string $module,
+        string $function,
+        ValueObject $object,
+        array $targets = [],
+        array $limitationsIdentifiers = []
+    ): LookupLimitationResult;
 }

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -10,6 +10,9 @@ namespace eZ\Publish\API\Repository\Tests;
 
 use Doctrine\DBAL\Connection;
 use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
+use eZ\Publish\API\Repository\Exceptions\ForbiddenException;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Tests\PHPUnitConstraint\ValidationErrorOccurs as PHPUnitConstraintValidationErrorOccurs;
 use eZ\Publish\API\Repository\Tests\SetupFactory\Legacy;
 use eZ\Publish\API\Repository\Values\Content\Content;
@@ -581,7 +584,9 @@ abstract class BaseTest extends TestCase
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
-     * @throws \Exception
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
     public function createUserWithPolicies($login, array $policiesData)
     {
@@ -607,7 +612,7 @@ abstract class BaseTest extends TestCase
             $repository->commit();
 
             return $user;
-        } catch (\Exception $ex) {
+        } catch (ForbiddenException | NotFoundException | UnauthorizedException $ex) {
             $repository->rollback();
             throw $ex;
         }

--- a/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/BaseLimitationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/BaseLimitationIntegrationTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Limitation\PermissionResolver;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * Base class for all Limitation integration tests.
+ */
+abstract class BaseLimitationIntegrationTest extends BaseTest
+{
+    /**
+     * @var \eZ\Publish\API\Repository\PermissionResolver
+     */
+    protected $permissionResolver;
+
+    public function setUp(): void
+    {
+        $repository = $this->getRepository(false);
+        $this->permissionResolver = $repository->getPermissionResolver();
+    }
+
+    /**
+     * Map Limitations list to readable string for debugging purposes.
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
+     *
+     * @return string
+     */
+    protected function getLimitationsListAsString(array $limitations): string
+    {
+        $str = '';
+        foreach ($limitations as $limitation) {
+            $str .= sprintf(
+                '%s[%s]',
+                get_class($limitation),
+                implode(', ', $limitation->limitationValues)
+            );
+        }
+
+        return $str;
+    }
+
+    /**
+     * Create Editor user with the given Policy and Limitations and set it as current user.
+     *
+     * @param string $module
+     * @param string $function
+     * @param array $limitations
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    protected function loginAsEditorUserWithLimitations(string $module, string $function, array $limitations = []): void
+    {
+        $user = $this->createUserWithPolicies(
+            uniqid('editor'),
+            [
+                ['module' => $module, 'function' => $function, 'limitations' => $limitations],
+            ]
+        );
+
+        $this->permissionResolver->setCurrentUserReference($user);
+    }
+
+    /**
+     * @param bool $expectedResult
+     * @param string $module
+     * @param string $function
+     * @param array $limitations
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $object
+     * @param array $targets
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    protected function assertCanUser(
+        bool $expectedResult,
+        string $module,
+        string $function,
+        array $limitations,
+        ValueObject $object,
+        array $targets = []
+    ): void {
+        self::assertEquals(
+            $expectedResult,
+            $this->permissionResolver->canUser($module, $function, $object, $targets),
+            sprintf(
+                'Failure for %s/%s with limitations: %s',
+                $module,
+                $function,
+                $this->getLimitationsListAsString($limitations)
+            )
+        );
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/ContentLimitationsMixIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/ContentLimitationsMixIntegrationTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Limitation\PermissionResolver;
+
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+
+/**
+ * Test mix of chosen core Content Limitations.
+ */
+class ContentLimitationsMixIntegrationTest extends BaseLimitationIntegrationTest
+{
+    const LIMITATION_VALUES = 'limitationValues';
+
+    /**
+     * {@inheritdoc}
+     *
+     * Provides lists of:
+     *
+     * <code>[string $module, string $function, array $limitations, bool $expectedResult]</code>
+     *
+     * This provider also checks if all registered Limitations are used.
+     */
+    public function providerForCanUser(): array
+    {
+        $commonLimitations = $this->getCommonLimitations();
+        $contentCreateLimitations = array_merge(
+            $commonLimitations,
+            [
+                new Limitation\ParentContentTypeLimitation([self::LIMITATION_VALUES => [1]]),
+                new Limitation\ParentDepthLimitation([self::LIMITATION_VALUES => [2]]),
+                new Limitation\LanguageLimitation([self::LIMITATION_VALUES => ['eng-US']]),
+            ]
+        );
+
+        $contentEditLimitations = array_merge(
+            $commonLimitations,
+            [
+                new Limitation\ObjectStateLimitation(
+                    [self::LIMITATION_VALUES => [1, 2]]
+                ),
+                new Limitation\LanguageLimitation([self::LIMITATION_VALUES => ['eng-US']]),
+            ]
+        );
+
+        $contentVersionReadLimitations = array_merge(
+            $commonLimitations,
+            [
+                new Limitation\StatusLimitation(
+                    [self::LIMITATION_VALUES => [VersionInfo::STATUS_PUBLISHED]]
+                ),
+            ]
+        );
+
+        return [
+            ['content', 'create', $contentCreateLimitations, true],
+            ['content', 'edit', $contentEditLimitations, true],
+            ['content', 'publish', $contentEditLimitations, true],
+            ['content', 'versionread', $contentVersionReadLimitations, true],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForCanUser
+     *
+     * @param string $module
+     * @param string $function
+     * @param array $limitations
+     * @param bool $expectedResult
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testCanUser(
+        string $module,
+        string $function,
+        array $limitations,
+        bool $expectedResult
+    ): void {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $folder = $this->createFolder(['eng-US' => 'Folder'], 2);
+        $location = $locationService->loadLocation($folder->contentInfo->mainLocationId);
+
+        $this->loginAsEditorUserWithLimitations($module, $function, $limitations);
+
+        $this->assertCanUser(
+            $expectedResult,
+            $module,
+            $function,
+            $limitations,
+            $folder,
+            [$location]
+        );
+    }
+
+    /**
+     * Get a list of Limitations common to all test cases.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Limitation[]
+     */
+    private function getCommonLimitations(): array
+    {
+        return [
+            new Limitation\ContentTypeLimitation([self::LIMITATION_VALUES => [1]]),
+            new Limitation\SectionLimitation([self::LIMITATION_VALUES => [1]]),
+            new Limitation\SubtreeLimitation([self::LIMITATION_VALUES => ['/1/2']]),
+        ];
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LanguageLimitationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LanguageLimitationIntegrationTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Limitation\PermissionResolver;
+
+use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation;
+
+/**
+ * Integration test for chosen use cases of calls to PermissionResolver::canUser.
+ */
+class LanguageLimitationIntegrationTest extends BaseLimitationIntegrationTest
+{
+    private const LANG_ENG_GB = 'eng-GB';
+    private const LANG_ENG_US = 'eng-US';
+    private const LANG_GER_DE = 'ger-DE';
+
+    /**
+     * Data provider for testCanUserCreateContent.
+     *
+     * @see testCanUserCreateContent
+     *
+     * @return array
+     */
+    public function providerForCanUserCreateContent(): array
+    {
+        $limitationForGerman = new LanguageLimitation();
+        $limitationForGerman->limitationValues = [self::LANG_GER_DE];
+
+        $limitationForBritishEnglish = new LanguageLimitation();
+        $limitationForBritishEnglish->limitationValues = [self::LANG_ENG_GB];
+
+        $multilingualLimitation = new LanguageLimitation();
+        $multilingualLimitation->limitationValues = [self::LANG_ENG_US, self::LANG_GER_DE];
+
+        return [
+            // trying to create German Content, so for British it's false
+            [[$limitationForBritishEnglish], false],
+            [[$limitationForGerman], true],
+            // at least one multilingual limitation must match
+            [[$multilingualLimitation], true],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForCanUserCreateContent
+     *
+     * @param array $limitations
+     * @param bool $expectedResult
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testCanUserCreateContent(array $limitations, bool $expectedResult): void
+    {
+        $repository = $this->getRepository();
+        $contentTypeService = $repository->getContentTypeService();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+
+        $this->loginAsEditorUserWithLimitations('content', 'create', $limitations);
+
+        $folderType = $contentTypeService->loadContentTypeByIdentifier(
+            'folder'
+        );
+        $contentCreateStruct = $contentService->newContentCreateStruct(
+            $folderType,
+            self::LANG_GER_DE
+        );
+        $targets = [
+            $locationService->newLocationCreateStruct(2),
+        ];
+
+        $this->assertCanUser(
+            $expectedResult,
+            'content',
+            'create',
+            $limitations,
+            $contentCreateStruct,
+            $targets
+        );
+    }
+
+    /**
+     * Data provider for testCanUserEditContent and testCanUserPublishContent.
+     *
+     * @see testCanUserEditContent
+     * @see testCanUserPublishContent
+     */
+    public function providerForCanUserEditOrPublishContent(): array
+    {
+        $limitationForGerman = new LanguageLimitation();
+        $limitationForGerman->limitationValues = [self::LANG_GER_DE];
+
+        $limitationForBritishEnglish = new LanguageLimitation();
+        $limitationForBritishEnglish->limitationValues = [self::LANG_ENG_GB];
+
+        $multilingualLimitation = new LanguageLimitation();
+        $multilingualLimitation->limitationValues = [self::LANG_ENG_US, self::LANG_GER_DE];
+
+        return [
+            // dealing with British content, so true only for British Language Limitation
+            [[$limitationForBritishEnglish], true],
+            [[$limitationForGerman], false],
+            [[$multilingualLimitation], false],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForCanUserEditOrPublishContent
+     *
+     * @param array $limitations
+     * @param bool $expectedResult
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testCanUserEditContent(array $limitations, bool $expectedResult): void
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $content = $this->createFolder([self::LANG_ENG_GB => 'British Folder'], 2);
+        $contentInfo = $content->contentInfo;
+        $location = $locationService->loadLocation($contentInfo->mainLocationId);
+
+        $this->loginAsEditorUserWithLimitations('content', 'edit', $limitations);
+
+        $this->assertCanUser(
+            $expectedResult,
+            'content',
+            'edit',
+            $limitations,
+            $contentInfo,
+            [$location]
+        );
+    }
+
+    /**
+     * @dataProvider providerForCanUserEditOrPublishContent
+     *
+     * @param array $limitations
+     * @param bool $expectedResult
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testCanUserPublishContent(array $limitations, bool $expectedResult): void
+    {
+        $content = $this->createFolder([self::LANG_ENG_GB => 'British Folder'], 2);
+
+        $this->loginAsEditorUserWithLimitations('content', 'publish', $limitations);
+
+        $this->assertCanUser($expectedResult, 'content', 'publish', $limitations, $content);
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -1,151 +1,238 @@
 <?php
 
 /**
- * File containing the LanguageLimitationTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;
+declare(strict_types=1);
 
+namespace eZ\Publish\API\Repository\Tests\Limitation;
+
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\Tests\BaseTest;
 use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation;
+use eZ\Publish\API\Repository\Values\User\User;
 
 /**
- * Test case for the {@link \eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation}
- * class.
+ * Test cases for ContentService APIs calls made by user with LanguageLimitation on chosen policies.
  *
- * @see eZ\Publish\API\Repository\Values\User\Limitation
- * @see eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation
+ * @uses \eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation
+ *
  * @group integration
- * @group limitation
+ * @group authorization
+ * @group language-limited-content-mgm
  */
-class LanguageLimitationTest extends BaseLimitationTest
+class LanguageLimitationTest extends BaseTest
 {
     /**
-     * Test for the LanguageLimitation.
+     * Create editor who is allowed to modify only specific translations of a Content item.
      *
-     * @see \eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation
+     * @param array $allowedTranslationsList list of translations (language codes) which editor can modify.
      *
-     * @throws \ErrorException
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testLanguageLimitationAllow()
+    private function createEditorUserWithLanguageLimitation(array $allowedTranslationsList): User
     {
-        $repository = $this->getRepository();
+        $limitations = [
+            // limitation for specific translations
+            new LanguageLimitation(['limitationValues' => $allowedTranslationsList]),
+        ];
 
-        $contentId = $this->generateId('content', 58);
-        /* BEGIN: Use Case */
-        $user = $this->createUserVersion1();
-
-        $roleService = $repository->getRoleService();
-
-        $role = $roleService->loadRoleByIdentifier('Editor');
-
-        $editPolicy = null;
-        foreach ($role->getPolicies() as $policy) {
-            if ('content' != $policy->module || 'edit' != $policy->function) {
-                continue;
-            }
-            $editPolicy = $policy;
-            break;
-        }
-
-        if (null === $editPolicy) {
-            throw new \ErrorException('No content:edit policy found.');
-        }
-
-        // Only allow eng-GB content
-        $policyUpdate = $roleService->newPolicyUpdateStruct();
-        $policyUpdate->addLimitation(
-            new LanguageLimitation(
-                array('limitationValues' => array('eng-GB'))
-            )
-        );
-        $roleService->updatePolicy($editPolicy, $policyUpdate);
-
-        $roleService->assignRoleToUser($role, $user);
-
-        $contentService = $repository->getContentService();
-
-        $repository->setCurrentUser($user);
-
-        $contentUpdate = $contentService->newContentUpdateStruct();
-        $contentUpdate->setField('name', 'Contact Me');
-
-        $draft = $contentService->createContentDraft(
-            $contentService->loadContentInfo($contentId)
-        );
-
-        // Update content object
-        $draft = $contentService->updateContent(
-            $draft->versionInfo,
-            $contentUpdate
-        );
-
-        $contentService->publishVersion($draft->versionInfo);
-        /* END: Use Case */
-
-        $this->assertEquals(
-            'Contact Me',
-            $contentService->loadContent($contentId)
-                ->getFieldValue('name')->text
+        return $this->createUserWithPolicies(
+            'editor',
+            [
+                ['module' => 'content', 'function' => 'read'],
+                ['module' => 'content', 'function' => 'versionread'],
+                ['module' => 'content', 'function' => 'view_embed'],
+                ['module' => 'content', 'function' => 'create', 'limitations' => $limitations],
+                ['module' => 'content', 'function' => 'edit', 'limitations' => $limitations],
+                ['module' => 'content', 'function' => 'publish', 'limitations' => $limitations],
+            ]
         );
     }
 
     /**
-     * Test for the LanguageLimitation.
-     *
-     * @see \eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     *
-     * @throws \ErrorException
+     * @return array
+     * @see testCreateAndPublishContent
      */
-    public function testLanguageLimitationForbid()
+    public function providerForCreateAndPublishContent(): array
+    {
+        // $names (as admin), $allowedTranslationsList (editor limitations)
+        return [
+            [
+                ['ger-DE' => 'German Folder'],
+                ['ger-DE'],
+            ],
+            [
+                ['ger-DE' => 'German Folder', 'eng-GB' => 'British Folder'],
+                ['ger-DE', 'eng-GB'],
+            ],
+        ];
+    }
+
+    /**
+     * Test creating and publishing a fresh Content item in a language restricted by LanguageLimitation.
+     *
+     * @param array $names
+     * @param array $allowedTranslationsList
+     *
+     * @dataProvider providerForCreateAndPublishContent
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testCreateAndPublishContent(array $names, array $allowedTranslationsList): void
     {
         $repository = $this->getRepository();
-
-        $contentId = $this->generateId('content', 58);
-        /* BEGIN: Use Case */
-        $user = $this->createUserVersion1();
-
-        $roleService = $repository->getRoleService();
-
-        $role = $roleService->loadRoleByIdentifier('Editor');
-
-        $editPolicy = null;
-        foreach ($role->getPolicies() as $policy) {
-            if ('content' != $policy->module || 'edit' != $policy->function) {
-                continue;
-            }
-            $editPolicy = $policy;
-            break;
-        }
-
-        if (null === $editPolicy) {
-            throw new \ErrorException('No content:edit policy found.');
-        }
-
-        // Only allow eng-US content
-        $policyUpdate = $roleService->newPolicyUpdateStruct();
-        $policyUpdate->addLimitation(
-            new LanguageLimitation(
-                array('limitationValues' => array('eng-US'))
-            )
+        $repository->getPermissionResolver()->setCurrentUserReference(
+            $this->createEditorUserWithLanguageLimitation($allowedTranslationsList)
         );
-        $roleService->updatePolicy($editPolicy, $policyUpdate);
 
-        $roleService->assignRoleToUser($role, $user);
+        $folder = $this->createFolder($names, 2);
 
+        foreach ($names as $languageCode => $translatedName) {
+            self::assertEquals(
+                $translatedName,
+                $folder->getField('name', $languageCode)->value->text
+            );
+        }
+    }
+
+    /**
+     * Data provider for testPublishVersionWithLanguageLimitation.
+     *
+     * @return array
+     * @see testPublishVersionIsNotAllowedIfModifiedOtherTranslations
+     *
+     * @see testPublishVersion
+     */
+    public function providerForPublishVersionWithLanguageLimitation(): array
+    {
+        // $names (as admin), $namesToUpdate (as editor), $allowedTranslationsList (editor limitations)
+        return [
+            [
+                ['eng-US' => 'American Folder'],
+                ['ger-DE' => 'Updated German Folder'],
+                ['ger-DE'],
+            ],
+            [
+                ['eng-US' => 'American Folder', 'ger-DE' => 'German Folder'],
+                ['ger-DE' => 'Updated German Folder'],
+                ['ger-DE'],
+            ],
+            [
+                [
+                    'eng-US' => 'American Folder',
+                    'eng-GB' => 'British Folder',
+                    'ger-DE' => 'German Folder',
+                ],
+                ['ger-DE' => 'Updated German Folder', 'eng-GB' => 'British Folder'],
+                ['ger-DE', 'eng-GB'],
+            ],
+            [
+                ['eng-US' => 'American Folder', 'ger-DE' => 'German Folder'],
+                ['ger-DE' => 'Updated German Folder', 'eng-GB' => 'British Folder'],
+                ['ger-DE', 'eng-GB'],
+            ],
+        ];
+    }
+
+    /**
+     * Test publishing Version with translations restricted by LanguageLimitation.
+     *
+     * @param array $names
+     * @param array $namesToUpdate
+     * @param array $allowedTranslationsList
+     *
+     * @dataProvider providerForPublishVersionWithLanguageLimitation
+     *
+     * @covers \eZ\Publish\API\Repository\ContentService::createContentDraft
+     * @covers \eZ\Publish\API\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\API\Repository\ContentService::publishVersion
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \Exception
+     */
+    public function testPublishVersion(
+        array $names,
+        array $namesToUpdate,
+        array $allowedTranslationsList
+    ): void {
+        $repository = $this->getRepository();
         $contentService = $repository->getContentService();
 
-        $repository->setCurrentUser($user);
+        $folder = $this->createFolder($names, 2);
 
-        $contentUpdate = $contentService->newContentUpdateStruct();
-        $contentUpdate->setField('name', 'Contact Me');
-
-        // This call will fail with an UnauthorizedException
-        $contentService->createContentDraft(
-            $contentService->loadContentInfo($contentId)
+        $repository->getPermissionResolver()->setCurrentUserReference(
+            $this->createEditorUserWithLanguageLimitation($allowedTranslationsList)
         );
-        /* END: Use Case */
+
+        $folderDraft = $contentService->createContentDraft($folder->contentInfo);
+        $folderUpdateStruct = $contentService->newContentUpdateStruct();
+        // set modified translation of Version to the first modified as multiple are not supported yet
+        $folderUpdateStruct->initialLanguageCode = array_keys($namesToUpdate)[0];
+        foreach ($namesToUpdate as $languageCode => $translatedName) {
+            $folderUpdateStruct->setField('name', $translatedName, $languageCode);
+        }
+        $folderDraft = $contentService->updateContent(
+            $folderDraft->getVersionInfo(),
+            $folderUpdateStruct
+        );
+        $contentService->publishVersion($folderDraft->getVersionInfo());
+
+        $folder = $contentService->loadContent($folder->id);
+        $updatedNames = array_merge($names, $namesToUpdate);
+        foreach ($updatedNames as $languageCode => $expectedValue) {
+            self::assertEquals(
+                $expectedValue,
+                $folder->getField('name', $languageCode)->value->text,
+                "Unexpected Field value for {$languageCode}"
+            );
+        }
+    }
+
+    /**
+     * Test that publishing version with changes to translations outside limitation values throws unauthorized exception.
+     *
+     * @param array $names
+     *
+     * @dataProvider providerForPublishVersionWithLanguageLimitation
+     *
+     * @covers \eZ\Publish\API\Repository\ContentService::createContentDraft
+     * @covers \eZ\Publish\API\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\API\Repository\ContentService::publishVersion
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testPublishVersionIsNotAllowedIfModifiedOtherTranslations(array $names): void
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $folder = $this->createFolder($names, 2);
+        $folderDraft = $contentService->createContentDraft($folder->contentInfo);
+        $folderUpdateStruct = $contentService->newContentUpdateStruct();
+        $folderUpdateStruct->setField('name', 'Updated American Folder', 'eng-US');
+        $folderDraft = $contentService->updateContent(
+            $folderDraft->getVersionInfo(),
+            $folderUpdateStruct
+        );
+
+        // switch context to the user not allowed to publish eng-US
+        $repository->getPermissionResolver()->setCurrentUserReference(
+            $this->createEditorUserWithLanguageLimitation(['ger-DE'])
+        );
+
+        $this->expectException(UnauthorizedException::class);
+        $contentService->publishVersion($folderDraft->getVersionInfo());
     }
 }

--- a/eZ/Publish/API/Repository/Values/User/LookupLimitationResult.php
+++ b/eZ/Publish/API/Repository/Values/User/LookupLimitationResult.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\User;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * This class represents a LookupLimitation for module and function in the context of current User.
+ */
+final class LookupLimitationResult extends ValueObject
+{
+    /**
+     * @var bool
+     */
+    protected $hasAccess;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\User\Limitation[]
+     */
+    protected $roleLimitations;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\User\LookupPolicyLimitations[]
+     */
+    protected $lookupPolicyLimitations;
+
+    /**
+     * @param bool $hasAccess
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $roleLimitations
+     * @param \eZ\Publish\API\Repository\Values\User\LookupPolicyLimitations[] $lookupPolicyLimitations
+     */
+    public function __construct(
+        bool $hasAccess,
+        array $roleLimitations = [],
+        array $lookupPolicyLimitations = []
+    ) {
+        parent::__construct();
+
+        $this->hasAccess = $hasAccess;
+        $this->lookupPolicyLimitations = $lookupPolicyLimitations;
+        $this->roleLimitations = $roleLimitations;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/User/LookupPolicyLimitations.php
+++ b/eZ/Publish/API/Repository/Values/User/LookupPolicyLimitations.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\User;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * This class represents a result of lookup limitation for module and function in the context of current User.
+ */
+final class LookupPolicyLimitations extends ValueObject
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Values\User\Policy
+     */
+    protected $policy;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\User\Limitation[]
+     */
+    protected $limitations;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
+     */
+    public function __construct(Policy $policy, array $limitations = [])
+    {
+        parent::__construct();
+
+        $this->policy = $policy;
+        $this->limitations = $limitations;
+    }
+}

--- a/eZ/Publish/Core/Limitation/LanguageLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitationType.php
@@ -1,59 +1,98 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Limitation;
 
-use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
-use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\Content;
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
-use eZ\Publish\API\Repository\Values\Content\VersionInfo;
-use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
-use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation as APILanguageLimitation;
-use eZ\Publish\API\Repository\Values\User\Limitation as APILimitationValue;
-use eZ\Publish\SPI\Limitation\Type as SPILimitationTypeInterface;
-use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
+use eZ\Publish\API\Repository\Values\User\Limitation as APILimitationValue;
+use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation as APILanguageLimitation;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\Base\Exceptions\BadStateException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\SPI\Limitation\Target;
+use eZ\Publish\SPI\Limitation\TargetAwareType as SPITargetAwareLimitationType;
+use eZ\Publish\SPI\Persistence\Content\Handler as SPIPersistenceContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Language\Handler as SPIPersistenceLanguageHandler;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo as SPIVersionInfo;
 
 /**
  * LanguageLimitation is a Content limitation.
  */
-class LanguageLimitationType extends AbstractPersistenceLimitationType implements SPILimitationTypeInterface
+class LanguageLimitationType implements SPITargetAwareLimitationType
 {
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Language\Handler
+     */
+    private $persistenceLanguageHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Handler
+     */
+    private $persistenceContentHandler;
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Language\Handler $persistenceLanguageHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Handler $persistenceContentHandler
+     */
+    public function __construct(
+        SPIPersistenceLanguageHandler $persistenceLanguageHandler,
+        SPIPersistenceContentHandler $persistenceContentHandler
+    ) {
+        $this->persistenceLanguageHandler = $persistenceLanguageHandler;
+        $this->persistenceContentHandler = $persistenceContentHandler;
+    }
+
     /**
      * Accepts a Limitation value and checks for structural validity.
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitationValue
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APILanguageLimitation) {
-            throw new InvalidArgumentType('$limitationValue', 'APILanguageLimitation', $limitationValue);
+            throw new InvalidArgumentType(
+                '$limitationValue',
+                APILanguageLimitation::class,
+                $limitationValue
+            );
         } elseif (!is_array($limitationValue->limitationValues)) {
-            throw new InvalidArgumentType('$limitationValue->limitationValues', 'array', $limitationValue->limitationValues);
+            throw new InvalidArgumentType(
+                '$limitationValue->limitationValues',
+                'array',
+                $limitationValue->limitationValues
+            );
         }
 
         foreach ($limitationValue->limitationValues as $key => $value) {
             if (!is_string($value)) {
-                throw new InvalidArgumentType("\$limitationValue->limitationValues[{$key}]", 'string', $value);
+                throw new InvalidArgumentType(
+                    "\$limitationValue->limitationValues[{$key}]",
+                    'string',
+                    $value
+                );
             }
         }
     }
 
     /**
-     * Makes sure LimitationValue->limitationValues is valid according to valueSchema().
+     * Makes sure every language code defined as limitation exists.
      *
      * Make sure {@link acceptValue()} is checked first!
      *
@@ -61,22 +100,24 @@ class LanguageLimitationType extends AbstractPersistenceLimitationType implement
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = array();
-        foreach ($limitationValue->limitationValues as $key => $value) {
-            try {
-                $this->persistence->contentLanguageHandler()->loadByLanguageCode($value);
-            } catch (APINotFoundException $e) {
-                $validationErrors[] = new ValidationError(
-                    "limitationValues[%key%] => '%value%' does not exist in the backend",
-                    null,
-                    array(
-                        'value' => $value,
-                        'key' => $key,
-                    )
-                );
-            }
+        $existingLanguages = $this->persistenceLanguageHandler->loadListByLanguageCodes(
+            $limitationValue->limitationValues
+        );
+        $missingLanguages = array_diff(
+            $limitationValue->limitationValues,
+            array_keys($existingLanguages)
+        );
+        if (!empty($missingLanguages)) {
+            $validationErrors[] = new ValidationError(
+                "limitationValues[] => '%languageCodes%' translation(s) do not exist",
+                null,
+                [
+                    'languageCodes' => implode(', ', $missingLanguages),
+                ]
+            );
         }
 
         return $validationErrors;
@@ -85,66 +126,188 @@ class LanguageLimitationType extends AbstractPersistenceLimitationType implement
     /**
      * Create the Limitation Value.
      *
-     * @param mixed[] $limitationValues
+     * @param array[] $limitationValues
      *
      * @return \eZ\Publish\API\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
-        return new APILanguageLimitation(array('limitationValues' => $limitationValues));
+        return new APILanguageLimitation(['limitationValues' => $limitationValues]);
     }
 
     /**
-     * Evaluate permission against content & target(placement/parent/assignment).
+     * Evaluate permission against content & target.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
-     * @param \eZ\Publish\API\Repository\Values\ValueObject $object
-     * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
-     *
-     * @return bool
+     * {@inheritdoc}
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
-    {
-        if (!$value instanceof APILanguageLimitation) {
-            throw new InvalidArgumentException('$value', 'Must be of type: APILanguageLimitation');
+    public function evaluate(
+        APILimitationValue $value,
+        APIUserReference $currentUser,
+        ValueObject $object,
+        array $targets = null
+    ): ?bool {
+        if (null == $targets) {
+            $targets = [];
         }
 
+        // the main focus here is an intent to update to a new Version
+        foreach ($targets as $target) {
+            if (!$target instanceof Target\Version) {
+                continue;
+            }
+
+            $accessVote = $this->evaluateVersionTarget($target, $value);
+
+            // continue evaluation of targets if there was no explicit grant/deny
+            if ($accessVote === self::ACCESS_ABSTAIN) {
+                continue;
+            }
+
+            return $accessVote;
+        }
+
+        // in other cases we need to evaluate object
+        return $this->evaluateObject($object, $value);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $object
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
+     *
+     * @return bool|null
+     */
+    private function evaluateObject(ValueObject $object, APILimitationValue $value): ?bool
+    {
+        // by default abstain from making decision for unknown object
+        $accessVote = self::ACCESS_ABSTAIN;
+
+        // load for evaluation VersionInfo for Content & ContentInfo objects
         if ($object instanceof Content) {
             $object = $object->getVersionInfo();
-        } elseif (!$object instanceof VersionInfo && !$object instanceof ContentInfo && !$object instanceof ContentCreateStruct) {
-            throw new InvalidArgumentException(
-                '$object',
-                'Must be of type: ContentCreateStruct, Content, VersionInfo or ContentInfo'
+        } elseif ($object instanceof ContentInfo) {
+            try {
+                $object = $this->persistenceContentHandler->loadVersionInfo(
+                    $object->id,
+                    $object->currentVersionNo
+                );
+            } catch (NotFoundException $e) {
+                return self::ACCESS_DENIED;
+            }
+        }
+
+        // cover creating Content Draft for new Content item
+        if ($object instanceof ContentCreateStruct) {
+            $accessVote = $this->evaluateContentCreateStruct($object, $value);
+        } elseif ($object instanceof VersionInfo || $object instanceof SPIVersionInfo) {
+            $accessVote = in_array($object->initialLanguageCode, $value->limitationValues)
+                ? self::ACCESS_GRANTED
+                : self::ACCESS_DENIED;
+        }
+
+        return $accessVote;
+    }
+
+    /**
+     * Evaluate language codes of allowed translations for ContentCreateStruct.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\ContentCreateStruct $object
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
+     *
+     * @return bool|null
+     */
+    private function evaluateContentCreateStruct(
+        ContentCreateStruct $object,
+        APILimitationValue $value
+    ): ?bool {
+        $languageCodes = $this->getAllLanguageCodesFromCreateStruct($object);
+
+        // check if object contains only allowed language codes
+        return empty(array_diff($languageCodes, $value->limitationValues))
+            ? self::ACCESS_GRANTED
+            : self::ACCESS_DENIED;
+    }
+
+    /**
+     * Evaluate permissions to create new Version.
+     *
+     * @param \eZ\Publish\SPI\Limitation\Target\Version $version
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
+     *
+     * @return bool|null
+     */
+    private function evaluateVersionTarget(
+        Target\Version $version,
+        APILimitationValue $value
+    ): ?bool {
+        // intentionally evaluate all conditions separately from the least to the most important
+        $accessVote = self::ACCESS_ABSTAIN;
+
+        // allow creating new drafts
+        if ($version->newStatus === VersionInfo::STATUS_DRAFT) {
+            $accessVote = self::ACCESS_GRANTED;
+        }
+
+        // ... unless there's a specific list of target translations
+        if (!empty($version->allLanguageCodesList)) {
+            $accessVote = $this->evaluateMatchingAnyLimitation(
+                $version->allLanguageCodesList,
+                $value->limitationValues
             );
         }
 
-        if (empty($value->limitationValues)) {
-            return false;
-        }
-
-        if ($object instanceof ContentInfo || $object instanceof ContentCreateStruct) {
-            return in_array($object->mainLanguageCode, $value->limitationValues, true);
-        }
-
-        /*
-         * @var $object VersionInfo
-         */
-        foreach ($value->limitationValues as $limitationLanguageCode) {
-            if ($object->initialLanguageCode === $limitationLanguageCode) {
-                return true;
+        // ... or there's an intent to update Version
+        if (!empty($version->forUpdateLanguageCodesList) || null !== $version->forUpdateInitialLanguageCode) {
+            if (!empty($version->forUpdateLanguageCodesList)) {
+                $diff = array_diff($version->forUpdateLanguageCodesList, $value->limitationValues);
+                $accessVote = empty($diff) ? self::ACCESS_GRANTED : self::ACCESS_DENIED;
             }
-            if (in_array($limitationLanguageCode, $object->languageCodes, true)) {
-                return true;
+
+            if ($accessVote !== self::ACCESS_DENIED && null !== $version->forUpdateInitialLanguageCode) {
+                $accessVote = in_array(
+                    $version->forUpdateInitialLanguageCode,
+                    $value->limitationValues
+                )
+                    ? self::ACCESS_GRANTED
+                    : self::ACCESS_DENIED;
             }
         }
 
-        return false;
+        return $accessVote;
+    }
+
+    /**
+     * Allow access if any of the given language codes for translations matches any of the limitation values.
+     *
+     * @param string[] $languageCodesList
+     * @param string[] $limitationValues
+     *
+     * @return bool
+     */
+    private function evaluateMatchingAnyLimitation(
+        array $languageCodesList,
+        array $limitationValues
+    ): bool {
+        return empty(array_intersect($languageCodesList, $limitationValues))
+            ? self::ACCESS_DENIED
+            : self::ACCESS_GRANTED;
+    }
+
+    /**
+     * Get unique list of language codes for all used translations, including mainLanguageCode.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\ContentCreateStruct $contentCreateStruct
+     *
+     * @return string[]
+     */
+    private function getAllLanguageCodesFromCreateStruct(
+        ContentCreateStruct $contentCreateStruct
+    ): array {
+        $languageCodes = [$contentCreateStruct->mainLanguageCode];
+        foreach ($contentCreateStruct->fields as $field) {
+            $languageCodes[] = $field->languageCode;
+        }
+
+        return array_unique($languageCodes);
     }
 
     /**
@@ -154,17 +317,19 @@ class LanguageLimitationType extends AbstractPersistenceLimitationType implement
      * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
-    {
+    public function getCriterion(
+        APILimitationValue $value,
+        APIUserReference $currentUser
+    ): CriterionInterface {
         if (empty($value->limitationValues)) {
             // no limitation values
-            throw new \RuntimeException('$value->limitationValues is empty, it should not have been stored in the first place');
-        }
-
-        if (!isset($value->limitationValues[1])) {
-            // 1 limitation value: EQ operation
-            return new Criterion\LanguageCode($value->limitationValues[0]);
+            throw new BadStateException(
+                '$value',
+                '$value->limitationValues is empty, it should not have been stored in the first place'
+            );
         }
 
         // several limitation values: IN operation
@@ -172,13 +337,12 @@ class LanguageLimitationType extends AbstractPersistenceLimitationType implement
     }
 
     /**
-     * Returns info on valid $limitationValues.
+     * For LanguageLimitationType it returns an empty array because schema is not deterministic.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
-     *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
+     * @see validate for business logic.
      */
-    public function valueSchema()
+    public function valueSchema(): array
     {
-        throw new \eZ\Publish\API\Repository\Exceptions\NotImplementedException(__METHOD__);
+        return [];
     }
 }

--- a/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
+++ b/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
@@ -9,6 +9,7 @@ namespace eZ\Publish\Core\Repository\Permission;
 use eZ\Publish\API\Repository\PermissionResolver as APIPermissionResolver;
 use eZ\Publish\API\Repository\PermissionCriterionResolver as APIPermissionCriterionResolver;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
+use eZ\Publish\API\Repository\Values\User\LookupLimitationResult;
 use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use Exception;
@@ -101,6 +102,19 @@ class CachedPermissionService implements APIPermissionResolver, APIPermissionCri
     public function canUser($module, $function, ValueObject $object, array $targets = [])
     {
         return $this->permissionResolver->canUser($module, $function, $object, $targets);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lookupLimitations(
+        string $module,
+        string $function,
+        ValueObject $object,
+        array $targets = [],
+        array $limitations = []
+    ): LookupLimitationResult {
+        return $this->permissionResolver->lookupLimitations($module, $function, $object, $targets, $limitations);
     }
 
     public function getPermissionsCriterion($module = 'content', $function = 'read', ?array $targets = null)

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
+use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\Core\Repository\Helper\RelationProcessor;
 use eZ\Publish\Core\Search\Common\BackgroundIndexer\NullIndexer;
 use PHPUnit\Framework\TestCase;
@@ -35,6 +36,11 @@ abstract class Base extends TestCase
      * @var \eZ\Publish\API\Repository\Repository|\PHPUnit\Framework\MockObject\MockObject
      */
     private $repositoryMock;
+
+    /**
+     * @var \eZ\Publish\API\Repository\PermissionResolver|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $permissionResolverMock;
 
     /**
      * @var \eZ\Publish\SPI\Persistence\Handler|\PHPUnit\Framework\MockObject\MockObject
@@ -136,6 +142,18 @@ abstract class Base extends TestCase
         }
 
         return $this->repositoryMock;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\PermissionResolver|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function getPermissionResolverMock()
+    {
+        if (!isset($this->permissionResolverMock)) {
+            $this->permissionResolverMock = $this->createMock(PermissionResolver::class);
+        }
+
+        return $this->permissionResolverMock;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
+use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
@@ -2859,7 +2860,7 @@ class ContentTest extends BaseServiceMockTest
      */
     public function testUpdateContentThrowsUnauthorizedException()
     {
-        $repositoryMock = $this->getRepositoryMock();
+        $permissionResolverMock = $this->getPermissionResolverMock();
         $mockedService = $this->getPartlyMockedContentService(array('loadContent'));
         $contentUpdateStruct = new ContentUpdateStruct();
         $versionInfo = new VersionInfo(
@@ -2886,12 +2887,13 @@ class ContentTest extends BaseServiceMockTest
                 $this->returnValue($content)
             );
 
-        $repositoryMock->expects($this->once())
+        $permissionResolverMock->expects($this->once())
             ->method('canUser')
             ->with(
                 $this->equalTo('content'),
                 $this->equalTo('edit'),
-                $this->equalTo($content)
+                $this->equalTo($content),
+                $this->isType('array')
             )->will($this->returnValue(false));
 
         $mockedService->updateContent($versionInfo, $contentUpdateStruct);
@@ -3049,6 +3051,7 @@ class ContentTest extends BaseServiceMockTest
         $execute = true
     ) {
         $repositoryMock = $this->getRepositoryMock();
+        $permissionResolverMock = $this->getPermissionResolverMock();
         $mockedService = $this->getPartlyMockedContentService(array('loadContent', 'loadRelations'));
         /** @var \PHPUnit\Framework\MockObject\MockObject $contentHandlerMock */
         $contentHandlerMock = $this->getPersistenceMock()->contentHandler();
@@ -3116,12 +3119,13 @@ class ContentTest extends BaseServiceMockTest
 
         $repositoryMock->expects($this->once())->method('beginTransaction');
 
-        $repositoryMock->expects($this->once())
+        $permissionResolverMock->expects($this->once())
             ->method('canUser')
             ->with(
                 $this->equalTo('content'),
                 $this->equalTo('edit'),
-                $this->equalTo($content)
+                $this->equalTo($content),
+                $this->isType('array')
             )->will($this->returnValue(true));
 
         $contentTypeServiceMock->expects($this->once())
@@ -4556,6 +4560,7 @@ class ContentTest extends BaseServiceMockTest
     public function testUpdateContentWithInvalidLanguage($initialLanguageCode, $structFields)
     {
         $repositoryMock = $this->getRepositoryMock();
+        $permissionResolverMock = $this->getPermissionResolverMock();
         $mockedService = $this->getPartlyMockedContentService(array('loadContent'));
         /** @var \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
@@ -4605,12 +4610,13 @@ class ContentTest extends BaseServiceMockTest
                 $this->returnValue($content)
             );
 
-        $repositoryMock->expects($this->once())
+        $permissionResolverMock->expects($this->once())
             ->method('canUser')
             ->with(
                 $this->equalTo('content'),
                 $this->equalTo('edit'),
-                $this->equalTo($content)
+                $this->equalTo($content),
+                $this->isType('array')
             )->will($this->returnValue(true));
 
         $contentUpdateStruct = new ContentUpdateStruct(
@@ -4629,6 +4635,7 @@ class ContentTest extends BaseServiceMockTest
         $fieldDefinitions = array()
     ) {
         $repositoryMock = $this->getRepositoryMock();
+        $permissionResolverMock = $this->getPermissionResolverMock();
         $mockedService = $this->getPartlyMockedContentService(array('loadContent'));
         /** @var \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
@@ -4680,12 +4687,13 @@ class ContentTest extends BaseServiceMockTest
                 $this->returnValue($content)
             );
 
-        $repositoryMock->expects($this->once())
+        $permissionResolverMock->expects($this->once())
             ->method('canUser')
             ->with(
                 $this->equalTo('content'),
                 $this->equalTo('edit'),
-                $this->equalTo($content)
+                $this->equalTo($content),
+                $this->isType('array')
             )->will($this->returnValue(true));
 
         $contentTypeServiceMock->expects($this->once())
@@ -4801,6 +4809,7 @@ class ContentTest extends BaseServiceMockTest
         $fieldDefinitions
     ) {
         $repositoryMock = $this->getRepositoryMock();
+        $permissionResolver = $this->getPermissionResolverMock();
         $mockedService = $this->getPartlyMockedContentService(array('loadContent'));
         /** @var \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
@@ -4856,12 +4865,13 @@ class ContentTest extends BaseServiceMockTest
                 $this->returnValue($content)
             );
 
-        $repositoryMock->expects($this->once())
+        $permissionResolver->expects($this->once())
             ->method('canUser')
             ->with(
                 $this->equalTo('content'),
                 $this->equalTo('edit'),
-                $this->equalTo($content)
+                $this->equalTo($content),
+                $this->isType('array')
             )->will($this->returnValue(true));
 
         $contentTypeServiceMock->expects($this->once())
@@ -4999,6 +5009,7 @@ class ContentTest extends BaseServiceMockTest
         $fieldDefinitions
     ) {
         $repositoryMock = $this->getRepositoryMock();
+        $permissionResolverMock = $this->getPermissionResolverMock();
         $mockedService = $this->getPartlyMockedContentService(array('loadContent'));
         /** @var \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
@@ -5058,12 +5069,13 @@ class ContentTest extends BaseServiceMockTest
                 $this->returnValue($content)
             );
 
-        $repositoryMock->expects($this->once())
+        $permissionResolverMock->expects($this->once())
             ->method('canUser')
             ->with(
                 $this->equalTo('content'),
                 $this->equalTo('edit'),
-                $this->equalTo($content)
+                $this->equalTo($content),
+                $this->isType('array')
             )->will($this->returnValue(true));
 
         $contentTypeServiceMock->expects($this->once())
@@ -5407,10 +5419,7 @@ class ContentTest extends BaseServiceMockTest
         $location = new Location(['id' => $locationCreateStruct->parentLocationId]);
         $user = $this->getStubbedUser(14);
 
-        $permissionResolverMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\PermissionResolver')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $permissionResolverMock = $this->getPermissionResolverMock();
 
         $permissionResolverMock
             ->method('getCurrentUserReference')
@@ -5536,10 +5545,7 @@ class ContentTest extends BaseServiceMockTest
         $location = new Location(['id' => $locationCreateStruct->parentLocationId]);
         $user = $this->getStubbedUser(14);
 
-        $permissionResolverMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\PermissionResolver')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $permissionResolverMock = $this->getPermissionResolverMock();
 
         $permissionResolverMock
             ->method('getCurrentUserReference')
@@ -5662,10 +5668,7 @@ class ContentTest extends BaseServiceMockTest
         $locationServiceMock = $this->getLocationServiceMock();
         $user = $this->getStubbedUser(14);
 
-        $permissionResolverMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\PermissionResolver')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $permissionResolverMock = $this->getPermissionResolverMock();
 
         $permissionResolverMock
             ->method('getCurrentUserReference')
@@ -6053,5 +6056,19 @@ class ContentTest extends BaseServiceMockTest
         }
 
         return $this->partlyMockedContentService;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Repository|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function getRepositoryMock(): Repository
+    {
+        $repositoryMock = parent::getRepositoryMock();
+        $repositoryMock
+            ->expects($this->any())
+            ->method('getPermissionResolver')
+            ->willReturn($this->getPermissionResolverMock());
+
+        return $repositoryMock;
     }
 }

--- a/eZ/Publish/Core/settings/roles.yml
+++ b/eZ/Publish/Core/settings/roles.yml
@@ -29,7 +29,9 @@ services:
 
     ezpublish.api.role.limitation_type.language:
         class: "%ezpublish.api.role.limitation_type.language.class%"
-        arguments: ["@ezpublish.api.persistence_handler"]
+        arguments:
+            - "@ezpublish.spi.persistence.language_handler"
+            - "@ezpublish.spi.persistence.content_handler"
         tags:
             - {name: ezpublish.limitationType, alias: Language}
 

--- a/eZ/Publish/SPI/Limitation/Target.php
+++ b/eZ/Publish/SPI/Limitation/Target.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Limitation;
+
+/**
+ * Marker interface for PermissionResolver::canUser $targets objects.
+ *
+ * It's aimed to provide Limitations with information about intent (result of an action) to evaluate.
+ *
+ * @see \eZ\Publish\API\Repository\PermissionResolver::canUser
+ */
+interface Target
+{
+}

--- a/eZ/Publish/SPI/Limitation/Target/Builder/VersionBuilder.php
+++ b/eZ/Publish/SPI/Limitation/Target/Builder/VersionBuilder.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Limitation\Target\Builder;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\SPI\Limitation\Target;
+
+/**
+ * Builder of \eZ\Publish\SPI\Limitation\Target\Version instance.
+ *
+ * @see \eZ\Publish\SPI\Limitation\Target\Version
+ */
+final class VersionBuilder
+{
+    /**
+     * @var array
+     */
+    private $targetVersionProperties = [];
+
+    public function build(): Target\Version
+    {
+        return new Target\Version($this->targetVersionProperties);
+    }
+
+    /**
+     * Set intent to translate, to an unspecified (yet) language, any from the given list.
+     *
+     * @param array $languageCodes
+     *
+     * @return self
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function translateToAnyLanguageOf(array $languageCodes): self
+    {
+        foreach ($languageCodes as $languageCode) {
+            if (!is_string($languageCode) || empty($languageCode)) {
+                throw new InvalidArgumentException('$languageCodes', 'All language codes should be non-empty strings');
+            }
+        }
+
+        $this->targetVersionProperties['allLanguageCodesList'] = $languageCodes;
+
+        return $this;
+    }
+
+    /**
+     * Set intent to change Version status.
+     *
+     * Supported: <code>VersionInfo::STATUS_DRAFT, VersionInfo::STATUS_PUBLISHED, VersionInfo::STATUS_ARCHIVED</code>
+     *
+     * @see \eZ\Publish\API\Repository\Values\Content\VersionInfo
+     *
+     * @param int $status
+     *
+     * @return self
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function changeStatusTo(int $status): self
+    {
+        if (!in_array(
+            $status,
+            [VersionInfo::STATUS_DRAFT, VersionInfo::STATUS_PUBLISHED, VersionInfo::STATUS_ARCHIVED]
+        )) {
+            throw new InvalidArgumentException(
+                '$status',
+                'Status should be one of the following: STATUS_DRAFT, STATUS_PUBLISHED, STATUS_ARCHIVED'
+            );
+        }
+
+        $this->targetVersionProperties['newStatus'] = $status;
+
+        return $this;
+    }
+
+    /**
+     * Set intent to update Content Version Fields.
+     *
+     * @param string|null $initialLanguageCode
+     * @param \eZ\Publish\API\Repository\Values\Content\Field[] $fields
+     *
+     * @return self
+     */
+    public function updateFieldsTo(?string $initialLanguageCode, array $fields): self
+    {
+        $languageCodes = array_map(
+            function (Field $field) {
+                return $field->languageCode;
+            },
+            $fields
+        );
+
+        $this->targetVersionProperties['forUpdateInitialLanguageCode'] = $initialLanguageCode;
+        $this->targetVersionProperties['forUpdateLanguageCodesList'] = array_values(
+            array_unique($languageCodes)
+        );
+
+        return $this;
+    }
+}

--- a/eZ/Publish/SPI/Limitation/Target/Version.php
+++ b/eZ/Publish/SPI/Limitation/Target/Version.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Limitation\Target;
+
+use eZ\Publish\SPI\Limitation\Target;
+use eZ\Publish\SPI\Persistence\ValueObject;
+
+/**
+ * Version Limitation target. Indicates an intent to create new Version.
+ *
+ * @property-read string[] $allLanguageCodesList
+ * @property-read int $newStatus
+ * @property-read string $forUpdateInitialLanguageCode
+ * @property-read string[] $forUpdateLanguageCodesList
+ */
+final class Version extends ValueObject implements Target
+{
+    /**
+     * List of language codes of translations. At least one must match Limitation values.
+
+     * @var string[]
+     */
+    protected $allLanguageCodesList = [];
+
+    /**
+     * Language code of a translation used when updated, can be null for e.g. multiple translations changed.
+     *
+     * @var string|null
+     */
+    protected $forUpdateInitialLanguageCode;
+
+    /**
+     * List of language codes of translations to update. All must match Limitation values.
+     *
+     * @var string[]
+     */
+    protected $forUpdateLanguageCodesList = [];
+
+    /**
+     * One of the following: STATUS_DRAFT, STATUS_PUBLISHED, STATUS_ARCHIVED.
+     *
+     * @see \eZ\Publish\API\Repository\Values\Content\VersionInfo::STATUS_DRAFT
+     * @see \eZ\Publish\API\Repository\Values\Content\VersionInfo::STATUS_PUBLISHED
+     * @see \eZ\Publish\API\Repository\Values\Content\VersionInfo::STATUS_ARCHIVED
+     *
+     * @var int|null
+     */
+    protected $newStatus;
+}

--- a/eZ/Publish/SPI/Limitation/TargetAwareType.php
+++ b/eZ/Publish/SPI/Limitation/TargetAwareType.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Limitation;
+
+use eZ\Publish\API\Repository\Values\ValueObject as APIValueObject;
+use eZ\Publish\API\Repository\Values\User\Limitation as APILimitationValue;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
+
+/**
+ * Represents Limitation type.
+ * Indicates that Limitation Type implementation properly supports $targets passed as instances of Target.
+ *
+ * @see \eZ\Publish\SPI\Limitation\Type
+ * @see \eZ\Publish\SPI\Limitation\Target
+ */
+interface TargetAwareType extends Type
+{
+    /**
+     * Evaluate ("Vote") against a main value object and targets for the context.
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $object
+     * @param \eZ\Publish\SPI\Limitation\Target[]|null $targets $targets An array of location, parent or "assignment"
+     *                                                                 objects, if null: none where provided by caller
+     *
+     * @return bool|null Returns one of ACCESS_* constants
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     */
+    public function evaluate(
+        APILimitationValue $value,
+        APIUserReference $currentUser,
+        APIValueObject $object,
+        array $targets = null
+    ): ?bool;
+}

--- a/eZ/Publish/SPI/Tests/Limitation/Target/Builder/VersionBuilderTest.php
+++ b/eZ/Publish/SPI/Tests/Limitation/Target/Builder/VersionBuilderTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Tests\Limitation\Target\Builder;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\SPI\Limitation\Target\Builder\VersionBuilder;
+use eZ\Publish\SPI\Limitation\Target;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \eZ\Publish\SPI\Limitation\Target\Builder\VersionBuilder
+ */
+class VersionBuilderTest extends TestCase
+{
+    /**
+     * Data provider for testBuild.
+     *
+     * @see testBuild
+     *
+     * @return array
+     */
+    public function providerForTestBuild(): array
+    {
+        $versionStatuses = [
+            VersionInfo::STATUS_DRAFT,
+            VersionInfo::STATUS_PUBLISHED,
+            VersionInfo::STATUS_ARCHIVED,
+        ];
+
+        $data = [];
+        foreach ($versionStatuses as $versionStatus) {
+            $languagesList = ['ger-DE', 'eng-US', 'eng-GB'];
+            $initialLanguageCode = 'eng-US';
+            $fields = [
+                new Field(['languageCode' => 'ger-DE']),
+                new Field(['languageCode' => 'ger-DE']),
+                new Field(['languageCode' => 'eng-US']),
+            ];
+            $updateTranslationsLanguageCodes = ['ger-DE', 'eng-US'];
+
+            $data[] = [
+                new Target\Version(
+                    [
+                        'newStatus' => $versionStatus,
+                        'allLanguageCodesList' => $languagesList,
+                        'forUpdateLanguageCodesList' => $updateTranslationsLanguageCodes,
+                        'forUpdateInitialLanguageCode' => $initialLanguageCode,
+                    ]
+                ),
+                $versionStatus,
+                $initialLanguageCode,
+                $fields,
+                $languagesList,
+            ];
+
+            // no published content
+            $data[] = [
+                new Target\Version(
+                    [
+                        'newStatus' => $versionStatus,
+                        'allLanguageCodesList' => $languagesList,
+                        'forUpdateLanguageCodesList' => $updateTranslationsLanguageCodes,
+                        'forUpdateInitialLanguageCode' => $initialLanguageCode,
+                    ]
+                ),
+                $versionStatus,
+                $initialLanguageCode,
+                $fields,
+                $languagesList,
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @covers       \eZ\Publish\SPI\Limitation\Target\Builder\VersionBuilder::build
+     *
+     * @dataProvider providerForTestBuild
+     *
+     * @param \eZ\Publish\SPI\Limitation\Target\Version $expectedTargetVersion
+     * @param int $newStatus
+     * @param string $initialLanguageCode
+     * @param \eZ\Publish\API\Repository\Values\Content\Field[] $newFields
+     * @param string[] $languagesList
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testBuild(
+        Target\Version $expectedTargetVersion,
+        int $newStatus,
+        string $initialLanguageCode,
+        array $newFields,
+        array $languagesList
+    ): void {
+        $versionBuilder = new VersionBuilder();
+        $versionBuilder
+            ->changeStatusTo($newStatus)
+            ->updateFieldsTo($initialLanguageCode, $newFields)
+            ->translateToAnyLanguageOf($languagesList);
+
+        self::assertInstanceOf(VersionBuilder::class, $versionBuilder);
+        self::assertEquals($expectedTargetVersion, $versionBuilder->build());
+    }
+}

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -20,6 +20,7 @@
             <directory>eZ/Publish/API/Repository/Tests/Values/Content</directory>
             <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
             <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
+            <directory>eZ/Publish/API/Repository/Tests/Limitation</directory>
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/PermissionResolverTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30344](https://jira.ez.no/browse/EZP-30344)
| **Required by** | ezsystems/ezplatform-admin-ui#934
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `7.5.1` for eZ Platform `2.5.1 LTS`
| **BC breaks**      | yes, minor (see JIRA issue)
| **Tests pass**     | yes
| **Doc needed**     | yes

## Summary
This PR:
- [x] Improves `Language` Limitation by limiting user's ability to create, edit and publish content in a given language to a list of translations set by that Limitation.
- [x] e6e5aa0 implements `PermissionResolver::lookupLimitations` which provides more standardized and API-oriented way to fetch information about existing Limitations for the given object in the context of the given policy (by @mikadamczyk).

Squashed into one PR due to time constraints.

### Implementation details

Many Limitations throw exception when dealing with unknown objects or targets, which makes it impossible to set some specific mixes of Limitations on a given policy. This had hit us in the past and now makes current changes impossible to implement.

To solve this issue we're introducing two new interfaces:
- [x] `\eZ\Publish\SPI\Limitation\Target` which is a marker for a new `Target` object which is designed in a new way and provides more information about an intent of a `canUser` check.
- [x] `\eZ\Publish\SPI\Limitation\TargetAwareType` for LimitationType (service which implements Limitation evaluation logic) which does not throw exception when dealing with an unknown object. Such LimitationType should at the end return `ACCESS_ABSTAIN`. `TargetAwareType` LimitationType expects `$targets` to be an array of instances of `Target`, however if different object is passed, it won't throw exception (behaves as described).

We've created the first class which objects follows the described behavior:
- [x] `\eZ\Publish\SPI\Limitation\Target\Version`

and a builder for DX and readability
- [x] `\eZ\Publish\SPI\Limitation\Target\Builder\VersionBuilder`
which provides behavioral, intent-driven API.

Consider the following `updateContent` use case:
```php
        $this->repository->getPermissionResolver()->canUser(
            'content',
            'edit',
            $content,
            [
                (new Target\Builder\VersionBuilder())
                    ->updateFieldsTo(
                        $contentUpdateStruct->initialLanguageCode,
                        $contentUpdateStruct->fields
                    )
                    ->build(),
            ]
        )
```
it checks if a user is able to edit the Content if new Version would contain new initial language and given fields (actually used only to extract language codes of modified translation).

`Limitation\Target\Version` is passed as one of the targets to the following `ContentService` methods:
- [x] `createContentDraft` // from existing Version
- [x] `updateContent`
- ~`publishVersion`~ // not needed

We could try handling `ContentUpdateStruct`, but this `Target` is also designed to provide Limitation lookup for which creating artificial update struct is an overkill.

To provide BC for existing Limitations other than `Language` and avoid known issues when mixing Limitations for a single policy, the logic of `PermissionResolver::canUser` is changed as follows:
- [x] for LimitationTypes not implementing `Limitation\TargetAwareType` only targets which _are not_ instances of `Limitation\Target` are passed (array is filtered prior passing). If an array is empty, `null` is returned as some Limitations rely on that.
- [x] for Target-aware Limitation types (implementing `Limitation\TargetAwareType`) only targets which _are_ instances of `Limitation\Target` are passed.

**TODO**:
- [x] Cover COTF requirements mix (Translation, Content type, Parent Location) with integration tests.
- [x] Implement Languages diff to determine if publishing should be allowed.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
