### PR TITLE
Fix EZP-30492: Cannot use fos js commands from console

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Routing/JsRouting/ExposedRoutesExtractor.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/JsRouting/ExposedRoutesExtractor.php
@@ -25,7 +25,7 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
      */
     private $masterRequest;
 
-    public function __construct(ExposedRoutesExtractorInterface $innerExtractor, Request $masterRequest)
+    public function __construct(ExposedRoutesExtractorInterface $innerExtractor, Request $masterRequest = null)
     {
         $this->innerExtractor = $innerExtractor;
         $this->masterRequest = $masterRequest;
@@ -46,6 +46,11 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
     public function getBaseUrl()
     {
         $baseUrl = $this->innerExtractor->getBaseUrl();
+
+        if (null === $this->masterRequest) {
+            return $baseUrl;
+        }
+
         $siteAccess = $this->masterRequest->attributes->get('siteaccess');
         if ($siteAccess instanceof SiteAccess && $siteAccess->matcher instanceof SiteAccess\URILexer) {
             $baseUrl .= $siteAccess->matcher->analyseLink('');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30492](https://jira.ez.no/browse/EZP-30492)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

To be honest, i don't really know if this is the way to fix this. It looks like workaround. The thing is as we don't have request when executing the command from the console, the script fails. Hence i made the masterRequest param optional and modified the getBaseUrl method a little bit. 

ping @lserwatka 