### PR TITLE
EZP-28135: Removed @internal tag from SignalSlot classes

### DIFF
--- a/eZ/Publish/Core/SignalSlot/Signal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal.php
@@ -15,8 +15,6 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  *
  * A Signal must always be fully export and re-creatable. It must therefore not
  * depend on external object references, resources or similar.
- *
- * @internal
  */
 abstract class Signal extends ValueObject
 {

--- a/eZ/Publish/Core/SignalSlot/Slot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot.php
@@ -10,8 +10,6 @@ namespace eZ\Publish\Core\SignalSlot;
 
 /**
  * A Slot can be assigned to receive a certain Signal.
- *
- * @internal
  */
 abstract class Slot
 {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28135](https://jira.ez.no/browse/EZP-28135)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This class has been used by other packages for ages so this removes some deprecation notices from the logs.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
