### PR TITLE
EZP-30298: As a Cluster User I want in-memory cache for all content related lookups

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
@@ -271,6 +271,15 @@ abstract class AbstractInMemoryHandler
         return $list;
     }
 
+    /**
+     * Escape an argument for use in cache keys when needed.
+     *
+     * WARNING: Only use the result of this in cache keys, it won't work to use loading the item from backend on miss.
+     *
+     * @param string $identifier
+     *
+     * @return string
+     */
     final protected function escapeForCacheKey(string $identifier)
     {
         return \str_replace(

--- a/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
@@ -76,12 +76,13 @@ abstract class AbstractInMemoryHandler
         callable $backendLoader,
         callable $cacheTagger,
         callable $cacheIndexes,
-        string $keySuffix = ''
+        string $keySuffix = '',
+        array $arguments = []
     ) {
         $key = $keyPrefix . $id . $keySuffix;
         // In-memory
         if ($object = $this->inMemory->get($key)) {
-            $this->logger->logCacheHit([$id], 3, true);
+            $this->logger->logCacheHit($arguments ?: [$id], 3, true);
 
             return $object;
         }
@@ -89,7 +90,7 @@ abstract class AbstractInMemoryHandler
         // Cache pool
         $cacheItem = $this->cache->getItem($key);
         if ($cacheItem->isHit()) {
-            $this->logger->logCacheHit([$id], 3);
+            $this->logger->logCacheHit($arguments ?: [$id], 3);
             $this->inMemory->setMulti([$object = $cacheItem->get()], $cacheIndexes);
 
             return $object;
@@ -98,7 +99,7 @@ abstract class AbstractInMemoryHandler
         // Backend
         $object = $backendLoader($id);
         $this->inMemory->setMulti([$object], $cacheIndexes);
-        $this->logger->logCacheMiss([$id], 3);
+        $this->logger->logCacheMiss($arguments ?: [$id], 3);
         $this->cache->save(
             $cacheItem
                 ->set($object)
@@ -196,7 +197,8 @@ abstract class AbstractInMemoryHandler
         callable $backendLoader,
         callable $cacheTagger,
         callable $cacheIndexes,
-        string $keySuffix = ''
+        string $keySuffix = '',
+        array $arguments = []
     ): array {
         if (empty($ids)) {
             return [];
@@ -218,7 +220,7 @@ abstract class AbstractInMemoryHandler
 
         // No in-memory misses
         if (empty($cacheKeys)) {
-            $this->logger->logCacheHit($ids, 3, true);
+            $this->logger->logCacheHit($arguments ?: $ids, 3, true);
 
             return $list;
         }
@@ -239,7 +241,7 @@ abstract class AbstractInMemoryHandler
 
         // No cache pool misses, cache loaded items in-memory and return
         if (empty($cacheMisses)) {
-            $this->logger->logCacheHit($ids, 3);
+            $this->logger->logCacheHit($arguments ?: $ids, 3);
             $this->inMemory->setMulti($loaded, $cacheIndexes);
 
             return $list;
@@ -264,7 +266,7 @@ abstract class AbstractInMemoryHandler
 
         $this->inMemory->setMulti($loaded, $cacheIndexes);
         unset($loaded, $backendLoadedList);
-        $this->logger->logCacheMiss($cacheMisses, 3);
+        $this->logger->logCacheMiss($arguments ?: $cacheMisses, 3);
 
         return $list;
     }

--- a/eZ/Publish/Core/Persistence/Cache/Adapter/InMemoryClearingProxyAdapter.php
+++ b/eZ/Publish/Core/Persistence/Cache/Adapter/InMemoryClearingProxyAdapter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\Persistence\Cache\Adapter;
 
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
-use eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache;
 use Psr\Cache\CacheItemInterface;
 
 /**
@@ -25,7 +24,7 @@ class InMemoryClearingProxyAdapter implements TagAwareAdapterInterface
     private $pool;
 
     /**
-     * @var \eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache
+     * @var \eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache[]
      */
     private $inMemory;
 
@@ -33,9 +32,9 @@ class InMemoryClearingProxyAdapter implements TagAwareAdapterInterface
      * InMemoryClearingProxyAdapter constructor.
      *
      * @param \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface $pool
-     * @param \eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache $inMemory
+     * @param \eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache[] $inMemory
      */
-    public function __construct(TagAwareAdapterInterface $pool, InMemoryCache $inMemory)
+    public function __construct(TagAwareAdapterInterface $pool, array $inMemory)
     {
         $this->pool = $pool;
         $this->inMemory = $inMemory;
@@ -70,7 +69,9 @@ class InMemoryClearingProxyAdapter implements TagAwareAdapterInterface
      */
     public function deleteItem($key)
     {
-        $this->inMemory->deleteMulti([$key]);
+        foreach ($this->inMemory as $inMemory) {
+            $inMemory->deleteMulti([$key]);
+        }
 
         return $this->pool->deleteItem($key);
     }
@@ -80,7 +81,9 @@ class InMemoryClearingProxyAdapter implements TagAwareAdapterInterface
      */
     public function deleteItems(array $keys)
     {
-        $this->inMemory->deleteMulti($keys);
+        foreach ($this->inMemory as $inMemory) {
+            $inMemory->deleteMulti($keys);
+        }
 
         return $this->pool->deleteItems($keys);
     }
@@ -91,7 +94,9 @@ class InMemoryClearingProxyAdapter implements TagAwareAdapterInterface
     public function invalidateTags(array $tags)
     {
         // No tracking of tags in in-memory, as it's anyway meant to only optimize for reads (GETs) and not writes.
-        $this->inMemory->clear();
+        foreach ($this->inMemory as $inMemory) {
+            $inMemory->clear();
+        }
 
         return $this->pool->invalidateTags($tags);
     }
@@ -101,7 +106,9 @@ class InMemoryClearingProxyAdapter implements TagAwareAdapterInterface
      */
     public function clear()
     {
-        $this->inMemory->clear();
+        foreach ($this->inMemory as $inMemory) {
+            $inMemory->clear();
+        }
 
         return $this->pool->clear();
     }

--- a/eZ/Publish/Core/Persistence/Cache/Adapter/InMemoryClearingProxyAdapter.php
+++ b/eZ/Publish/Core/Persistence/Cache/Adapter/InMemoryClearingProxyAdapter.php
@@ -24,20 +24,18 @@ class InMemoryClearingProxyAdapter implements TagAwareAdapterInterface
     private $pool;
 
     /**
-     * @var \eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache[]
+     * @var \eZ\Publish\Core\Persistence\Cache\inMemory\InMemoryCache[]
      */
-    private $inMemory;
+    private $inMemoryPools;
 
     /**
-     * InMemoryClearingProxyAdapter constructor.
-     *
      * @param \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface $pool
-     * @param \eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache[] $inMemory
+     * @param \eZ\Publish\Core\Persistence\Cache\inMemory\InMemoryCache[] $inMemoryPools
      */
-    public function __construct(TagAwareAdapterInterface $pool, array $inMemory)
+    public function __construct(TagAwareAdapterInterface $pool, iterable $inMemoryPools)
     {
         $this->pool = $pool;
-        $this->inMemory = $inMemory;
+        $this->inMemoryPools = $inMemoryPools;
     }
 
     /**
@@ -69,7 +67,7 @@ class InMemoryClearingProxyAdapter implements TagAwareAdapterInterface
      */
     public function deleteItem($key)
     {
-        foreach ($this->inMemory as $inMemory) {
+        foreach ($this->inMemoryPools as $inMemory) {
             $inMemory->deleteMulti([$key]);
         }
 
@@ -81,7 +79,7 @@ class InMemoryClearingProxyAdapter implements TagAwareAdapterInterface
      */
     public function deleteItems(array $keys)
     {
-        foreach ($this->inMemory as $inMemory) {
+        foreach ($this->inMemoryPools as $inMemory) {
             $inMemory->deleteMulti($keys);
         }
 
@@ -94,7 +92,7 @@ class InMemoryClearingProxyAdapter implements TagAwareAdapterInterface
     public function invalidateTags(array $tags)
     {
         // No tracking of tags in in-memory, as it's anyway meant to only optimize for reads (GETs) and not writes.
-        foreach ($this->inMemory as $inMemory) {
+        foreach ($this->inMemoryPools as $inMemory) {
             $inMemory->clear();
         }
 
@@ -106,7 +104,7 @@ class InMemoryClearingProxyAdapter implements TagAwareAdapterInterface
      */
     public function clear()
     {
-        foreach ($this->inMemory as $inMemory) {
+        foreach ($this->inMemoryPools as $inMemory) {
             $inMemory->clear();
         }
 

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -21,9 +21,53 @@ use eZ\Publish\SPI\Persistence\Content\Relation\CreateStruct as RelationCreateSt
 /**
  * @see \eZ\Publish\SPI\Persistence\Content\Handler
  */
-class ContentHandler extends AbstractHandler implements ContentHandlerInterface
+class ContentHandler extends AbstractInMemoryPersistenceHandler implements ContentHandlerInterface
 {
     const ALL_TRANSLATIONS_KEY = '0';
+
+    /** @var callable */
+    private $getContentInfoTags;
+
+    /** @var callable */
+    private $getContentInfoKeys;
+
+    /** @var callable */
+    private $getContentTags;
+
+    protected function init(): void
+    {
+        $this->getContentInfoTags = function (ContentInfo $info, array $tags = []) {
+            $tags[] = 'content-' . $info->id;
+
+            if ($info->mainLocationId) {
+                $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($info->id);
+                foreach ($locations as $location) {
+                    $tags[] = 'location-' . $location->id;
+                    foreach (explode('/', trim($location->pathString, '/')) as $pathId) {
+                        $tags[] = 'location-path-' . $pathId;
+                    }
+                }
+            }
+
+            return $tags;
+        };
+        $this->getContentInfoKeys = function (ContentInfo $info) {
+            return [
+                'ez-content-info-' . $info->id,
+                'ez-content-info-byRemoteId-' . $this->escapeForCacheKey($info->remoteId),
+            ];
+        };
+
+        $this->getContentTags = function (Content $content) {
+            $versionInfo = $content->versionInfo;
+            $tags = [
+                'content-fields-' . $versionInfo->contentInfo->id,
+                'content-fields-type-' . $versionInfo->contentInfo->contentTypeId,
+            ];
+
+            return $this->getCacheTagsForVersion($versionInfo, $tags);
+        };
+    }
 
     /**
      * {@inheritdoc}
@@ -67,42 +111,42 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
      */
     public function load($contentId, $versionNo = null, array $translations = null)
     {
-        $versionKey = $versionNo ? "-${versionNo}" : '';
-        $translationsKey = empty($translations) ? self::ALL_TRANSLATIONS_KEY : implode('|', $translations);
-        $cacheItem = $this->cache->getItem("ez-content-${contentId}${versionKey}-${translationsKey}");
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
+        $keySuffix = $versionNo ? "-${versionNo}-" : '-';
+        $keySuffix .= empty($translations) ? self::ALL_TRANSLATIONS_KEY : implode('|', $translations);
 
-        $this->logger->logCall(__METHOD__, array('content' => $contentId, 'version' => $versionNo, 'translations' => $translations));
-        $content = $this->persistenceHandler->contentHandler()->load($contentId, $versionNo, $translations);
-        $cacheItem->set($content);
-        $cacheItem->tag($this->getCacheTagsForContent($content));
-        $this->cache->save($cacheItem);
-
-        return $content;
+        return $this->getCacheValue(
+            (int) $contentId,
+            'ez-content-',
+            function ($id) use ($versionNo, $translations) {
+                return $this->persistenceHandler->contentHandler()->load($id, $versionNo, $translations);
+            },
+            $this->getContentTags,
+            static function (Content $content) use ($keySuffix) {
+                // Version number & translations is part of keySuffix here and depends on what user asked for
+                return ['ez-content-' . $content->versionInfo->contentInfo->id . $keySuffix];
+            },
+            $keySuffix,
+            ['content' => $contentId, 'version' => $versionNo, 'translations' => $translations]
+        );
     }
 
     public function loadContentList(array $contentIds, array $translations = null): array
     {
-        // Extract suffix for each one
-        $keySuffixes = [];
-        foreach ($contentIds as $contentId) {
-            $keySuffixes[$contentId] = '-' . (empty($translations) ? self::ALL_TRANSLATIONS_KEY : implode('|', $translations));
-        }
+        $keySuffix = '-' . (empty($translations) ? self::ALL_TRANSLATIONS_KEY : implode('|', $translations));
 
-        return $this->getMultipleCacheItems(
+        return $this->getMultipleCacheValues(
             $contentIds,
             'ez-content-',
             function (array $cacheMissIds) use ($translations) {
-                $this->logger->logCall(__CLASS__ . '::loadContentList', ['content' => $cacheMissIds]);
-
                 return $this->persistenceHandler->contentHandler()->loadContentList($cacheMissIds, $translations);
             },
-            function (Content $content) {
-                return $this->getCacheTagsForContent($content);
+            $this->getContentTags,
+            static function (Content $content) use ($keySuffix) {
+                // Version number & translations is part of keySuffix here and depends on what user asked for
+                return ['ez-content-' . $content->versionInfo->contentInfo->id . $keySuffix];
             },
-            $keySuffixes
+            $keySuffix,
+            ['content' => $contentIds, 'translations' => $translations]
         );
     }
 
@@ -111,33 +155,31 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
      */
     public function loadContentInfo($contentId)
     {
-        $cacheItem = $this->cache->getItem("ez-content-info-${contentId}");
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
-
-        $this->logger->logCall(__METHOD__, array('content' => $contentId));
-        $contentInfo = $this->persistenceHandler->contentHandler()->loadContentInfo($contentId);
-        $cacheItem->set($contentInfo);
-        $cacheItem->tag($this->getCacheTags($contentInfo));
-        $this->cache->save($cacheItem);
-
-        return $contentInfo;
+        return $this->getCacheValue(
+            $contentId,
+            'ez-content-info-',
+            function ($contentId) {
+                return $this->persistenceHandler->contentHandler()->loadContentInfo($contentId);
+            },
+            $this->getContentInfoTags,
+            $this->getContentInfoKeys,
+            '',
+            ['content' => $contentId]
+        );
     }
 
     public function loadContentInfoList(array $contentIds)
     {
-        return $this->getMultipleCacheItems(
+        return $this->getMultipleCacheValues(
             $contentIds,
             'ez-content-info-',
             function (array $cacheMissIds) {
-                $this->logger->logCall(__CLASS__ . '::loadContentInfoList', ['content' => $cacheMissIds]);
-
                 return $this->persistenceHandler->contentHandler()->loadContentInfoList($cacheMissIds);
             },
-            function (ContentInfo $info) {
-                return $this->getCacheTags($info);
-            }
+            $this->getContentInfoTags,
+            $this->getContentInfoKeys,
+            '',
+            ['content' => $contentIds]
         );
     }
 
@@ -146,18 +188,17 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
      */
     public function loadContentInfoByRemoteId($remoteId)
     {
-        $cacheItem = $this->cache->getItem('ez-content-info-byRemoteId-' . $this->escapeForCacheKey($remoteId));
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
-
-        $this->logger->logCall(__METHOD__, array('content' => $remoteId));
-        $contentInfo = $this->persistenceHandler->contentHandler()->loadContentInfoByRemoteId($remoteId);
-        $cacheItem->set($contentInfo);
-        $cacheItem->tag($this->getCacheTags($contentInfo));
-        $this->cache->save($cacheItem);
-
-        return $contentInfo;
+        return $this->getCacheValue(
+            $this->escapeForCacheKey($remoteId),
+            'ez-content-info-byRemoteId-',
+            function () use ($remoteId)  {
+                return $this->persistenceHandler->contentHandler()->loadContentInfoByRemoteId($remoteId);
+            },
+            $this->getContentInfoTags,
+            $this->getContentInfoKeys,
+            '',
+            ['content' => $remoteId]
+        );
     }
 
     /**
@@ -167,10 +208,12 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
     {
         $cacheItem = $this->cache->getItem("ez-content-version-info-${contentId}-${versionNo}");
         if ($cacheItem->isHit()) {
+            $this->logger->logCacheHit(['content' => $contentId, 'version' => $versionNo]);
+
             return $cacheItem->get();
         }
 
-        $this->logger->logCall(__METHOD__, ['content' => $contentId, 'version' => $versionNo]);
+        $this->logger->logCacheMiss(['content' => $contentId, 'version' => $versionNo]);
         $versionInfo = $this->persistenceHandler->contentHandler()->loadVersionInfo($contentId, $versionNo);
         $cacheItem->set($versionInfo);
         $cacheItem->tag($this->getCacheTagsForVersion($versionInfo));
@@ -245,18 +288,19 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
 
         $return = $this->persistenceHandler->contentHandler()->deleteContent($contentId);
 
-        $this->cache->invalidateTags(['content-' . $contentId]);
         if (!empty($reverseRelations)) {
-            $this->cache->invalidateTags(
-                array_map(
-                    function ($relation) {
-                        // only the full content object *with* fields is affected by this
-                        return 'content-fields-' . $relation->sourceContentId;
-                    },
-                    $reverseRelations
-                )
+            $tags = \array_map(
+                static function ($relation) {
+                    // only the full content object *with* fields is affected by this
+                    return 'content-fields-' . $relation->sourceContentId;
+                },
+                $reverseRelations
             );
+        } else {
+            $tags = [];
         }
+        $tags[] = 'content-' . $contentId;
+        $this->cache->invalidateTags($tags);
 
         return $return;
     }
@@ -280,10 +324,12 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
     {
         $cacheItem = $this->cache->getItem("ez-content-${contentId}-version-list" . ($status ? "-byStatus-${status}" : '') . "-limit-{$limit}");
         if ($cacheItem->isHit()) {
+            $this->logger->logCacheHit(['content' => $contentId, 'status' => $status]);
+
             return $cacheItem->get();
         }
 
-        $this->logger->logCall(__METHOD__, array('content' => $contentId, 'status' => $status));
+        $this->logger->logCacheMiss(['content' => $contentId, 'status' => $status]);
         $versions = $this->persistenceHandler->contentHandler()->listVersions($contentId, $status, $limit);
         $cacheItem->set($versions);
         $tags = ["content-{$contentId}", "content-{$contentId}-version-list"];
@@ -403,37 +449,21 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
      *
      * For use when generating cache, not on invalidation.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\ContentInfo $contentInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
      * @param array $tags Optional, can be used to specify other tags.
      *
      * @return array
      */
-    private function getCacheTags(ContentInfo $contentInfo, array $tags = [])
-    {
-        $tags[] = 'content-' . $contentInfo->id;
-
-        if ($contentInfo->mainLocationId) {
-            $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($contentInfo->id);
-            foreach ($locations as $location) {
-                $tags[] = 'location-' . $location->id;
-                foreach (explode('/', trim($location->pathString, '/')) as $pathId) {
-                    $tags[] = 'location-path-' . $pathId;
-                }
-            }
-        }
-
-        return array_unique($tags);
-    }
-
-    private function getCacheTagsForVersion(VersionInfo $versionInfo, array $tags = [])
+    private function getCacheTagsForVersion(VersionInfo $versionInfo, array $tags = []): array
     {
         $contentInfo = $versionInfo->contentInfo;
         $tags[] = 'content-' . $contentInfo->id . '-version-' . $versionInfo->versionNo;
+        $getContentInfoTagsFn = $this->getContentInfoTags;
 
-        return $this->getCacheTags($contentInfo, $tags);
+        return $getContentInfoTagsFn($contentInfo, $tags);
     }
 
-    private function getCacheTagsForContent(Content $content)
+    private function getCacheTagsForContent(Content $content): array
     {
         $versionInfo = $content->versionInfo;
         $tags = [

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -25,13 +25,19 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
 {
     const ALL_TRANSLATIONS_KEY = '0';
 
-    /** @var callable */
+    /**
+     * @var callable
+     */
     private $getContentInfoTags;
 
-    /** @var callable */
+    /**
+     * @var callable
+     */
     private $getContentInfoKeys;
 
-    /** @var callable */
+    /**
+     * @var callable
+     */
     private $getContentTags;
 
     protected function init(): void

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -8,7 +8,6 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache;
 
-use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandlerInterface;
 use eZ\Publish\SPI\Persistence\Content\Location\CreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct;
@@ -19,10 +18,14 @@ use eZ\Publish\SPI\Persistence\Content\Location;
  */
 class LocationHandler extends AbstractInMemoryPersistenceHandler implements LocationHandlerInterface
 {
-    /** @var callable */
+    /**
+     * @var callable
+     */
     private $getLocationTags;
 
-    /** @var callable */
+    /**
+     * @var callable
+     */
     private $getLocationKeys;
 
     protected function init(): void

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache;
 
+use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandlerInterface;
 use eZ\Publish\SPI\Persistence\Content\Location\CreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct;
@@ -16,49 +17,77 @@ use eZ\Publish\SPI\Persistence\Content\Location;
 /**
  * @see \eZ\Publish\SPI\Persistence\Content\Location\Handler
  */
-class LocationHandler extends AbstractHandler implements LocationHandlerInterface
+class LocationHandler extends AbstractInMemoryPersistenceHandler implements LocationHandlerInterface
 {
+    /** @var callable */
+    private $getLocationTags;
+
+    /** @var callable */
+    private $getLocationKeys;
+
+    protected function init(): void
+    {
+        $this->getLocationTags = static function (Location $location) {
+            $tags = [
+                 'content-' . $location->contentId,
+                 'location-' . $location->id,
+                 'location-data-' . $location->id,
+             ];
+            foreach (\explode('/', \trim($location->pathString, '/')) as $pathId) {
+                $tags[] = 'location-path-' . $pathId;
+                $tags[] = 'location-path-data-' . $pathId;
+            }
+
+            return $tags;
+        };
+        $this->getLocationKeys = function (Location $location, $keySuffix = '-1') {
+            return [
+                 'ez-location-' . $location->id . $keySuffix,
+                 'ez-location-remoteid-' . $this->escapeForCacheKey($location->remoteId) . $keySuffix,
+             ];
+        };
+    }
+
     /**
      * {@inheritdoc}
      */
     public function load($locationId, array $translations = null, bool $useAlwaysAvailable = true)
     {
-        $translationsKey = $this->getCacheTranslationKey($translations, $useAlwaysAvailable);
-        $cacheItem = $this->cache->getItem("ez-location-${locationId}-${translationsKey}");
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
+        $keySuffix = '-' . $this->getCacheTranslationKey($translations, $useAlwaysAvailable);
+        $getLocationKeysFn = $this->getLocationKeys;
 
-        $this->logger->logCall(
-            __METHOD__,
-            ['location' => $locationId, 'translations' => $translations, 'always-available' => $useAlwaysAvailable]
+        return $this->getCacheValue(
+            (int) $locationId,
+            'ez-location-',
+            function ($id) use ($translations, $useAlwaysAvailable) {
+                return $this->persistenceHandler->locationHandler()->load($id, $translations, $useAlwaysAvailable);
+            },
+            $this->getLocationTags,
+            static function (Location $location) use ($keySuffix, $getLocationKeysFn) {
+                return $getLocationKeysFn($location, $keySuffix);
+            },
+            $keySuffix,
+            ['location' => $locationId, 'translations' => $translations, 'alwaysAvailable' => $useAlwaysAvailable]
         );
-        $location = $this->persistenceHandler->locationHandler()->load($locationId, $translations, $useAlwaysAvailable);
-
-        $cacheItem->set($location);
-        $cacheItem->tag($this->getCacheTags($location));
-        $this->cache->save($cacheItem);
-
-        return $location;
     }
 
     public function loadList(array $locationIds, array $translations = null, bool $useAlwaysAvailable = true): iterable
     {
-        return $this->getMultipleCacheItems(
+        $keySuffix = '-' . $this->getCacheTranslationKey($translations, $useAlwaysAvailable);
+        $getLocationKeysFn = $this->getLocationKeys;
+
+        return $this->getMultipleCacheValues(
             $locationIds,
             'ez-location-',
-            function (array $cacheMissIds) use ($translations, $useAlwaysAvailable) {
-                $this->logger->logCall(
-                    __CLASS__ . '::loadList',
-                    ['location' => $cacheMissIds, 'translations' => $translations, 'always-available' => $useAlwaysAvailable]
-                );
-
-                return $this->persistenceHandler->locationHandler()->loadList($cacheMissIds, $translations, $useAlwaysAvailable);
+            function (array $ids) use ($translations, $useAlwaysAvailable) {
+                return $this->persistenceHandler->locationHandler()->loadList($ids, $translations, $useAlwaysAvailable);
             },
-            function (Location $location) {
-                return $this->getCacheTags($location);
+            $this->getLocationTags,
+            static function (Location $location) use ($keySuffix, $getLocationKeysFn) {
+                return $getLocationKeysFn($location, $keySuffix);
             },
-            array_fill_keys($locationIds, '-' . $this->getCacheTranslationKey($translations, $useAlwaysAvailable))
+            $keySuffix,
+            ['location' => $locationIds, 'translations' => $translations, 'alwaysAvailable' => $useAlwaysAvailable]
         );
     }
 
@@ -69,10 +98,12 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
     {
         $cacheItem = $this->cache->getItem("ez-location-subtree-${locationId}");
         if ($cacheItem->isHit()) {
+            $this->logger->logCacheHit(['location' => $locationId]);
+
             return $cacheItem->get();
         }
 
-        $this->logger->logCall(__METHOD__, array('location' => $locationId));
+        $this->logger->logCacheMiss(['location' => $locationId]);
         $locationIds = $this->persistenceHandler->locationHandler()->loadSubtreeIds($locationId);
 
         $cacheItem->set($locationIds);
@@ -101,10 +132,12 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
         }
 
         if ($cacheItem->isHit()) {
+            $this->logger->logCacheHit(['content' => $contentId, 'root' => $rootLocationId]);
+
             return $cacheItem->get();
         }
 
-        $this->logger->logCall(__METHOD__, array('content' => $contentId, 'root' => $rootLocationId));
+        $this->logger->logCacheMiss(['content' => $contentId, 'root' => $rootLocationId]);
         $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($contentId, $rootLocationId);
 
         $cacheItem->set($locations);
@@ -124,10 +157,12 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
     {
         $cacheItem = $this->cache->getItem("ez-content-locations-${contentId}-parentForDraft");
         if ($cacheItem->isHit()) {
+            $this->logger->logCacheHit(['content' => $contentId]);
+
             return $cacheItem->get();
         }
 
-        $this->logger->logCall(__METHOD__, array('content' => $contentId));
+        $this->logger->logCacheMiss(['content' => $contentId]);
         $locations = $this->persistenceHandler->locationHandler()->loadParentLocationsForDraftContent($contentId);
 
         $cacheItem->set($locations);
@@ -146,24 +181,22 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
      */
     public function loadByRemoteId($remoteId, array $translations = null, bool $useAlwaysAvailable = true)
     {
-        $translationsKey = $this->getCacheTranslationKey($translations, $useAlwaysAvailable);
-        $keyRemoteId = $this->escapeForCacheKey($remoteId);
-        $cacheItem = $this->cache->getItem("ez-location-remoteid-${keyRemoteId}-${translationsKey}");
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
+        $keySuffix = '-' . $this->getCacheTranslationKey($translations, $useAlwaysAvailable);
+        $getLocationKeysFn = $this->getLocationKeys;
 
-        $this->logger->logCall(
-            __METHOD__,
-            ['location' => $remoteId, 'translations' => $translations, 'always-available' => $useAlwaysAvailable]
+        return $this->getCacheValue(
+            $this->escapeForCacheKey($remoteId),
+            'ez-location-remoteid-',
+            function () use ($remoteId, $translations, $useAlwaysAvailable) {
+                return $this->persistenceHandler->locationHandler()->loadByRemoteId($remoteId, $translations, $useAlwaysAvailable);
+            },
+            $this->getLocationTags,
+            static function (Location $location) use ($keySuffix, $getLocationKeysFn) {
+                return $getLocationKeysFn($location, $keySuffix);
+            },
+            $keySuffix,
+            ['location' => $remoteId, 'translations' => $translations, 'alwaysAvailable' => $useAlwaysAvailable]
         );
-        $location = $this->persistenceHandler->locationHandler()->loadByRemoteId($remoteId, $translations, $useAlwaysAvailable);
-
-        $cacheItem->set($location);
-        $cacheItem->tag($this->getCacheTags($location));
-        $this->cache->save($cacheItem);
-
-        return $location;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
@@ -80,7 +80,7 @@ abstract class AbstractBaseHandlerTest extends TestCase
         $this->persistenceCacheHandler = new CacheHandler(
             $this->persistenceHandlerMock,
             new CacheSectionHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
-            new CacheLocationHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
+            new CacheLocationHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),
             new CacheContentHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),
             new CacheContentLanguageHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),
             new CacheContentTypeHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
@@ -87,7 +87,7 @@ abstract class AbstractBaseHandlerTest extends TestCase
             new CacheUserHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),
             new CacheTransactionHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),
             new CacheTrashHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
-            new CacheUrlAliasHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
+            new CacheUrlAliasHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),
             new CacheObjectStateHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
             new CacheUrlHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
             new CacheBookmarkHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
@@ -81,7 +81,7 @@ abstract class AbstractBaseHandlerTest extends TestCase
             $this->persistenceHandlerMock,
             new CacheSectionHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
             new CacheLocationHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
-            new CacheContentHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
+            new CacheContentHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),
             new CacheContentLanguageHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),
             new CacheContentTypeHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),
             new CacheUserHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),

--- a/eZ/Publish/Core/Persistence/Cache/Tests/Adapter/InMemoryClearingProxyAdapterTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/Adapter/InMemoryClearingProxyAdapterTest.php
@@ -51,7 +51,7 @@ class InMemoryClearingProxyAdapterTest extends TestCase
 
         $this->cache = new InMemoryClearingProxyAdapter(
             $this->innerPool,
-            $this->inMemory
+            [$this->inMemory]
         );
 
         $this->cacheItemsClosure = \Closure::bind(

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -23,7 +23,7 @@ use eZ\Publish\SPI\Persistence\Content\Handler as SPIContentHandler;
 /**
  * Test case for Persistence\Cache\ContentHandler.
  */
-class ContentHandlerTest extends AbstractCacheHandlerTest
+class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
 {
     public function getHandlerMethodName(): string
     {
@@ -122,14 +122,9 @@ class ContentHandlerTest extends AbstractCacheHandlerTest
             ->method('deleteItem');
 
         $this->cacheMock
-            ->expects($this->at(0))
+            ->expects($this->once())
             ->method('invalidateTags')
-            ->with(['content-2']);
-
-        $this->cacheMock
-            ->expects($this->at(1))
-            ->method('invalidateTags')
-            ->with(['content-fields-42']);
+            ->with(['content-fields-42', 'content-2']);
 
         $handler = $this->persistenceCacheHandler->contentHandler();
         $handler->deleteContent(2);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
@@ -16,7 +16,7 @@ use eZ\Publish\SPI\Persistence\Content\Location\Handler as SPILocationHandler;
 /**
  * Test case for Persistence\Cache\LocationHandler.
  */
-class LocationHandlerTest extends AbstractCacheHandlerTest
+class LocationHandlerTest extends AbstractInMemoryCacheHandlerTest
 {
     public function getHandlerMethodName(): string
     {

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -14,7 +14,7 @@ use eZ\Publish\SPI\Persistence\Content\UrlAlias\Handler as SPIUrlAliasHandler;
 /**
  * Test case for Persistence\Cache\UrlAliasHandler.
  */
-class UrlAliasHandlerTest extends AbstractCacheHandlerTest
+class UrlAliasHandlerTest extends AbstractInMemoryCacheHandlerTest
 {
     public function getHandlerMethodName(): string
     {

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -90,7 +90,7 @@ services:
 
     ezpublish.spi.persistence.cache.contentHandler:
         class: "%ezpublish.spi.persistence.cache.contentHandler.class%"
-        parent: ezpublish.spi.persistence.cache.abstractHandler
+        parent: ezpublish.spi.persistence.cache.abstractInMemoryPersistenceHandler
 
     ezpublish.spi.persistence.cache.contentLanguageHandler:
         class: "%ezpublish.spi.persistence.cache.contentLanguageHandler.class%"

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -23,8 +23,9 @@ parameters:
     ezpublish.spi.persistence.cache.inmemory.limit: 100
     ezpublish.spi.persistence.cache.inmemory.enable: true
     # Global in-memory settings, for content in-memory cache
-    ezpublish.spi.persistence.cache.inmemory.content.ttl: 300
-    ezpublish.spi.persistence.cache.inmemory.content.limit: 50
+    ## TTL on purpose low to avoid getting outdated data in prod, in dev it will be x2 to account for debug overhead
+    ezpublish.spi.persistence.cache.inmemory.content.ttl: 400
+    ezpublish.spi.persistence.cache.inmemory.content.limit: 100
     ezpublish.spi.persistence.cache.inmemory.content.enable: true
 
 services:
@@ -66,7 +67,7 @@ services:
         public: false
         class: eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache
         arguments:
-            - "%ezpublish.spi.persistence.cache.inmemory.content.ttl%"
+            - "@=container.getParameter('kernel.debug') ? parameter('ezpublish.spi.persistence.cache.inmemory.content.ttl')  *2 : parameter('ezpublish.spi.persistence.cache.inmemory.content.ttl')"
             - "%ezpublish.spi.persistence.cache.inmemory.content.limit%"
             - "%ezpublish.spi.persistence.cache.inmemory.content.enable%"
 

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -23,8 +23,8 @@ parameters:
     ezpublish.spi.persistence.cache.inmemory.limit: 100
     ezpublish.spi.persistence.cache.inmemory.enable: true
     # Global in-memory settings, for content in-memory cache
-    ## TTL on purpose low to avoid getting outdated data in prod, in dev it will be x2 to account for debug overhead
-    ezpublish.spi.persistence.cache.inmemory.content.ttl: 400
+    ## WARNING: TTL on purpose low to avoid getting outdated data in prod! For dev config you can safely increase by x3
+    ezpublish.spi.persistence.cache.inmemory.content.ttl: 300
     ezpublish.spi.persistence.cache.inmemory.content.limit: 100
     ezpublish.spi.persistence.cache.inmemory.content.enable: true
 
@@ -34,7 +34,7 @@ services:
         class: eZ\Publish\Core\Persistence\Cache\Adapter\InMemoryClearingProxyAdapter
         arguments:
           - "@ezpublish.cache_pool.inner"
-          - [ "@ezpublish.spi.persistence.cache.inmemory", "@ezpublish.spi.persistence.cache.inmemory.content" ]
+          - !tagged ez.spi.persistence.cache.inmemory
 
     ezpublish.cache_pool.inner:
         public: false
@@ -62,14 +62,16 @@ services:
             - "%ezpublish.spi.persistence.cache.inmemory.ttl%"
             - "%ezpublish.spi.persistence.cache.inmemory.limit%"
             - "%ezpublish.spi.persistence.cache.inmemory.enable%"
+        tags: ['ez.spi.persistence.cache.inmemory']
 
     ezpublish.spi.persistence.cache.inmemory.content:
         public: false
         class: eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache
         arguments:
-            - "@=container.getParameter('kernel.debug') ? parameter('ezpublish.spi.persistence.cache.inmemory.content.ttl')  *2 : parameter('ezpublish.spi.persistence.cache.inmemory.content.ttl')"
+            - "%ezpublish.spi.persistence.cache.inmemory.content.ttl%"
             - "%ezpublish.spi.persistence.cache.inmemory.content.limit%"
             - "%ezpublish.spi.persistence.cache.inmemory.content.enable%"
+        tags: ['ez.spi.persistence.cache.inmemory']
 
     # SPI Persistence Cache Handlers, incl abstracts
     ezpublish.spi.persistence.cache.abstractHandler:

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -99,12 +99,14 @@ services:
 
     ezpublish.spi.persistence.cache.locationHandler:
         class: "%ezpublish.spi.persistence.cache.locationHandler.class%"
-        parent: ezpublish.spi.persistence.cache.abstractHandler
+        parent: ezpublish.spi.persistence.cache.abstractInMemoryPersistenceHandler
+        arguments: # Overload argument to use content in-memory service
+            index_2: '@ezpublish.spi.persistence.cache.inmemory.content'
 
     ezpublish.spi.persistence.cache.contentHandler:
         class: "%ezpublish.spi.persistence.cache.contentHandler.class%"
         parent: ezpublish.spi.persistence.cache.abstractInMemoryPersistenceHandler
-        arguments: # Overload arguments to use content in-memory service
+        arguments: # Overload argument to use content in-memory service
             index_2: '@ezpublish.spi.persistence.cache.inmemory.content'
 
     ezpublish.spi.persistence.cache.contentLanguageHandler:

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -18,16 +18,22 @@ parameters:
     ezpublish.spi.persistence.cache.persistenceLogger.class: eZ\Publish\Core\Persistence\Cache\PersistenceLogger
     # Make sure logging is only enabled for debug by default
     ezpublish.spi.persistence.cache.persistenceLogger.enableCallLogging: "%kernel.debug%"
-    # Global in-memory settings
+    # Global in-memory settings, for meta data
     ezpublish.spi.persistence.cache.inmemory.ttl: 3000
     ezpublish.spi.persistence.cache.inmemory.limit: 100
     ezpublish.spi.persistence.cache.inmemory.enable: true
+    # Global in-memory settings, for content in-memory cache
+    ezpublish.spi.persistence.cache.inmemory.content.ttl: 300
+    ezpublish.spi.persistence.cache.inmemory.content.limit: 50
+    ezpublish.spi.persistence.cache.inmemory.content.enable: true
 
 services:
     # Setup cache pool, with InMemoryCacheAdapter as decorator
     ezpublish.cache_pool:
         class: eZ\Publish\Core\Persistence\Cache\Adapter\InMemoryClearingProxyAdapter
-        arguments: ["@ezpublish.cache_pool.inner", "@ezpublish.spi.persistence.cache.inmemory"]
+        arguments:
+          - "@ezpublish.cache_pool.inner"
+          - [ "@ezpublish.spi.persistence.cache.inmemory", "@ezpublish.spi.persistence.cache.inmemory.content" ]
 
     ezpublish.cache_pool.inner:
         public: false
@@ -56,6 +62,13 @@ services:
             - "%ezpublish.spi.persistence.cache.inmemory.limit%"
             - "%ezpublish.spi.persistence.cache.inmemory.enable%"
 
+    ezpublish.spi.persistence.cache.inmemory.content:
+        public: false
+        class: eZ\Publish\Core\Persistence\Cache\InMemory\InMemoryCache
+        arguments:
+            - "%ezpublish.spi.persistence.cache.inmemory.content.ttl%"
+            - "%ezpublish.spi.persistence.cache.inmemory.content.limit%"
+            - "%ezpublish.spi.persistence.cache.inmemory.content.enable%"
 
     # SPI Persistence Cache Handlers, incl abstracts
     ezpublish.spi.persistence.cache.abstractHandler:
@@ -91,6 +104,8 @@ services:
     ezpublish.spi.persistence.cache.contentHandler:
         class: "%ezpublish.spi.persistence.cache.contentHandler.class%"
         parent: ezpublish.spi.persistence.cache.abstractInMemoryPersistenceHandler
+        arguments: # Overload arguments to use content in-memory service
+            index_2: '@ezpublish.spi.persistence.cache.inmemory.content'
 
     ezpublish.spi.persistence.cache.contentLanguageHandler:
         class: "%ezpublish.spi.persistence.cache.contentLanguageHandler.class%"

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -132,7 +132,9 @@ services:
 
     ezpublish.spi.persistence.cache.urlAliasHandler:
         class: "%ezpublish.spi.persistence.cache.urlAliasHandler.class%"
-        parent: ezpublish.spi.persistence.cache.abstractHandler
+        parent: ezpublish.spi.persistence.cache.abstractInMemoryPersistenceHandler
+        arguments: # Overload argument to use content in-memory service
+          index_2: '@ezpublish.spi.persistence.cache.inmemory.content'
 
     ezpublish.spi.persistence.cache.objectStateHandler:
         class: "%ezpublish.spi.persistence.cache.objectStateHandler.class%"


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30298](https://jira.ez.no/browse/EZP-30298)
| **Improvement**| yes
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | maybe

Adds in-memory cache for content but with a lower TTL and seperate pool so it does not compete about place with metadata which is tiny bit more long lived. The Symfony cache pool decorator becomes helpful here so cache clearing is always sent to all pools, in-memory or not.

**Description**
This, together with improvements in TagsBundle 3.4 concludes the work on improving caching performance in eZ Platform 2.x for now by also adding in-memory caching for content, locations and content related lookups for url aliases to fix some of the most prominent performance issues when running on cluster.

Here is an overview over cache lookups done on some pages _(this is ee demo data, I expect somewhat gains on larger installs, especially on page builder)_:

|   |  2.5.0 | +TagsBundle 3.4  | +This PR | 
|---|---|---|---|
| admin/dashboard  |  691 | 279  | 85  | 
|  Content >Content structure   | 119  | 118  | 62  | 
| Page > Places & Tasts  | 86  | 85  | 47  | 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
