### PR TITLE
Fix the ParentLocation for new content location

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -2031,7 +2031,7 @@ XML Example
 
     <?xml version="1.0" encoding="UTF-8"?>
     <LocationCreate>
-      <ParentLocation href="/content/locations/1/5/73" />
+      <ParentLocation href="/api/ezp/v2/content/locations/1/5/73" />
       <priority>0</priority>
       <hidden>false</hidden>
       <sortField>PATH</sortField>


### PR DESCRIPTION
Fix the ParentLocation path when Creating a new location for a content object. Missing the `/api/ezp/v2/` part will result in 406 errorCode `No route matched`

| Question           | Answer
| ------------------ | ------------------
| **Bug/Improvement**| yes
