### PR TITLE
[CS] Bumped php-cs-fixer to v2.15.0

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -19,6 +19,13 @@ return PhpCsFixer\Config::create()
         'space_after_semicolon' => false,
         'yoda_style' => false,
         'no_break_comment' => false,
+        'native_function_invocation' => false,
+        'native_constant_invocation' => false,
+        'phpdoc_types_order' => false,
+        'php_unit_mock_short_will_return' => false,
+        'php_unit_construct' => false,
+        'standardize_increment' => false,
+        'fopen_flags' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,8 @@ matrix:
     - php: 7.2
       env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~3.4.26"
 # 7.3
-    # Temp: Need to use --ignore-platform-reqs due to: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3697
     - php: 7.3
-      env: TEST_CONFIG="phpunit.xml" COMPOSER_FLAGS="--ignore-platform-reqs"
+      env: TEST_CONFIG="phpunit.xml"
 
 # test only master, stable branches and pull requests
 branches:

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "twig/twig": "~1.35|~2.4"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.7.5",
+        "friendsofphp/php-cs-fixer": "~2.15.0",
         "phpunit/phpunit": "^4.8.35",
         "matthiasnoback/symfony-dependency-injection-test": "~0.7.6",
         "mockery/mockery": "~0.9.10",

--- a/eZ/Bundle/EzPublishCoreBundle/Command/DebugConfigResolverCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/DebugConfigResolverCommand.php
@@ -38,7 +38,6 @@ class DebugConfigResolverCommand extends Command
         parent::__construct();
     }
 
-
     /**
      * {@inheritdoc}.
      */
@@ -104,7 +103,7 @@ EOM
 
         $output->writeln('<comment>SiteAccess name:</comment> ' . $this->siteAccess->name);
 
-        $output->writeln("<comment>Parameter:</comment>");
+        $output->writeln('<comment>Parameter:</comment>');
         $cloner = new VarCloner();
         $dumper = new CliDumper();
         $output->write(

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -273,7 +273,7 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
                 // Symfony 3.4+: . (PHP_SAPI === 'cli' ? 'make the affected commands lazy, ' : '')
                 . 'make the service lazy or see if you can inject another lazy service.',
                 $blame,
-                '"$' . implode(array_unique($params), '$", "$') . '$"'
+                '"$' . implode('$", "$', array_unique($params)) . '$"'
             ));
         }
 

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -11,7 +11,6 @@ namespace eZ\Publish\API\Repository\Tests;
 use Doctrine\DBAL\Connection;
 use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
 use eZ\Publish\API\Repository\Tests\PHPUnitConstraint\ValidationErrorOccurs as PHPUnitConstraintValidationErrorOccurs;
-use eZ\Publish\API\Repository\Values\Content\Location;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\API\Repository\Repository;

--- a/eZ/Publish/Core/FieldType/RichText/Converter/Link.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Link.php
@@ -13,7 +13,6 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\FieldType\RichText\Converter;
 use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
 use Psr\Log\LoggerInterface;
-use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException as APIUnauthorizedException;
 use DOMDocument;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/MatcherInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/MatcherInterface.php
@@ -8,8 +8,6 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher;
 
-use eZ\Publish\Core\MVC\Symfony\View\View;
-
 /**
  * Base interface for matchers.
  *

--- a/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
@@ -16,7 +16,6 @@ use eZ\Publish\Core\Repository\Values\User\RoleDraft;
 use eZ\Publish\API\Repository\Values\User\RoleCreateStruct as APIRoleCreateStruct;
 use eZ\Publish\Core\Repository\Values\User\UserRoleAssignment;
 use eZ\Publish\Core\Repository\Values\User\UserGroupRoleAssignment;
-use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
 use eZ\Publish\SPI\Persistence\User\Policy as SPIPolicy;

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/SortClauseVisitor/Field/MapLocationDistance.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/SortClauseVisitor/Field/MapLocationDistance.php
@@ -9,7 +9,6 @@
 namespace eZ\Publish\Core\Search\Elasticsearch\Content\SortClauseVisitor\Field;
 
 use eZ\Publish\Core\Search\Elasticsearch\Content\SortClauseVisitor\FieldBase;
-use eZ\Publish\Core\Search\Elasticsearch\Content\SortClauseVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Search\Common\FieldNameResolver;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`, `6.13`, `7.4`, `7.5`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR
- [x] bumps php-cs-fixer to v2.15.0,
- [x] drops Travis workarounds to execute tests on PHP 7.3 (old version of php-cs-fixer blocked it),
- [x] adjusts php-cs-fixer configuration (`.php_cs`) disabling new rules which we don't use yet (some of them might be useful, but that's for the follow ups on this),
- [x] fixes outstanding CS issues that the new version of the tool was able to identify.

As a follow-up there will be a PR adding Code Style check via Travis job, which will depend on these changes.

**TODO**:
- [x] Wait for Travis.
- [x] Create PR with CS check via Travis job #2648.
- [x] Ask for Code Review.
