### PR TITLE
EZP-30502: Fix handling of int in RemoteId

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -1035,6 +1035,19 @@ class SearchServiceTest extends BaseTest
         );
     }
 
+    /**
+     * @expectedException \ez\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testFindSingleNumericRemoteId()
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+
+        $searchService->findSingle(
+            new Criterion\RemoteId(123)
+        );
+    }
+
     public function testFindNoPerformCount()
     {
         $repository = $this->getRepository();
@@ -4532,6 +4545,34 @@ class SearchServiceTest extends BaseTest
         $result = $searchService->findContent($query);
 
         $this->assertTrue(($result->totalCount === 1 || $result->totalCount === 2));
+    }
+
+    /**
+     * Test fix for EZP-30502.
+     */
+    public function testFindContentNumericRemoteId()
+    {
+        $query = new Query();
+        $query->filter = new Criterion\RemoteId(123);
+
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+
+        $searchService->findContent($query);
+    }
+
+    /**
+     * Test fix for EZP-30502.
+     */
+    public function testFindContentNumericRemoteIdArray()
+    {
+        $query = new Query();
+        $query->filter = new Criterion\RemoteId([123, 456]);
+
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+
+        $searchService->findContent($query);
     }
 
     private function createContentWithFieldType(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/RemoteId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/RemoteId.php
@@ -23,13 +23,20 @@ class RemoteId extends Criterion
     /**
      * Creates a new remoteId criterion.
      *
-     * @param int|int[] $value One or more remoteId that must be matched
+     * @param int|int[]|string|string[] $value One or more remoteId that must be matched
      *
      * @throws \InvalidArgumentException if a non numeric id is given
      * @throws \InvalidArgumentException if the value type doesn't match the operator
      */
     public function __construct($value)
     {
+        // EZP-30502 Convert int to string to avoid database errors
+        if (\is_int($value)) {
+            $value = (string) $value;
+        }
+        if (\is_array($value)) {
+            $value = \array_map('strval', $value);
+        }
         parent::__construct(null, null, $value);
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30502](https://jira.ez.no/browse/EZP-30502)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Allow using integer as remoteId

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
