### PR TITLE
[CS][Travis] Added Code Style checking job to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,10 @@ branches:
 before_install:
   # Disable memory_limit for Composer
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  # Disable XDebug for all jobs as we don't generate test coverge on travis
+  - phpenv config-rm xdebug.ini
+  # make sure we use UTF-8 encoding
+  - echo "default_charset=UTF-8" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   # Install igbinary & lzf PHP extensions if necessary
   - if [ "$REDIS_ENABLE_IGBINARY" = true ] ; then pecl install igbinary ; fi
   - if [ "$REDIS_ENABLE_LZF" = true ] ; then printf "no\n" | pecl install lzf ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,9 @@ matrix:
 # 7.3
     - php: 7.3
       env: TEST_CONFIG="phpunit.xml"
+    - name: 'Code Style Check'
+      php: 7.3
+      env: CHECK_CS=1
 
 # test only master, stable branches and pull requests
 branches:
@@ -79,7 +82,7 @@ before_install:
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
 
 install:
-  -  if [ "$TEST_CONFIG" != "" ] ; then travis_retry composer install --no-progress --no-interaction --prefer-dist $COMPOSER_FLAGS; fi
+  - if [ "$TEST_CONFIG" != "" -o "$CHECK_CS" = "1" ] ; then travis_retry composer install --no-progress --no-interaction --prefer-dist $COMPOSER_FLAGS; fi
   # Setup Solr search if asked for
   - if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then ./vendor/ezsystems/ezplatform-solr-search-engine/bin/.travis/init_solr.sh; fi
 
@@ -88,6 +91,7 @@ script:
   - if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 vendor/bin/phpunit -c $TEST_CONFIG ; fi
   - if [ "$BEHAT_OPTS" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/behat $BEHAT_OPTS" ; fi
   - if [ "$REST_TEST_CONFIG" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"  ; fi
+  - if [ "$CHECK_CS" = "1" ] ; then ./bin/.travis/check_code_style.sh; fi
 
 notifications:
   slack:

--- a/bin/.travis/check_code_style.sh
+++ b/bin/.travis/check_code_style.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]
+then
+    # limit checking to *.php files which were changed by the current PR
+    # HEAD^1 is a merge commit of all changes and it's strictly related to how Travis checks out PRs
+    FILES_LIST=$(git diff HEAD^1 --diff-filter=ACMR --name-only "*.php"|paste -sd ' ');
+    if [[ -z "${FILES_LIST}" ]]
+    then
+        echo "> Code Style check: nothing to check"
+        exit 0;
+    fi
+    echo "> Code Style check: checking the following files: ${FILES_LIST}";
+else
+    # for non-PR builds check entire codebase
+    FILES_LIST=""
+    echo "> Code Style check: checking the entire codebase";
+fi
+
+php ./vendor/bin/php-cs-fixer fix \
+    --config=.php_cs \
+    --path-mode=intersection \
+    --dry-run -v \
+    --show-progress=estimating ${FILES_LIST};

--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -2,13 +2,6 @@
 
 # File for setting up system for unit/integration testing
 
-# Disable xdebug to speed things up as we don't currently generate coverge on travis
-# And make sure we use UTF-8 encoding
-if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] ; then
-    phpenv config-rm xdebug.ini
-    echo "default_charset = UTF-8" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-fi
-
 # Enable redis
 if [ "$CUSTOM_CACHE_POOL" = "singleredis" ] ; then
     echo extension = redis.so >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Requires** | #2647
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`, `6.13`, `7.4`, `7.5`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR:
- [x] disables XDebug and sets UTF8 for all jobs (including CS checking),
- [x] adds a bash script to check CS (tightly coupled with Travis build environment),
- [x] adds a Travis job for checking CS.

The CS job checks only PHP files modified in a PR.

It has been successfully tested via #2681 - ref. [failing build](https://travis-ci.org/ezsystems/ezpublish-kernel/builds/551807410).

**TODO**:
- [x] **Wait for #2647 and rebase**
- [x] Wait for Travis to confirm
- [x] Ask for Code Review.
