### PR TITLE
Move kriswallsmith/buzz to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "ext-curl": "*",
         "symfony/symfony": "^3.4.17",
         "symfony-cmf/routing": "^2.1",
-        "kriswallsmith/buzz": "^0.17.2",
         "sensio/distribution-bundle": "^5.0.22",
         "nelmio/cors-bundle": "^1.5.0",
         "hautelook/templated-uri-bundle": "^2.1",
@@ -34,6 +33,7 @@
         "twig/twig": "^2.5"
     },
     "require-dev": {
+        "kriswallsmith/buzz": "^0.17.2",
         "brianium/paratest": "^2.2",
         "friendsofphp/php-cs-fixer": "~2.7.5",
         "phpunit/phpunit": "^7.0",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.4`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

It seems that `kriswallsmith/buzz` package is needed only in tests.

Additionally, it blocks installing `psr/http-client` 1.x, as it seems to depend on 0.1.x.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
