### PR TITLE
EZP-30567: Impl. ez_query:pagingQueryAction to handle pagination

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/query_controller.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/query_controller.feature
@@ -49,3 +49,151 @@ Scenario: A content view can be configured to run and render a query
      Then a LocationChildren Query is built from the LocationChildren QueryType
       And a Location Search is executed with the LocationChildren Query
       And the Query results are assigned to the "children" twig variable
+
+Scenario: A content view can be configured to run and render a query and return a PagerFanta Object
+    Given a content item that matches the view configuration block below
+    And the following content view configuration block with paging action:
+      """
+      controller: ez_query:pagingQueryAction
+      params:
+          query:
+              query_type: 'LocationChildren'
+              parameters:
+                  parentLocationId: 2
+              assign_results_to: 'children'
+      """
+    And a LocationChildren QueryType defined in "src/QueryType/LocationChildrenQueryType.php":
+      """
+      <?php
+      namespace App\QueryType;
+
+      use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+      use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;
+      use eZ\Publish\Core\QueryType\QueryType;
+
+      class LocationChildrenQueryType implements QueryType
+      {
+          public function getQuery(array $parameters = [])
+          {
+              return new LocationQuery([
+                  'filter' => new ParentLocationId($parameters['parentLocationId']),
+              ]);
+          }
+
+          public function getSupportedParameters()
+          {
+              return ['parentLocationId'];
+          }
+
+          public static function getName()
+          {
+              return 'LocationChildren';
+          }
+      }
+      """
+    When I view a content matched by the view configuration above
+    Then the Query results assigned to the "children" twig variable is a "Pagerfanta" object
+
+Scenario: A content view can be configured to run and render a query return a PagerFanta Object and set limit and page name
+    Given a content item that matches the view configuration block below
+    And the following template defined in "templates/tests.html.twig":
+      """
+      <div id='currentPage'>{{ children.currentPage }}</div>
+      <div id='maxPerPage'>{{ children.maxPerPage }}</div>
+      """
+    And the following content view configuration block with paging action and the template set above:
+      """
+      controller: ez_query:pagingQueryAction
+      template: tests.html.twig
+      params:
+          query:
+              query_type: 'LocationChildren'
+              parameters:
+                  parentLocationId: 2
+              limit: 1
+              assign_results_to: 'children'
+      """
+    And a LocationChildren QueryType defined in "src/QueryType/LocationChildrenQueryType.php":
+      """
+      <?php
+      namespace App\QueryType;
+
+      use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+      use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;
+      use eZ\Publish\Core\QueryType\QueryType;
+
+      class LocationChildrenQueryType implements QueryType
+      {
+          public function getQuery(array $parameters = [])
+          {
+              return new LocationQuery([
+                  'filter' => new ParentLocationId($parameters['parentLocationId']),
+              ]);
+          }
+
+          public function getSupportedParameters()
+          {
+              return ['parentLocationId'];
+          }
+
+          public static function getName()
+          {
+              return 'LocationChildren';
+          }
+      }
+      """
+    When I view a content matched by the view configuration above
+    Then the Query results assigned to the twig variable is a Pagerfanta object and has limit "1" and selected page "1"
+
+Scenario: A content view can be configured to run and render a query and set a specific page
+    Given a content item that matches the view configuration block below
+    And "3" contents are created to test paging
+    And the following template defined in "templates/tests.html.twig":
+      """
+      <div id='currentPage'>{{ children.currentPage }}</div>
+      <div id='maxPerPage'>{{ children.maxPerPage }}</div>
+      """
+    And the following content view configuration block with paging action and the template set above:
+      """
+      controller: ez_query:pagingQueryAction
+      template: tests.html.twig
+      params:
+          query:
+              query_type: 'LocationChildren'
+              parameters:
+                  parentLocationId: 2
+              limit: 1
+              page_param: p
+              assign_results_to: 'children'
+      """
+    And a LocationChildren QueryType defined in "src/QueryType/LocationChildrenQueryType.php":
+      """
+      <?php
+      namespace App\QueryType;
+
+      use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+      use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;
+      use eZ\Publish\Core\QueryType\QueryType;
+
+      class LocationChildrenQueryType implements QueryType
+      {
+          public function getQuery(array $parameters = [])
+          {
+              return new LocationQuery([
+                  'filter' => new ParentLocationId($parameters['parentLocationId']),
+              ]);
+          }
+
+          public function getSupportedParameters()
+          {
+              return ['parentLocationId'];
+          }
+
+          public static function getName()
+          {
+              return 'LocationChildren';
+          }
+      }
+      """
+    When I view a content matched by the view configuration above on page "2" with the "p" parameter
+    Then the Query results assigned to the twig variable is a Pagerfanta object and has limit "1" and selected page "2"

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/QueryController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/QueryController.php
@@ -5,8 +5,15 @@
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;
 
 use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchHitAdapter;
+use eZ\Publish\Core\Pagination\Pagerfanta\LocationSearchHitAdapter;
 use eZ\Publish\Core\QueryType\ContentViewQueryTypeMapper;
+use Pagerfanta\Adapter\AdapterInterface;
+use Pagerfanta\Pagerfanta;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * A content view controller that runs queries based on the matched view configuration.
@@ -80,5 +87,53 @@ class QueryController
             $this->contentViewQueryTypeMapper->map($view)
         );
         $view->addParameters([$view->getParameter('query')['assign_results_to'] => $searchResults]);
+    }
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\View\ContentView $view
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \eZ\Publish\Core\MVC\Symfony\View\ContentView
+     */
+    public function pagingQueryAction(ContentView $view, Request $request)
+    {
+        $this->runPagingQuery($view, $request);
+
+        return $view;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\View\ContentView $view
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     */
+    private function runPagingQuery(ContentView $view, Request $request)
+    {
+        $queryParameters = $view->getParameter('query');
+
+        $limit = $queryParameters['limit'] ?? 10;
+        $pageParam = $queryParameters['page_param'] ?? 'page';
+
+        $page = $request->get($pageParam, 1);
+
+        $pager = new Pagerfanta(
+            $this->getAdapter($this->contentViewQueryTypeMapper->map($view))
+        );
+
+        $pager->setMaxPerPage($limit);
+        $pager->setCurrentPage($page);
+
+        $view->addParameters([$queryParameters['assign_results_to'] => $pager]);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @return \Pagerfanta\Adapter\AdapterInterface
+     */
+    private function getAdapter(Query $query): AdapterInterface
+    {
+        if ($query instanceof LocationQuery) {
+            return new LocationSearchHitAdapter($query, $this->searchService);
+        }
+
+        return new ContentSearchHitAdapter($query, $this->searchService);
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30567](https://jira.ez.no/browse/EZP-30567)
| **Improvement**| yes
| **New feature**    | yes
| **Target version** | `master (8.0@dev)` for eZ Platform `v3.0`.
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

The ez_query:pagingQueryAction will return a pagerFanta object set to the assign_to_result parameter.

alongside with the assign_to_result param as described a limit parameter can be added to set the page number of items.

### QA

- [x] Configure and test results of `ez_query:pagingQueryAction` Query controller (very well described by the Behat tests in the PR).

**TODO**:
- [x] Implement `ez_query:pagingQueryAction`.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
