### PR TITLE
EZEE-2661: Allowed translation filtering when publishing version

### DIFF
--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\API\Repository;
 
 use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
@@ -285,14 +286,16 @@ interface ContentService
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is not a draft
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
-     * @param string[] $translations - Array of language codes in which version is going to be published.
-     *                                 If empty - all translations from current version will be published
-     *                                          and missing one will be copied from published Version.
-     *                                 If some provided - those will be published from provided version
-     *                                          and rest will be copied from published version overriding those in version.
+     * @param string[] $translations List of language codes of translations which will be included
+     *                               in a published version.
+     *                               By default all translations from the current version will be published.
+     *                               If the list is provided but does not cover all currently published translations,
+     *                               the missing ones will be copied from the currently published version,
+     *                               overriding those in the current version.
+     *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
-    public function publishVersion(VersionInfo $versionInfo, array $translations = []);
+    public function publishVersion(VersionInfo $versionInfo, array $translations = Language::ALL);
 
     /**
      * Removes the given version.

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -285,10 +285,14 @@ interface ContentService
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is not a draft
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
-     *
+     * @param string[] $translations - Array of language codes in which version is going to be published.
+     *                                 If empty - all translations from current version will be published
+     *                                          and missing one will be copied from published Version.
+     *                                 If some provided - those will be published from provided version
+     *                                          and rest will be copied from published version overriding those in version.
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
-    public function publishVersion(VersionInfo $versionInfo);
+    public function publishVersion(VersionInfo $versionInfo, array $translations = []);
 
     /**
      * Removes the given version.
@@ -421,6 +425,9 @@ interface ContentService
 
     /**
      * Delete specified Translation from a Content Draft.
+     *
+     * When using together with ContentService::publishVersion() method, make sure to not provide deleted translation
+     * in translations array, as it is going to be copied again from published version.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified Translation
      *         is the only one the Content Draft has or it is the main Translation of a Content Object.

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -6654,66 +6654,37 @@ XML
         );
     }
 
-    public function testCopyTranslationsWithSelectedLanguages()
+    public function testPublishVersionWithSelectedLanguages()
     {
         $repository = $this->getRepository();
 
         $contentService = $repository->getContentService();
 
-        $contentDraft = $this->createContentDraft(
-            'folder',
-            $this->generateId('location', 2),
+        $publishedContent = $this->createFolder(
             [
-                'name' => 'Published US',
-            ]
+                'eng-US' => 'Published US',
+                'ger-DE' => 'Published DE',
+            ],
+            $this->generateId('location', 2)
         );
 
-        $publishedContent = $contentService->publishVersion($contentDraft->versionInfo);
-
-        $usDraft1 = $contentService->createContentDraft($publishedContent->contentInfo);
+        $draft = $contentService->createContentDraft($publishedContent->contentInfo);
         $contentUpdateStruct = new ContentUpdateStruct([
             'initialLanguageCode' => 'eng-US',
-            'fields' => $contentDraft->getFields(),
         ]);
         $contentUpdateStruct->setField('name', 'Draft 1 US', 'eng-US');
-        $contentService->updateContent($usDraft1->versionInfo, $contentUpdateStruct);
-
-
-        $deDraft = $contentService->createContentDraft($publishedContent->contentInfo);
-        $contentUpdateStruct = new ContentUpdateStruct([
-            'initialLanguageCode' => 'ger-DE',
-            'fields' => $contentDraft->getFields(),
-        ]);
-        $contentUpdateStruct->setField('name', 'Published GER', 'ger-DE');
-        $gerContent = $contentService->updateContent($deDraft->versionInfo, $contentUpdateStruct);
-        $contentService->publishVersion($gerContent->versionInfo);
-
-        $publishedContent = $contentService->publishVersion($usDraft1->versionInfo);
-
-        $usDraft2 = $contentService->createContentDraft($publishedContent->contentInfo);
-        $contentUpdateStruct = new ContentUpdateStruct([
-            'initialLanguageCode' => 'eng-US',
-            'fields' => $contentDraft->getFields(),
-        ]);
-        $contentUpdateStruct->setField('name', 'Draft 2 US', 'eng-US');
-        $contentService->updateContent($usDraft2->versionInfo, $contentUpdateStruct);
-
-        $deDraft1 = $contentService->createContentDraft($publishedContent->contentInfo);
-        $contentUpdateStruct = new ContentUpdateStruct([
-            'initialLanguageCode' => 'ger-DE',
-            'fields' => $contentDraft->getFields(),
-        ]);
         $contentUpdateStruct->setField('name', 'Draft 1 DE', 'ger-DE');
-        $contentService->updateContent($deDraft1->versionInfo, $contentUpdateStruct);
 
-        $contentService->publishVersion($usDraft2->versionInfo);
-        $dePublished = $contentService->publishVersion($deDraft1->versionInfo, ['ger-DE']);
+        $contentService->updateContent($draft->versionInfo, $contentUpdateStruct);
+
+        $contentService->publishVersion($draft->versionInfo, ['ger-DE']);
+        $content = $contentService->loadContent($draft->contentInfo->id);
         $this->assertEquals(
             [
-                'eng-US' => 'Draft 2 US',
+                'eng-US' => 'Published US',
                 'ger-DE' => 'Draft 1 DE',
             ],
-            $dePublished->fields['name']
+            $content->fields['name']
         );
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\SPI\Persistence\Content;
-use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
 use eZ\Publish\SPI\Persistence\Content\Type;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
@@ -253,33 +252,21 @@ class ContentHandlerTest extends TestCase
             ->with(23, 1)
             ->will(
                 $this->returnValue(
-                    new VersionInfo(array('versionNo' => 1, 'contentInfo' => new ContentInfo(array('currentVersionNo' => 1))))
+                    new VersionInfo(array('contentInfo' => new ContentInfo(array('currentVersionNo' => 1))))
                 )
             );
 
         $contentRows = [['ezcontentobject_version_version' => 1]];
 
-        $gatewayMock->expects($this->exactly(3))
+        $gatewayMock->expects($this->once())
             ->method('load')
-            ->withConsecutive(
-                [
-                    $this->equalTo(23),
-                    $this->equalTo(null),
-                    $this->equalTo(null),
-                ],
-                [
-                    $this->equalTo(23),
-                    $this->equalTo(1),
-                    $this->equalTo(null),
-                ],
-                [
-                    $this->equalTo(23),
-                    $this->equalTo(1),
-                    $this->equalTo(null),
-                ]
+            ->with(
+                $this->equalTo(23),
+                $this->equalTo(1),
+                $this->equalTo(null)
             )->willReturn($contentRows);
 
-        $gatewayMock->expects($this->exactly(3))
+        $gatewayMock->expects($this->once())
             ->method('loadVersionedNameData')
             ->with(
                 $this->equalTo(array(array('id' => 23, 'version' => 1)))
@@ -287,12 +274,12 @@ class ContentHandlerTest extends TestCase
                 $this->returnValue(array(22))
             );
 
-        $mapperMock->expects($this->exactly(3))
+        $mapperMock->expects($this->once())
             ->method('extractContentFromRows')
             ->with($this->equalTo($contentRows), $this->equalTo(array(22)))
             ->will($this->returnValue(array($this->getContentFixtureForDraft())));
 
-        $fieldHandlerMock->expects($this->exactly(3))
+        $fieldHandlerMock->expects($this->once())
             ->method('loadExternalFieldData')
             ->with($this->isInstanceOf(Content::class));
 
@@ -337,7 +324,7 @@ class ContentHandlerTest extends TestCase
             ->with(23, 2)
             ->will(
                 $this->returnValue(
-                    new VersionInfo(array('versionNo' => 2, 'contentInfo' => new ContentInfo(array('currentVersionNo' => 1))))
+                    new VersionInfo(array('contentInfo' => new ContentInfo(array('currentVersionNo' => 1))))
                 )
             );
 
@@ -348,22 +335,16 @@ class ContentHandlerTest extends TestCase
 
         $contentRows = [['ezcontentobject_version_version' => 2]];
 
-        $gatewayMock->expects($this->exactly(2))
+        $gatewayMock->expects($this->once())
             ->method('load')
-            ->withConsecutive(
-                [
-                    $this->equalTo(23),
-                    $this->equalTo(null),
-                    $this->equalTo(null),
-                ],
-                [
-                    $this->equalTo(23),
-                    $this->equalTo(2),
-                    $this->equalTo(null),
-                ]
-            )->willReturn($contentRows);
+            ->with(
+                $this->equalTo(23),
+                $this->equalTo(2),
+                $this->equalTo(null)
+            )
+            ->willReturn($contentRows);
 
-        $gatewayMock->expects($this->exactly(2))
+        $gatewayMock->expects($this->once())
             ->method('loadVersionedNameData')
             ->with(
                 $this->equalTo(array(array('id' => 23, 'version' => 2)))
@@ -371,12 +352,12 @@ class ContentHandlerTest extends TestCase
                 $this->returnValue(array(22))
             );
 
-        $mapperMock->expects($this->exactly(2))
+        $mapperMock->expects($this->once())
             ->method('extractContentFromRows')
             ->with($this->equalTo($contentRows), $this->equalTo(array(22)))
             ->will($this->returnValue(array($this->getContentFixtureForDraft())));
 
-        $fieldHandlerMock->expects($this->exactly(2))
+        $fieldHandlerMock->expects($this->once())
             ->method('loadExternalFieldData')
             ->with($this->isInstanceOf(Content::class));
 
@@ -1507,8 +1488,7 @@ class ContentHandlerTest extends TestCase
                 $this->getSlugConverterMock(),
                 $this->getUrlAliasGatewayMock(),
                 $this->getContentTypeHandlerMock(),
-                $this->getTreeHandlerMock(),
-                $this->getLanguageHandlerMock()
+                $this->getTreeHandlerMock()
             );
         }
 
@@ -1536,7 +1516,6 @@ class ContentHandlerTest extends TestCase
                     $this->getUrlAliasGatewayMock(),
                     $this->getContentTypeHandlerMock(),
                     $this->getTreeHandlerMock(),
-                    $this->getLanguageHandlerMock(),
                 )
             )
             ->getMock();
@@ -1666,17 +1645,5 @@ class ContentHandlerTest extends TestCase
         }
 
         return $this->urlAliasGatewayMock;
-    }
-
-    /**
-     * @return \eZ\Publish\SPI\Persistence\Content\Language\Handler
-     */
-    protected function getLanguageHandlerMock()
-    {
-        if (!isset($this->languageHandlerMock)) {
-            $this->languageHandlerMock = $this->getMockForAbstractClass(LanguageHandler::class);
-        }
-
-        return $this->languageHandlerMock;
     }
 }

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -499,13 +499,14 @@ class ContentService implements APIContentService, Sessionable
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is not a draft
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
+     * @param string[] $translations
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to publish this version
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is not a draft
      */
-    public function publishVersion(VersionInfo $versionInfo)
+    public function publishVersion(VersionInfo $versionInfo, array $translations = [])
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\TranslationInfo;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
@@ -506,7 +507,7 @@ class ContentService implements APIContentService, Sessionable
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to publish this version
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is not a draft
      */
-    public function publishVersion(VersionInfo $versionInfo, array $translations = [])
+    public function publishVersion(VersionInfo $versionInfo, array $translations = Language::ALL)
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1618,6 +1618,8 @@ class ContentService implements ContentServiceInterface
 
         // Find only translatable fields to update with selected languages
         $updateStruct = $this->newContentUpdateStruct();
+        $updateStruct->initialLanguageCode = $versionInfo->initialLanguageCode;
+
         foreach ($currentContent->getFields() as $field) {
             $fieldDefinition = $contentType->getFieldDefinition($field->fieldDefIdentifier);
 

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -141,9 +141,9 @@ class ContentService implements ContentServiceInterface
         return $this->service->updateContent($versionInfo, $contentUpdateStruct);
     }
 
-    public function publishVersion(VersionInfo $versionInfo)
+    public function publishVersion(VersionInfo $versionInfo, array $translations = [])
     {
-        return $this->service->publishVersion($versionInfo);
+        return $this->service->publishVersion($versionInfo, $translations);
     }
 
     public function deleteVersion(VersionInfo $versionInfo)

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\ContentService as ContentServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\User\User;
@@ -141,7 +142,7 @@ class ContentService implements ContentServiceInterface
         return $this->service->updateContent($versionInfo, $contentUpdateStruct);
     }
 
-    public function publishVersion(VersionInfo $versionInfo, array $translations = [])
+    public function publishVersion(VersionInfo $versionInfo, array $translations = Language::ALL)
     {
         return $this->service->publishVersion($versionInfo, $translations);
     }

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -432,12 +432,13 @@ class ContentService implements ContentServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is not a draft
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
+     * @param string[] $translations
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
-    public function publishVersion(VersionInfo $versionInfo)
+    public function publishVersion(VersionInfo $versionInfo, array $translations = [])
     {
-        $returnValue = $this->service->publishVersion($versionInfo);
+        $returnValue = $this->service->publishVersion($versionInfo, $translations);
         $this->signalDispatcher->emit(
             new PublishVersionSignal(
                 array(

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\ContentService as ContentServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
@@ -436,7 +437,7 @@ class ContentService implements ContentServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
-    public function publishVersion(VersionInfo $versionInfo, array $translations = [])
+    public function publishVersion(VersionInfo $versionInfo, array $translations = Language::ALL)
     {
         $returnValue = $this->service->publishVersion($versionInfo, $translations);
         $this->signalDispatcher->emit(
@@ -444,6 +445,7 @@ class ContentService implements ContentServiceInterface
                 array(
                     'contentId' => $versionInfo->getContentInfo()->id,
                     'versionNo' => $versionInfo->versionNo,
+                    'affectedTranslations' => $translations,
                 )
             )
         );

--- a/eZ/Publish/Core/SignalSlot/Signal/ContentService/PublishVersionSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/ContentService/PublishVersionSignal.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Signal\ContentService;
 
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\Core\SignalSlot\Signal;
 
 /**
@@ -28,4 +29,18 @@ class PublishVersionSignal extends Signal
      * @var int
      */
     public $versionNo;
+
+    /**
+     * List of language codes of translations affected by the given publish operation.
+     *
+     * The list is taken from the <code>$translations</code> argument of
+     * the ContentService::publishVersion API.
+     *
+     * @see \eZ\Publish\API\Repository\ContentService::publishVersion
+     *
+     * Other translations were copied from the previously published Version.
+     *
+     * @var string[]
+     */
+    public $affectedTranslations = Language::ALL;
 }

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
@@ -192,7 +192,7 @@ class ContentServiceTest extends ServiceTest
             ),
             array(
                 'publishVersion',
-                array($versionInfo),
+                array($versionInfo, []),
                 $content,
                 1,
                 ContentServiceSignals\PublishVersionSignal::class,

--- a/eZ/Publish/Core/settings/storage_engines/legacy/content.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/content.yml
@@ -68,6 +68,5 @@ services:
             - "@ezpublish.persistence.legacy.url_alias.gateway"
             - "@ezpublish.spi.persistence.legacy.content_type.handler"
             - "@ezpublish.persistence.legacy.tree_handler"
-            - '@ezpublish.spi.persistence.legacy.language.handler'
             - "@logger"
         lazy: true


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-2661](https://jira.ez.no/browse/EZEE-2661)
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `7.5` (`2.5.1`)
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

As a part of fix, we decided to add possibility to publish specific translations only.
As it seems more clearer now, I have decided to move previous logic from Handler inside ContentService and resolve it on API level.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
