### PR TITLE
EZP-30635: Fixed infinite loop in Reindex Command on the last iteration

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Command;
 
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\Core\Search\Common\Indexer;
 use eZ\Publish\Core\Search\Common\IncrementalIndexer;
@@ -162,7 +163,7 @@ EOT
         $iterationCount = $input->getOption('iteration-count');
         $this->siteaccess = $input->getOption('siteaccess');
         if (!is_numeric($iterationCount) || (int) $iterationCount < 1) {
-            throw new RuntimeException("'--iteration-count' option should be > 0, got '{$iterationCount}'");
+            throw new InvalidArgumentException('--iteration-count', "Option should be > 0, got '{$iterationCount}'");
         }
 
         if (!$this->searchIndexer instanceof IncrementalIndexer) {
@@ -390,7 +391,7 @@ EOT
     private function getPhpProcess(array $contentIds, $commit)
     {
         if (empty($contentIds)) {
-            throw new RuntimeException("'--content-ids=' can not be empty on parallel sub process");
+            throw new InvalidArgumentException('--content-ids', '$contentIds can not be empty');
         }
 
         $consolePath = file_exists('bin/console') ? 'bin/console' : 'app/console';

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -370,6 +370,8 @@ EOT
             for ($i = 0; $i < $iterationCount; ++$i) {
                 if ($contentId = $stmt->fetch(PDO::FETCH_COLUMN)) {
                     $contentIds[] = $contentId;
+                } elseif (empty($contentIds)) {
+                    return;
                 } else {
                     break;
                 }
@@ -387,6 +389,10 @@ EOT
      */
     private function getPhpProcess(array $contentIds, $commit)
     {
+        if (empty($contentIds)) {
+            throw new RuntimeException("'--content-ids=' can not be empty on parallel sub process");
+        }
+
         $consolePath = file_exists('bin/console') ? 'bin/console' : 'app/console';
         $subProcessArgs = [
             $consolePath,


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30635](https://jira.ez.no/browse/EZP-30635)
| **Bug/Improvement**| yes
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

When content-count % iteration-count === 0, aka when last iteration would have empty results, there would be faulty call to with empty ´--content-ids=´ causing whole new index process to start again with purge and everything.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
