### PR TITLE
EZP-30475: Escape user login name so domain login names works as intended

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -837,6 +837,19 @@ class UserServiceTest extends BaseTest
     }
 
     /**
+     * Test for creating user with Active Directory login name.
+     */
+    public function testNewUserWithDomainName()
+    {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+        $createdUser = $this->createUserVersion1('ez-user-Domain\username-by-login');
+        $loadedUser = $userService->loadUserByLogin('ez-user-Domain\username-by-login');
+
+        $this->assertEquals($createdUser, $loadedUser);
+    }
+
+    /**
      * Test for the createUser() method.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User

--- a/eZ/Publish/Core/Persistence/Cache/AbstractHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractHandler.php
@@ -121,4 +121,13 @@ abstract class AbstractHandler
 
         return $list;
     }
+
+    final protected function escapeForCacheKey(string $identifier)
+    {
+        return \str_replace(
+            ['_', '/', ':', '(', ')', '@', '\\', '{', '}'],
+            ['__', '_S', '_C', '_BO', '_BC', '_A', '_BS', '_CBO', '_CBC'],
+            $identifier
+        );
+    }
 }

--- a/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
@@ -268,4 +268,13 @@ abstract class AbstractInMemoryHandler
 
         return $list;
     }
+
+    final protected function escapeForCacheKey(string $identifier)
+    {
+        return \str_replace(
+            ['_', '/', ':', '(', ')', '@', '\\', '{', '}'],
+            ['__', '_S', '_C', '_BO', '_BC', '_A', '_BS', '_CBO', '_CBC'],
+            $identifier
+        );
+    }
 }

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -146,7 +146,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
      */
     public function loadContentInfoByRemoteId($remoteId)
     {
-        $cacheItem = $this->cache->getItem("ez-content-info-byRemoteId-${remoteId}");
+        $cacheItem = $this->cache->getItem('ez-content-info-byRemoteId-' . $this->escapeForCacheKey($remoteId));
         if ($cacheItem->isHit()) {
             return $cacheItem->get();
         }

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -147,7 +147,8 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
     public function loadByRemoteId($remoteId, array $translations = null, bool $useAlwaysAvailable = true)
     {
         $translationsKey = $this->getCacheTranslationKey($translations, $useAlwaysAvailable);
-        $cacheItem = $this->cache->getItem("ez-location-remoteid-${remoteId}-${translationsKey}");
+        $keyRemoteId = $this->escapeForCacheKey($remoteId);
+        $cacheItem = $this->cache->getItem("ez-location-remoteid-${keyRemoteId}-${translationsKey}");
         if ($cacheItem->isHit()) {
             return $cacheItem->get();
         }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
@@ -43,8 +43,8 @@ class UserHandlerTest extends AbstractInMemoryCacheHandlerTest
         return [
             ['create', [$user], ['content-fields-14'], [
                 'ez-user-14',
-                'ez-user-' . str_replace('@', '§', $user->login) . '-by-login',
-                'ez-user-' . str_replace('@', '§', $user->email) . '-by-email',
+                'ez-user-' . str_replace('@', '_A', $user->login) . '-by-login',
+                'ez-user-' . str_replace('@', '_A', $user->email) . '-by-email',
             ]],
             ['update', [$user], ['content-fields-14', 'user-14']],
             ['updateUserToken', [$userToken], ['user-14-account-key'], ['ez-user-4irj8t43r-by-account-key']],
@@ -80,7 +80,7 @@ class UserHandlerTest extends AbstractInMemoryCacheHandlerTest
         return [
             ['load', [14], 'ez-user-14', $user],
             ['loadByLogin', ['admin'], 'ez-user-admin-by-login', $user],
-            ['loadByEmail', ['nospam@ez.no'], 'ez-user-nospam§ez.no-by-email', [$user]],
+            ['loadByEmail', ['nospam@ez.no'], 'ez-user-nospam_Aez.no-by-email', [$user]],
             ['loadUserByToken', ['hash'], 'ez-user-hash-by-account-key', $user],
             ['loadRole', [9], 'ez-role-9', $role],
             ['loadRoleByIdentifier', ['member'], 'ez-role-member-by-identifier', $role],

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -179,7 +179,7 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
     public function lookup($url)
     {
         $cacheItem = $this->cache->getItem(
-            'ez-urlAlias-url-' . str_replace(['_', '/', ':', '(', ')', '@', '\\', '{', '}'], ['__', '_S', '_C', '_BO', '_BC', '_A', '_BS', '_CBO', '_CBC'], $url)
+            'ez-urlAlias-url-' . $this->escapeForCacheKey($url)
         );
         if ($cacheItem->isHit()) {
             if (($return = $cacheItem->get()) === self::NOT_FOUND) {

--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -48,10 +48,10 @@ class UserHandler extends AbstractInMemoryPersistenceHandler implements UserHand
         $this->getUserTags = static function (User $user) {
             return ['content-' . $user->id, 'user-' . $user->id];
         };
-        $this->getUserKeys = static function (User $user) {
+        $this->getUserKeys = function (User $user) {
             return [
                 'ez-user-' . $user->id,
-                'ez-user-' . \str_replace('@', '§', $user->login) . '-by-login',
+                'ez-user-' . $this->escapeForCacheKey($user->login) . '-by-login',
                 //'ez-user-' . $hash . '-by-account-key',
             ];
         };
@@ -90,8 +90,8 @@ class UserHandler extends AbstractInMemoryPersistenceHandler implements UserHand
         $this->cache->invalidateTags(['content-fields-' . $user->id]);
         $this->cache->deleteItems([
             'ez-user-' . $user->id,
-            'ez-user-' . str_replace('@', '§', $user->login) . '-by-login',
-            'ez-user-' . str_replace('@', '§', $user->email) . '-by-email',
+            'ez-user-' . $this->escapeForCacheKey($user->login) . '-by-login',
+            'ez-user-' . $this->escapeForCacheKey($user->email) . '-by-email',
         ]);
 
         return $return;
@@ -119,7 +119,7 @@ class UserHandler extends AbstractInMemoryPersistenceHandler implements UserHand
     public function loadByLogin($login)
     {
         return $this->getCacheValue(
-            str_replace('@', '§', $login),
+            $this->escapeForCacheKey($login),
             'ez-user-',
             function ($escapedLogin) use ($login) {
                 return $this->persistenceHandler->userHandler()->loadByLogin($login);
@@ -137,7 +137,7 @@ class UserHandler extends AbstractInMemoryPersistenceHandler implements UserHand
     {
         // As load by email can return several items we threat it like a list here.
         return $this->getListCacheValue(
-            'ez-user-' . str_replace('@', '§', $email) . '-by-email',
+            'ez-user-' . $this->escapeForCacheKey($email) . '-by-email',
             function () use ($email) {
                 return $this->persistenceHandler->userHandler()->loadByEmail($email);
             },


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30475](https://jira.ez.no/browse/EZP-30475)
| **Bug/Improvement**| yes
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Changes cache key escape logic to be seperate function to be able to reuse consistently in cases known to maybe contain disallowed characters:
- login name _(e.g. Active directory login names as reported in JITA issue)_
- email addresses
- url
- remote id


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
