### PR TITLE
EZP-29858: Fix broken Core tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,12 @@ matrix:
       env: REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
     - php: 7.1
       env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat
+    - name: "Kernel Behat Core tests"
+      env:
+        - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
+        - BEHAT_OPTS="--profile=core --tags=~@broken"
+        - SYMFONY_ENV=behat
+        - SYMFONY_DEBUG=1
     - php: 7.1
       env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
     - php: 7.1

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Content/content_preview.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Content/content_preview.feature
@@ -5,20 +5,20 @@ Feature: Preview of content drafts
     I need to preview the result before publishing
 
     Scenario: Previewing the first version of a content item works
-        Given I have "administrator" permissions
+        Given that I am logged in
           And I create an folder draft
          When I preview this draft
          Then the output is valid
 
     @broken
     Scenario: Previewing the first version of a content item with a custom location controller works
-        Given I have "administrator" permissions
+        Given that I am logged in
           And I create a draft for a content type that uses a custom location controller
          When I preview this draft
          Then the output is valid
 
     Scenario: Previewing a draft of a content item with published version(s) works
-        Given I have "administrator" permissions
+        Given that I am logged in
           And I create a draft of an existing content item
           And I modify a field from the draft
          When I preview this draft

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentPreviewContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentPreviewContext.php
@@ -70,8 +70,8 @@ class ContentPreviewContext extends RawMinkContext
 
     protected function checkForExceptions()
     {
-        $exceptionElements = $this->getXpath()->findXpath("//div[@class='text-exception']/h1");
-        $exceptionStackTraceItems = $this->getXpath()->findXpath("//ol[@id='traces-0']/li");
+        $exceptionElements = $this->getSession()->getPage()->findAll('xpath', "//div[@class='text-exception']/h1");
+        $exceptionStackTraceItems = $this->getSession()->getPage()->findAll('xpath', "//ol[@id='traces-0']/li");
         if (count($exceptionElements) > 0) {
             $exceptionElement = $exceptionElements[0];
             $exceptionLines = [$exceptionElement->getText(), ''];


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Follow up to https://jira.ez.no/browse/EZP-29858
| **Bug/Improvement**| no
| **New feature**    | no
| **Target version** | master (3.0)
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

In https://jira.ez.no/browse/EZP-29858 I've been refactoring BehatBundle (and it's usage in Kernel) and missed that changes are required to these tests (making them broken in the process).

Failing on master: https://travis-ci.org/ezsystems/ezplatform/jobs/533048313
Passing on 2.5: https://travis-ci.org/ezsystems/ezplatform/jobs/532772906

This PR contains two changes:
1) Adds execution of Core Kernel suite to Travis matrix - up to discussion, it's currently executed on `ezplatform` repository. Do we want to include it here/backport it to 6.7? If not this can be treated as a TMP commit that proves that the tests are passing again
2) Fix tests so that they're passing - the behaviour in tests is exactly the same, only different step is used.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.