### PR TITLE
[EZP-30590] Fix noLayout default value

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/NoLayout.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/NoLayout.php
@@ -24,7 +24,7 @@ class NoLayout implements EventSubscriberInterface
 
         $event->getParameterBag()->set(
             'noLayout',
-            isset($parameters['layout']) ? !(bool) $parameters['layout'] : false
+            isset($parameters['layout']) ? !(bool) $parameters['layout'] : true
         );
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30590](https://jira.ez.no/browse/EZP-30590)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 6.7 / 6.13 / 7.5
| **BC breaks**      | no
| **Tests pass**     | 
| **Doc needed**     | 

Prior to v6.0, `ViewController::viewLocation()` and `ViewController::viewContent()` had parameter [`$layout` default value to `false`](https://github.com/ezsystems/ezpublish-kernel/blob/6.7/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php#L143). The consequence was that [`noLayout` parameter, injected further
down in templates, had `true` as default value](https://github.com/ezsystems/ezpublish-kernel/blob/6.7/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php#L436) (the exact opposite).

The goal of such parameter was to ensure that templates used in subrequests always had the information not to use the main pagelayout by default, [especially when rendering content from legacy](https://github.com/ezsystems/LegacyBridge/blob/master/mvc/View/TwigContentViewLayoutDecorator.php#L111-L122) (templates not migrated yet to Twig).

We could also do stuff like the following:

```jinja
{% extends noLayout == true ? viewbaseLayout : pagelayout %}
```

Problem with the value injected by `NoLayout` injector is that the default value of `noLayout` parameter changed. It currently checks if `layout` parameter is present (which is not the case by default with the new view system) and if not, defaults to `false`. 
Consequence is that when migrating an instance from eZ Publish 5 to Platform with legacy bridge, main layout is always used. This sounds like an undocumented BC break to me :wink:.

Before opening a Jira issue, I wanted to know is that could be an acceptable fix. I don't see any possible regression here since even using Symfony stack, `noLayout` variable will never have the expected value anyway without this fix.


**TODO**:
- [x] Open Jira issue
- [ ] Tests