### PR TITLE
EZP-30369: Fixing SiteAccess match on non-master Platform.sh environments

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -107,7 +107,7 @@ class SiteAccessMatchListener implements EventSubscriberInterface
             new SimplifiedRequest(
                 array(
                     'scheme' => $request->getScheme(),
-                    'host' => $request->getHost(),
+                    'host' => $this->getHost($request),
                     'port' => $request->getPort(),
                     'pathinfo' => $request->getPathInfo(),
                     'queryParams' => $request->query->all(),
@@ -116,5 +116,23 @@ class SiteAccessMatchListener implements EventSubscriberInterface
                 )
             )
         );
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return string
+     */
+    private function getHost(Request $request)
+    {
+        if ($request->server->has('HTTP_X_ORIGINAL_ROUTE')) {
+            $originalRoute = rtrim($request->server->get('HTTP_X_ORIGINAL_ROUTE'), '/');
+            $originalHost = parse_url($originalRoute, PHP_URL_HOST);
+            if ($originalHost) {
+                return $originalHost;
+            }
+        }
+
+        return $request->getHost();
     }
 }


### PR DESCRIPTION
(cherry picked from commit 968423fd09dc721b89bdfe52d065de4da47f070f)

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30369](https://jira.ez.no/browse/EZP-30369)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

You have eZ Platform project with multiple siteaccess, which runs on Platform.sh:

* [en.site.com](en.site.com): `en` siteaccess, which is default
* [fr.site.com](fr.site.com): `fr` siteaccess

When you create a stage (or any other) environment for this project on Platform.sh, following URLs will be assigned to created env:

* [en—site—com—%ENV%-%REGION%-%PLATFORM_PROJECT_ID%.us.platform.sh](en—site—com—%ENV%-%REGION%-%PLATFORM_PROJECT_ID%.us.platform.sh)
* [fr—site—com—%ENV%-%REGION%-%PLATFORM_PROJECT_ID%.us.platform.sh](fr—site—com—%ENV%-%REGION%-%PLATFORM_PROJECT_ID%.us.platform.sh)
And those URLs will not be mapped to any siteaccess, so default one will be used for each of that stage env URLs. It means [fr—site—com—%ENV%-%REGION%-%PLATFORM_PROJECT_ID%.us.platform.sh](fr—site—com—%ENV%-%REGION%-%PLATFORM_PROJECT_ID%.us.platform.sh) will open `en` (but not `fr`) siteaccess.

You can manually modify stage env siteaccess match parameters. Which might be a huge pain if there are tons of siteaccesses in your project.

This fix should replace [https://packagist.org/packages/contextualcode/platformsh-siteaccess-matcher-bundle](https://packagist.org/packages/contextualcode/platformsh-siteaccess-matcher-bundle).

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
