### PR TITLE
EZP-30664: Skipped indexing erroneous Content and logged all exceptions

### DIFF
--- a/eZ/Publish/Core/Search/Common/IncrementalIndexer.php
+++ b/eZ/Publish/Core/Search/Common/IncrementalIndexer.php
@@ -71,6 +71,8 @@ abstract class IncrementalIndexer extends Indexer
      * - not published (draft or trashed)
      * Then item is removed from index, if not it is added/updated.
      *
+     * If generic unhandled exception is thrown, then item indexing is skipped and warning is logged.
+     *
      * @param int[] $contentIds
      * @param bool $commit
      */

--- a/eZ/Publish/Core/Search/Legacy/Content/Indexer.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Indexer.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Search\Legacy\Content;
 
+use Exception;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\Search\Common\IncrementalIndexer;
@@ -46,6 +47,12 @@ class Indexer extends IncrementalIndexer
                 }
             } catch (NotFoundException $e) {
                 $this->searchHandler->deleteContent($contentId);
+            } catch (Exception $e) {
+                $context = [
+                    'contentId' => $contentId,
+                    'error' => $e->getMessage(),
+                ];
+                $this->logger->error('Unable to index the content', $context);
             }
         }
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30664](https://jira.ez.no/browse/EZP-30664)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Similar to https://github.com/ezsystems/ezplatform-solr-search-engine/pull/139, but it is done for legacy search engine.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
