### PR TITLE
EZP-30573: As a Developer I want to filter by status when using ContentService::loadVersions method

### DIFF
--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -312,7 +312,7 @@ interface ContentService
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] an array of {@link \eZ\Publish\API\Repository\Values\Content\VersionInfo} sorted by creation date
      */
-    public function loadVersions(ContentInfo $contentInfo, $status = null);
+    public function loadVersions(ContentInfo $contentInfo, ?int $status = null);
 
     /**
      * Copies the content to a new location. If no version is given,

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -308,7 +308,7 @@ interface ContentService
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the given status is invalid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param null|int $status
+     * @param int|null $status
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] an array of {@link \eZ\Publish\API\Repository\Values\Content\VersionInfo} sorted by creation date
      */

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -305,10 +305,10 @@ interface ContentService
      * Loads all versions for the given content.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to list versions
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException if invalid status
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the given status is invalid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param int $status
+     * @param null|int $status
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] an array of {@link \eZ\Publish\API\Repository\Values\Content\VersionInfo} sorted by creation date
      */

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -305,12 +305,14 @@ interface ContentService
      * Loads all versions for the given content.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to list versions
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException if invalid status
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     * @param int $status
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] an array of {@link \eZ\Publish\API\Repository\Values\Content\VersionInfo} sorted by creation date
      */
-    public function loadVersions(ContentInfo $contentInfo);
+    public function loadVersions(ContentInfo $contentInfo, $status = null);
 
     /**
      * Copies the content to a new location. If no version is given,

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -5961,6 +5961,48 @@ XML
     }
 
     /**
+     * Tests loading list of content versions of status draft.
+     */
+    public function testLoadVersionsOfStatusDraft()
+    {
+        $repository = $this->getRepository();
+
+        $contentService = $repository->getContentService();
+
+        $content = $this->createContentVersion1();
+
+        $contentService->createContentDraft($content->contentInfo);
+        $contentService->createContentDraft($content->contentInfo);
+        $contentService->createContentDraft($content->contentInfo);
+
+        $versions = $contentService->loadVersions($content->contentInfo, VersionInfo::STATUS_DRAFT);
+
+        $this->assertSame(\count($versions), 3);
+    }
+
+    /**
+     * Tests loading list of content versions of status archived.
+     */
+    public function testLoadVersionsOfStatusArchived()
+    {
+        $repository = $this->getRepository();
+
+        $contentService = $repository->getContentService();
+
+        $content = $this->createContentVersion1();
+
+        $draft1 = $contentService->createContentDraft($content->contentInfo);
+        $contentService->publishVersion($draft1->versionInfo);
+
+        $draft2 = $contentService->createContentDraft($content->contentInfo);
+        $contentService->publishVersion($draft2->versionInfo);
+
+        $versions = $contentService->loadVersions($content->contentInfo, VersionInfo::STATUS_ARCHIVED);
+
+        $this->assertSame(\count($versions), 2);
+    }
+
+    /**
      * Asserts that all aliases defined in $expectedAliasProperties with the
      * given properties are available in $actualAliases and not more.
      *

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -535,7 +535,7 @@ class ContentService implements APIContentService, Sessionable
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] Sorted by creation date
      */
-    public function loadVersions(ContentInfo $contentInfo, $status = null)
+    public function loadVersions(ContentInfo $contentInfo, ?int $status = null)
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -531,7 +531,7 @@ class ContentService implements APIContentService, Sessionable
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the given status is invalid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param null|int $status
+     * @param int|null $status
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] Sorted by creation date
      */

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -528,10 +528,10 @@ class ContentService implements APIContentService, Sessionable
      * Loads all versions for the given content.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to list versions
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException if invalid status
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the given status is invalid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param int $status
+     * @param null|int $status
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] Sorted by creation date
      */

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -528,12 +528,14 @@ class ContentService implements APIContentService, Sessionable
      * Loads all versions for the given content.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to list versions
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException if invalid status
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     * @param int $status
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] Sorted by creation date
      */
-    public function loadVersions(ContentInfo $contentInfo)
+    public function loadVersions(ContentInfo $contentInfo, $status = null)
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1695,18 +1695,29 @@ class ContentService implements ContentServiceInterface
      * Loads all versions for the given content.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to list versions
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException if invalid status
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     * @param int $status
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] Sorted by creation date
      */
-    public function loadVersions(ContentInfo $contentInfo)
+    public function loadVersions(ContentInfo $contentInfo, $status = null)
     {
         if (!$this->repository->canUser('content', 'versionread', $contentInfo)) {
             throw new UnauthorizedException('content', 'versionread', array('contentId' => $contentInfo->id));
         }
 
-        $spiVersionInfoList = $this->persistenceHandler->contentHandler()->listVersions($contentInfo->id);
+        if ($status !== null && !in_array((int)$status, [VersionInfo::STATUS_DRAFT, VersionInfo::STATUS_PUBLISHED, VersionInfo::STATUS_ARCHIVED], true)) {
+            throw new InvalidArgumentException(
+                'status',
+                sprintf(
+                    'it can be one of %d (draft), %d (published), %d (archived), %d given',
+                    VersionInfo::STATUS_DRAFT, VersionInfo::STATUS_PUBLISHED, VersionInfo::STATUS_ARCHIVED, $status
+                ));
+        }
+
+        $spiVersionInfoList = $this->persistenceHandler->contentHandler()->listVersions($contentInfo->id, $status);
 
         $versions = array();
         foreach ($spiVersionInfoList as $spiVersionInfo) {

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1695,10 +1695,10 @@ class ContentService implements ContentServiceInterface
      * Loads all versions for the given content.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to list versions
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException if invalid status
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the given status is invalid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param int $status
+     * @param null|int $status
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] Sorted by creation date
      */

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1702,7 +1702,7 @@ class ContentService implements ContentServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] Sorted by creation date
      */
-    public function loadVersions(ContentInfo $contentInfo, $status = null)
+    public function loadVersions(ContentInfo $contentInfo, ?int $status = null)
     {
         if (!$this->repository->canUser('content', 'versionread', $contentInfo)) {
             throw new UnauthorizedException('content', 'versionread', array('contentId' => $contentInfo->id));

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1698,7 +1698,7 @@ class ContentService implements ContentServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the given status is invalid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param null|int $status
+     * @param int|null $status
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] Sorted by creation date
      */

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -151,7 +151,7 @@ class ContentService implements ContentServiceInterface
         return $this->service->deleteVersion($versionInfo);
     }
 
-    public function loadVersions(ContentInfo $contentInfo, $status = null)
+    public function loadVersions(ContentInfo $contentInfo, ?int $status = null)
     {
         return $this->service->loadVersions($contentInfo, $status);
     }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -151,9 +151,9 @@ class ContentService implements ContentServiceInterface
         return $this->service->deleteVersion($versionInfo);
     }
 
-    public function loadVersions(ContentInfo $contentInfo)
+    public function loadVersions(ContentInfo $contentInfo, $status = null)
     {
-        return $this->service->loadVersions($contentInfo);
+        return $this->service->loadVersions($contentInfo, $status);
     }
 
     public function copyContent(ContentInfo $contentInfo, LocationCreateStruct $destinationLocationCreateStruct, VersionInfo $versionInfo = null)

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -478,14 +478,16 @@ class ContentService implements ContentServiceInterface
      * Loads all versions for the given content.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to list versions
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException if invalid status
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     * @param int $status
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] Sorted by creation date
      */
-    public function loadVersions(ContentInfo $contentInfo)
+    public function loadVersions(ContentInfo $contentInfo, $status = null)
     {
-        return $this->service->loadVersions($contentInfo);
+        return $this->service->loadVersions($contentInfo, $status);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -485,7 +485,7 @@ class ContentService implements ContentServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] Sorted by creation date
      */
-    public function loadVersions(ContentInfo $contentInfo, $status = null)
+    public function loadVersions(ContentInfo $contentInfo, ?int $status = null)
     {
         return $this->service->loadVersions($contentInfo, $status);
     }

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -481,7 +481,7 @@ class ContentService implements ContentServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the given status is invalid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param null|int $status
+     * @param int|null $status
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] Sorted by creation date
      */

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -478,10 +478,10 @@ class ContentService implements ContentServiceInterface
      * Loads all versions for the given content.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to list versions
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException if invalid status
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the given status is invalid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param int $status
+     * @param null|int $status
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo[] Sorted by creation date
      */

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
@@ -214,7 +214,7 @@ class ContentServiceTest extends ServiceTest
             ),
             array(
                 'loadVersions',
-                array($contentInfo),
+                array($contentInfo, null),
                 array($versionInfo),
                 0,
             ),


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30573](https://jira.ez.no/browse/EZP-30573)
| **Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`/`master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR introduces the new `$status` argument for `ContentService::loadVersions` method.
For more information please refer to JIRA ticket. 

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
