### PR TITLE
EZP-30281: Added deprecation info to Core RichText FT namespace

### DIFF
--- a/doc/bc/changes-7.4.md
+++ b/doc/bc/changes-7.4.md
@@ -12,3 +12,9 @@ Changes affecting version compatibility with former or future versions.
     Passing translations in all languages is no longer needed, all you have to do is pass language version 
     you wish to modify.
 * New method `\eZ\Publish\API\Repository\ContentTypeService::removeContentTypeTranslation` is introduced.
+
+## Deprecations
+
+* `eZ\Publish\Core\FieldType\RichText` namespace has been deprecated and will be removed in 8.0.
+
+  Enable [eZ Platform RichText Bundle](https://github.com/ezsystems/ezplatform-richtext) instead.

--- a/eZ/Publish/Core/FieldType/RichText/Converter.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter.php
@@ -12,6 +12,8 @@ use DOMDocument;
 
 /**
  * Interface for rich text conversion.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Converter from EzPlatformRichTextBundle.
  */
 interface Converter
 {

--- a/eZ/Publish/Core/FieldType/RichText/Converter/Aggregate.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Aggregate.php
@@ -13,6 +13,8 @@ use DOMDocument;
 
 /**
  * Aggregate converter converts using configured converters in prioritized order.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Converter\Aggregate from EzPlatformRichTextBundle.
  */
 class Aggregate implements Converter
 {

--- a/eZ/Publish/Core/FieldType/RichText/Converter/Link.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Link.php
@@ -19,6 +19,9 @@ use eZ\Publish\API\Repository\Exceptions\UnauthorizedException as APIUnauthorize
 use DOMDocument;
 use DOMXPath;
 
+/**
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Converter\Link from EzPlatformRichTextBundle.
+ */
 class Link implements Converter
 {
     /**

--- a/eZ/Publish/Core/FieldType/RichText/Converter/ProgramListing.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/ProgramListing.php
@@ -16,6 +16,8 @@ use DOMXPath;
  * Class ProgramListing.
  *
  * Processes <code>programlisting</code> DocBook tag.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Converter\ProgramListing from EzPlatformRichTextBundle.
  */
 class ProgramListing implements Converter
 {

--- a/eZ/Publish/Core/FieldType/RichText/Converter/Render.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Render.php
@@ -14,6 +14,8 @@ use DOMNode;
 
 /**
  * Base class for Render converters.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Converter\Render from EzPlatformRichTextBundle.
  */
 abstract class Render
 {

--- a/eZ/Publish/Core/FieldType/RichText/Converter/Render/Embed.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Render/Embed.php
@@ -17,6 +17,8 @@ use DOMElement;
 
 /**
  * RichText Embed converter injects rendered embed payloads into embed elements.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Converter\Render\Embed from EzPlatformRichTextBundle.
  */
 class Embed extends Render implements Converter
 {

--- a/eZ/Publish/Core/FieldType/RichText/Converter/Render/Template.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Render/Template.php
@@ -20,6 +20,8 @@ use Psr\Log\NullLogger;
 
 /**
  * RichText Template converter injects rendered template payloads into template elements.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Converter\Render\Template from EzPlatformRichTextBundle.
  */
 class Template extends Render implements Converter
 {

--- a/eZ/Publish/Core/FieldType/RichText/Converter/Xslt.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Xslt.php
@@ -17,6 +17,8 @@ use RuntimeException;
 
 /**
  * Converts DOMDocument objects using XSLT stylesheets.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Converter\Xslt from EzPlatformRichTextBundle.
  */
 class Xslt extends XmlBase implements Converter
 {

--- a/eZ/Publish/Core/FieldType/RichText/ConverterDispatcher.php
+++ b/eZ/Publish/Core/FieldType/RichText/ConverterDispatcher.php
@@ -13,6 +13,8 @@ use DOMDocument;
 
 /**
  * Dispatcher for various converters depending on the XML document namespace.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\ConverterDispatcher from EzPlatformRichTextBundle.
  */
 class ConverterDispatcher
 {

--- a/eZ/Publish/Core/FieldType/RichText/CustomTagsValidator.php
+++ b/eZ/Publish/Core/FieldType/RichText/CustomTagsValidator.php
@@ -16,6 +16,8 @@ use DOMXPath;
  *
  * The Validator checks if the given XML reflects proper Custom Tags configuration,
  * mostly existence of specific Custom Tag and its required attributes.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Validator\CustomTagsValidator from EzPlatformRichTextBundle.
  */
 class CustomTagsValidator
 {

--- a/eZ/Publish/Core/FieldType/RichText/InternalLinkValidator.php
+++ b/eZ/Publish/Core/FieldType/RichText/InternalLinkValidator.php
@@ -16,6 +16,8 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * Validator for RichText internal format links.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Validator\InternalLinkValidator from EzPlatformRichTextBundle.
  */
 class InternalLinkValidator
 {

--- a/eZ/Publish/Core/FieldType/RichText/Normalizer.php
+++ b/eZ/Publish/Core/FieldType/RichText/Normalizer.php
@@ -10,6 +10,8 @@ namespace eZ\Publish\Core\FieldType\RichText;
 
 /**
  * Abstract class for XML normalization of string input.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Normalizer from EzPlatformRichTextBundle.
  */
 abstract class Normalizer
 {

--- a/eZ/Publish/Core/FieldType/RichText/Normalizer/Aggregate.php
+++ b/eZ/Publish/Core/FieldType/RichText/Normalizer/Aggregate.php
@@ -12,6 +12,8 @@ use eZ\Publish\Core\FieldType\RichText\Normalizer;
 
 /**
  * Aggregate normalizer converts using configured normalizers in prioritized order.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Normalizer\Aggregate from EzPlatformRichTextBundle.
  */
 class Aggregate extends Normalizer
 {

--- a/eZ/Publish/Core/FieldType/RichText/Normalizer/DocumentTypeDefinition.php
+++ b/eZ/Publish/Core/FieldType/RichText/Normalizer/DocumentTypeDefinition.php
@@ -16,6 +16,8 @@ use eZ\Publish\Core\FieldType\RichText\Normalizer;
  * namespace.
  *
  * Note: if input already contains DTD it won't be accepted for normalization.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Normalizer\DocumentTypeDefinition from EzPlatformRichTextBundle.
  */
 class DocumentTypeDefinition extends Normalizer
 {

--- a/eZ/Publish/Core/FieldType/RichText/README.md
+++ b/eZ/Publish/Core/FieldType/RichText/README.md
@@ -1,5 +1,13 @@
 # RichText field type for eZ Platform
 
+***
+**NOTE**: As of eZ Platform v2.4 the entire `eZ\Publish\Core\FieldType\RichText` namespace
+is deprecated.
+
+Use `\EzSystems\EzPlatformRichTextBundle\EzPlatformRichTextBundle` provided by the
+[`ezsystems/ezplatform-richtext`](https://github.com/ezsystems/ezplatform-richtext) package instead.
+***
+
 This is the RichText field type for eZ Platform, it's a field type for supporting
 rich formatted text stored in a structured xml format.
 

--- a/eZ/Publish/Core/FieldType/RichText/RendererInterface.php
+++ b/eZ/Publish/Core/FieldType/RichText/RendererInterface.php
@@ -10,6 +10,8 @@ namespace eZ\Publish\Core\FieldType\RichText;
 
 /**
  * RichText field type renderer interface, to be implemented in MVC layer.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\RendererInterface from EzPlatformRichTextBundle.
  */
 interface RendererInterface
 {

--- a/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway.php
@@ -14,6 +14,8 @@ use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway as UrlGateway;
 /**
  * Abstract gateway class for RichText type.
  * Handles data that is not directly included in raw XML value from the field (i.e. URLs).
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\FieldType\RichText\RichTextStorage\Gateway from EzPlatformRichTextBundle.
  */
 abstract class Gateway extends StorageGateway
 {

--- a/eZ/Publish/Core/FieldType/RichText/SearchField.php
+++ b/eZ/Publish/Core/FieldType/RichText/SearchField.php
@@ -17,6 +17,8 @@ use DOMNode;
 
 /**
  * Indexable definition for RichText field type.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\FieldType\RichText\SearchField from EzPlatformRichTextBundle.
  */
 class SearchField implements Indexable
 {

--- a/eZ/Publish/Core/FieldType/RichText/Type.php
+++ b/eZ/Publish/Core/FieldType/RichText/Type.php
@@ -73,6 +73,14 @@ class Type extends FieldType
         InternalLinkValidator $internalLinkValidator = null,
         CustomTagsValidator $customTagsValidator = null
     ) {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since eZ Platform v2.4, enable RichTextBundle instead',
+                __CLASS__
+            ),
+            E_USER_DEPRECATED
+        );
+
         $this->internalFormatValidator = $internalFormatValidator;
         $this->inputConverterDispatcher = $inputConverterDispatcher;
         $this->inputNormalizer = $inputNormalizer;

--- a/eZ/Publish/Core/FieldType/RichText/Type.php
+++ b/eZ/Publish/Core/FieldType/RichText/Type.php
@@ -22,6 +22,8 @@ use RuntimeException;
 
 /**
  * RichText field type.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Type from EzPlatformRichTextBundle.
  */
 class Type extends FieldType
 {

--- a/eZ/Publish/Core/FieldType/RichText/Validator.php
+++ b/eZ/Publish/Core/FieldType/RichText/Validator.php
@@ -16,6 +16,8 @@ use RuntimeException;
 
 /**
  * Validates XML document using ISO Schematron (as XSLT stylesheet), XSD and RELAX NG schemas.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Validator\Validator from EzPlatformRichTextBundle.
  */
 class Validator extends XmlBase
 {

--- a/eZ/Publish/Core/FieldType/RichText/ValidatorDispatcher.php
+++ b/eZ/Publish/Core/FieldType/RichText/ValidatorDispatcher.php
@@ -13,6 +13,8 @@ use DOMDocument;
 
 /**
  * Dispatcher for various validators depending on the XML document namespace.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\Validator\ValidatorDispatcher from EzPlatformRichTextBundle.
  */
 class ValidatorDispatcher
 {

--- a/eZ/Publish/Core/FieldType/RichText/Value.php
+++ b/eZ/Publish/Core/FieldType/RichText/Value.php
@@ -13,6 +13,8 @@ use DOMDocument;
 
 /**
  * Value for RichText field type.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Value from EzPlatformRichTextBundle.
  */
 class Value extends BaseValue
 {

--- a/eZ/Publish/Core/FieldType/RichText/XmlBase.php
+++ b/eZ/Publish/Core/FieldType/RichText/XmlBase.php
@@ -14,6 +14,8 @@ use RuntimeException;
 
 /**
  * A base class for XML document handlers.
+ *
+ * @deprecated since 7.4, use \EzSystems\EzPlatformRichText\eZ\RichText\XmlBase from EzPlatformRichTextBundle.
  */
 abstract class XmlBase
 {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30281](https://jira.ez.no/browse/EZP-30281)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.4`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

## Brief

`eZ\Publish\Core\FieldType` has been deprecated since eZ Platform 2.4, when we introduced [RichTextBundle](https://github.com/ezsystems/ezplatform-richtext), but I've forgotten to add proper deprecation notices.

## Doc

I can't find this information explicitly available, so maybe we need to add a note saying that 
> Relying on any class from the `eZ\Publish\Core\FieldType` namespace is deprecated.
> If you're implementing any interface or extending any base class from that namespace, refer to its PhpDoc to see what to implement or extend instead.
> Make sure to enable eZ Platform `RichTextBundle` provided by the [`ezsystems/ezplatform-richtext`](https://github.com/ezsystems/ezplatform-richtext) package.

I expected to find it:
1. https://doc.ezplatform.com/en/latest/releases/ez_platform_v2.4/#richtext-field-type
2. https://doc.ezplatform.com/en/latest/api/field_type_reference/#richtext-field-type

**TODO**:
- [x] Add `@deprecated` notice to the classes inside `eZ\Publish\Core\FieldType` 
- [x] Add `@trigger_error E_USER_DEPRECATED` in a single, most relevant place
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
