### PR TITLE
EZP-30546: Several core services risks having wrong instance due to early config resolver use

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/Resolver/RelativeResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/Resolver/RelativeResolver.php
@@ -6,54 +6,20 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\Resolver;
 
-use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
+use Liip\ImagineBundle\Imagine\Cache\Resolver\ProxyResolver as ImagineProxyResolver;
 
-class RelativeResolver implements ResolverInterface
+/**
+ * Relative resolver, omits host info.
+ */
+class RelativeResolver extends ImagineProxyResolver
 {
-    /**
-     * @var \Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface
-     */
-    private $resolver;
-
     /**
      * @param \Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface $resolver
      */
     public function __construct(ResolverInterface $resolver)
     {
-        $this->resolver = $resolver;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isStored($path, $filter)
-    {
-        return $this->resolver->isStored($path, $filter);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function resolve($path, $filter)
-    {
-        return $this->rewriteUrl($this->resolver->resolve($path, $filter));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function store(BinaryInterface $binary, $path, $filter)
-    {
-        return $this->resolver->store($binary, $path, $filter);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function remove(array $paths, array $filters)
-    {
-        return $this->resolver->remove($paths, $filters);
+        parent::__construct($resolver, []);
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -95,9 +95,10 @@ services:
             - '%ezpublish.image_alias.imagine.cache_resolver_decorator_relative.class%'
 
     ezpublish.image_alias.imagine.cache_resolver_decorator:
-        class: Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface
+        class: Liip\ImagineBundle\Imagine\Cache\Resolver\ProxyResolver
         factory: 'ezpublish.image_alias.imagine.cache_resolver_decorator_factory:createCacheResolver'
         decorates: ezpublish.image_alias.imagine.cache_resolver
+        lazy: true
 
     ezpublish.image_alias.imagine.cache.alias_generator_decorator:
         class: '%ezpublish.image_alias.imagine.cache.alias_generator_decorator.class%'
@@ -128,7 +129,6 @@ services:
     ezpublish.image_alias.imagine.alias_cleaner:
         class: "%ezpublish.image_alias.imagine.alias_cleaner.class%"
         arguments: ["@ezpublish.image_alias.imagine.cache_resolver"]
-        lazy: true
 
     ezpublish.image_alias.imagine.filter.loader.scaledown.base:
         abstract: true

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -242,7 +242,7 @@ services:
         class: eZ\Bundle\EzPublishCoreBundle\Command\CleanupVersionsCommand
         arguments:
             - "@ezpublish.signalslot.repository"
-            - "@ezpublish.api.repository_configuration_provider"
+            - "@ezpublish.config.resolver"
             - "@ezpublish.persistence.connection"
         tags:
             - { name: console.command }

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -23,6 +23,7 @@ parameters:
 services:
     ezpublish.cache_pool:
         class: "%ezpublish.cache_pool.class%"
+        lazy: true
         arguments: ["@?ezpublish.cache_pool.driver"]
 
     ezpublish.cache_pool.spi.cache.decorator:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30546](https://jira.ez.no/browse/EZP-30546)
| **Bug/Improvement**| yes
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This fixes warnings that will show up in EE 1.7 once #2636 is merged.
TL;DR; Commands are loaded to get their name long before siteaccess event is fired, so they have services with wrong SA settings injected.

Partly replaces #2634 with aim to have fix for all branches, and w/o having to rely on lazy commands unless needed _(remaining cases will be commands directly or indirectly relying on config resolver in ctor/configure/init, @alongosz should be happy :) )_.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
