### PR TITLE
EZP-29470: As a developer I want improved trace for all Persistence calls

### DIFF
--- a/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
@@ -105,8 +105,8 @@ class PersistenceCacheCollector extends DataCollector
             // Get traces, and order them to have the most called first
             $calls[$hash]['traces'] = $call['traces'];
             $traceCount = [];
-            foreach ($traces as $key => $traceData) {
-                $traceCount[$key] = $traceData['count'];
+            foreach ($traces as $traceHash => $traceData) {
+                $traceCount[$traceHash] = $traceData['count'];
             }
             \array_multisort($traceCount, SORT_DESC, SORT_NUMERIC, $calls[$hash]['traces']);
             

--- a/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
@@ -103,8 +103,8 @@ class PersistenceCacheCollector extends DataCollector
                 'traces' => $call['traces'],
                 'stats' => $call['stats'],
             ];
-            // Leave out in-memory lookups from sorting
-            $count[$hash] = $call['stats']['uncached'] + $call['stats']['miss'] + $call['stats']['hit'];
+            // Weight in-memory lookups lower for sorting
+            $count[$hash] = $call['stats']['uncached'] + $call['stats']['miss'] + $call['stats']['hit'] + $call['stats']['memory']*0.001;
         }
 
         array_multisort($count, SORT_DESC, $calls);

--- a/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
@@ -92,9 +92,9 @@ class PersistenceCacheCollector extends DataCollector
 
         $calls = $count = [];
         foreach ($this->data['calls'] as $hash => $call) {
-            list($class, $method) = explode('::', $call['method']);
-            $namespace = explode('\\', $class);
-            $class = array_pop($namespace);
+            list($class, $method) = \explode('::', $call['method']);
+            $namespace = \explode('\\', $class);
+            $class = \array_pop($namespace);
             $calls[$hash] = [
                 'namespace' => $namespace,
                 'class' => $class,
@@ -102,21 +102,21 @@ class PersistenceCacheCollector extends DataCollector
                 'arguments' => $call['arguments'],
                 'stats' => $call['stats'],
             ];
-            // Weight in-memory lookups lower for sorting
-            $count[$hash] = $call['stats']['uncached'] + $call['stats']['miss'] + $call['stats']['hit'] + $call['stats']['memory'] * 0.001;
-
-            // Order traces to have the most called first
-            $traces = $call['traces'];
+            // Get traces, and order them to have the most called first
+            $calls[$hash]['traces'] = $call['traces'];
             $traceCount = [];
             foreach ($traces as $key => $traceData) {
                 $traceCount[$key] = $traceData['count'];
             }
-            array_multisort($traceCount, SORT_DESC, $traces);
-            $calls[$hash]['traces'] = $traces;
+            \array_multisort($traceCount, SORT_DESC, SORT_NUMERIC, $calls[$hash]['traces']);
+            
+            // For call sorting count all calls, but weight in-memory lookups lower
+            $count[$hash] = $call['stats']['uncached'] + $call['stats']['miss'] + $call['stats']['hit'] + ($call['stats']['memory'] * 0.001);
+
         }
 
         // Order calls
-        array_multisort($count, SORT_DESC, $calls);
+        \array_multisort($count, SORT_DESC, SORT_NUMERIC, $calls);
 
         return $calls;
     }

--- a/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
@@ -100,13 +100,22 @@ class PersistenceCacheCollector extends DataCollector
                 'class' => $class,
                 'method' => $method,
                 'arguments' => $call['arguments'],
-                'traces' => $call['traces'],
                 'stats' => $call['stats'],
             ];
             // Weight in-memory lookups lower for sorting
             $count[$hash] = $call['stats']['uncached'] + $call['stats']['miss'] + $call['stats']['hit'] + $call['stats']['memory'] * 0.001;
+
+            // Order traces to have the most called first
+            $traces = $call['traces'];
+            $traceCount = [];
+            foreach ($traces as $key => $traceData) {
+                $traceCount[$key] = $traceData['count'];
+            }
+            array_multisort($traceCount, SORT_DESC, $traces);
+            $calls[$hash]['traces'] = $traces;
         }
 
+        // Order calls
         array_multisort($count, SORT_DESC, $calls);
 
         return $calls;

--- a/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
@@ -104,7 +104,7 @@ class PersistenceCacheCollector extends DataCollector
                 'stats' => $call['stats'],
             ];
             // Weight in-memory lookups lower for sorting
-            $count[$hash] = $call['stats']['uncached'] + $call['stats']['miss'] + $call['stats']['hit'] + $call['stats']['memory']*0.001;
+            $count[$hash] = $call['stats']['uncached'] + $call['stats']['miss'] + $call['stats']['hit'] + $call['stats']['memory'] * 0.001;
         }
 
         array_multisort($count, SORT_DESC, $calls);

--- a/eZ/Publish/Core/Persistence/Cache/PersistenceLogger.php
+++ b/eZ/Publish/Core/Persistence/Cache/PersistenceLogger.php
@@ -160,8 +160,6 @@ class PersistenceLogger
         }
         ++$this->calls[$callHash]['stats'][$type];
 
-        // @todo If we want/need to save more memory we can consider making an value object holding "trace", and share
-        // the object across all calls having same trace (quite often the case).
         $trace = $this->getSimpleCallTrace($trimmedBacktrace);
         $traceHash = \hash('adler32', \implode($trace));
         if (empty($this->calls[$callHash]['traces'][$traceHash])) {

--- a/eZ/Publish/Core/Persistence/Cache/PersistenceLogger.php
+++ b/eZ/Publish/Core/Persistence/Cache/PersistenceLogger.php
@@ -71,7 +71,7 @@ class PersistenceLogger
             $method,
             $arguments,
             \array_slice(
-                \debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 7),
+                \debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 9),
                 2
             ),
             'uncached'
@@ -93,7 +93,7 @@ class PersistenceLogger
             return;
         }
 
-        $trace = \debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 7 + $traceOffset);
+        $trace = \debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 8 + $traceOffset);
         $this->collectCacheCallData(
             $trace[$traceOffset - 1]['class'] . '::' . $trace[$traceOffset - 1]['function'],
             $arguments,
@@ -124,7 +124,7 @@ class PersistenceLogger
             return;
         }
 
-        $trace = \debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 7 + $traceOffset);
+        $trace = \debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 8 + $traceOffset);
         $this->collectCacheCallData(
             $trace[$traceOffset - 1]['class'] . '::' . $trace[$traceOffset - 1]['function'],
             $arguments,
@@ -187,6 +187,7 @@ class PersistenceLogger
     private function getSimpleCallTrace(array $backtrace): array
     {
         $calls = [];
+        $exitOnNext = false;
         foreach ($backtrace as $call) {
             if (!isset($call['class'][2]) || ($call['class'][2] !== '\\' && \strpos($call['class'], '\\') === false)) {
                 // skip if class has no namespace (Symfony lazy proxy or plain function)
@@ -195,9 +196,13 @@ class PersistenceLogger
 
             $calls[] = $call['class'] . $call['type'] . $call['function'] . '()';
 
-            // Break out as soon as we have listed 1 class outside of kernel
-            if ($call['class'][0] !== 'e' && \strpos($call['class'], 'eZ\\Publish\\Core\\') !== 0) {
+            if ($exitOnNext) {
                 break;
+            }
+
+            // Break out as soon as we have listed 2 classes outside of kernel
+            if ($call['class'][0] !== 'e' && \strpos($call['class'], 'eZ\\Publish\\Core\\') !== 0) {
+                $exitOnNext = true;
             }
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29470](https://jira.ez.no/browse/EZP-29470)
| **Bug/Improvement**| yes
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

As a developer I want a trace when using Repo/Persistence which more clearly shows which part of my code is triggering the call so I can more easily find it.

Example:
<img width="1229" alt="Screenshot 2019-04-11 at 21 35 26 " src="https://user-images.githubusercontent.com/289757/55988297-d2594080-5ca3-11e9-8da3-13a79d53e0e3.png">



As future improvment, maybe find a way to allow developer to expand trace further himself as long as this does not eat up to much memory.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
