### PR TITLE
[CI] Fixed AppVeyor memory issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ init:
     - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v DelayedExpansion /t REG_DWORD /d 1 /f
 
 install:
-    - cinst php -y -i --version 7.1.15
+    - cinst php -y -i --version 7.1.29
     - cinst composer -y -i
     - refreshenv
     - cd c:\Tools\php71
@@ -33,7 +33,7 @@ install:
     - echo extension=php_openssl.dll >> php.ini
     - echo extension=php_fileinfo.dll >> php.ini
     - echo extension=php_curl.dll >> php.ini
-    - echo memory_limit=512M >> php.ini
+    - echo memory_limit=3G >> php.ini
     - echo default_charset="utf-8" >> php.ini
     - cd c:\projects\ezpublish-kernel
     - composer install --no-suggest --no-progress --ansi


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`, `7.4`, `7.5`, `master`
| **BC breaks**      | no
| **Tests pass**     | TBD
| **Doc needed**     | no

My attempts to setup Travis for Windows testing seems to be pointless, because php is not supported directly with windows there and also it's not possible to prepare uniform travis.yml nor to launch test matrix for alternative `.travis.yaml` (AFAICS).

So for now we need to stick to AppVeyor unfortunately.

This PR:
- [x] upgrades bugfix release of PHP to the latest available (wildcards are not supported)
- [x] increases php memory limit.

**TODO**:
- [x] Confirm it works on AppVeyor.
- [x] Ask for Code Review.
