### PR TITLE
EZP-30508: Fixed Exception being thrown when previewing

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/PreviewRequestListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/PreviewRequestListener.php
@@ -1,13 +1,12 @@
 <?php
 
 /**
- * File containing the PreviewRequestListener class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
 
+use eZ\Publish\Core\MVC\Symfony\Controller\Content\PreviewController;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -26,11 +25,11 @@ class PreviewRequestListener implements EventSubscriberInterface
         $this->requestStack = $requestStack;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
-        return array(
+        return [
             KernelEvents::REQUEST => array('onKernelRequest', 200),
-        );
+        ];
     }
 
     /**
@@ -43,8 +42,8 @@ class PreviewRequestListener implements EventSubscriberInterface
         }
 
         $parentRequest = $this->requestStack->getParentRequest();
-        if ($parentRequest->get('isPreview', false)) {
-            $this->requestStack->getCurrentRequest()->attributes->set('isPreview', true);
+        if ($parentRequest->attributes->get(PreviewController::PREVIEW_PARAMETER_NAME, false)) {
+            $this->requestStack->getCurrentRequest()->attributes->set(PreviewController::PREVIEW_PARAMETER_NAME, true);
         }
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/PreviewRequestListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/PreviewRequestListener.php
@@ -42,7 +42,7 @@ class PreviewRequestListener implements EventSubscriberInterface
         }
 
         $parentRequest = $this->requestStack->getParentRequest();
-        if ($parentRequest->attributes->get(PreviewController::PREVIEW_PARAMETER_NAME, false)) {
+        if ($parentRequest !== null && $parentRequest->attributes->get(PreviewController::PREVIEW_PARAMETER_NAME, false)) {
             $this->requestStack->getCurrentRequest()->attributes->set(PreviewController::PREVIEW_PARAMETER_NAME, true);
         }
     }

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/PreviewRequestListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/PreviewRequestListener.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * File containing the PreviewRequestListener class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class PreviewRequestListener implements EventSubscriberInterface
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestStack
+     */
+    private $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array('onKernelRequest', 200),
+        );
+    }
+
+    /**
+     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if ($event->getRequestType() == HttpKernelInterface::MASTER_REQUEST) {
+            return;
+        }
+
+        $parentRequest = $this->requestStack->getParentRequest();
+        if ($parentRequest->get('isPreview', false)) {
+            $this->requestStack->getCurrentRequest()->attributes->set('isPreview', true);
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/PreviewRequestListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/PreviewRequestListener.php
@@ -28,16 +28,16 @@ class PreviewRequestListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => array('onKernelRequest', 200),
+            KernelEvents::REQUEST => ['onKernelRequest', 200],
         ];
     }
 
     /**
      * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
-        if ($event->getRequestType() == HttpKernelInterface::MASTER_REQUEST) {
+        if ($event->getRequestType() === HttpKernelInterface::MASTER_REQUEST) {
             return;
         }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -21,6 +21,7 @@ parameters:
     ezpublish.route_reference.generator.class: eZ\Publish\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator
     ezpublish.route_reference.listener.language_switch.class: eZ\Publish\Core\MVC\Symfony\EventListener\LanguageSwitchListener
     ezpublish.original_request_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\OriginalRequestListener
+    ezpublish.preview_request_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\PreviewRequestListener
     ezpublish.route_reference.listener.content_download.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ContentDownloadRouteReferenceListener
 
 services:
@@ -128,6 +129,12 @@ services:
 
     ezpublish.original_request_listener:
         class: "%ezpublish.original_request_listener.class%"
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezpublish.preview_request_listener:
+        class: "%ezpublish.preview_request_listener.class%"
+        arguments: ["@request_stack"]
         tags:
             - { name: kernel.event_subscriber }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -213,6 +213,7 @@ services:
             - "@ezpublish.siteaccessaware.repository"
             - "@ezpublish.view.configurator"
             - "@ezpublish.view.view_parameters.injector.dispatcher"
+            - "@request_stack"
             - "@ezpublish.content_info_location_loader.main"
 
     ezpublish.view_builder.block:

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -29,6 +29,7 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class PreviewController
 {
+    const PREVIEW_PARAMETER_NAME = 'isPreview';
     const INTERNAL_LOCATION_VIEW_ROUTE = '_ezpublishLocation';
 
     /**
@@ -159,7 +160,7 @@ EOF;
             'params' => array(
                 'content' => $content,
                 'location' => $location,
-                'isPreview' => true,
+                self::PREVIEW_PARAMETER_NAME => true,
                 'language' => $language,
             ),
             'siteaccess' => $previewSiteAccess,

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -233,10 +233,10 @@ class ContentViewBuilder implements ViewBuilder
                 return $repository->getLocationService()->loadLocation($locationId);
             }
         );
-        if ($location->invisible) {
-            $request = $this->requestStack->getCurrentRequest();
 
-            if (!$request || !$request->attributes->get(PreviewController::PREVIEW_PARAMETER_NAME, false)) {
+        $request = $this->requestStack->getCurrentRequest();
+        if (!$request || !$request->attributes->get(PreviewController::PREVIEW_PARAMETER_NAME, false)) {
+            if ($location->invisible) {
                 throw new HiddenLocationException($location, 'Location cannot be displayed as it is flagged as invisible.');
             }
         }

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -18,6 +18,7 @@ use eZ\Publish\Core\MVC\Symfony\View\Configurator;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
 use eZ\Publish\Core\MVC\Symfony\View\EmbedView;
 use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 /**
@@ -37,6 +38,9 @@ class ContentViewBuilder implements ViewBuilder
     /** @var \eZ\Publish\Core\MVC\Symfony\View\ParametersInjector */
     private $viewParametersInjector;
 
+    /** @var \Symfony\Component\HttpFoundation\RequestStack */
+    private $requestStack;
+
     /**
      * Default templates, indexed per viewType (full, line, ...).
      * @var array
@@ -52,6 +56,7 @@ class ContentViewBuilder implements ViewBuilder
         Repository $repository,
         Configurator $viewConfigurator,
         ParametersInjector $viewParametersInjector,
+        RequestStack $requestStack,
         ContentInfoLocationLoader $locationLoader = null
     ) {
         $this->repository = $repository;
@@ -59,6 +64,7 @@ class ContentViewBuilder implements ViewBuilder
         $this->viewParametersInjector = $viewParametersInjector;
         $this->locationLoader = $locationLoader;
         $this->permissionResolver = $this->repository->getPermissionResolver();
+        $this->requestStack = $requestStack;
     }
 
     public function matches($argument)
@@ -150,9 +156,9 @@ class ContentViewBuilder implements ViewBuilder
 
         // deprecated controller actions are replaced with their new equivalent, viewAction and embedAction
         if (!$view->getControllerReference() instanceof ControllerReference) {
-            if (in_array($parameters['_controller'], ['ez_content:viewLocation', 'ez_content:viewContent'])) {
+            if (\in_array($parameters['_controller'], ['ez_content:viewLocation', 'ez_content:viewContent'])) {
                 $view->setControllerReference(new ControllerReference('ez_content:viewAction'));
-            } elseif (in_array($parameters['_controller'], ['ez_content:embedLocation', 'ez_content:embedContent'])) {
+            } elseif (\in_array($parameters['_controller'], ['ez_content:embedLocation', 'ez_content:embedContent'])) {
                 $view->setControllerReference(new ControllerReference('ez_content:embedAction'));
             }
         }
@@ -227,7 +233,11 @@ class ContentViewBuilder implements ViewBuilder
             }
         );
         if ($location->invisible) {
-            throw new HiddenLocationException($location, 'Location cannot be displayed as it is flagged as invisible.');
+            $request = $this->requestStack->getCurrentRequest();
+
+            if (!$request || !$request->get('isPreview', false)) {
+                throw new HiddenLocationException($location, 'Location cannot be displayed as it is flagged as invisible.');
+            }
         }
 
         return $location;
@@ -264,7 +274,7 @@ class ContentViewBuilder implements ViewBuilder
         if ($parameters['_controller'] === 'ez_content:embedAction') {
             return true;
         }
-        if (in_array($parameters['viewType'], ['embed', 'embed-inline'])) {
+        if (\in_array($parameters['viewType'], ['embed', 'embed-inline'])) {
             return true;
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\Core\Helper\ContentInfoLocationLoader;
 use eZ\Publish\Core\MVC\Exception\HiddenLocationException;
+use eZ\Publish\Core\MVC\Symfony\Controller\Content\PreviewController;
 use eZ\Publish\Core\MVC\Symfony\View\Configurator;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
 use eZ\Publish\Core\MVC\Symfony\View\EmbedView;
@@ -235,7 +236,7 @@ class ContentViewBuilder implements ViewBuilder
         if ($location->invisible) {
             $request = $this->requestStack->getCurrentRequest();
 
-            if (!$request || !$request->get('isPreview', false)) {
+            if (!$request || !$request->attributes->get(PreviewController::PREVIEW_PARAMETER_NAME, false)) {
                 throw new HiddenLocationException($location, 'Location cannot be displayed as it is flagged as invisible.');
             }
         }

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/ContentViewBuilderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/ContentViewBuilderTest.php
@@ -62,6 +62,11 @@ class ContentViewBuilderTest extends TestCase
      */
     private $permissionResolver;
 
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestStack|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $requestStack;
+
     public function setUp(): void
     {
         $this->repository = $this->getMockBuilder(Repository::class)->disableOriginalConstructor()->setMethods(['sudo', 'getPermissionResolver'])->getMock();
@@ -69,6 +74,7 @@ class ContentViewBuilderTest extends TestCase
         $this->parametersInjector = $this->getMockBuilder(ParametersInjector::class)->getMock();
         $this->contentInfoLocationLoader = $this->getMockBuilder(ContentInfoLocationLoader::class)->getMock();
         $this->permissionResolver = $this->getMockBuilder(PermissionResolver::class)->getMock();
+        $this->requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $this->repository
             ->expects($this->any())
             ->method('getPermissionResolver')
@@ -78,7 +84,7 @@ class ContentViewBuilderTest extends TestCase
             $this->repository,
             $this->viewConfigurator,
             $this->parametersInjector,
-            new RequestStack(),
+            $this->requestStack,
             $this->contentInfoLocationLoader
         );
     }

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/ContentViewBuilderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/ContentViewBuilderTest.php
@@ -24,6 +24,7 @@ use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpFoundation\RequestStack;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -77,6 +78,7 @@ class ContentViewBuilderTest extends TestCase
             $this->repository,
             $this->viewConfigurator,
             $this->parametersInjector,
+            new RequestStack(),
             $this->contentInfoLocationLoader
         );
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30508](https://jira.ez.no/browse/EZP-30508)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR fixes 500 being thrown when previewing content that requests hidden content in its template. More in JIRA issue.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [ ] Write test covering changes