### PR TITLE
EZP-30546: Cache service has wrong instance on command line

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
@@ -5,7 +5,6 @@ services:
     ezpublish.cache_pool.inner:
         # As we support custom TagAware services, we set class as interface here so lazy class is "correct"
         class: Symfony\Component\Cache\Adapter\TagAwareAdapterInterface
-        lazy: true
         factory: ["@ezpublish.cache_pool.factory", getCachePool]
         arguments: ["@ezpublish.config.resolver"]
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -248,7 +248,7 @@ services:
         arguments:
             - '@ezpublish.api.repository'
         tags:
-            - { name: console.command }
+            - { name: console.command, command: ezplatform:delete-content-translation }
 
     ezplatform.core.command.cleanup_versions:
         class: eZ\Bundle\EzPublishCoreBundle\Command\CleanupVersionsCommand
@@ -257,7 +257,7 @@ services:
             - "@ezpublish.api.repository_configuration_provider"
             - "@ezpublish.persistence.connection"
         tags:
-            - { name: console.command }
+            - { name: console.command, command: ezplatform:content:cleanup-versions }
 
     ezplatform.core.session.handler.native_redis:
         class: eZ\Bundle\EzPublishCoreBundle\Session\Handler\NativeSessionHandler
@@ -269,6 +269,8 @@ services:
         class: eZ\Bundle\EzPublishCoreBundle\Command\CopySubtreeCommand
         autowire: true
         autoconfigure: true
+        tags:
+            - { name: console.command, command: ezplatform:copy-subtree }
 
     ezplatform.core.command.resize_original_images:
         class: eZ\Bundle\EzPublishCoreBundle\Command\ResizeOriginalImagesCommand
@@ -277,3 +279,5 @@ services:
         arguments:
             $ioService: '@ezpublish.fieldType.ezimage.io_service.published'
             $imagine: '@liip_imagine'
+        tags:
+            - { name: console.command, command: ezplatform:images:resize-original }

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -30,4 +30,4 @@ services:
             - '@ezpublish.cache_pool'
             - "%kernel.environment%"
         tags:
-            - { name: console.command }
+            - { name: console.command, command: ezplatform:install }

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -32,6 +32,7 @@ services:
     # Setup cache pool, with InMemoryCacheAdapter as decorator
     ezpublish.cache_pool:
         class: eZ\Publish\Core\Persistence\Cache\Adapter\InMemoryClearingProxyAdapter
+        lazy: true
         arguments:
           - "@ezpublish.cache_pool.inner"
           - !tagged ez.spi.persistence.cache.inmemory


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30546](https://jira.ez.no/browse/EZP-30546)
| **Bug/Improvement**| yes
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Cache service being in wrong instance seems to be caused by a few things:
- Changes in 2.5 where `ezplublish.cache_pool.inner` service was introduced ( 8baa4f4bdb37be39d9477405d1d7c385a4d02d0f) seems to cause it to no longer be lazy loaded.
    - I'm actually a bit unsure why, however opted to move lazy definition to same as had this before: `ezpublish.cache_pool`. 
- The loading was caused by command services that rely on repo services, these are loaded long before console event is triggered and siteaccess is set. To avoid similar issues like this in the future, take advantage of [Symfony 3.4 feature to lazy load command services](https://symfony.com/blog/new-in-symfony-3-4-lazy-commands) by setting name on tag. 


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
