### PR TITLE
EZP-30504: Removed trailing space from img attributes

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -443,7 +443,7 @@
             {% if parameters.ezlink.target is defined %} target="{{ parameters.ezlink.target|e('html_attr') }}"{% endif %}
         >
     {% endif %}
-            <img src="{{ src }}" alt="{{ parameters.alternativeText|default(field.value.alternativeText) }}" {% for attrname, attrvalue in attrs if attrvalue %}{{ attrname }}="{{ attrvalue }} " {% endfor %}/>
+            <img src="{{ src }}" alt="{{ parameters.alternativeText|default(field.value.alternativeText) }}" {% for attrname, attrvalue in attrs if attrvalue %}{{ attrname }}="{{ attrvalue }}" {% endfor %}/>
     {% if parameters.ezlink|default({}) is not empty %}
         </a>
     {% endif %}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30504](https://jira.ez.no/browse/EZP-30504)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 7.x
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

The blank space in the twig template after each img attr makes w3c output some error. fix is quite simple, just delete the space there. 

ping @andrerom @lserwatka 

