### PR TITLE
EZP-30300: Fixed "Undefined offset: 0" notice when LocationService::loadLocationList is invoked with id of the root location

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -614,6 +614,26 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
+     * Test for the loadLocationList() method.
+     *
+     * @covers \eZ\Publish\API\Repository\LocationService::loadLocationList
+     */
+    public function testLoadLocationListWithRootLocationId()
+    {
+        $repository = $this->getRepository();
+
+        // 1 is the ID of an root location
+        $locationService = $repository->getLocationService();
+        $locations = $locationService->loadLocationList([1]);
+
+        self::assertInternalType('iterable', $locations);
+        self::assertCount(1, $locations);
+        self::assertEquals([1], array_keys($locations));
+        self::assertInstanceOf(Location::class, $locations[1]);
+        self::assertEquals(1, $locations[1]->id);
+    }
+
+    /**
      * Test for the loadLocationByRemoteId() method.
      *
      * @see \eZ\Publish\API\Repository\LocationService::loadLocationByRemoteId()

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -247,8 +247,8 @@ class LocationService implements LocationServiceInterface
         foreach ($spiLocations as $spiLocation) {
             $location = $this->domainMapper->buildLocationWithContent(
                 $spiLocation,
-                $contentProxyList[$spiLocation->contentId],
-                $spiContentInfoList[$spiLocation->contentId]
+                $contentProxyList[$spiLocation->contentId] ?? null,
+                $spiContentInfoList[$spiLocation->contentId] ?? null
             );
 
             if ($permissionResolver->canUser('content', 'read', $location->getContentInfo(), [$location])) {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30300](https://jira.ez.no/browse/EZP-30300)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.4`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Follow up for https://github.com/ezsystems/ezpublish-kernel/pull/2560. If the first argument of  `\eZ\Publish\API\Repository\LocationService::loadLocationList` contains the id of root location, it will generate `Notice: Undefined offset: 0`in https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Repository/LocationService.php#L250


**TODO**:
- [X] Implement feature / fix a bug.
- [x] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
