### PR TITLE
Bumped minimal Symfony version to reduce Composer's work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,10 @@ matrix:
       env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
 # 7.1
     - php: 7.1
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" CUSTOM_CACHE_POOL="singleredis" REDIS_ENABLE_LZF="true" REDIS_ENABLE_IGBINARY="true" SYMFONY_VERSION="~3.4.17"
+      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" CUSTOM_CACHE_POOL="singleredis" REDIS_ENABLE_LZF="true" REDIS_ENABLE_IGBINARY="true" SYMFONY_VERSION="~3.4.26"
 # 7.2
     - php: 7.2
-      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~3.4.17"
+      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~3.4.26"
 # 7.3
     # Temp: Need to use --ignore-platform-reqs due to: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3697
     - php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-SPL": "*",
         "ext-xsl": "*",
         "zetacomponents/mail": "^1.8.3",
-        "symfony/symfony": "^2.8.46 | ^3.4.17",
+        "symfony/symfony": "^2.8.50 | ^3.4.26",
         "symfony-cmf/routing": "~1.4",
         "qafoo/rmf": "1.0.*",
         "kriswallsmith/buzz": "~0.16.1",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| n/a
| **New feature**    | n/a
| **Target version** | 6.7 and 6.13, not applicable for higher versions
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Some jobs for 6.13 branch are failing by exceeding Composer's memory limits, see: https://travis-ci.org/ezsystems/ezpublish-kernel/builds/521932866

Bumping the minimal required Symfony version should do the trick, as it makes Composer's job easier when it comes to resolving dependencies. Using latest values from 2.x and 3.x releases: https://github.com/symfony/symfony/releases