### PR TITLE
EZP-30584 DateTrashed SortClause default

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/DateTrashed.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/DateTrashed.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\DateTrashed class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
+
+/**
+ * Sets sort direction on the trashed date for Trash query.
+ */
+class DateTrashed extends Location
+{
+    /**
+     * Constructs a new DateTrashed SortClause.
+     *
+     * @param string $sortDirection
+     */
+    public function __construct($sortDirection = Query::SORT_DESC)
+    {
+        parent::__construct('trashed', $sortDirection);
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1323,7 +1323,7 @@ class DoctrineDatabase extends Gateway
             ->select('*')
             ->from($this->handler->quoteTable('ezcontentobject_trash'));
 
-        $sort = $sort ?: array();
+        $sort = $sort ?: [new SortClause\Location\DateTrashed()];
         foreach ($sort as $condition) {
             $sortDirection = $condition->direction === Query::SORT_ASC ? SelectQuery::ASC : SelectQuery::DESC;
             switch (true) {
@@ -1337,6 +1337,10 @@ class DoctrineDatabase extends Gateway
 
                 case $condition instanceof SortClause\Location\Priority:
                     $query->orderBy('priority', $sortDirection);
+                    break;
+
+                case $condition instanceof SortClause\Location\DateTrashed:
+                    $query->orderBy('trashed', $sortDirection);
                     break;
 
                 default:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30584](https://jira.ez.no/browse/EZP-30584)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** |  master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Date Trashed property was recently added, but it's not allowed to order by trash date. Until we can add filters to Query on TrashService maybe set 'trashed' date default


**TODO**:
- [x] Implement feature 
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
