### PR TITLE
[Composer][6.7] Dropped mikey179/vfsStream from dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.7.5",
-        "mikey179/vfsStream": "1.1.0",
         "phpunit/phpunit": "^4.8.35",
         "matthiasnoback/symfony-dependency-injection-test": "~0.7.6",
         "mockery/mockery": "~0.9.10",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`, `6.13`, done in `7.x` via #2247
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Looks like this is a follow up for #2247.

Quick grep looking for `org\bovigo` namespace registered by the `mikey179/vfsStream` package tells me it's not used anymore even in `6.7`. It's also a require-dev dependency, so it seems safe to drop it completely.

The reason for doing it for all supported branches also is that it shows deprecation error on every install:
```
Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.
```
Of course I could adjust the name, but since it is not used... :)

**TODO**:
- [x] Drop `mikey179/vfsStream` from `require-dev`
- [x] See if Travis agrees
- [x] Ask for Code Review.
