### PR TITLE
EZP-25721: Warn development upfront of ConfigResolver initialization order issues

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -274,6 +274,9 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
         return $this->defaultScope ?: $this->siteAccess->name;
     }
 
+    /**
+     * @param string $scope The default "scope" aka siteaccess name, as opposed to the self::SCOPE_DEFAULT.
+     */
     public function setDefaultScope($scope)
     {
         $this->defaultScope = $scope;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -223,53 +223,6 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
     }
 
     /**
-     * If in run-time debug mode, before SiteAccess is initialized, log getParameter() usages.
-     *
-     * @return string
-     */
-    private function logTooEarlyLoadedListIfNeeded($paramName)
-    {
-        if ($this->container instanceof ContainerBuilder) {
-            return;
-        }
-
-        if (!$this->container->getParameter('kernel.debug')) {
-            return;
-        }
-
-        if ($this->siteAccess->matchingType !== 'uninitialized') {
-            return;
-        }
-
-        $serviceName = '??';
-        $resettableServiceIds = $this->container->getParameter('ezpublish.config_resolver.resettable_services');
-        $updatableServices = $this->container->getParameter('ezpublish.config_resolver.updateable_services');
-        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10) as $t) {
-            if (!isset($t['function']) || $t['function'] === 'getParameter' || $t['function'] === __FUNCTION__) {
-                continue;
-            }
-
-            // Extract service name from first service matching getXXService pattern
-            if (\strpos($t['function'], 'get') === 0 && \strpos($t['function'], 'Service') === \strlen($t['function']) -7) {
-                $serviceName = \strtolower(\preg_replace('/\B([A-Z])/', '_$1', \str_replace('_', '.', \substr($t['function'], 3, -7))));
-                if (isset($updatableServices[$serviceName])) {
-                    // Skip, no need to warn about this as system will be able to update the value
-                    return;
-                }
-
-                if (!in_array($serviceName, $resettableServiceIds, true)) {
-                    // Name not found, probably class name based service where namespace is missing from compiled fn
-                    $serviceName = '->' . $t['function'] . '()';
-                }
-
-                break;
-            }
-        }
-
-        $this->tooEarlyLoadedList[$paramName][] = $serviceName;
-    }
-
-    /**
      * Changes the default namespace to look parameter into.
      *
      * @param string $defaultNamespace
@@ -313,18 +266,74 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
 
         $logger = $this->container->get('logger');
         foreach ($this->tooEarlyLoadedList as $param => $services) {
-            // Ideally we we would want to skip warnings for services that use dynamic settings on setters as that means
-            // parameter will get update on scope change, but we don't have a way to detect that here.
             $logger->warning(sprintf(
-                'ConfigResolver was used to load parameter "%s" before SiteAccess was loaded by the following services: %s. This should be avoided; '
-                . 'first try to use ConfigResolver lazily in these services instead of "$dynamic_paramter$" injection, '
-                . (PHP_SAPI == 'cli' ? 'if not possible make sure your commands that rely on them are lazy loaded, ' : '')
-                . 'if nothing else helps try to mark the service in question as lazy.',
+                'ConfigResolver was used to load parameter "%s" before SiteAccess was loaded by services: %s. This can cause issues. '
+                . 'Try to use ConfigResolver lazily, '
+                . (PHP_SAPI === 'cli' ? 'make commands that rely on them lazy, ' : '')
+                . 'or try to mark the service as lazy.',
                 $param,
                 '"' . implode($services, '", "') . '"'
             ));
         }
 
         $this->tooEarlyLoadedList = [];
+    }
+
+    /**
+     * If in run-time debug mode, before SiteAccess is initialized, log getParameter() usages when considered "unsafe".
+     *
+     * @return string
+     */
+    private function logTooEarlyLoadedListIfNeeded($paramName)
+    {
+        if ($this->container instanceof ContainerBuilder) {
+            return;
+        }
+
+        if ($this->siteAccess->matchingType !== 'uninitialized') {
+            return;
+        }
+
+        // So we are in a state where we need to warn about unsafe use of config resolver parameters...
+        // .. it's a bit costly to do so, so we only do it in debug mode
+        $container = $this->container;
+        if (!$container->getParameter('kernel.debug')) {
+            return;
+        }
+
+        $serviceName = '??';
+        $resettableServiceIds = $container->getParameter('ezpublish.config_resolver.resettable_services');
+        $updatableServices = $container->getParameter('ezpublish.config_resolver.updateable_services');
+        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10) as $t) {
+            if (!isset($t['function']) || $t['function'] === 'getParameter' || $t['function'] === __FUNCTION__) {
+                continue;
+            }
+
+            // Extract service name from first service matching getXXService pattern
+            if (\strpos($t['function'], 'get') === 0 && \strpos($t['function'], 'Service') === \strlen($t['function']) -7) {
+                $serviceName = \strtolower(\preg_replace('/\B([A-Z])/', '_$1', \str_replace('_', '.', \substr($t['function'], 3, -7))));
+
+                // This (->setter('$dynamic_param$')) is safe as the system is able to update it on scope changes
+                if (isset($updatableServices[$serviceName])) {
+                    return;
+                }
+
+                // !! The remaining cases are not safe, typically:
+                // - ctor('$dynamic_param$') => this should be avoided, use setter or use config resolver instead
+                // - config resolver use in service factory => the service (or decorator, if any) should be marked lazy
+
+                // Exception are up-datable cases where we where unable to reverse engineer service name
+                // Which is the case for any class name based services, as namespace is omitted from compiled fn
+                if (!in_array($serviceName, $resettableServiceIds, true) && !$container->has($serviceName)) {
+                    // So in this case we are not sure if this is a warning or not, but we stay safe and warn about it
+                    // TODO: Might be possible to introspect the compiled container to extract class/service name
+                    $serviceName = '->' . $t['function'] . '()';
+                }
+
+                break;
+            }
+        }
+
+        $this->tooEarlyLoadedList[$paramName][] = $serviceName;
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-25721](https://jira.ez.no/browse/EZP-25721)
| **Bug/Improvement**| yes
| **Target version** | `6.7`
| **BC breaks**      | _Aiming for no_
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no


Detect if parameters are read before siteaccess has been initialized, and warn developer about unsafe usage of this to avoid very hard to debug issues.

*WARNING*: For class based services, will currently warm even when service is what DynamicSettingsListener considers as $updatableServices which is safe. So might warn for cases where we don't need to warn as system is able to update value inline _(when setter is used)_.

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
