### PR TITLE
EZP-30365: Accessing some invalid links will result in 500 error instead of 404

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -179,7 +179,7 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
     public function lookup($url)
     {
         $cacheItem = $this->cache->getItem(
-            'ez-urlAlias-url-' . str_replace(['/', ':', '(', ')', '@', '\\', '{', '}'], ['_S', '_C', '_B', '_B', '_A', '_BS', '_CB', '_CB'], $url)
+            'ez-urlAlias-url-' . str_replace(['/', ':', '(', ')', '@', '\\', '{', '}'], ['__S', '__C', '__B', '__B', '__A', '__BS', '__CB', '__CB'], $url)
         );
         if ($cacheItem->isHit()) {
             if (($return = $cacheItem->get()) === self::NOT_FOUND) {

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -179,7 +179,7 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
     public function lookup($url)
     {
         $cacheItem = $this->cache->getItem(
-            'ez-urlAlias-url-' . str_replace(['/', ':', '(', ')', '@', '\\', '{', '}'], ['__S', '__C', '__B', '__B', '__A', '__BS', '__CB', '__CB'], $url)
+            'ez-urlAlias-url-' . str_replace(['_', '/', ':', '(', ')', '@', '\\', '{', '}'], ['__', '_S', '_C', '_BO', '_BC', '_A', '_BS', '_CBO', '_CBC'], $url)
         );
         if ($cacheItem->isHit()) {
             if (($return = $cacheItem->get()) === self::NOT_FOUND) {

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -179,7 +179,7 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
     public function lookup($url)
     {
         $cacheItem = $this->cache->getItem(
-            'ez-urlAlias-url-' . str_replace(['/', ':', '(', ')', '@'], ['_S', '_C', '_B', '_B', '_A'], $url)
+            'ez-urlAlias-url-' . str_replace(['/', ':', '(', ')', '@', '\\', '{', '}'], ['_S', '_C', '_B', '_B', '_A', '_BS', '_CB', '_CB'], $url)
         );
         if ($cacheItem->isHit()) {
             if (($return = $cacheItem->get()) === self::NOT_FOUND) {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30365](https://jira.ez.no/browse/EZP-30365)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.4`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

For more information please refer to the JIRA ticket. 

This PR covers filtering of missing _reserved characters_ (ref: https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Cache/CacheItem.php#L161).

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
