### PR TITLE
EZP-30643: Images are stored under wrong path

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -1,6 +1,6 @@
 parameters:
     # Kernel related params
-    webroot_dir: "%kernel.root_dir%/../web"
+    webroot_dir: "%kernel.root_dir%/../public"
 
     ###
     # ezsettings namespace, default scope


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30643](https://jira.ez.no/browse/EZP-30643)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** |`master` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

fixes configuration

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
