### PR TITLE
User flysystem cache if present

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/Flysystem.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/Flysystem.php
@@ -63,7 +63,11 @@ abstract class Flysystem implements ConfigurationFactory, ContainerAwareInterfac
      */
     private function createFilesystem(ContainerBuilder $container, $name, $adapter)
     {
-        $adapterId = sprintf('oneup_flysystem.%s_adapter', $adapter);
+        $adapterId = sprintf('oneup_flysystem.%s_adapter_cached', $adapter);
+        if (!$container->hasDefinition($adapterId)) {
+            $adapterId = sprintf('oneup_flysystem.%s_adapter', $adapter);
+        }
+
         if (!$container->hasDefinition($adapterId)) {
             throw new InvalidConfigurationException("Unknown flysystem adapter $adapter");
         }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | 
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes/no

It is currently not possible to use the flysystem cache adapter. If is installed and configured like docs, it creates an adapter with '_cached' at the end. 

With this PR first we look for that adapter.

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
