### PR TITLE
EZP-30405: Fixed user load by email if someone changes email to it

### DIFF
--- a/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
@@ -109,10 +109,9 @@ class PersistenceCacheCollector extends DataCollector
                 $traceCount[$traceHash] = $traceData['count'];
             }
             \array_multisort($traceCount, SORT_DESC, SORT_NUMERIC, $calls[$hash]['traces']);
-            
+
             // For call sorting count all calls, but weight in-memory lookups lower
             $count[$hash] = $call['stats']['uncached'] + $call['stats']['miss'] + $call['stats']['hit'] + ($call['stats']['memory'] * 0.001);
-
         }
 
         // Order calls

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1609,17 +1609,17 @@ class UserServiceTest extends BaseTest
         // Create a user
         $user = $this->createUserVersion1();
 
-        // Warmup cache and check we get what we expect
+        // Check we get what we expect (and implicit warmup any kind of cache)
         $users = $userService->loadUsersByEmail('user2@example.com');
         $this->assertCount(0, $users);
 
-        // Update user with warmed up email
+        // Update user with the given email address
         $userUpdate = $userService->newUserUpdateStruct();
         $userUpdate->email = 'user2@example.com';
         $updatedUser = $userService->updateUser($user, $userUpdate);
         $this->assertInstanceOf(User::class, $updatedUser);
 
-        // Check that we can user by email
+        // Check that we can load user by email
         $users = $userService->loadUsersByEmail('user2@example.com');
         $this->assertCount(1, $users);
         $this->assertInstanceOf(User::class, $users[0]);

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1599,9 +1599,9 @@ class UserServiceTest extends BaseTest
     }
 
     /**
-     * Test for the updateUser() method when others have same email.
+     * Test for the updateUser() and loadUsersByEmail() method on change to email.
      */
-    public function testUpdateUserEmailClash(): void
+    public function testUpdateUserEmail(): void
     {
         $repository = $this->getRepository();
         $userService = $repository->getUserService();

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1593,12 +1593,36 @@ class UserServiceTest extends BaseTest
         $userVersion2 = $userService->updateUser($user, $userUpdate);
         /* END: Use Case */
 
-        $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\User',
-            $user
-        );
+        $this->assertInstanceOf(User::class, $userVersion2);
 
         return $userVersion2;
+    }
+
+    /**
+     * Test for the updateUser() method when others have same email.
+     */
+    public function testUpdateUserEmailClash(): void
+    {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+
+        // Create a user
+        $user = $this->createUserVersion1();
+
+        // Warmup cache and check we get what we expect
+        $users = $userService->loadUsersByEmail('user2@example.com');
+        $this->assertCount(0, $users);
+
+        // Update user with warmed up email
+        $userUpdate = $userService->newUserUpdateStruct();
+        $userUpdate->email = 'user2@example.com';
+        $updatedUser = $userService->updateUser($user, $userUpdate);
+        $this->assertInstanceOf(User::class, $updatedUser);
+
+        // Check that we can user by email
+        $users = $userService->loadUsersByEmail('user2@example.com');
+        $this->assertCount(1, $users);
+        $this->assertInstanceOf(User::class, $users[0]);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
@@ -46,7 +46,9 @@ class UserHandlerTest extends AbstractInMemoryCacheHandlerTest
                 'ez-user-' . str_replace('@', '_A', $user->login) . '-by-login',
                 'ez-user-' . str_replace('@', '_A', $user->email) . '-by-email',
             ]],
-            ['update', [$user], ['content-fields-14', 'user-14']],
+            ['update', [$user], ['content-fields-14', 'user-14'], [
+                'ez-user-' . str_replace('@', '_A', $user->email) . '-by-email'
+            ]],
             ['updateUserToken', [$userToken], ['user-14-account-key'], ['ez-user-4irj8t43r-by-account-key']],
             ['expireUserToken', ['4irj8t43r'], null, ['ez-user-4irj8t43r-by-account-key']],
             ['delete', [14], ['content-fields-14', 'user-14']],

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
@@ -47,7 +47,7 @@ class UserHandlerTest extends AbstractInMemoryCacheHandlerTest
                 'ez-user-' . str_replace('@', '_A', $user->email) . '-by-email',
             ]],
             ['update', [$user], ['content-fields-14', 'user-14'], [
-                'ez-user-' . str_replace('@', '_A', $user->email) . '-by-email'
+                'ez-user-' . str_replace('@', '_A', $user->email) . '-by-email',
             ]],
             ['updateUserToken', [$userToken], ['user-14-account-key'], ['ez-user-4irj8t43r-by-account-key']],
             ['expireUserToken', ['4irj8t43r'], null, ['ez-user-4irj8t43r-by-account-key']],

--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -187,6 +187,8 @@ class UserHandler extends AbstractInMemoryPersistenceHandler implements UserHand
 
         // Clear corresponding content cache as update of the User changes it's external data
         $this->cache->invalidateTags(['content-fields-' . $user->id, 'user-' . $user->id]);
+        // Clear especially by email key as it might already be cached and this might represent change to email
+        $this->cache->deleteItems(['ez-user-' . $this->escapeForCacheKey($user->email) . '-by-email']);
 
         return $return;
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30405](https://jira.ez.no/browse/EZP-30405)
| **Bug/Improvement**| yes
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

On case where user changes email, the cache code failed to clear the cache for lookups by that email.

Given email lookup is essentially a list of objects, this can cause issues for `loadByEmail()` if:
- Cache is warmed up and contains 0 hits
- There is another user with that email already and cache is warmed up with 1 user hit
    - _SIDE NOTE: @Plopix I think eZ Core Extra Bundle will fail in this case, [it assumes only one user](https://github.com/lolautruche/EzCoreExtraBundle/blob/master/Security/UserProvider.php#L60) with a given email._

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
