### PR TITLE
[Tests] Called DbPlatform::addEventSubscribers prior to connecting

### DIFF
--- a/eZ/Publish/Core/Persistence/Tests/DatabaseConnectionFactory.php
+++ b/eZ/Publish/Core/Persistence/Tests/DatabaseConnectionFactory.php
@@ -61,6 +61,8 @@ class DatabaseConnectionFactory
         $driverName = 'pdo_' . $scheme;
         if (isset($this->databasePlatforms[$driverName])) {
             $params['platform'] = $this->databasePlatforms[$driverName];
+            // add predefined event subscribers only for the relevant connection
+            $params['platform']->addEventSubscribers($this->eventManager);
         }
 
         return DriverManager::getConnection($params, null, $this->eventManager);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a, follow-up for #2548 
| **Requires** | ezsystems/doctrine-dbal-schema#5
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

The event subscriber enabling foreign keys for Sqlite is unfortunately always added which causes warnings (this is why I didn't spot this earlier) when executing tests using SchemaImporter. 

It also causes [failures](https://travis-ci.org/ezsystems/ezplatform-richtext/jobs/521305165#L664) in our other repositories relying on these tests, which was visible only after merging.

This is a result of tagging every instance of `DbPlatform` and injecting a list. At that time all constructors are called. 

I'm introducing via ezsystems/doctrine-dbal-schema#5 a way to explicitly add events only when proper DbPlatform is chosen, by calling `addEventSubscribers`.

**TODO**:
- [x] **Remove TMP commit**
- [x] Fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
