### PR TITLE
EZP-30374: Limited PK columns lengths to fix max index size limit

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml
@@ -985,7 +985,7 @@ tables:
         indexes:
             authcode_client_id: { fields: [client_id], options: { lengths: ['191'] } }
         id:
-            id: { type: string, nullable: false, length: 200, options: { default: '', lengths: ['191'] } }
+            id: { type: string, nullable: false, length: 191, options: { default: '', lengths: ['191'] } }
         fields:
             client_id: { type: string, nullable: false, length: 200, options: { default: '' } }
             expirytime: { type: bigint, nullable: false, options: { default: '0' } }
@@ -1019,7 +1019,7 @@ tables:
         indexes:
             token_client_id: { fields: [client_id], options: { lengths: ['191'] } }
         id:
-            id: { type: string, nullable: false, length: 200, options: { default: '', lengths: ['191'] } }
+            id: { type: string, nullable: false, length: 191, options: { default: '', lengths: ['191'] } }
         fields:
             client_id: { type: string, nullable: false, length: 200, options: { default: '' } }
             expirytime: { type: bigint, nullable: false, options: { default: '0' } }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30374](https://jira.ez.no/browse/EZP-30374)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5 for eZ Platform 2.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR limits varchar columns lengths which are a part of primary key so they can fit maximum index length when `innodb_large_prefix` is set to `OFF` on MySQL instance (less characters can fit as we've switched to `utf8mb4` (4-bytes-long UTF8 characters)).

Related to tables/columns:
* `ezprest_authcode`.`id`
* `ezprest_token`.`id`

Note: my initial idea to workaround `Doctrine\DBAL\Schema` missing feature of including that length by extending `Schema` is not possible to implement.

**TODO**:
- [x] Fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
