### PR TITLE
EZP-30333: The host's port is added to image variations URIs when configured through image_host

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/Resolver/ProxyResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/Resolver/ProxyResolver.php
@@ -13,7 +13,10 @@ class ProxyResolver extends ImagineProxyResolver
     /**
      * Replaces host with given proxy host.
      *
-     * @param $url
+     * The original method from Liip\ImagineBundle\Imagine\Cache\Resolver\ProxyResolver:rewriteUrl()
+     * doesn't behave correctly when working with domain and port or with host which contains trailing slash.
+     *
+     * @param string $url
      * @return string
      */
     protected function rewriteUrl($url)

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/Resolver/ProxyResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/Resolver/ProxyResolver.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\Resolver;
+
+use Liip\ImagineBundle\Imagine\Cache\Resolver\ProxyResolver as ImagineProxyResolver;
+
+class ProxyResolver extends ImagineProxyResolver
+{
+    /**
+     * Replaces host with given proxy host.
+     *
+     * @param $url
+     * @return string
+     */
+    protected function rewriteUrl($url)
+    {
+        if (empty($this->hosts)) {
+            return $url;
+        }
+
+        $proxyHost = rtrim(reset($this->hosts), '/');
+        $relativeUrl = parse_url($url, PHP_URL_PATH);
+
+        return $proxyHost . $relativeUrl;
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -4,7 +4,7 @@ parameters:
     ezpublish.image_alias.imagine.binary_loader.class: eZ\Bundle\EzPublishCoreBundle\Imagine\BinaryLoader
     ezpublish.image_alias.imagine.cache_resolver_decorator_factory.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\ResolverFactory
     ezpublish.image_alias.imagine.cache_resolver_decorator_relative.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\Resolver\RelativeResolver
-    ezpublish.image_alias.imagine.cache_resolver_decorator_proxy.class: Liip\ImagineBundle\Imagine\Cache\Resolver\ProxyResolver
+    ezpublish.image_alias.imagine.cache_resolver_decorator_proxy.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\Resolver\ProxyResolver
     ezpublish.image_alias.imagine.cache_resolver.class: eZ\Bundle\EzPublishCoreBundle\Imagine\IORepositoryResolver
     ezpublish.image_alias.imagine.cache.alias_generator_decorator.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\AliasGeneratorDecorator
     ezpublish.image_alias.imagine.variation.imagine_alias_generator.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Variation\ImagineAwareAliasGenerator

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Cache\Resolver;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\Resolver\ProxyResolver;
+use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
+use PHPUnit\Framework\TestCase;
+
+class ProxyResolverTest extends TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface
+     */
+    private $resolver;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var string
+     */
+    private $filter;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->resolver = $this->getMockBuilder(ResolverInterface::class)->getMock();
+        $this->path = '7/4/2/0/247-1-eng-GB/img_0885.jpg';
+        $this->filter = 'medium';
+    }
+
+    public function testResolveUsingProxyHostWithTrailingSlash()
+    {
+        $hosts = ['http://ezplatform.com/'];
+        $proxyResolver = new ProxyResolver($this->resolver, $hosts);
+
+        $resolvedPath = 'http://ez.no/var/site/storage/images/_aliases/medium/7/4/2/0/247-1-eng-GB/img_0885.jpg';
+
+        $this->resolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($this->path, $this->filter)
+            ->willReturn($resolvedPath);
+
+        $expected = 'http://ezplatform.com/var/site/storage/images/_aliases/medium/7/4/2/0/247-1-eng-GB/img_0885.jpg';
+
+        $this->assertEquals($expected, $proxyResolver->resolve($this->path, $this->filter));
+    }
+
+    public function testResolveAndRemovePortUsingProxyHost()
+    {
+        $hosts = ['http://ez.no'];
+        $proxyResolver = new ProxyResolver($this->resolver, $hosts);
+
+        $resolvedPath = 'http://ez.no:8060/var/site/storage/images/_aliases/medium/7/4/2/0/247-1-eng-GB/img_0885.jpg';
+
+        $this->resolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($this->path, $this->filter)
+            ->willReturn($resolvedPath);
+
+        $expected = 'http://ez.no/var/site/storage/images/_aliases/medium/7/4/2/0/247-1-eng-GB/img_0885.jpg';
+
+        $this->assertEquals($expected, $proxyResolver->resolve($this->path, $this->filter));
+    }
+
+    public function testResolveAndRemovePortUsingProxyHostWithTrailingSlash()
+    {
+        $hosts = ['http://ez.no'];
+        $proxyResolver = new ProxyResolver($this->resolver, $hosts);
+
+        $resolvedPath = 'http://ezplatform.com:8080/var/site/storage/images/_aliases/medium/7/4/2/0/247-1-eng-GB/img_0885.jpg';
+
+        $this->resolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($this->path, $this->filter)
+            ->willReturn($resolvedPath);
+
+        $expected = 'http://ez.no/var/site/storage/images/_aliases/medium/7/4/2/0/247-1-eng-GB/img_0885.jpg';
+
+        $this->assertEquals($expected, $proxyResolver->resolve($this->path, $this->filter));
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30333](https://jira.ez.no/browse/EZP-30333)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`/`6.13`/`7.4`/`7.5`/`master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Please take a look at JIRA ticket for more information. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
