### PR TITLE
EZP-30629: Injected ConfigResolver into LanguageResolver

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
@@ -59,6 +59,10 @@ services:
         arguments:
             - "@ezpublish.api.repository"
 
-    ezpublish.helper.language_resolver:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver
-        arguments: ['$languages$']
+    eZ\Bundle\EzPublishCoreBundle\SiteAccess\LanguageResolver:
+        parent: eZ\Publish\Core\Repository\SiteAccessAware\Language\AbstractLanguageResolver
+        arguments:
+            $configResolver: '@ezpublish.config.resolver'
+
+    eZ\Publish\API\Repository\LanguageResolver:
+        alias: eZ\Bundle\EzPublishCoreBundle\SiteAccess\LanguageResolver

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/LanguageResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/LanguageResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\Repository\SiteAccessAware\Language\AbstractLanguageResolver;
+
+/**
+ * Resolves language settings for use in SiteAccess aware Repository.
+ */
+final class LanguageResolver extends AbstractLanguageResolver
+{
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    public function __construct(
+        ConfigResolverInterface $configResolver,
+        bool $defaultUseAlwaysAvailable = true,
+        bool $defaultShowAllTranslations = false
+    ) {
+        $this->configResolver = $configResolver;
+        parent::__construct($defaultUseAlwaysAvailable, $defaultShowAllTranslations);
+    }
+
+    /**
+     * Get list of languages configured via scope/SiteAccess context.
+     *
+     * @return string[]
+     */
+    protected function getConfiguredLanguages(): array
+    {
+        return $this->configResolver->getParameter('languages');
+    }
+}

--- a/eZ/Publish/API/Repository/LanguageResolver.php
+++ b/eZ/Publish/API/Repository/LanguageResolver.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository;
+
+/**
+ * Resolve language settings for Repository layer.
+ */
+interface LanguageResolver
+{
+    /**
+     * For use by custom events / logic setting language for all retrieved objects from repository.
+     *
+     * If set, user (context) language will be prepended to a list of configured prioritized languages.
+     *
+     * Languages forced by PHP API consumer when retrieving Repository objects will still take priority,
+     * setting both context language and prioritized languages list as a fallback.
+     *
+     * @param null|string $contextLanguage
+     */
+    public function setContextLanguage(?string $contextLanguage): void;
+
+    /**
+     * Get prioritized languages taking into account forced, context, and configured languages.
+     *
+     * @param array|null $forcedLanguages Optional, typically arguments provided to API, will be used first if set.
+     *
+     * @return string[]
+     */
+    public function getPrioritizedLanguages(?array $forcedLanguages = null): array;
+
+    /**
+     * Get currently set UseAlwaysAvailable.
+     *
+     * @param bool|null $forcedUseAlwaysAvailable Optional, if set will be used instead of configured value,
+     *        typically arguments provided to API.
+     *
+     * @return bool
+     */
+    public function getUseAlwaysAvailable(?bool $forcedUseAlwaysAvailable = null): bool;
+
+    /**
+     * Get currently set showAllTranslations.
+     *
+     * @param bool|null $forcedShowAllTranslations Optional, if set will be used instead of configured value,
+     *        typically arguments provided to API.
+     *
+     * @return bool
+     */
+    public function getShowAllTranslations(?bool $forcedShowAllTranslations = null): bool;
+
+    /**
+     * For use by event listening to config resolver scope changes (or other event changing configured languages).
+     *
+     * @param bool $defaultShowAllTranslations
+     */
+    public function setShowAllTranslations(bool $defaultShowAllTranslations): void;
+
+    /**
+     * For use by event listening to config resolver scope changes (or other event changing configured languages).
+     *
+     * @param bool $defaultUseAlwaysAvailable
+     */
+    public function setDefaultUseAlwaysAvailable(bool $defaultUseAlwaysAvailable): void;
+}

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver;
+use eZ\Publish\API\Repository\LanguageResolver;
 
 /**
  * SiteAccess aware implementation of ContentService injecting languages where needed.
@@ -28,14 +28,14 @@ class ContentService implements ContentServiceInterface
     /** @var \eZ\Publish\API\Repository\ContentService */
     protected $service;
 
-    /** @var \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver */
+    /** @var \eZ\Publish\API\Repository\LanguageResolver */
     protected $languageResolver;
 
     /**
      * Construct service object from aggregated service and LanguageResolver.
      *
      * @param \eZ\Publish\API\Repository\ContentService $service
-     * @param \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver $languageResolver
+     * @param \eZ\Publish\API\Repository\LanguageResolver $languageResolver
      */
     public function __construct(
         ContentServiceInterface $service,

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
@@ -20,7 +20,7 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\API\Repository\Values\User\User;
-use eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver;
+use eZ\Publish\API\Repository\LanguageResolver;
 
 /**
  * SiteAccess aware implementation of ContentTypeService injecting languages where needed.
@@ -30,14 +30,14 @@ class ContentTypeService implements ContentTypeServiceInterface
     /** @var \eZ\Publish\API\Repository\ContentTypeService */
     protected $service;
 
-    /** @var \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver */
+    /** @var \eZ\Publish\API\Repository\LanguageResolver */
     protected $languageResolver;
 
     /**
      * Construct service object from aggregated service and LanguageResolver.
      *
      * @param \eZ\Publish\API\Repository\ContentTypeService $service
-     * @param \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver $languageResolver
+     * @param \eZ\Publish\API\Repository\LanguageResolver $languageResolver
      */
     public function __construct(
         ContentTypeServiceInterface $service,

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Language/AbstractLanguageResolver.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Language/AbstractLanguageResolver.php
@@ -18,14 +18,10 @@ use eZ\Publish\API\Repository\Values\Content\Language;
  */
 abstract class AbstractLanguageResolver implements APILanguageResolver
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $defaultUseAlwaysAvailable;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $defaultShowAllTranslations;
 
     /**

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Language/AbstractLanguageResolver.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Language/AbstractLanguageResolver.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Repository\SiteAccessAware\Language;
+
+use eZ\Publish\API\Repository\LanguageResolver as APILanguageResolver;
+use eZ\Publish\API\Repository\Values\Content\Language;
+
+/**
+ * Common abstract implementation of Language resolver.
+ *
+ * @internal
+ */
+abstract class AbstractLanguageResolver implements APILanguageResolver
+{
+    /**
+     * @var bool
+     */
+    private $defaultUseAlwaysAvailable;
+
+    /**
+     * @var bool
+     */
+    private $defaultShowAllTranslations;
+
+    /**
+     * Values typically provided by user context, will need to be set depending on your own custom logic using setter.
+     *
+     * E.g. Backend UI might expose a language selector for the whole backend that should be reflected on both
+     *      UI strings as well as default languages to prioritize for repository objects.
+     *
+     * If set, this will have priority over configured languages.
+     *
+     * @var string|null
+     */
+    private $contextLanguage;
+
+    /**
+     * @param bool $defaultUseAlwaysAvailable
+     * @param bool $defaultShowAllTranslations
+     */
+    public function __construct(
+        bool $defaultUseAlwaysAvailable = true,
+        bool $defaultShowAllTranslations = false
+    ) {
+        $this->defaultUseAlwaysAvailable = $defaultUseAlwaysAvailable;
+        $this->defaultShowAllTranslations = $defaultShowAllTranslations;
+    }
+
+    /**
+     * Get list of languages configured via dedicated layer.
+     *
+     * @return string[]
+     */
+    abstract protected function getConfiguredLanguages(): array;
+
+    /**
+     * For use by custom events / logic setting language for all retrieved objects from repository.
+     *
+     * User language will, if set, will have prepended before configured languages. But in cases PHP API consumer
+     * specifies languages to retrieve repository objects in it will instead be appended as a fallback.
+     *
+     * If set, this will have priority over configured languages.
+     *
+     * @param string|null $contextLanguage
+     */
+    final public function setContextLanguage(?string $contextLanguage): void
+    {
+        $this->contextLanguage = $contextLanguage;
+    }
+
+    /**
+     * Get context language currently set by custom logic.
+     *
+     * @return null|string
+     */
+    final public function getContextLanguage(): ?string
+    {
+        return $this->contextLanguage;
+    }
+
+    /**
+     * Get prioritized languages taking into account forced and context languages.
+     *
+     * @param array|null $forcedLanguages Optional, typically arguments provided to API, will be used first if set.
+     *
+     * @return array
+     */
+    final public function getPrioritizedLanguages(?array $forcedLanguages = null): array
+    {
+        // Skip if languages param has been set by API user
+        if ($forcedLanguages !== null) {
+            return $forcedLanguages;
+        }
+
+        // Detect if we should load all languages by default
+        if ($this->defaultShowAllTranslations) {
+            return Language::ALL;
+        }
+
+        // create language based on context and configuration, where context language is made most important one
+        $languages = [];
+        if ($this->contextLanguage !== null) {
+            $languages[] = $this->contextLanguage;
+        }
+
+        return array_values(array_unique(array_merge($languages, $this->getConfiguredLanguages())));
+    }
+
+    /**
+     * For use by event listening to config resolver scope changes (or other event changing configured languages).
+     *
+     * @param bool $defaultUseAlwaysAvailable
+     */
+    final public function setDefaultUseAlwaysAvailable(bool $defaultUseAlwaysAvailable): void
+    {
+        $this->defaultUseAlwaysAvailable = $defaultUseAlwaysAvailable;
+    }
+
+    /**
+     * Get currently set UseAlwaysAvailable.
+     *
+     * @param bool|null $forcedUseAlwaysAvailable Optional, if set will be used instead of configured value,
+     *        typically arguments provided to API.
+     *
+     * @return bool
+     */
+    final public function getUseAlwaysAvailable(?bool $forcedUseAlwaysAvailable = null): bool
+    {
+        if ($forcedUseAlwaysAvailable !== null) {
+            return $forcedUseAlwaysAvailable;
+        }
+
+        return $this->defaultUseAlwaysAvailable;
+    }
+
+    /**
+     * For use by event listening to config resolver scope changes (or other event changing configured languages).
+     *
+     * @param bool $defaultShowAllTranslations
+     */
+    final public function setShowAllTranslations(bool $defaultShowAllTranslations): void
+    {
+        $this->defaultShowAllTranslations = $defaultShowAllTranslations;
+    }
+
+    /**
+     * Get currently set showAllTranslations.
+     *
+     * @param bool|null $forcedShowAllTranslations Optional, if set will be used instead of configured value,
+     *        typically arguments provided to API.
+     *
+     * @return bool
+     */
+    final public function getShowAllTranslations(?bool $forcedShowAllTranslations = null): bool
+    {
+        if ($forcedShowAllTranslations !== null) {
+            return $forcedShowAllTranslations;
+        }
+
+        return $this->defaultShowAllTranslations;
+    }
+}

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Language/LanguageResolver.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Language/LanguageResolver.php
@@ -8,39 +8,17 @@
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Language;
 
-use eZ\Publish\API\Repository\Values\Content\Language;
-
 /**
  * Resolves language settings for use in SiteAccess aware Repository.
  */
-class LanguageResolver
+final class LanguageResolver extends AbstractLanguageResolver
 {
     /**
      * Values typically provided by configuration.
      *
-     * These will need to change when configuration (scope) changes mid flight using setters below.
-     *
-     * @var array
+     * @var string[]
      */
     private $configLanguages;
-
-    /** @var bool */
-    private $defaultUseAlwaysAvailable;
-
-    /** @var bool */
-    private $defaultShowAllTranslations;
-
-    /**
-     * Values typically provided by user context, will need to be set depending on your own custom logic using setter.
-     *
-     * E.g. Backend UI might expose a language selector for the whole backend that should be reflected on both
-     *      UI strings as well as default languages to prioritize for repository objects.
-     *
-     * If set, this will have priority over configured languages.
-     *
-     * @var string|null
-     */
-    private $contextLanguage;
 
     public function __construct(
         array $configLanguages,
@@ -48,114 +26,11 @@ class LanguageResolver
         bool $defaultShowAllTranslations = false
     ) {
         $this->configLanguages = $configLanguages;
-        $this->defaultUseAlwaysAvailable = $defaultUseAlwaysAvailable;
-        $this->defaultShowAllTranslations = $defaultShowAllTranslations;
+        parent::__construct($defaultUseAlwaysAvailable, $defaultShowAllTranslations);
     }
 
-    /**
-     * For use by event listening to config resolver scope changes (or other event changing configured languages).
-     *
-     * @param array $configLanguages
-     */
-    public function setConfigLanguages(array $configLanguages): void
+    protected function getConfiguredLanguages(): array
     {
-        $this->configLanguages = $configLanguages;
-    }
-
-    /**
-     * For use by custom events / logic setting language for all retrieved objects from repository.
-     *
-     * User language will, if set, will have prepended before configured languages. But in cases PHP API consumer
-     * specifies languages to retrieve repository objects in it will instead be appended as a fallback.
-     *
-     * If set, this will have priority over configured languages.
-     *
-     * @param string|null $contextLanguage
-     */
-    public function setContextLanguage(?string $contextLanguage): void
-    {
-        $this->contextLanguage = $contextLanguage;
-    }
-
-    /**
-     * Get prioritized languages taking into account forced-, context- and lastly configured-languages.
-     *
-     * @param array|null $forcedLanguages Optional, typically arguments provided to API, will be used first if set.
-     *
-     * @return array
-     */
-    public function getPrioritizedLanguages(?array $forcedLanguages): array
-    {
-        // Skip if languages param has been set by API user
-        if ($forcedLanguages !== null) {
-            return $forcedLanguages;
-        }
-
-        // Detect if we should load all languages by default
-        if ($this->defaultShowAllTranslations) {
-            return Language::ALL;
-        }
-
-        // create language based on context and configuration, where context language is made most important one
-        $languages = [];
-        if ($this->contextLanguage !== null) {
-            $languages[] = $this->contextLanguage;
-        }
-
-        return array_values(array_unique(array_merge($languages, $this->configLanguages)));
-    }
-
-    /**
-     * For use by event listening to config resolver scope changes (or other event changing configured languages).
-     *
-     * @param bool $defaultUseAlwaysAvailable
-     */
-    public function setDefaultUseAlwaysAvailable(bool $defaultUseAlwaysAvailable): void
-    {
-        $this->defaultUseAlwaysAvailable = $defaultUseAlwaysAvailable;
-    }
-
-    /**
-     * Get currently set UseAlwaysAvailable.
-     *
-     * @param bool|null $forcedUseAlwaysAvailable Optional, if set will be used instead of configured value,
-     *        typically arguments provided to API.
-     *
-     * @return bool
-     */
-    public function getUseAlwaysAvailable(?bool $forcedUseAlwaysAvailable = null): bool
-    {
-        if ($forcedUseAlwaysAvailable !== null) {
-            return $forcedUseAlwaysAvailable;
-        }
-
-        return $this->defaultUseAlwaysAvailable;
-    }
-
-    /**
-     * For use by event listening to config resolver scope changes (or other event changing configured languages).
-     *
-     * @param bool $defaultShowAllTranslations
-     */
-    public function setShowAllTranslations(bool $defaultShowAllTranslations): void
-    {
-        $this->defaultShowAllTranslations = $defaultShowAllTranslations;
-    }
-
-    /**
-     * Get currently set showAllTranslations.
-     *
-     * @param bool|null $forcedShowAllTranslations Optional, if set will be used instead of configured value,
-     *        typically arguments provided to API.
-     *
-     * @return bool
-     */
-    public function getShowAllTranslations(?bool $forcedShowAllTranslations = null): bool
-    {
-        if ($forcedShowAllTranslations !== null) {
-            return $forcedShowAllTranslations;
-        }
-
-        return $this->defaultShowAllTranslations;
+        return $this->configLanguages;
     }
 }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct;
-use eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver;
+use eZ\Publish\API\Repository\LanguageResolver;
 
 /**
  * LocationService for SiteAccessAware layer.
@@ -26,14 +26,14 @@ class LocationService implements LocationServiceInterface
     /** @var \eZ\Publish\API\Repository\LocationService */
     protected $service;
 
-    /** @var \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver */
+    /** @var \eZ\Publish\API\Repository\LanguageResolver */
     protected $languageResolver;
 
     /**
      * Construct service object from aggregated service and LanguageResolver.
      *
      * @param \eZ\Publish\API\Repository\LocationService $service
-     * @param \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver $languageResolver
+     * @param \eZ\Publish\API\Repository\LanguageResolver $languageResolver
      */
     public function __construct(
         LocationServiceInterface $service,

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ObjectStateService.php
@@ -16,7 +16,7 @@ use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateUpdateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver;
+use eZ\Publish\API\Repository\LanguageResolver;
 
 /**
  * SiteAccess aware implementation of ObjectStateService injecting languages where needed.
@@ -26,14 +26,14 @@ class ObjectStateService implements ObjectStateServiceInterface
     /** @var \eZ\Publish\API\Repository\ObjectStateService */
     protected $service;
 
-    /** @var \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver */
+    /** @var \eZ\Publish\API\Repository\LanguageResolver */
     protected $languageResolver;
 
     /**
      * Construct service object from aggregated service and LanguageResolver.
      *
      * @param \eZ\Publish\API\Repository\ObjectStateService $service
-     * @param \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver $languageResolver
+     * @param \eZ\Publish\API\Repository\LanguageResolver $languageResolver
      */
     public function __construct(
         ObjectStateServiceInterface $service,

--- a/eZ/Publish/Core/Repository/SiteAccessAware/SearchService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/SearchService.php
@@ -12,7 +12,7 @@ use eZ\Publish\API\Repository\SearchService as SearchServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver;
+use eZ\Publish\API\Repository\LanguageResolver;
 
 /**
  * SiteAccess aware implementation of SearchService injecting languages where needed.
@@ -22,14 +22,14 @@ class SearchService implements SearchServiceInterface
     /** @var \eZ\Publish\API\Repository\SearchService */
     protected $service;
 
-    /** @var \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver */
+    /** @var \eZ\Publish\API\Repository\LanguageResolver */
     protected $languageResolver;
 
     /**
      * Construct service object from aggregated service and LanguageResolver.
      *
      * @param \eZ\Publish\API\Repository\SearchService $service
-     * @param \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver $languageResolver
+     * @param \eZ\Publish\API\Repository\LanguageResolver $languageResolver
      */
     public function __construct(
         SearchServiceInterface $service,

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/AbstractServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/AbstractServiceTest.php
@@ -2,7 +2,7 @@
 
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Tests;
 
-use eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver;
+use eZ\Publish\API\Repository\LanguageResolver;
 use PHPUnit\Framework\TestCase;
 use Closure;
 
@@ -30,7 +30,7 @@ abstract class AbstractServiceTest extends TestCase
     /** @var object */
     protected $service;
 
-    /** @var \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Publish\API\Repository\LanguageResolver|\PHPUnit_Framework_MockObject_MockObject */
     protected $languageResolverMock;
 
     abstract public function getAPIServiceClassName();

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/Language/LanguageResolverTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/Language/LanguageResolverTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Repository\SiteAccessAware\Tests\Language;
+
+use eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver;
+use PHPUnit\Framework\TestCase;
+
+class LanguageResolverTest extends TestCase
+{
+    /**
+     * @covers \eZ\Publish\Core\Repository\SiteAccessAware\Language\AbstractLanguageResolver::getPrioritizedLanguages
+     *
+     * @dataProvider getDataForTestGetPrioritizedLanguages
+     *
+     * @param array $expectedPrioritizedLanguagesList
+     * @param array $configLanguages
+     * @param bool $defaultShowAllTranslations
+     * @param null|array $forcedLanguages
+     * @param null|string $contextLanguage
+     */
+    public function testGetPrioritizedLanguages(
+        array $expectedPrioritizedLanguagesList,
+        array $configLanguages,
+        bool $defaultShowAllTranslations,
+        ?array $forcedLanguages,
+        ?string $contextLanguage
+    ) {
+        // note: "use always available" does not affect this test
+        $defaultUseAlwaysAvailable = true;
+
+        $languageResolver = new LanguageResolver(
+            $configLanguages,
+            $defaultUseAlwaysAvailable,
+            $defaultShowAllTranslations
+        );
+
+        $languageResolver->setContextLanguage($contextLanguage);
+
+        self::assertEquals(
+            $expectedPrioritizedLanguagesList,
+            $languageResolver->getPrioritizedLanguages($forcedLanguages)
+        );
+    }
+
+    /**
+     * Data provider for testGetPrioritizedLanguages.
+     *
+     * @see testGetPrioritizedLanguages
+     *
+     * @return array
+     */
+    public function getDataForTestGetPrioritizedLanguages(): array
+    {
+        return [
+            [
+                ['eng-GB', 'pol-PL'], ['eng-GB', 'pol-PL'], false, null, null,
+            ],
+            [
+                [], ['eng-GB', 'pol-PL'], false, [], null, ],
+            [
+                ['ger-DE'], ['eng-GB', 'pol-PL'], false, ['ger-DE'], null,
+            ],
+            [
+                [], ['eng-GB', 'pol-PL'], true, null, null,
+            ],
+            [
+                ['ger-DE', 'eng-GB', 'pol-PL'], ['eng-GB', 'pol-PL'], false, null, 'ger-DE',
+            ],
+        ];
+    }
+}

--- a/eZ/Publish/Core/Repository/SiteAccessAware/URLAliasService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/URLAliasService.php
@@ -10,7 +10,7 @@ namespace eZ\Publish\Core\Repository\SiteAccessAware;
 
 use eZ\Publish\API\Repository\URLAliasService as URLAliasServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\Location;
-use eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver;
+use eZ\Publish\API\Repository\LanguageResolver;
 
 /**
  * SiteAccess aware implementation of URLAliasService injecting languages where needed.
@@ -20,14 +20,14 @@ class URLAliasService implements URLAliasServiceInterface
     /** @var \eZ\Publish\API\Repository\URLAliasService */
     protected $service;
 
-    /** @var \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver */
+    /** @var \eZ\Publish\API\Repository\LanguageResolver */
     protected $languageResolver;
 
     /**
      * Construct service object from aggregated service and LanguageResolver.
      *
      * @param \eZ\Publish\API\Repository\URLAliasService $service
-     * @param \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver $languageResolver
+     * @param \eZ\Publish\API\Repository\LanguageResolver $languageResolver
      */
     public function __construct(
         URLAliasServiceInterface $service,

--- a/eZ/Publish/Core/Repository/SiteAccessAware/UserService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/UserService.php
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\User\UserGroup;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserTokenUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\UserUpdateStruct;
-use eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver;
+use eZ\Publish\API\Repository\LanguageResolver;
 
 /**
  * UserService for SiteAccessAware layer.
@@ -30,14 +30,14 @@ class UserService implements UserServiceInterface
     /** @var \eZ\Publish\API\Repository\UserService */
     protected $service;
 
-    /** @var \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver */
+    /** @var \eZ\Publish\API\Repository\LanguageResolver */
     protected $languageResolver;
 
     /**
      * Construct service object from aggregated service.
      *
      * @param \eZ\Publish\API\Repository\UserService $service
-     * @param \eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver $languageResolver
+     * @param \eZ\Publish\API\Repository\LanguageResolver $languageResolver
      */
     public function __construct(
         UserServiceInterface $service,

--- a/eZ/Publish/Core/settings/repository/siteaccessaware.yml
+++ b/eZ/Publish/Core/settings/repository/siteaccessaware.yml
@@ -1,3 +1,6 @@
+parameters:
+    languages: []
+
 services:
     ezpublish.siteaccessaware.repository:
         class: eZ\Publish\Core\Repository\SiteAccessAware\Repository
@@ -80,6 +83,17 @@ services:
             - '@eZ\Publish\Core\SignalSlot\NotificationService'
 
     # Helpers
-    ezpublish.helper.language_resolver:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver
+    eZ\Publish\Core\Repository\SiteAccessAware\Language\AbstractLanguageResolver:
+        arguments:
+            $defaultUseAlwaysAvailable: true
+            $defaultShowAllTranslations: false
+
+    eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver:
+        parent: eZ\Publish\Core\Repository\SiteAccessAware\Language\AbstractLanguageResolver
         arguments: ['%languages%']
+
+    eZ\Publish\API\Repository\LanguageResolver:
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\Language\LanguageResolver
+
+    ezpublish.helper.language_resolver:
+        alias: eZ\Publish\API\Repository\LanguageResolver


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30629](https://jira.ez.no/browse/EZP-30629)
| **Requires** | #2676
| **Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5` for eZ Platform `v2.5`, compatible with eZ Platform `v3.0`
| **BC breaks**      | TBD
| **Tests pass**     | yes
| **Doc needed**     | no

## TL;DR;

This PR:
- [x] Provides `LanguageResolver` API interface to be implemented by Bundle and Core layers.
- [x] Implements `LanguageResolver` for Bundle Layer.
- [x] Implements `LanguageResolver` for Core Layer.
- [x] Injects API `LanguageResolver` instead of Core into SA-aware services

## Summary

This PR fixes a few issues with LanguageResolver across Core and Bundle layer.

First of all we needed to get rid of injecting dynamic setting (`$languages$`) too early to avoid injecting them from unresolved SiteAccess scope.

On the other hand, we're forced to drop dynamic settings due to changes to Symfony Container in Symfony 4.x, so here we should inject ConfigResolver instead.

I've discovered a little bit of mix-up between Core and Bundle layers which didn't allow to do it in a clean way. `ConfigResolver` is defined as a service in Bundle layer, however Core layer (SiteAccessAware Repository services) required `LanguageResolver` which relied on dynamic settings. Core configuration is not aware of Bundle configuration, so this should not happen.

There are two solutions: either move `ConfigResolver` service definition to Core layer or redefine services that depend on parts of the Bundle on a Bundle level. First solution seems too excessive for now, at least for 7.5, so this PR redefines `LanguageResolver` with injected `ConfigResolver` on a Bundle level. Core `LanguageResolver` uses fallback parameter `%languages%` which is currently utilized only by integration tests.

The change calls for common contract for `LanguageResolver` and hence it is provided as `eZ\Publish\API\Repository\LanguageResolver`. All SiteAccessAware Repository services require now that contract instead of specific implementation. Anyway, that was on a `@todo` list as can be seen in diff ;)

I have a feeling that this entire mix-up, undetected because we used dynamic settings here before, could potentially be a cause of at least some races in the container when building services that rely on dynamic settings.

So while the change introduces a bit of redundancy, I feel it's much cleaner now.

## Open question

- [x] Should we use common base for LanguageResolver to avoid at least some redundancy, and if so, where should it be placed?

## BC concern

The changes here are a bit extensive, so they naturally raise BC concerns. I'd say we should not be worried about BC, because Language Resolver is not documented anywhere as a service provider interface and for consumers almost everything works the same. 

What is gone is `setConfigLanguages` method. If we were to provide BC it would be a flag indicating that `$configLanguages` were set by `setConfigLanguages` and should be returned directly instead of resolving it using `ConfigResolver`. However due to other extensive changes, is it a concern?

## QA

There's a cumulative fixes branch [`for-qa-ezp-30690-too-early-cr-combo-fix`](https://github.com/ezsystems/ezpublish-kernel/tree/for-qa-ezp-30690-too-early-cr-combo-fix) for testing

**TODO**:
- [x] fix `ezpublish.helper.language_resolver` in core configuration.
- [x] Confirm that all tests pass.