### PR TITLE
EZP-25721: Improve warning on config resolver eager loading to show more clear blame

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -314,7 +314,7 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
             }
 
             // Extract service name from first service matching getXXService pattern
-            if (\strpos($t['function'], 'get') === 0 && \strpos($t['function'], 'Service') === \strlen($t['function']) - 7) {
+            if (\strpos($t['function'], 'get') === 0 && \strrpos($t['function'], 'Service') === \strlen($t['function']) - 7) {
                 $potentialClassName = \substr($t['function'], 3, -7);
                 $serviceName = \strtolower(\preg_replace('/\B([A-Z])/', '_$1', \str_replace('_', '.', $potentialClassName)));
 
@@ -336,7 +336,7 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
                 }
 
                 // Detect if we found the command loading the service, if so add info to blame to make it easier to spot
-                if (PHP_SAPI === 'cli' && isset($t['file']) && \strpos($t['file'], 'CommandService.php') !== false) {
+                if (PHP_SAPI === 'cli' && isset($t['file']) && \stripos($t['file'], 'CommandService.php') !== false) {
                     $path = explode('/', $t['file']);
                     $blame = \substr($path[count($path) - 1], 3, -11) . '(' . $blame . ')';
                     break;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-25721](https://jira.ez.no/browse/EZP-25721)
| **Bug/Improvement**| yes
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes _for the warning message example_

_Updated on 4th of June:_ Followup on #2636

Improves output to show what might be more relevant blame for the eager loading, the first service triggering the load _(last in trace)_, command name if detected, and swaps the order to rather output params per blame found instead of opposite to produce less bloated output.

Gives the following output on 2.5-dev (EE):
> 19:46:46 WARNING   [app] ConfigResolver was used by "@ezpublish.helper.language_resolver" before SiteAccess was initialized, loading parameter(s) "$languages$". As this can cause very hard to debug issues, try to use ConfigResolver lazily, make the affected commands lazy, make the service lazy or see if you can inject another lazy service.
> 19:46:46 WARNING   [app] ConfigResolver was used by "CreateFormsContainerCommand(PermissionResolver)" before SiteAccess was initialized, loading parameter(s) "$repository$", "$workflows$", "$languages$", "$anonymous_user_id$". As this can cause very hard to debug issues, try to use ConfigResolver lazily, make the affected commands lazy, make the service lazy or see if you can inject another lazy service.

The first warning is fixed in #2662 by @alongosz, second issue is coming from `CreateFormsContainerCommand` which someone should probably just make lazy for now so we can make 2.5.2 release with no known SA config issues.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
