### PR TITLE
EZP-29301: Added class and data attributes support for embed(inline)

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -297,3 +297,7 @@ services:
             - [setEnableViewCache, [$content.view_cache$]]
         tags:
             - { name: kernel.event_subscriber }
+
+    eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\DataAttributesExtension:
+        autoconfigure: true
+        public: false

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed_inline.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed_inline.html.twig
@@ -1,5 +1,11 @@
+{%
+    set data_attributes_str = (data_attributes is defined)
+        ? ' ' ~ data_attributes|ez_data_attributes_serialize
+        : ''
+%}
+
 {% if location is defined %}
-    <a href="{{ path(location) }}">{{ content.name }}</a>
+    <a href="{{ path(location) }}"{% if class is defined %} class="{{ class }}"{% endif %}{{ data_attributes_str|raw }}>{{ content.name }}</a>
 {% else %}
-    <a href="{{ path( "ez_urlalias", {"contentId": content.id} ) }}">{{ content.name }}</a>
+    <a href="{{ path( "ez_urlalias", {"contentId": content.id} ) }}"{% if class is defined %} class="{{ class }}"{% endif %}{{ data_attributes_str|raw }}>{{ content.name }}</a>
 {% endif %}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/DataAttributesExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/DataAttributesExtensionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;
+
+use eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\DataAttributesExtension;
+use Twig\Test\IntegrationTestCase;
+
+class DataAttributesExtensionTest extends IntegrationTestCase
+{
+    public function getExtensions(): array
+    {
+        return [
+            new DataAttributesExtension(),
+        ];
+    }
+
+    protected function getFixturesDir(): string
+    {
+        return __DIR__ . '/_fixtures/filters';
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/filters/ez_data_attributes_serialize.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/filters/ez_data_attributes_serialize.test
@@ -1,0 +1,37 @@
+--TEST--
+"ez_data_attributes_serialize" filter
+--TEMPLATE--
+<a href="/article" {{ data_attributes|ez_data_attributes_serialize }}>Article</a>
+--DATA--
+return [
+    'data_attributes' => [
+        'my-attr1' => 'value1',
+        'my-attr2' => 'value2,value3',
+    ]
+];
+--EXPECT--
+<a href="/article" data-my-attr1="value1" data-my-attr2="value2,value3">Article</a>
+--DATA--
+return [
+    'data_attributes' => [
+        'attr' => 'foo" style="background: red',
+    ]
+];
+--EXPECT--
+<a href="/article" data-attr="foo&quot; style=&quot;background: red">Article</a>
+--DATA--
+return [
+    'data_attributes' => [
+        'attr' => true,
+    ]
+];
+--EXPECT--
+<a href="/article" data-attr="true">Article</a>
+--DATA--
+return [
+    'data_attributes' => [
+        'attr' => ['key1' => 'value1', 'key2' => 'value2'],
+    ]
+];
+--EXPECT--
+<a href="/article" data-attr="{&quot;key1&quot;:&quot;value1&quot;,&quot;key2&quot;:&quot;value2&quot;}">Article</a>

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/DataAttributesExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/DataAttributesExtension.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+/**
+ * Twig common extension for general use helpers.
+ */
+class DataAttributesExtension extends AbstractExtension
+{
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return array
+     */
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter(
+                'ez_data_attributes_serialize',
+                [$this, 'serializeDataAttributes'],
+                ['is_safe' => ['html']]
+            ),
+        ];
+    }
+
+    /**
+     * Processes an associative list of data attributes and returns them as HTML attributes list
+     * in the form of <code>data-<attribute_name>="<attribute_value>"</code>.
+     *
+     * @param array $dataAttributes
+     *
+     * @return string
+     */
+    public function serializeDataAttributes(array $dataAttributes): string
+    {
+        $result = '';
+        foreach ($dataAttributes as $attributeName => $attributeValue) {
+            if (!is_string($attributeValue)) {
+                $attributeValue = json_encode($attributeValue);
+            }
+
+            $result .= sprintf('data-%s="%s" ', $attributeName, htmlspecialchars($attributeValue));
+        }
+
+        return rtrim($result);
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29301](https://jira.ez.no/browse/EZP-29301)
| **Required by** | ezsystems/ezplatform-richtext#39
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `7.5.2` for eZ Platform `v2.5.2 LTS`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | ezsystems/developer-documentation#633

As a result of QA we found out that custom classes and data attributes set in OE are not rendered on the output (front SiteAccess). This is because `embed(inline)` elements are handled completely different, via `viewAction` subrequest.

This PR:
- [x] renders class propagated via https://github.com/ezsystems/ezplatform-richtext/pull/39/commits/b4650dc362c529b553502869b9e1991b8d504639
- [x] adds `ez_data_attributes_serialize` filter which processes data attributes associative array into HTML string of data attributes with their values.
For the input:
```php
[
    'my-attr1' => 'value1',
    'my-attr2' => 'value2,value3',
]
```
we get
```
data-my-attr1="value1" data-my-attr2="value2,value3"
```
- [x] renders data attributes propagated via https://github.com/ezsystems/ezplatform-richtext/pull/39/commits/4711e335f2ca1c83c72c45474aa52763ba246444 using `ez_data_attributes_serialize` filter.

Note: we need to handle here only `embedinline` classes and data attributes, because there's no tag to attach them for parent template in the RichText package. However for `embed` they're handled via the RichText package.

**TODO**:
- [x] Implement tests.
- [x] Decide where to place data attributes for `embedimage`. 
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
