### PR TITLE
Fix array_merge() expects at least 1 parameter

### DIFF
--- a/eZ/Publish/Core/Repository/Helper/DomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/DomainMapper.php
@@ -302,7 +302,10 @@ class DomainMapper
         ksort($fields, SORT_NUMERIC);
 
         // Flatten array
-        return array_merge(...$fields);
+        if (count($fields) === 0) {
+            return [];
+        }
+        return array_merge(...$fields); //  Warning: array_merge() expects at least 1 parameter, 0 given
     }
 
     /**


### PR DESCRIPTION
Fix Warning: array_merge() expects at least 1 parameter, 0 given if $fields is emty

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30557](https://jira.ez.no/browse/EZP-30557)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.x`/`7.x` for bug fixes or improvements _(on existing features)_, `master` for features
| **BC breaks**      | yes/no
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
