### PR TITLE
EZP-30675: Replaced deprecated PHPUnit asserts with proper ones

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -24,6 +24,8 @@ return PhpCsFixer\Config::create()
         'phpdoc_types_order' => false,
         'php_unit_mock_short_will_return' => false,
         'php_unit_construct' => false,
+        'php_unit_dedicate_assert' => true,
+        'php_unit_dedicate_assert_internal_type' => true,
         'standardize_increment' => false,
         'fopen_flags' => false,
     ])

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ComplexSettingsPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ComplexSettingsPassTest.php
@@ -34,7 +34,7 @@ class ComplexSettingsPassTest extends AbstractCompilerPassTestCase
 
         $expressionString = 'service("ezpublish.config.complex_setting_value.resolver").resolveSetting("/mnt/nfs/$var_dir$/$storage_dir$", "var_dir", service("ezpublish.config.resolver").getParameter("var_dir", null, null), "storage_dir", service("ezpublish.config.resolver").getParameter("storage_dir", null, null))';
         $arguments = $definition->getArguments();
-        self::assertSame(1, count($arguments));
+        self::assertCount(1, $arguments);
         self::assertInstanceOf(Expression::class, $arguments[0]);
         self::assertSame($expressionString, (string)$arguments[0]);
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -397,7 +397,7 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
         foreach ($repositoriesPar as $key => $repo) {
             $this->assertArrayHasKey($key, $expectedRepositories);
             $this->assertArrayHasKey('fields_groups', $repo);
-            $this->assertEquals($expectedRepositories[$key]['fields_groups'], $repo['fields_groups'], 'Invalid fields groups element', 0.0, 10, true);
+            $this->assertEqualsCanonicalizing($expectedRepositories[$key]['fields_groups'], $repo['fields_groups'], 'Invalid fields groups element');
         }
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
@@ -84,7 +84,7 @@ class BinaryLoaderTest extends TestCase
         try {
             $this->binaryLoader->find($path);
         } catch (NotLoadableException $e) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 "Suggested value: '1/2/3/123-name/name.png'",
                 $e->getMessage()
             );

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderProviderRegistryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderProviderRegistryTest.php
@@ -14,26 +14,40 @@ use PHPUnit\Framework\TestCase;
 
 class PlaceholderProviderRegistryTest extends TestCase
 {
+    private const FOO = 'foo';
+    private const BAR = 'bar';
+
+    /**
+     * @covers       \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProviderRegistry::__construct
+     * @uses         \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProviderRegistry::getProvider
+     * @depends      testGetProviderKnown
+     */
     public function testConstructor()
     {
         $providers = [
-            'foo' => $this->getPlaceholderProviderMock(),
-            'bar' => $this->getPlaceholderProviderMock(),
+            self::FOO => $this->getPlaceholderProviderMock(),
+            self::BAR => $this->getPlaceholderProviderMock(),
         ];
 
         $registry = new PlaceholderProviderRegistry($providers);
 
-        $this->assertAttributeSame($providers, 'providers', $registry);
+        $this->assertSame($providers[self::FOO], $registry->getProvider(self::FOO));
+        $this->assertSame($providers[self::BAR], $registry->getProvider(self::BAR));
     }
 
-    public function testAddProvider()
+    /**
+     * @covers       \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProviderRegistry::addProvider
+     * @uses         \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProviderRegistry::getProvider
+     * @depends      testGetProviderKnown
+     */
+    public function testAddProvider(): void
     {
         $provider = $this->getPlaceholderProviderMock();
 
         $registry = new PlaceholderProviderRegistry();
-        $registry->addProvider('foo', $provider);
+        $registry->addProvider(self::FOO, $provider);
 
-        $this->assertAttributeSame(['foo' => $provider], 'providers', $registry);
+        $this->assertSame($provider, $registry->getProvider(self::FOO));
     }
 
     public function testSupports()
@@ -51,10 +65,10 @@ class PlaceholderProviderRegistryTest extends TestCase
         $provider = $this->getPlaceholderProviderMock();
 
         $registry = new PlaceholderProviderRegistry([
-            'foo' => $provider,
+            self::FOO => $provider,
         ]);
 
-        $this->assertEquals($provider, $registry->getProvider('foo'));
+        $this->assertEquals($provider, $registry->getProvider(self::FOO));
     }
 
     public function testGetProviderUnknown()
@@ -62,10 +76,10 @@ class PlaceholderProviderRegistryTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         $registry = new PlaceholderProviderRegistry([
-            'foo' => $this->getPlaceholderProviderMock(),
+            self::FOO => $this->getPlaceholderProviderMock(),
         ]);
 
-        $registry->getProvider('bar');
+        $registry->getProvider(self::BAR);
     }
 
     private function getPlaceholderProviderMock(): PlaceholderProvider

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Translation/GlobCollectorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Translation/GlobCollectorTest.php
@@ -23,7 +23,7 @@ class GlobCollectorTest extends TestCase
         $collector = new GlobCollector($translationRootDir);
 
         $files = $collector->collect();
-        $this->assertEquals(3, count($files));
+        $this->assertCount(3, $files);
         foreach ($files as $file) {
             $this->assertTrue(in_array($file['domain'], ['messages', 'dashboard']));
             $this->assertTrue(in_array($file['locale'], ['fr', 'ach_UG']));

--- a/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
@@ -1627,9 +1627,9 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
         }
 
         // verify all expected relations were found
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($expectedRelations),
+            $expectedRelations,
             "Expected to find '" . (count($expectedRelations) + count($actualRelations))
             . "' relations found '" . count($actualRelations) . "'"
         );

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -2051,7 +2051,7 @@ XML
 
         // load first to make sure list gets updated also (cache)
         $versionInfoList = $contentService->loadVersions($content->contentInfo);
-        $this->assertEquals(1, count($versionInfoList));
+        $this->assertCount(1, $versionInfoList);
         $this->assertEquals(1, $versionInfoList[0]->versionNo);
 
         // Create a new draft with versionNo = 2
@@ -2080,7 +2080,7 @@ XML
 
         $versionInfoList = $contentService->loadVersions($content->contentInfo);
 
-        $this->assertEquals(6, count($versionInfoList));
+        $this->assertCount(6, $versionInfoList);
         $this->assertEquals(2, $versionInfoList[0]->versionNo);
         $this->assertEquals(7, $versionInfoList[5]->versionNo);
 
@@ -3366,9 +3366,9 @@ XML
             $contentCopied->id
         );
 
-        $this->assertEquals(
+        $this->assertCount(
             2,
-            count($contentService->loadVersions($contentCopied->contentInfo))
+            $contentService->loadVersions($contentCopied->contentInfo)
         );
 
         $this->assertEquals(2, $contentCopied->getVersionInfo()->versionNo);
@@ -3489,9 +3489,9 @@ XML
             $contentCopied->id
         );
 
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($contentService->loadVersions($contentCopied->contentInfo))
+            $contentService->loadVersions($contentCopied->contentInfo)
         );
 
         $this->assertEquals(1, $contentCopied->getVersionInfo()->versionNo);
@@ -3549,9 +3549,9 @@ XML
      */
     public function testAddRelationAddsRelationToContent($relations)
     {
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($relations)
+            $relations
         );
     }
 
@@ -3630,9 +3630,9 @@ XML
      */
     public function testCreateContentDraftWithRelationsCreatesRelations($relations)
     {
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($relations)
+            $relations
         );
 
         return $relations;
@@ -3939,8 +3939,8 @@ XML
         $this->assertEquals($contentInfo->id, $relation2->getDestinationContentInfo()->id);
         $this->assertEquals($demoDesignDraft->id, $relation2->getSourceContentInfo()->id);
 
-        $this->assertEquals(0, count($relations));
-        $this->assertEquals(2, count($reverseRelations));
+        $this->assertCount(0, $relations);
+        $this->assertCount(2, $reverseRelations);
 
         usort(
             $reverseRelations,
@@ -4041,8 +4041,8 @@ XML
         $this->assertEquals($contentInfo->id, $relation2->getDestinationContentInfo()->id);
         $this->assertEquals($demoDesignDraft->id, $relation2->getSourceContentInfo()->id);
 
-        $this->assertEquals(0, count($relations));
-        $this->assertEquals(1, count($reverseRelations));
+        $this->assertCount(0, $relations);
+        $this->assertCount(1, $reverseRelations);
 
         $this->assertEquals(
             array(
@@ -4117,8 +4117,8 @@ XML
         $this->assertEquals($media->contentInfo->id, $relation2->getDestinationContentInfo()->id);
         $this->assertEquals($demoDesignDraft->id, $relation2->getSourceContentInfo()->id);
 
-        $this->assertEquals(0, count($relations));
-        $this->assertEquals(1, count($reverseRelations));
+        $this->assertCount(0, $relations);
+        $this->assertCount(1, $reverseRelations);
 
         $this->assertEquals(
             array(
@@ -4170,7 +4170,7 @@ XML
         $relations = $contentService->loadRelations($draft->getVersionInfo());
         /* END: Use Case */
 
-        $this->assertEquals(1, count($relations));
+        $this->assertCount(1, $relations);
     }
 
     /**
@@ -5086,7 +5086,7 @@ XML
         )->locations;
         /* END: Use Case */
 
-        $this->assertEquals(1, count($locations));
+        $this->assertCount(1, $locations);
     }
 
     /**
@@ -5146,7 +5146,7 @@ XML
         )->locations;
         /* END: Use Case */
 
-        $this->assertEquals(2, count($locations));
+        $this->assertCount(2, $locations);
     }
 
     public function testURLAliasesCreatedForNewContent()

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -335,9 +335,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $loadedGroups = $contentTypeService->loadContentTypeGroups();
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedGroups
+        $this->assertIsArray($loadedGroups
         );
 
         foreach ($loadedGroups as $loadedGroup) {
@@ -366,7 +364,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
      */
     public function testLoadContentTypeGroupsIdentifiers($groups)
     {
-        $this->assertEquals(4, count($groups));
+        $this->assertCount(4, $groups);
 
         $expectedIdentifiers = array(
             'Content' => true,
@@ -1123,10 +1121,10 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
 
         /* @var $validationErrors */
         $this->assertTrue(isset($validationErrors));
-        $this->assertInternalType('array', $validationErrors);
+        $this->assertIsArray($validationErrors);
         $this->assertCount(1, $validationErrors);
         $this->assertArrayHasKey('temperature', $validationErrors);
-        $this->assertInternalType('array', $validationErrors['temperature']);
+        $this->assertIsArray($validationErrors['temperature']);
         $this->assertCount(1, $validationErrors['temperature']);
         $this->assertInstanceOf('eZ\\Publish\\Core\\FieldType\\ValidationError', $validationErrors['temperature'][0]);
 
@@ -1618,10 +1616,10 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
 
         /* @var $validationErrors */
         $this->assertTrue(isset($validationErrors));
-        $this->assertInternalType('array', $validationErrors);
+        $this->assertIsArray($validationErrors);
         $this->assertCount(1, $validationErrors);
         $this->assertArrayHasKey('temperature', $validationErrors);
-        $this->assertInternalType('array', $validationErrors['temperature']);
+        $this->assertIsArray($validationErrors['temperature']);
         $this->assertCount(1, $validationErrors['temperature']);
         $this->assertInstanceOf('eZ\\Publish\\Core\\FieldType\\ValidationError', $validationErrors['temperature'][0]);
 
@@ -2953,7 +2951,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
 
         $types = $contentTypeService->loadContentTypeList([3, 4]);
 
-        $this->assertInternalType('iterable', $types);
+        $this->assertIsIterable($types);
 
         $this->assertEquals(
             [
@@ -2985,7 +2983,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $types = $contentTypeService->loadContentTypes($contentTypeGroup);
         /* END: Use Case */
 
-        $this->assertInternalType('array', $types);
+        $this->assertIsArray($types);
 
         return $types;
     }

--- a/eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php
@@ -33,7 +33,7 @@ class FieldTypeServiceTest extends BaseTest
         /* END: Use Case */
 
         // Require at least 1 field type
-        $this->assertNotEquals(0, count($fieldTypes));
+        $this->assertNotCount(0, $fieldTypes);
 
         foreach ($fieldTypes as $fieldType) {
             $this->assertInstanceOf(

--- a/eZ/Publish/API/Repository/Tests/LanguageServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LanguageServiceTest.php
@@ -178,7 +178,7 @@ class LanguageServiceTest extends BaseTest
 
         $languages = $languageService->loadLanguageListById([$languageId]);
 
-        $this->assertInternalType('iterable', $languages);
+        $this->assertIsIterable($languages);
         $this->assertCount(1, $languages);
         $this->assertInstanceOf(Language::class, $languages[$languageId]);
     }
@@ -200,7 +200,7 @@ class LanguageServiceTest extends BaseTest
 
         $languages = $languageService->loadLanguageListById([$nonExistentLanguageId]);
 
-        $this->assertInternalType('iterable', $languages);
+        $this->assertIsIterable($languages);
         $this->assertCount(0, $languages);
 
         $this->expectException(NotFoundException::class);
@@ -368,7 +368,7 @@ class LanguageServiceTest extends BaseTest
 
         $languages = $languageService->loadLanguageListByCode(['eng-NZ']);
 
-        $this->assertInternalType('iterable', $languages);
+        $this->assertIsIterable($languages);
         $this->assertCount(1, $languages);
 
         $this->assertPropertiesCorrect(
@@ -397,7 +397,7 @@ class LanguageServiceTest extends BaseTest
 
         $languages = $languageService->loadLanguageListByCode(['fre-FR']);
 
-        $this->assertInternalType('iterable', $languages);
+        $this->assertIsIterable($languages);
         $this->assertCount(0, $languages);
 
         $this->expectException(NotFoundException::class);
@@ -449,7 +449,7 @@ class LanguageServiceTest extends BaseTest
         $languageService->createLanguage($languageCreateFrench);
 
         $languages = $languageService->loadLanguages();
-        self::assertInternalType('array', $languages);
+        self::assertIsArray($languages);
         foreach ($languages as $language) {
             self::assertInstanceOf(Language::class, $language);
             $singleLanguage = $languageService->loadLanguage($language->languageCode);
@@ -462,7 +462,7 @@ class LanguageServiceTest extends BaseTest
         /* END: Use Case */
 
         // eng-US, eng-GB, ger-DE + 2 newly created
-        $this->assertEquals(5, count($languages));
+        $this->assertCount(5, $languages);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
@@ -166,7 +166,7 @@ class LocationServiceAuthorizationTest extends BaseTest
 
         $locations = $locationService->loadLocationList([13]);
 
-        self::assertInternalType('iterable', $locations);
+        self::assertIsIterable($locations);
         self::assertCount(0, $locations);
     }
 

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -568,7 +568,7 @@ class LocationServiceTest extends BaseTest
         $locationService = $repository->getLocationService();
         $locations = $locationService->loadLocationList([5, 442]);
 
-        self::assertInternalType('iterable', $locations);
+        self::assertIsIterable($locations);
         self::assertCount(1, $locations);
         self::assertEquals([5], array_keys($locations));
         self::assertInstanceOf(Location::class, $locations[5]);
@@ -591,7 +591,7 @@ class LocationServiceTest extends BaseTest
         $locationService = $repository->getLocationService();
         $locations = $locationService->loadLocationList([5, 442], ['pol-PL'], false);
 
-        self::assertInternalType('iterable', $locations);
+        self::assertIsIterable($locations);
         self::assertCount(0, $locations);
     }
 
@@ -611,7 +611,7 @@ class LocationServiceTest extends BaseTest
         $locationService = $repository->getLocationService();
         $locations = $locationService->loadLocationList([5, 442], ['pol-PL'], true);
 
-        self::assertInternalType('iterable', $locations);
+        self::assertIsIterable($locations);
         self::assertCount(1, $locations);
         self::assertEquals([5], array_keys($locations));
         self::assertInstanceOf(Location::class, $locations[5]);
@@ -631,7 +631,7 @@ class LocationServiceTest extends BaseTest
         $locationService = $repository->getLocationService();
         $locations = $locationService->loadLocationList([1]);
 
-        self::assertInternalType('iterable', $locations);
+        self::assertIsIterable($locations);
         self::assertCount(1, $locations);
         self::assertEquals([1], array_keys($locations));
         self::assertInstanceOf(Location::class, $locations[1]);
@@ -705,7 +705,7 @@ class LocationServiceTest extends BaseTest
         $locations = $locationService->loadLocations($contentInfo);
         /* END: Use Case */
 
-        $this->assertInternalType('array', $locations);
+        $this->assertIsArray($locations);
         self::assertNotEmpty($locations);
 
         foreach ($locations as $location) {
@@ -727,7 +727,7 @@ class LocationServiceTest extends BaseTest
         $repository = $this->getRepository();
         $locationService = $repository->getLocationService();
 
-        $this->assertEquals(1, count($locations));
+        $this->assertCount(1, $locations);
         foreach ($locations as $loadedLocation) {
             $this->assertInstanceOf(
                 '\\eZ\\Publish\\API\\Repository\\Values\\Content\\Location',
@@ -795,7 +795,7 @@ class LocationServiceTest extends BaseTest
         );
         /* END: Use Case */
 
-        $this->assertInternalType('array', $locations);
+        $this->assertIsArray($locations);
 
         return $locations;
     }
@@ -810,7 +810,7 @@ class LocationServiceTest extends BaseTest
      */
     public function testLoadLocationsLimitedSubtreeContent(array $locations)
     {
-        $this->assertEquals(1, count($locations));
+        $this->assertCount(1, $locations);
 
         $this->assertEquals(
             $this->generateId('location', 54),
@@ -904,9 +904,9 @@ class LocationServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(LocationList::class, $childLocations);
-        $this->assertInternalType('array', $childLocations->locations);
+        $this->assertIsArray($childLocations->locations);
         $this->assertNotEmpty($childLocations->locations);
-        $this->assertInternalType('int', $childLocations->totalCount);
+        $this->assertIsInt($childLocations->totalCount);
 
         foreach ($childLocations->locations as $childLocation) {
             $this->assertInstanceOf(Location::class, $childLocation);
@@ -1000,7 +1000,7 @@ class LocationServiceTest extends BaseTest
      */
     public function testLoadLocationChildrenData(LocationList $locations)
     {
-        $this->assertEquals(5, count($locations->locations));
+        $this->assertCount(5, $locations->locations);
         $this->assertEquals(5, $locations->totalCount);
 
         foreach ($locations->locations as $location) {
@@ -1050,8 +1050,8 @@ class LocationServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\Content\\LocationList', $childLocations);
-        $this->assertInternalType('array', $childLocations->locations);
-        $this->assertInternalType('int', $childLocations->totalCount);
+        $this->assertIsArray($childLocations->locations);
+        $this->assertIsInt($childLocations->totalCount);
 
         return $childLocations;
     }
@@ -1066,7 +1066,7 @@ class LocationServiceTest extends BaseTest
      */
     public function testLoadLocationChildrenDataWithOffset(LocationList $locations)
     {
-        $this->assertEquals(3, count($locations->locations));
+        $this->assertCount(3, $locations->locations);
         $this->assertEquals(5, $locations->totalCount);
 
         foreach ($locations->locations as $location) {
@@ -1114,8 +1114,8 @@ class LocationServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\Content\\LocationList', $childLocations);
-        $this->assertInternalType('array', $childLocations->locations);
-        $this->assertInternalType('int', $childLocations->totalCount);
+        $this->assertIsArray($childLocations->locations);
+        $this->assertIsInt($childLocations->totalCount);
 
         return $childLocations;
     }
@@ -1130,7 +1130,7 @@ class LocationServiceTest extends BaseTest
      */
     public function testLoadLocationChildrenDataWithOffsetAndLimit(LocationList $locations)
     {
-        $this->assertEquals(2, count($locations->locations));
+        $this->assertCount(2, $locations->locations);
         $this->assertEquals(5, $locations->totalCount);
 
         foreach ($locations->locations as $location) {

--- a/eZ/Publish/API/Repository/Tests/NotificationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/NotificationServiceTest.php
@@ -33,8 +33,8 @@ class NotificationServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(NotificationList::class, $notificationList);
-        $this->assertInternalType('array', $notificationList->items);
-        $this->assertInternalType('int', $notificationList->totalCount);
+        $this->assertIsArray($notificationList->items);
+        $this->assertIsInt($notificationList->totalCount);
         $this->assertEquals(5, $notificationList->totalCount);
     }
 

--- a/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
@@ -397,7 +397,7 @@ class ObjectStateServiceTest extends BaseTest
         $loadedObjectStateGroups = $objectStateService->loadObjectStateGroups();
         /* END: Use Case */
 
-        $this->assertInternalType('array', $loadedObjectStateGroups);
+        $this->assertIsArray($loadedObjectStateGroups);
 
         $this->assertObjectsLoadedByIdentifiers(
             $expectedGroupIdentifiers,
@@ -502,7 +502,7 @@ class ObjectStateServiceTest extends BaseTest
         $loadedObjectStateGroups = $objectStateService->loadObjectStateGroups(2);
         /* END: Use Case */
 
-        $this->assertInternalType('array', $loadedObjectStateGroups);
+        $this->assertIsArray($loadedObjectStateGroups);
 
         $this->assertObjectsLoadedByIdentifiers(
             array_slice($existingGroupIdentifiers, 2),
@@ -551,7 +551,7 @@ class ObjectStateServiceTest extends BaseTest
         $loadedObjectStateGroups = $objectStateService->loadObjectStateGroups(1, 2);
         /* END: Use Case */
 
-        $this->assertInternalType('array', $loadedObjectStateGroups);
+        $this->assertIsArray($loadedObjectStateGroups);
 
         $this->assertObjectsLoadedByIdentifiers(
             array_slice($existingGroupIdentifiers, 1, 2),
@@ -585,9 +585,7 @@ class ObjectStateServiceTest extends BaseTest
         $loadedObjectStates = $objectStateService->loadObjectStates($objectStateGroup);
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedObjectStates
+        $this->assertIsArray($loadedObjectStates
         );
         $this->assertObjectsLoadedByIdentifiers(
             array('not_locked' => true, 'locked' => true),

--- a/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
+++ b/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
@@ -246,9 +246,7 @@ class PermissionResolverTest extends BaseTest
         $permissionSets = $permissionResolver->hasAccess('content', 'read');
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $permissionSets
+        $this->assertIsArray($permissionSets
         );
         $this->assertNotEmpty($permissionSets);
     }

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP21069Test.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP21069Test.php
@@ -102,7 +102,7 @@ class EZP21069Test extends BaseTest
         $results = $this->getRepository()->getSearchService()->findContent($query);
 
         $this->assertEquals(1, $results->totalCount);
-        $this->assertEquals(1, count($results->searchHits));
+        $this->assertCount(1, $results->searchHits);
     }
 
     public function testSearchOnDraftAttributeContentGivesNoResult()

--- a/eZ/Publish/API/Repository/Tests/RepositoryTest.php
+++ b/eZ/Publish/API/Repository/Tests/RepositoryTest.php
@@ -545,9 +545,7 @@ class RepositoryTest extends BaseTest
         $permissionSets = $repository->hasAccess('content', 'read');
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $permissionSets
+        $this->assertIsArray($permissionSets
         );
         $this->assertNotEmpty($permissionSets);
     }

--- a/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
@@ -937,7 +937,7 @@ class RoleServiceTest extends BaseTest
         $roleService->deleteRole($role);
         /* END: Use Case */
 
-        $this->assertEquals(5, count($roleService->loadRoles()));
+        $this->assertCount(5, $roleService->loadRoles());
     }
 
     /**
@@ -1913,7 +1913,7 @@ class RoleServiceTest extends BaseTest
 
         /* END: Use Case */
 
-        $this->assertEquals(2, count($roleAssignments));
+        $this->assertCount(2, $roleAssignments);
         $this->assertInstanceOf(
             '\\eZ\\Publish\\API\\Repository\\Values\\User\\UserGroupRoleAssignment',
             $roleAssignments[0]
@@ -2003,7 +2003,7 @@ class RoleServiceTest extends BaseTest
         /* END: Use Case */
 
         // Members + Partners + Anonymous + Example User
-        $this->assertEquals(4, count($roleAssignments));
+        $this->assertCount(4, $roleAssignments);
 
         // Get the role limitation
         $roleLimitation = null;
@@ -2042,7 +2042,7 @@ class RoleServiceTest extends BaseTest
         $roleAssignments = $roleService->getRoleAssignments($role);
 
         // Members + Partners + Anonymous + Example User
-        $this->assertEquals(5, count($roleAssignments));
+        $this->assertCount(5, $roleAssignments);
 
         // Get the role limitation
         $roleLimitations = [];
@@ -2236,7 +2236,7 @@ class RoleServiceTest extends BaseTest
         /* END: Use Case */
 
         // Members + Editors + Partners
-        $this->assertEquals(3, count($roleAssignments));
+        $this->assertCount(3, $roleAssignments);
     }
 
     /**
@@ -2337,7 +2337,7 @@ class RoleServiceTest extends BaseTest
         $roleAssignments = $roleService->getRoleAssignmentsForUser($adminUser);
         /* END: Use Case */
 
-        $this->assertEquals(0, count($roleAssignments));
+        $this->assertCount(0, $roleAssignments);
     }
 
     /**
@@ -2359,7 +2359,7 @@ class RoleServiceTest extends BaseTest
         $roleAssignments = $roleService->getRoleAssignmentsForUser($adminUser, true);
         /* END: Use Case */
 
-        $this->assertEquals(1, count($roleAssignments));
+        $this->assertCount(1, $roleAssignments);
         $this->assertInstanceOf(
             '\\eZ\\Publish\\API\\Repository\\Values\\User\\UserGroupRoleAssignment',
             reset($roleAssignments)
@@ -2391,7 +2391,7 @@ class RoleServiceTest extends BaseTest
         /* END: Use Case */
 
         // Administrator + Example Group
-        $this->assertEquals(2, count($roleAssignments));
+        $this->assertCount(2, $roleAssignments);
     }
 
     /**
@@ -2421,7 +2421,7 @@ class RoleServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertEmpty($initRoleAssignments);
-        $this->assertEquals(1, count($updatedRoleAssignments));
+        $this->assertCount(1, $updatedRoleAssignments);
     }
 
     /**
@@ -2457,7 +2457,7 @@ class RoleServiceTest extends BaseTest
         /* END: Use Case */
 
         // Members + Partners + Anonymous + Example Group
-        $this->assertEquals(4, count($roleAssignments));
+        $this->assertCount(4, $roleAssignments);
 
         // Get the role limitation
         $roleLimitation = null;
@@ -2492,7 +2492,7 @@ class RoleServiceTest extends BaseTest
         $roleAssignments = $roleService->getRoleAssignments($role);
 
         // Members + Partners + Anonymous + Example User
-        $this->assertEquals(5, count($roleAssignments));
+        $this->assertCount(5, $roleAssignments);
 
         // Get the role limitation
         $roleLimitations = [];
@@ -2695,7 +2695,7 @@ class RoleServiceTest extends BaseTest
         /* END: Use Case */
 
         // Members + Editors + Partners
-        $this->assertEquals(3, count($roleAssignments));
+        $this->assertCount(3, $roleAssignments);
     }
 
     /**
@@ -2843,7 +2843,7 @@ class RoleServiceTest extends BaseTest
         $roleAssignments = $roleService->getRoleAssignmentsForUserGroup($userGroup);
         /* END: Use Case */
 
-        $this->assertEquals(1, count($roleAssignments));
+        $this->assertCount(1, $roleAssignments);
         $this->assertInstanceOf(
             '\\eZ\\Publish\\API\\Repository\\Values\\User\\UserGroupRoleAssignment',
             reset($roleAssignments)

--- a/eZ/Publish/API/Repository/Tests/SectionServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceTest.php
@@ -369,7 +369,7 @@ class SectionServiceTest extends BaseTest
         }
         /* END: Use Case */
 
-        $this->assertEquals(6, count($sections));
+        $this->assertCount(6, $sections);
     }
 
     /**
@@ -719,7 +719,7 @@ class SectionServiceTest extends BaseTest
         $sectionService->deleteSection($section);
         /* END: Use Case */
 
-        $this->assertEquals(6, count($sectionService->loadSections()));
+        $this->assertCount(6, $sectionService->loadSections());
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
@@ -571,13 +571,11 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listLocationAliases($location);
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
+        $this->assertIsArray($loadedAliases
         );
 
         // Only 1 non-history alias
-        $this->assertEquals(1, count($loadedAliases));
+        $this->assertCount(1, $loadedAliases);
 
         return array($loadedAliases, $location);
     }
@@ -628,11 +626,9 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listLocationAliases($location, false, 'eng-US');
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
+        $this->assertIsArray($loadedAliases
         );
-        $this->assertEquals(1, count($loadedAliases));
+        $this->assertCount(1, $loadedAliases);
     }
 
     /**
@@ -659,11 +655,9 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listLocationAliases($location, true, 'eng-US');
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
+        $this->assertIsArray($loadedAliases
         );
-        $this->assertEquals(1, count($loadedAliases));
+        $this->assertCount(1, $loadedAliases);
     }
 
     /**
@@ -685,11 +679,9 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listGlobalAliases();
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
+        $this->assertIsArray($loadedAliases
         );
-        $this->assertEquals(3, count($loadedAliases));
+        $this->assertCount(3, $loadedAliases);
     }
 
     /**
@@ -738,11 +730,9 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listGlobalAliases('eng-US');
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
+        $this->assertIsArray($loadedAliases
         );
-        $this->assertEquals(2, count($loadedAliases));
+        $this->assertCount(2, $loadedAliases);
     }
 
     /**
@@ -764,11 +754,9 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listGlobalAliases(null, 1);
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
+        $this->assertIsArray($loadedAliases
         );
-        $this->assertEquals(2, count($loadedAliases));
+        $this->assertCount(2, $loadedAliases);
     }
 
     /**
@@ -790,11 +778,9 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listGlobalAliases(null, 0, 1);
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
+        $this->assertIsArray($loadedAliases
         );
-        $this->assertEquals(1, count($loadedAliases));
+        $this->assertCount(1, $loadedAliases);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/UserPreferenceServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserPreferenceServiceTest.php
@@ -32,8 +32,8 @@ class UserPreferenceServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(UserPreferenceList::class, $userPreferenceList);
-        $this->assertInternalType('array', $userPreferenceList->items);
-        $this->assertInternalType('int', $userPreferenceList->totalCount);
+        $this->assertIsArray($userPreferenceList->items);
+        $this->assertIsInt($userPreferenceList->totalCount);
         $this->assertEquals(5, $userPreferenceList->totalCount);
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/AuthorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/AuthorTest.php
@@ -507,7 +507,7 @@ class AuthorTest extends FieldTypeTest
         $value = new AuthorValue();
         $value->authors[] = $this->authors[0];
         self::assertSame(1, $this->authors[0]->id);
-        self::assertSame(1, count($value->authors));
+        self::assertCount(1, $value->authors);
 
         $this->authors[1]->id = 10;
         $value->authors[] = $this->authors[1];
@@ -516,7 +516,7 @@ class AuthorTest extends FieldTypeTest
         $this->authors[2]->id = -1;
         $value->authors[] = $this->authors[2];
         self::assertSame($this->authors[1]->id + 1, $this->authors[2]->id);
-        self::assertSame(3, count($value->authors));
+        self::assertCount(3, $value->authors);
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Tests/FieldTypeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FieldTypeTest.php
@@ -730,9 +730,7 @@ abstract class FieldTypeTest extends TestCase
 
         $validationResult = $fieldType->validateFieldSettings($inputSettings);
 
-        $this->assertInternalType(
-            'array',
-            $validationResult,
+        $this->assertIsArray($validationResult,
             'The method validateFieldSettings() must return an array.'
         );
         $this->assertEquals(
@@ -753,9 +751,7 @@ abstract class FieldTypeTest extends TestCase
 
         $validationResult = $fieldType->validateFieldSettings($inputSettings);
 
-        $this->assertInternalType(
-            'array',
-            $validationResult,
+        $this->assertIsArray($validationResult,
             'The method validateFieldSettings() must return an array.'
         );
 
@@ -785,9 +781,7 @@ abstract class FieldTypeTest extends TestCase
 
         $validationResult = $fieldType->validateValidatorConfiguration($inputConfiguration);
 
-        $this->assertInternalType(
-            'array',
-            $validationResult,
+        $this->assertIsArray($validationResult,
             'The method validateValidatorConfiguration() must return an array.'
         );
         $this->assertEquals(
@@ -808,9 +802,7 @@ abstract class FieldTypeTest extends TestCase
 
         $validationResult = $fieldType->validateValidatorConfiguration($inputConfiguration);
 
-        $this->assertInternalType(
-            'array',
-            $validationResult,
+        $this->assertIsArray($validationResult,
             'The method validateValidatorConfiguration() must return an array.'
         );
 
@@ -933,7 +925,7 @@ abstract class FieldTypeTest extends TestCase
     {
         $validationErrors = $this->doValidate($fieldDefinitionData, $value);
 
-        $this->assertInternalType('array', $validationErrors);
+        $this->assertIsArray($validationErrors);
         $this->assertEmpty($validationErrors, "Got value:\n" . var_export($validationErrors, true));
     }
 
@@ -944,7 +936,7 @@ abstract class FieldTypeTest extends TestCase
     {
         $validationErrors = $this->doValidate($fieldDefinitionData, $value);
 
-        $this->assertInternalType('array', $validationErrors);
+        $this->assertIsArray($validationErrors);
         $this->assertEquals($errors, $validationErrors);
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
@@ -293,7 +293,7 @@ class ImageAssetTest extends FieldTypeTest
 
         $validationErrors = $this->doValidate([], new ImageAsset\Value($destinationContentId));
 
-        $this->assertInternalType('array', $validationErrors);
+        $this->assertIsArray($validationErrors);
         $this->assertEquals([
             new ValidationError(
                 'Content %type% is not a valid asset target',
@@ -338,7 +338,7 @@ class ImageAssetTest extends FieldTypeTest
 
         $validationErrors = $this->doValidate([], new ImageAsset\Value($destinationContentId));
 
-        $this->assertInternalType('array', $validationErrors);
+        $this->assertIsArray($validationErrors);
         $this->assertEmpty($validationErrors, "Got value:\n" . var_export($validationErrors, true));
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/RichTextTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichTextTest.php
@@ -268,7 +268,7 @@ class RichTextTest extends TestCase
         $fieldType = $this->getFieldType();
         $fieldValue = $fieldType->toPersistenceValue($fieldType->acceptValue($xmlString));
 
-        self::assertInternalType('string', $fieldValue->data);
+        self::assertIsString($fieldValue->data);
         self::assertSame($xmlString, $fieldValue->data);
     }
 

--- a/eZ/Publish/Core/IO/Tests/IOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOServiceTest.php
@@ -107,7 +107,7 @@ class IOServiceTest extends TestCase
 
         self::assertInstanceOf(BinaryFileCreateStruct::class, $binaryCreateStruct);
         self::assertNull($binaryCreateStruct->id);
-        self::assertTrue(is_resource($binaryCreateStruct->inputStream));
+        self::assertIsResource($binaryCreateStruct->inputStream);
         self::assertEquals(filesize(__FILE__), $binaryCreateStruct->size);
         self::assertEquals('text/x-php', $binaryCreateStruct->mimeType);
 

--- a/eZ/Publish/Core/Limitation/Tests/BlockingLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/BlockingLimitationTypeTest.php
@@ -145,7 +145,7 @@ class BlockingLimitationTypeTest extends Base
         $value = $limitationType->buildValue($expected);
 
         self::assertInstanceOf(BlockingLimitation::class, $value);
-        self::assertInternalType('array', $value->limitationValues);
+        self::assertIsArray($value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
 
@@ -279,8 +279,8 @@ class BlockingLimitationTypeTest extends Base
         );
 
         self::assertInstanceOf(MatchNone::class, $criterion);
-        self::assertInternalType('null', $criterion->value);
-        self::assertInternalType('null', $criterion->operator);
+        self::assertNull($criterion->value);
+        self::assertNull($criterion->operator);
     }
 
     /**

--- a/eZ/Publish/Core/Limitation/Tests/ContentTypeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ContentTypeLimitationTypeTest.php
@@ -206,7 +206,7 @@ class ContentTypeLimitationTypeTest extends Base
         $value = $limitationType->buildValue($expected);
 
         self::assertInstanceOf(ContentTypeLimitation::class, $value);
-        self::assertInternalType('array', $value->limitationValues);
+        self::assertIsArray($value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
 
@@ -332,7 +332,7 @@ class ContentTypeLimitationTypeTest extends Base
             $targets
         );
 
-        self::assertInternalType('boolean', $value);
+        self::assertIsBool($value);
         self::assertEquals($expected, $value);
     }
 
@@ -417,8 +417,8 @@ class ContentTypeLimitationTypeTest extends Base
         );
 
         self::assertInstanceOf(ContentTypeId::class, $criterion);
-        self::assertInternalType('array', $criterion->value);
-        self::assertInternalType('string', $criterion->operator);
+        self::assertIsArray($criterion->value);
+        self::assertIsString($criterion->operator);
         self::assertEquals(Operator::EQ, $criterion->operator);
         self::assertEquals(array(9), $criterion->value);
     }
@@ -436,8 +436,8 @@ class ContentTypeLimitationTypeTest extends Base
         );
 
         self::assertInstanceOf(ContentTypeId::class, $criterion);
-        self::assertInternalType('array', $criterion->value);
-        self::assertInternalType('string', $criterion->operator);
+        self::assertIsArray($criterion->value);
+        self::assertIsString($criterion->operator);
         self::assertEquals(Operator::IN, $criterion->operator);
         self::assertEquals(array(9, 55), $criterion->value);
     }

--- a/eZ/Publish/Core/Limitation/Tests/LocationLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/LocationLimitationTypeTest.php
@@ -206,7 +206,7 @@ class LocationLimitationTypeTest extends Base
         $value = $limitationType->buildValue($expected);
 
         self::assertInstanceOf(LocationLimitation::class, $value);
-        self::assertInternalType('array', $value->limitationValues);
+        self::assertIsArray($value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
 
@@ -379,7 +379,7 @@ class LocationLimitationTypeTest extends Base
             $targets
         );
 
-        self::assertInternalType('boolean', $value);
+        self::assertIsBool($value);
         self::assertEquals($expected, $value);
     }
 
@@ -481,8 +481,8 @@ class LocationLimitationTypeTest extends Base
         );
 
         self::assertInstanceOf(LocationId::class, $criterion);
-        self::assertInternalType('array', $criterion->value);
-        self::assertInternalType('string', $criterion->operator);
+        self::assertIsArray($criterion->value);
+        self::assertIsString($criterion->operator);
         self::assertEquals(Operator::EQ, $criterion->operator);
         self::assertEquals(array(9), $criterion->value);
     }
@@ -500,8 +500,8 @@ class LocationLimitationTypeTest extends Base
         );
 
         self::assertInstanceOf(LocationId::class, $criterion);
-        self::assertInternalType('array', $criterion->value);
-        self::assertInternalType('string', $criterion->operator);
+        self::assertIsArray($criterion->value);
+        self::assertIsString($criterion->operator);
         self::assertEquals(Operator::IN, $criterion->operator);
         self::assertEquals(array(9, 55), $criterion->value);
     }

--- a/eZ/Publish/Core/Limitation/Tests/NewObjectStateLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/NewObjectStateLimitationTypeTest.php
@@ -203,7 +203,7 @@ class NewObjectStateLimitationTypeTest extends Base
         $value = $limitationType->buildValue($expected);
 
         self::assertInstanceOf(NewObjectStateLimitation::class, $value);
-        self::assertInternalType('array', $value->limitationValues);
+        self::assertIsArray($value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
 
@@ -287,7 +287,7 @@ class NewObjectStateLimitationTypeTest extends Base
             $targets
         );
 
-        self::assertInternalType('boolean', $value);
+        self::assertIsBool($value);
         self::assertEquals($expected, $value);
     }
 

--- a/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
@@ -209,7 +209,7 @@ class ObjectStateLimitationTypeTest extends Base
             $object
         );
 
-        self::assertInternalType('boolean', $value);
+        self::assertIsBool($value);
         self::assertEquals($expected, $value);
     }
 
@@ -241,8 +241,8 @@ class ObjectStateLimitationTypeTest extends Base
         );
 
         self::assertInstanceOf(ObjectStateId::class, $criterion);
-        self::assertInternalType('array', $criterion->value);
-        self::assertInternalType('string', $criterion->operator);
+        self::assertIsArray($criterion->value);
+        self::assertIsString($criterion->operator);
         self::assertEquals(Operator::EQ, $criterion->operator);
         self::assertEquals([2], $criterion->value);
     }
@@ -270,8 +270,8 @@ class ObjectStateLimitationTypeTest extends Base
         );
 
         self::assertInstanceOf(ObjectStateId::class, $criterion);
-        self::assertInternalType('array', $criterion->value);
-        self::assertInternalType('string', $criterion->operator);
+        self::assertIsArray($criterion->value);
+        self::assertIsString($criterion->operator);
         self::assertEquals(Operator::IN, $criterion->operator);
         self::assertEquals([1, 2], $criterion->value);
     }
@@ -299,15 +299,15 @@ class ObjectStateLimitationTypeTest extends Base
         );
 
         self::assertInstanceOf(LogicalAnd::class, $criterion);
-        self::assertInternalType('array', $criterion->criteria);
+        self::assertIsArray($criterion->criteria);
 
-        self::assertInternalType('array', $criterion->criteria[0]->value);
-        self::assertInternalType('string', $criterion->criteria[0]->operator);
+        self::assertIsArray($criterion->criteria[0]->value);
+        self::assertIsString($criterion->criteria[0]->operator);
         self::assertEquals(Operator::IN, $criterion->criteria[0]->operator);
         self::assertEquals([1, 2], $criterion->criteria[0]->value);
 
-        self::assertInternalType('array', $criterion->criteria[1]->value);
-        self::assertInternalType('string', $criterion->criteria[1]->operator);
+        self::assertIsArray($criterion->criteria[1]->value);
+        self::assertIsString($criterion->criteria[1]->operator);
         self::assertEquals(Operator::IN, $criterion->criteria[1]->operator);
         self::assertEquals([3], $criterion->criteria[1]->value);
     }

--- a/eZ/Publish/Core/Limitation/Tests/ParentContentTypeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ParentContentTypeLimitationTypeTest.php
@@ -223,7 +223,7 @@ class ParentContentTypeLimitationTypeTest extends Base
         $value = $limitationType->buildValue($expected);
 
         self::assertInstanceOf(ParentContentTypeLimitation::class, $value);
-        self::assertInternalType('array', $value->limitationValues);
+        self::assertIsArray($value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
 
@@ -568,7 +568,7 @@ class ParentContentTypeLimitationTypeTest extends Base
             $targets
         );
 
-        self::assertInternalType('boolean', $value);
+        self::assertIsBool($value);
         self::assertEquals($expected, $value);
     }
 

--- a/eZ/Publish/Core/Limitation/Tests/ParentDepthLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ParentDepthLimitationTypeTest.php
@@ -144,7 +144,7 @@ class ParentDepthLimitationTypeTest extends Base
            ParentDepthLimitation::class,
             $value
         );
-        self::assertInternalType('array', $value->limitationValues);
+        self::assertIsArray($value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
 
@@ -338,7 +338,7 @@ class ParentDepthLimitationTypeTest extends Base
             $targets
         );
 
-        self::assertInternalType('boolean', $value);
+        self::assertIsBool($value);
         self::assertEquals($expected, $value);
     }
 

--- a/eZ/Publish/Core/Limitation/Tests/SectionLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SectionLimitationTypeTest.php
@@ -216,7 +216,7 @@ class SectionLimitationTypeTest extends Base
         $value = $limitationType->buildValue($expected);
 
         self::assertInstanceOf(SectionLimitation::class, $value);
-        self::assertInternalType('array', $value->limitationValues);
+        self::assertIsArray($value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
 
@@ -453,8 +453,8 @@ class SectionLimitationTypeTest extends Base
         );
 
         self::assertInstanceOf(SectionId::class, $criterion);
-        self::assertInternalType('array', $criterion->value);
-        self::assertInternalType('string', $criterion->operator);
+        self::assertIsArray($criterion->value);
+        self::assertIsString($criterion->operator);
         self::assertEquals(Operator::EQ, $criterion->operator);
         self::assertEquals(array('9'), $criterion->value);
     }
@@ -472,8 +472,8 @@ class SectionLimitationTypeTest extends Base
         );
 
         self::assertInstanceOf(SectionId::class, $criterion);
-        self::assertInternalType('array', $criterion->value);
-        self::assertInternalType('string', $criterion->operator);
+        self::assertIsArray($criterion->value);
+        self::assertIsString($criterion->operator);
         self::assertEquals(Operator::IN, $criterion->operator);
         self::assertEquals(array('9', '55'), $criterion->value);
     }

--- a/eZ/Publish/Core/Limitation/Tests/SiteAccessLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SiteAccessLimitationTypeTest.php
@@ -168,7 +168,7 @@ class SiteAccessLimitationTypeTest extends Base
         $value = $limitationType->buildValue($expected);
 
         self::assertInstanceOf('\eZ\Publish\API\Repository\Values\User\Limitation\SiteAccessLimitation', $value);
-        self::assertInternalType('array', $value->limitationValues);
+        self::assertIsArray($value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
 
@@ -218,7 +218,7 @@ class SiteAccessLimitationTypeTest extends Base
             $object
         );
 
-        self::assertInternalType('boolean', $value);
+        self::assertIsBool($value);
         self::assertEquals($expected, $value);
     }
 

--- a/eZ/Publish/Core/Limitation/Tests/StatusLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/StatusLimitationTypeTest.php
@@ -170,7 +170,7 @@ class StatusLimitationTypeTest extends Base
         $value = $limitationType->buildValue($expected);
 
         self::assertInstanceOf(StatusLimitation::class, $value);
-        self::assertInternalType('array', $value->limitationValues);
+        self::assertIsArray($value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
 
@@ -278,7 +278,7 @@ class StatusLimitationTypeTest extends Base
             $object
         );
 
-        self::assertInternalType('boolean', $value);
+        self::assertIsBool($value);
         self::assertEquals($expected, $value);
     }
 

--- a/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
@@ -248,7 +248,7 @@ class SubtreeLimitationTypeTest extends Base
         $value = $limitationType->buildValue($expected);
 
         self::assertInstanceOf(SubtreeLimitation::class, $value);
-        self::assertInternalType('array', $value->limitationValues);
+        self::assertIsArray($value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
 
@@ -539,8 +539,8 @@ class SubtreeLimitationTypeTest extends Base
         // Assert that $criterion is instance of API type (for Solr/ES), and internal type(optimization for SQL engines)
         self::assertInstanceOf(Subtree::class, $criterion);
         self::assertInstanceOf(PermissionSubtree::class, $criterion);
-        self::assertInternalType('array', $criterion->value);
-        self::assertInternalType('string', $criterion->operator);
+        self::assertIsArray($criterion->value);
+        self::assertIsString($criterion->operator);
         self::assertEquals(Operator::EQ, $criterion->operator);
         self::assertEquals(array('/1/9/'), $criterion->value);
     }
@@ -560,8 +560,8 @@ class SubtreeLimitationTypeTest extends Base
         // Assert that $criterion is instance of API type (for Solr/ES), and internal type(optimization for SQL engines)
         self::assertInstanceOf(Subtree::class, $criterion);
         self::assertInstanceOf(PermissionSubtree::class, $criterion);
-        self::assertInternalType('array', $criterion->value);
-        self::assertInternalType('string', $criterion->operator);
+        self::assertIsArray($criterion->value);
+        self::assertIsString($criterion->operator);
         self::assertEquals(Operator::IN, $criterion->operator);
         self::assertEquals(array('/1/9/', '/1/55/'), $criterion->value);
     }

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/MultipleValuedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/MultipleValuedTest.php
@@ -23,7 +23,7 @@ class MultipleValuedTest extends BaseTest
         $matcher = $this->getMultipleValuedMatcherMock();
         $matcher->setMatchingConfig($matchingConfig);
         $values = $matcher->getValues();
-        $this->assertInternalType('array', $values);
+        $this->assertIsArray($values);
 
         $matchingConfig = is_array($matchingConfig) ? $matchingConfig : array($matchingConfig);
         foreach ($matchingConfig as $val) {

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundAndTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundAndTest.php
@@ -85,7 +85,7 @@ class CompoundAndTest extends TestCase
         $compoundMatcher->setRequest($this->createMock(SimplifiedRequest::class));
         $compoundMatcher->setMatcherBuilder($this->matcherBuilder);
         $matchers = $compoundMatcher->getSubMatchers();
-        $this->assertInternalType('array', $matchers);
+        $this->assertIsArray($matchers);
         foreach ($matchers as $matcher) {
             $this->assertInstanceOf(Matcher::class, $matcher);
         }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundOrTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundOrTest.php
@@ -77,7 +77,7 @@ class CompoundOrTest extends TestCase
         $compoundMatcher->setRequest($this->createMock(SimplifiedRequest::class));
         $compoundMatcher->setMatcherBuilder($this->matcherBuilder);
         $matchers = $compoundMatcher->getSubMatchers();
-        $this->assertInternalType('array', $matchers);
+        $this->assertIsArray($matchers);
         foreach ($matchers as $matcher) {
             $this->assertInstanceOf(Matcher::class, $matcher);
         }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterTest.php
@@ -99,7 +99,7 @@ class RouterTest extends TestCase
         $this->assertSame($siteAccess, $sa->name);
         // SiteAccess must be serializable as a whole
         // See https://jira.ez.no/browse/EZP-21613
-        $this->assertInternalType('string', serialize($sa));
+        $this->assertIsString(serialize($sa));
         $router->setSiteAccess();
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
@@ -88,7 +88,7 @@ abstract class FileSystemTwigIntegrationTestCase extends IntegrationTestCase
                 $output = trim($template->render(eval($match[1] . ';')), "\n ");
             } catch (Exception $e) {
                 if (false !== $exception) {
-                    $this->assertContains(
+                    $this->assertStringContainsString(
                         trim($exception),
                         trim(
                             sprintf('%s: %s', get_class($e), $e->getMessage())

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
@@ -227,9 +227,9 @@ class ContentHandlerTest extends TestCase
             $res->versionInfo->id,
             'Version ID not set correctly'
         );
-        $this->assertEquals(
+        $this->assertCount(
             2,
-            count($res->fields),
+            $res->fields,
             'Fields not set correctly in version'
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
@@ -110,31 +110,6 @@ class ContentHandlerTest extends TestCase
     protected $contentTypeHandlerMock;
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Handler::__construct
-     */
-    public function testCtor()
-    {
-        $handler = $this->getContentHandler();
-
-        $this->assertAttributeSame(
-            $this->getGatewayMock(),
-            'contentGateway',
-            $handler
-        );
-        $this->assertAttributeSame(
-            $this->getMapperMock(),
-            'mapper',
-            $handler
-        );
-        $this->assertAttributeSame(
-            $this->getFieldHandlerMock(),
-            'fieldHandler',
-            $handler
-        );
-        // @todo Assert missing properties
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Handler::create
      *
      * @todo Current method way to complex to test, refactor!

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/AuthorTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/AuthorTest.php
@@ -109,7 +109,7 @@ EOT;
         $fieldValue = new FieldValue();
 
         $this->converter->toFieldValue($storageFieldValue, $fieldValue);
-        self::assertInternalType('array', $fieldValue->data);
+        self::assertIsArray($fieldValue->data);
 
         $authorsXml = $doc->getElementsByTagName('author');
         self::assertSame($authorsXml->length, count($fieldValue->data));

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateAndTimeTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateAndTimeTest.php
@@ -257,7 +257,7 @@ class DateAndTimeTest extends TestCase
         sleep(1);
         $dateTimeFromString = new DateTime($fieldDef->defaultValue->data['timestring']);
 
-        self::assertInternalType('array', $fieldDef->defaultValue->data);
+        self::assertIsArray($fieldDef->defaultValue->data);
         self::assertCount(3, $fieldDef->defaultValue->data);
         self::assertNull($fieldDef->defaultValue->data['rfc850']);
         self::assertGreaterThanOrEqual($time, $fieldDef->defaultValue->data['timestamp']);
@@ -288,7 +288,7 @@ class DateAndTimeTest extends TestCase
         $this->converter->toFieldDefinition($storageDef, $fieldDef);
         $dateTimeFromString = new DateTime($fieldDef->defaultValue->data['timestring']);
 
-        self::assertInternalType('array', $fieldDef->defaultValue->data);
+        self::assertIsArray($fieldDef->defaultValue->data);
         self::assertCount(3, $fieldDef->defaultValue->data);
         self::assertNull($fieldDef->defaultValue->data['rfc850']);
         self::assertGreaterThanOrEqual($timestamp, $fieldDef->defaultValue->data['timestamp']);
@@ -324,7 +324,7 @@ class DateAndTimeTest extends TestCase
         $this->converter->toFieldDefinition($storageDef, $fieldDef);
         $dateTimeFromString = new DateTime($fieldDef->defaultValue->data['timestring']);
 
-        self::assertInternalType('array', $fieldDef->defaultValue->data);
+        self::assertIsArray($fieldDef->defaultValue->data);
         self::assertCount(3, $fieldDef->defaultValue->data);
         self::assertNull($fieldDef->defaultValue->data['rfc850']);
         self::assertGreaterThanOrEqual($timestamp, $fieldDef->defaultValue->data['timestamp']);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateAndTimeTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateAndTimeTest.php
@@ -261,7 +261,7 @@ class DateAndTimeTest extends TestCase
         self::assertCount(3, $fieldDef->defaultValue->data);
         self::assertNull($fieldDef->defaultValue->data['rfc850']);
         self::assertGreaterThanOrEqual($time, $fieldDef->defaultValue->data['timestamp']);
-        self::assertEquals($time + 1, $dateTimeFromString->getTimestamp(), 'Time does not match within 1s delta', 1);
+        self::assertEqualsWithDelta($time + 1, $dateTimeFromString->getTimestamp(), 1, 'Time does not match within 1s delta');
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateTest.php
@@ -166,7 +166,7 @@ class DateTest extends TestCase
         );
 
         $this->converter->toFieldDefinition($storageDef, $fieldDef);
-        self::assertInternalType('array', $fieldDef->defaultValue->data);
+        self::assertIsArray($fieldDef->defaultValue->data);
         self::assertCount(3, $fieldDef->defaultValue->data);
         self::assertNull($fieldDef->defaultValue->data['rfc850']);
         self::assertSame($timestamp, $fieldDef->defaultValue->data['timestamp']);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/UrlTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/UrlTest.php
@@ -66,7 +66,7 @@ class UrlTest extends TestCase
         $fieldValue = new FieldValue();
 
         $this->converter->toFieldValue($storageFieldValue, $fieldValue);
-        self::assertInternalType('array', $fieldValue->data);
+        self::assertIsArray($fieldValue->data);
         self::assertFalse($fieldValue->sortKey);
         self::assertSame($text, $fieldValue->data['text']);
         self::assertEquals($urlId, $fieldValue->data['urlId']);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValueConverterRegistryTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValueConverterRegistryTest.php
@@ -17,21 +17,17 @@ use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
  */
 class FieldValueConverterRegistryTest extends TestCase
 {
+    private const TYPE_NAME = 'some-type';
+
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry::register
      */
     public function testRegister()
     {
         $converter = $this->getFieldValueConverterMock();
-        $registry = new Registry(array('some-type' => $converter));
+        $registry = new Registry(array(self::TYPE_NAME => $converter));
 
-        $this->assertAttributeSame(
-            array(
-                'some-type' => $converter,
-            ),
-            'converterMap',
-            $registry
-        );
+        $this->assertSame($converter, $registry->getConverter(self::TYPE_NAME));
     }
 
     /**
@@ -40,9 +36,9 @@ class FieldValueConverterRegistryTest extends TestCase
     public function testGetStorage()
     {
         $converter = $this->getFieldValueConverterMock();
-        $registry = new Registry(array('some-type' => $converter));
+        $registry = new Registry(array(self::TYPE_NAME => $converter));
 
-        $res = $registry->getConverter('some-type');
+        $res = $registry->getConverter(self::TYPE_NAME);
 
         $this->assertSame(
             $converter,

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Gateway/DoctrineDatabaseTest.php
@@ -34,21 +34,6 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
     protected $databaseGateway;
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Gateway\DoctrineDatabase::__construct
-     */
-    public function testCtor()
-    {
-        $handlerMock = $this->getDatabaseHandler();
-        $gateway = $this->getDatabaseGateway();
-
-        $this->assertAttributeSame(
-            $handlerMock,
-            'dbHandler',
-            $gateway
-        );
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Gateway\DoctrineDatabase::insertContentObject
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Gateway\DoctrineDatabase::generateLanguageMask
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Gateway/DoctrineDatabaseTest.php
@@ -654,15 +654,15 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $gateway = $this->getDatabaseGateway();
         $res = $gateway->listVersions(226);
 
-        $this->assertEquals(
+        $this->assertCount(
             2,
-            count($res)
+            $res
         );
 
         foreach ($res as $row) {
-            $this->assertEquals(
+            $this->assertCount(
                 23,
-                count($row)
+                $row
             );
         }
 
@@ -712,15 +712,15 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $gateway = $this->getDatabaseGateway();
         $res = $gateway->listVersionsForUser(14);
 
-        $this->assertEquals(
+        $this->assertCount(
             2,
-            count($res)
+            $res
         );
 
         foreach ($res as $row) {
-            $this->assertEquals(
+            $this->assertCount(
                 23,
-                count($row)
+                $row
             );
         }
 
@@ -842,9 +842,9 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
             array('4'),
             $res
         );
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($res)
+            $res
         );
     }
 
@@ -861,9 +861,9 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $gateway = $this->getDatabaseGateway();
         $res = $gateway->load(226, 2, array('de-DE'));
 
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($res)
+            $res
         );
     }
 
@@ -1317,7 +1317,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
 
         $relations = $gateway->loadRelations(57);
 
-        $this->assertEquals(3, count($relations));
+        $this->assertCount(3, $relations);
 
         $this->assertValuesInRows(
             'ezcontentobject_link_to_contentobject_id',
@@ -1348,7 +1348,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
 
         $relations = $gateway->loadRelations(57, null, \eZ\Publish\API\Repository\Values\Content\Relation::COMMON);
 
-        $this->assertEquals(1, count($relations), 'Expecting one relation to be loaded');
+        $this->assertCount(1, $relations, 'Expecting one relation to be loaded');
 
         $this->assertValuesInRows(
             'ezcontentobject_link_relation_type',
@@ -1374,7 +1374,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
 
         $relations = $gateway->loadRelations(57, 1);
 
-        $this->assertEquals(1, count($relations), 'Expecting one relation to be loaded');
+        $this->assertCount(1, $relations, 'Expecting one relation to be loaded');
 
         $this->assertValuesInRows(
             'ezcontentobject_link_to_contentobject_id',
@@ -1394,7 +1394,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
 
         $relations = $gateway->loadRelations(57, 1, \eZ\Publish\API\Repository\Values\Content\Relation::EMBED);
 
-        $this->assertEquals(0, count($relations), 'Expecting no relation to be loaded');
+        $this->assertCount(0, $relations, 'Expecting no relation to be loaded');
     }
 
     /**
@@ -1408,7 +1408,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
 
         $relations = $gateway->loadReverseRelations(58);
 
-        self::assertEquals(2, count($relations));
+        self::assertCount(2, $relations);
 
         $this->assertValuesInRows(
             'ezcontentobject_link_from_contentobject_id',
@@ -1428,7 +1428,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
 
         $relations = $gateway->loadReverseRelations(58, \eZ\Publish\API\Repository\Values\Content\Relation::COMMON);
 
-        self::assertEquals(1, count($relations));
+        self::assertCount(1, $relations);
 
         $this->assertValuesInRows(
             'ezcontentobject_link_from_contentobject_id',

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/CachingLanguageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/CachingLanguageHandlerTest.php
@@ -44,34 +44,6 @@ class CachingLanguageHandlerTest extends TestCase
     protected $languageCacheMock;
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Language\CachingHandler::__construct
-     */
-    public function testCtorPropertyInnerHandler()
-    {
-        $handler = $this->getLanguageHandler();
-
-        $this->assertAttributeSame(
-            $this->getInnerLanguageHandlerMock(),
-            'innerHandler',
-            $handler
-        );
-    }
-
-    /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Language\CachingHandler::__construct
-     */
-    public function testCtorPropertyLanguageCache()
-    {
-        $handler = $this->getLanguageHandler();
-
-        $this->assertAttributeSame(
-            $this->getLanguageCacheMock(),
-            'cache',
-            $handler
-        );
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Language\CachingHandler::create
      */
     public function testCreate()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/CachingLanguageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/CachingLanguageHandlerTest.php
@@ -261,9 +261,7 @@ class CachingLanguageHandlerTest extends TestCase
 
         $result = $handler->loadAll();
 
-        $this->assertInternalType(
-            'array',
-            $result
+        $this->assertIsArray($result
         );
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/Gateway/DoctrineDatabaseTest.php
@@ -37,21 +37,6 @@ class DoctrineDatabaseTest extends TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\DoctrineDatabase::__construct
-     */
-    public function testCtor()
-    {
-        $handler = $this->getDatabaseHandler();
-        $gateway = $this->getDatabaseGateway();
-
-        $this->assertAttributeSame(
-            $handler,
-            'dbHandler',
-            $gateway
-        );
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\DoctrineDatabase::insertLanguage
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\DoctrineDatabase::setCommonLanguageColumns
      */

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/LanguageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/LanguageHandlerTest.php
@@ -239,9 +239,7 @@ class LanguageHandlerTest extends TestCase
 
         $result = $handler->loadAll();
 
-        $this->assertInternalType(
-            'array',
-            $result
+        $this->assertIsArray($result
         );
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTrashTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTrashTest.php
@@ -255,9 +255,9 @@ class DoctrineDatabaseTrashTest extends LanguageAwareTestCase
         $handler = $this->getLocationGateway();
         $this->trashSubtree();
 
-        $this->assertEquals(
+        $this->assertCount(
             8,
-            count($handler->listTrashed(0, null, array()))
+            $handler->listTrashed(0, null, array())
         );
     }
 
@@ -270,9 +270,9 @@ class DoctrineDatabaseTrashTest extends LanguageAwareTestCase
         $handler = $this->getLocationGateway();
         $this->trashSubtree();
 
-        $this->assertEquals(
+        $this->assertCount(
             5,
-            count($handler->listTrashed(0, 5, array()))
+            $handler->listTrashed(0, 5, array())
         );
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
@@ -118,7 +118,7 @@ class LocationHandlerTest extends TestCase
                 )
             );
 
-        $this->assertEquals(2, count($this->getLocationHandler()->loadSubtreeIds(77)));
+        $this->assertCount(2, $this->getLocationHandler()->loadSubtreeIds(77));
     }
 
     public function testLoadLocationByRemoteId()
@@ -170,7 +170,7 @@ class LocationHandlerTest extends TestCase
 
         $locations = $handler->loadLocationsByContent(23, 42);
 
-        $this->assertInternalType('array', $locations);
+        $this->assertIsArray($locations);
     }
 
     public function loadParentLocationsForDraftContent()
@@ -195,7 +195,7 @@ class LocationHandlerTest extends TestCase
 
         $locations = $handler->loadParentLocationsForDraftContent(23);
 
-        $this->assertInternalType('array', $locations);
+        $this->assertIsArray($locations);
     }
 
     public function testMoveSubtree()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/MapperTest.php
@@ -37,22 +37,6 @@ class MapperTest extends LanguageAwareTestCase
     protected $valueConverterRegistryMock;
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Mapper::__construct
-     */
-    public function testCtor()
-    {
-        $regMock = $this->getValueConverterRegistryMock();
-
-        $mapper = $this->getMapper();
-
-        $this->assertAttributeSame(
-            $regMock,
-            'converterRegistry',
-            $mapper
-        );
-    }
-
-    /**
      * Returns a eZ\Publish\SPI\Persistence\Content\CreateStruct fixture.
      *
      * @return \eZ\Publish\SPI\Persistence\Content\CreateStruct

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/MapperTest.php
@@ -247,9 +247,9 @@ class MapperTest extends LanguageAwareTestCase
         $mapper = new Mapper($reg, $this->getLanguageHandler());
         $result = $mapper->extractContentFromRows($rowsFixture, $nameRowsFixture);
 
-        $this->assertEquals(
+        $this->assertCount(
             2,
-            count($result)
+            $result
         );
 
         $this->assertEquals(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/Gateway/DoctrineDatabaseTest.php
@@ -49,21 +49,6 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway\DoctrineDatabase::__construct
-     */
-    public function testCtor()
-    {
-        $handler = $this->getDatabaseHandler();
-        $gateway = $this->getDatabaseGateway();
-
-        $this->assertAttributeSame(
-            $handler,
-            'dbHandler',
-            $gateway
-        );
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway\DoctrineDatabase::loadObjectStateData
      */
     public function testLoadObjectStateData()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Section/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Section/Gateway/DoctrineDatabaseTest.php
@@ -36,21 +36,6 @@ class DoctrineDatabaseTest extends TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway\DoctrineDatabase::__construct
-     */
-    public function testCtor()
-    {
-        $handler = $this->getDatabaseHandler();
-        $gateway = $this->getDatabaseGateway();
-
-        $this->assertAttributeSame(
-            $handler,
-            'dbHandler',
-            $gateway
-        );
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway\DoctrineDatabase::insertSection
      */
     public function testInsertSection()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageRegistryTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageRegistryTest.php
@@ -18,21 +18,17 @@ use eZ\Publish\Core\FieldType\NullStorage;
  */
 class StorageRegistryTest extends TestCase
 {
+    private const TYPE_NAME = 'some-type';
+
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry::register
      */
-    public function testRegister()
+    public function testRegister(): void
     {
         $storage = $this->getStorageMock();
-        $registry = new StorageRegistry(array('some-type' => $storage));
+        $registry = new StorageRegistry(array(self::TYPE_NAME => $storage));
 
-        $this->assertAttributeSame(
-            array(
-                'some-type' => $storage,
-            ),
-            'storageMap',
-            $registry
-        );
+        $this->assertSame($storage, $registry->getStorage(self::TYPE_NAME));
     }
 
     /**
@@ -41,9 +37,9 @@ class StorageRegistryTest extends TestCase
     public function testGetStorage()
     {
         $storage = $this->getStorageMock();
-        $registry = new StorageRegistry(array('some-type' => $storage));
+        $registry = new StorageRegistry(array(self::TYPE_NAME => $storage));
 
-        $res = $registry->getStorage('some-type');
+        $res = $registry->getStorage(self::TYPE_NAME);
 
         $this->assertSame(
             $storage,

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
@@ -50,30 +50,6 @@ class ContentTypeHandlerTest extends TestCase
     protected $updateHandlerMock;
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler::__construct
-     */
-    public function testCtor()
-    {
-        $handler = $this->getHandler();
-
-        $this->assertAttributeSame(
-            $this->getGatewayMock(),
-            'contentTypeGateway',
-            $handler
-        );
-        $this->assertAttributeSame(
-            $this->getMapperMock(),
-            'mapper',
-            $handler
-        );
-        $this->assertAttributeSame(
-            $this->getUpdateHandlerMock(),
-            'updateHandler',
-            $handler
-        );
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler::createGroup
      */
     public function testCreateGroup()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/AddFieldTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/AddFieldTest.php
@@ -60,7 +60,7 @@ class AddFieldTest extends TestCase
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater::__construct
      */
-    public function testCtor()
+    public function testConstructor()
     {
         $action = new AddField(
             $this->getContentGatewayMock(),
@@ -70,21 +70,7 @@ class AddFieldTest extends TestCase
             $this->getContentMapperMock()
         );
 
-        $this->assertAttributeSame(
-            $this->getContentGatewayMock(),
-            'contentGateway',
-            $action
-        );
-        $this->assertAttributeEquals(
-            $this->getFieldDefinitionFixture(),
-            'fieldDefinition',
-            $action
-        );
-        $this->assertAttributeSame(
-            $this->getFieldValueConverterMock(),
-            'fieldValueConverter',
-            $action
-        );
+        $this->assertInstanceOf(AddField::class, $action);
     }
 
     public function testApplySingleVersionSingleTranslation()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/RemoveFieldTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/RemoveFieldTest.php
@@ -47,25 +47,6 @@ class RemoveFieldTest extends TestCase
     protected $removeFieldAction;
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater::__construct
-     */
-    public function testCtor()
-    {
-        $action = $this->getRemoveFieldAction();
-
-        $this->assertAttributeSame(
-            $this->getContentGatewayMock(),
-            'contentGateway',
-            $action
-        );
-        $this->assertAttributeEquals(
-            $this->getFieldDefinitionFixture(),
-            'fieldDefinition',
-            $action
-        );
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater\Action\RemoveField::apply
      */
     public function testApplySingleVersionSingleTranslation()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdaterTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdaterTest.php
@@ -64,25 +64,6 @@ class ContentUpdaterTest extends TestCase
     protected $contentMapperMock;
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater::__construct
-     */
-    public function testCtor()
-    {
-        $updater = $this->getContentUpdater();
-
-        $this->assertAttributeSame(
-            $this->getContentGatewayMock(),
-            'contentGateway',
-            $updater
-        );
-        $this->assertAttributeSame(
-            $this->getConverterRegistryMock(),
-            'converterRegistry',
-            $updater
-        );
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater::determineActions
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater::hasFieldDefinition
      */

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
@@ -343,9 +343,9 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $gateway = $this->getGateway();
         $data = $gateway->loadAllGroupsData();
 
-        $this->assertEquals(
+        $this->assertCount(
             3,
-            count($data)
+            $data
         );
 
         $this->assertEquals(
@@ -373,9 +373,9 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $gateway = $this->getGateway();
         $rows = $gateway->loadTypesDataForGroup(1, 0);
 
-        $this->assertEquals(
+        $this->assertCount(
             6,
-            count($rows)
+            $rows
         );
     }
 
@@ -393,13 +393,13 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $gateway = $this->getGateway();
         $rows = $gateway->loadTypeData(1, 0);
 
-        $this->assertEquals(
+        $this->assertCount(
             5,
-            count($rows)
+            $rows
         );
-        $this->assertEquals(
+        $this->assertCount(
             49,
-            count($rows[0])
+            $rows[0]
         );
 
         /*
@@ -426,13 +426,13 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $gateway = $this->getGateway();
         $rows = $gateway->loadTypeDataByIdentifier('folder', 0);
 
-        $this->assertEquals(
+        $this->assertCount(
             5,
-            count($rows)
+            $rows
         );
-        $this->assertEquals(
+        $this->assertCount(
             49,
-            count($rows[0])
+            $rows[0]
         );
     }
 
@@ -450,13 +450,13 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $gateway = $this->getGateway();
         $rows = $gateway->loadTypeDataByRemoteId('a3d405b81be900468eb153d774f4f0d2', 0);
 
-        $this->assertEquals(
+        $this->assertCount(
             5,
-            count($rows)
+            $rows
         );
-        $this->assertEquals(
+        $this->assertCount(
             49,
-            count($rows[0])
+            $rows[0]
         );
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
@@ -38,21 +38,6 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase::__construct
-     */
-    public function testCtor()
-    {
-        $handlerMock = $this->getDatabaseHandler();
-        $gateway = $this->getGateway();
-
-        $this->assertAttributeSame(
-            $handlerMock,
-            'dbHandler',
-            $gateway
-        );
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase::insertGroup
      */
     public function testInsertGroup()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/MapperTest.php
@@ -292,9 +292,9 @@ class MapperTest extends TestCase
         $mapper = $this->getNonConvertingMapper();
         $types = $mapper->extractTypesFromRows($rows);
 
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($types),
+            $types,
             'Incorrect number of types extracted'
         );
 
@@ -324,9 +324,9 @@ class MapperTest extends TestCase
             $types[0]
         );
 
-        $this->assertEquals(
+        $this->assertCount(
             6,
-            count($types[0]->fieldDefinitions),
+            $types[0]->fieldDefinitions,
             'Incorrect number of field definitions'
         );
         $this->assertPropertiesCorrect(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/Gateway/DoctrineDatabaseTest.php
@@ -30,21 +30,6 @@ class DoctrineDatabaseTest extends TestCase
     protected $gateway;
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\DoctrineDatabase::__construct
-     */
-    public function testConstructor()
-    {
-        $dbHandler = $this->getDatabaseHandler();
-        $gateway = $this->getGateway();
-
-        $this->assertAttributeSame(
-            $dbHandler,
-            'dbHandler',
-            $gateway
-        );
-    }
-
-    /**
      * Test for the loadUrlAliasData() method.
      *
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\DoctrineDatabase::loadUrlAliasData

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/SlugConverterTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/SlugConverterTest.php
@@ -22,28 +22,6 @@ use PHPUnit\Framework\TestSuite;
 class SlugConverterTest extends TestCase
 {
     /**
-     * Test for the __construct() method.
-     *
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\SlugConverter::__construct
-     */
-    public function testConstructor()
-    {
-        $slugConverter = $this->getMockedSlugConverter();
-
-        $this->assertAttributeSame(
-            $this->getTransformationProcessorMock(),
-            'transformationProcessor',
-            $slugConverter
-        );
-
-        $this->assertAttributeInternalType(
-            'array',
-            'configuration',
-            $slugConverter
-        );
-    }
-
-    /**
      * Test for the convert() method.
      *
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\SlugConverter::convert

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/Gateway/DoctrineDatabaseTest.php
@@ -46,23 +46,6 @@ class DoctrineDatabaseTest extends TestCase
     );
 
     /**
-     * Test for the __construct() method.
-     *
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway\DoctrineDatabase::__construct
-     */
-    public function testConstructor()
-    {
-        $dbHandler = $this->getDatabaseHandler();
-        $gateway = $this->getGateway();
-
-        $this->assertAttributeSame(
-            $dbHandler,
-            'dbHandler',
-            $gateway
-        );
-    }
-
-    /**
      * Test for the loadUrlWildcardData() method.
      *
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway\DoctrineDatabase::loadUrlWildcardData

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/UrlWildcardHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/UrlWildcardHandlerTest.php
@@ -20,27 +20,6 @@ use eZ\Publish\SPI\Persistence\Content\UrlWildcard;
 class UrlWildcardHandlerTest extends TestCase
 {
     /**
-     * Test for the __construct() method.
-     *
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Handler::__construct
-     */
-    public function testConstructor()
-    {
-        $handler = $this->getHandler();
-
-        self::assertAttributeSame(
-            $this->gateway,
-            'gateway',
-            $handler
-        );
-        self::assertAttributeSame(
-            $this->mapper,
-            'mapper',
-            $handler
-        );
-    }
-
-    /**
      * Test for the load() method.
      *
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Handler::load

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/TransactionHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/TransactionHandlerTest.php
@@ -42,30 +42,6 @@ class TransactionHandlerTest extends \PHPUnit\Framework\TestCase
     protected $languageHandlerMock;
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\TransactionHandler::__construct
-     */
-    public function testConstruct()
-    {
-        $handler = $this->getTransactionHandler();
-
-        $this->assertAttributeSame(
-            $this->getDatabaseHandlerMock(),
-            'dbHandler',
-            $handler
-        );
-        $this->assertAttributeSame(
-            $this->getContentTypeHandlerMock(),
-            'contentTypeHandler',
-            $handler
-        );
-        $this->assertAttributeSame(
-            $this->getLanguageHandlerMock(),
-            'languageHandler',
-            $handler
-        );
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\TransactionHandler::beginTransaction
      */
     public function testBeginTransaction()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/Gateway/DoctrineDatabaseTest.php
@@ -36,21 +36,6 @@ class DoctrineDatabaseTest extends TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\User\Gateway\DoctrineDatabase::__construct
-     */
-    public function testCtor()
-    {
-        $handler = $this->getDatabaseHandler();
-        $gateway = $this->getDatabaseGateway();
-
-        $this->assertAttributeSame(
-            $handler,
-            'handler',
-            $gateway
-        );
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\User\Gateway\DoctrineDatabase::removeRoleAssignmentById
      */
     public function testRemoveRoleByAssignmentId()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/Role/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/Role/Gateway/DoctrineDatabaseTest.php
@@ -37,21 +37,6 @@ class DoctrineDatabaseTest extends TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\DoctrineDatabase::__construct
-     */
-    public function testCtor()
-    {
-        $handler = $this->getDatabaseHandler();
-        $gateway = $this->getDatabaseGateway();
-
-        $this->assertAttributeSame(
-            $handler,
-            'handler',
-            $gateway
-        );
-    }
-
-    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\DoctrineDatabase::createRole
      */
     public function testCreateRole()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -928,7 +928,7 @@ class UserHandlerTest extends TestCase
                 true
             )
         );
-        $this->assertEquals(8, count($policies));
+        $this->assertCount(8, $policies);
     }
 
     public function testLoadRoleAssignmentsByGroupId()

--- a/eZ/Publish/Core/Persistence/Tests/FieldTypeRegistryTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/FieldTypeRegistryTest.php
@@ -18,20 +18,19 @@ use eZ\Publish\SPI\Persistence\FieldType as SPIPersistenceFieldType;
  */
 class FieldTypeRegistryTest extends TestCase
 {
+    private const FIELD_TYPE_IDENTIFIER = 'some-type';
+
     /**
      * @covers \eZ\Publish\Core\Persistence\FieldTypeRegistry::__construct
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $fieldType = $this->getFieldTypeMock();
-        $registry = new FieldTypeRegistry(array('some-type' => $fieldType));
+        $registry = new FieldTypeRegistry(array(self::FIELD_TYPE_IDENTIFIER => $fieldType));
 
-        $this->assertAttributeSame(
-            array(
-                'some-type' => $fieldType,
-            ),
-            'coreFieldTypeMap',
-            $registry
+        $this->assertInstanceOf(
+            SPIPersistenceFieldType::class,
+            $registry->getFieldType(self::FIELD_TYPE_IDENTIFIER)
         );
     }
 
@@ -41,16 +40,11 @@ class FieldTypeRegistryTest extends TestCase
     public function testGetFieldTypeInstance()
     {
         $instance = $this->getFieldTypeMock();
-        $registry = new FieldTypeRegistry(array('some-type' => $instance));
+        $registry = new FieldTypeRegistry(array(self::FIELD_TYPE_IDENTIFIER => $instance));
 
-        $result = $registry->getFieldType('some-type');
+        $result = $registry->getFieldType(self::FIELD_TYPE_IDENTIFIER);
 
         $this->assertInstanceOf(SPIPersistenceFieldType::class, $result);
-        $this->assertAttributeSame(
-            $instance,
-            'internalFieldType',
-            $result
-        );
     }
 
     /**
@@ -62,16 +56,11 @@ class FieldTypeRegistryTest extends TestCase
         $closure = function () use ($instance) {
             return $instance;
         };
-        $registry = new FieldTypeRegistry(array('some-type' => $closure));
+        $registry = new FieldTypeRegistry(array(self::FIELD_TYPE_IDENTIFIER => $closure));
 
-        $result = $registry->getFieldType('some-type');
+        $result = $registry->getFieldType(self::FIELD_TYPE_IDENTIFIER);
 
         $this->assertInstanceOf(SPIPersistenceFieldType::class, $result);
-        $this->assertAttributeSame(
-            $instance,
-            'internalFieldType',
-            $result
-        );
     }
 
     /**
@@ -107,8 +96,8 @@ class FieldTypeRegistryTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $registry = new FieldTypeRegistry(array('some-type' => new \DateTime()));
-        $registry->getFieldType('some-type');
+        $registry = new FieldTypeRegistry(array(self::FIELD_TYPE_IDENTIFIER => new \DateTime()));
+        $registry->getFieldType(self::FIELD_TYPE_IDENTIFIER);
     }
 
     /**
@@ -118,14 +107,11 @@ class FieldTypeRegistryTest extends TestCase
     {
         $fieldType = $this->getFieldTypeMock();
         $registry = new FieldTypeRegistry(array());
-        $registry->register('some-type', $fieldType);
+        $registry->register(self::FIELD_TYPE_IDENTIFIER, $fieldType);
 
-        $this->assertAttributeSame(
-            array(
-                'some-type' => $fieldType,
-            ),
-            'coreFieldTypeMap',
-            $registry
+        $this->assertInstanceOf(
+            SPIPersistenceFieldType::class,
+            $registry->getFieldType(self::FIELD_TYPE_IDENTIFIER)
         );
     }
 

--- a/eZ/Publish/Core/Repository/Tests/Helper/FieldTypeRegistryTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Helper/FieldTypeRegistryTest.php
@@ -121,7 +121,7 @@ class FieldTypeRegistryTest extends TestCase
 
         $fieldTypes = $registry->getFieldTypes();
 
-        $this->assertInternalType('array', $fieldTypes);
+        $this->assertIsArray($fieldTypes);
         $this->assertCount(2, $fieldTypes);
         $this->assertArrayHasKey('one', $fieldTypes);
         $this->assertInstanceOf(

--- a/eZ/Publish/Core/Repository/Tests/Helper/FieldTypeRegistryTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Helper/FieldTypeRegistryTest.php
@@ -16,17 +16,15 @@ use PHPUnit\Framework\TestCase;
  */
 class FieldTypeRegistryTest extends TestCase
 {
+    private const FIELD_TYPE_ID = 'one';
+
     public function testConstructor()
     {
-        $fieldTypes = array('field types');
+        $fieldType = $this->getFieldTypeMock();
+        $fieldTypes = [self::FIELD_TYPE_ID => $fieldType];
 
         $registry = new FieldTypeRegistry($fieldTypes);
-
-        $this->assertAttributeSame(
-            $fieldTypes,
-            'fieldTypes',
-            $registry
-        );
+        $this->assertTrue($registry->hasFieldType(self::FIELD_TYPE_ID));
     }
 
     protected function getFieldTypeMock()
@@ -44,12 +42,12 @@ class FieldTypeRegistryTest extends TestCase
     public function testGetFieldType()
     {
         $fieldTypes = array(
-            'one' => $this->getFieldTypeMock(),
+            self::FIELD_TYPE_ID => $this->getFieldTypeMock(),
         );
 
         $registry = new FieldTypeRegistry($fieldTypes);
 
-        $fieldType = $registry->getFieldType('one');
+        $fieldType = $registry->getFieldType(self::FIELD_TYPE_ID);
 
         $this->assertInstanceOf(
             FieldType::class,
@@ -60,12 +58,12 @@ class FieldTypeRegistryTest extends TestCase
     public function testGetClosureFieldType()
     {
         $fieldTypes = array(
-            'one' => $this->getClosure($this->getFieldTypeMock()),
+            self::FIELD_TYPE_ID => $this->getClosure($this->getFieldTypeMock()),
         );
 
         $registry = new FieldTypeRegistry($fieldTypes);
 
-        $fieldType = $registry->getFieldType('one');
+        $fieldType = $registry->getFieldType(self::FIELD_TYPE_ID);
 
         $this->assertInstanceOf(
             FieldType::class,
@@ -113,7 +111,7 @@ class FieldTypeRegistryTest extends TestCase
     public function testGetFieldTypes()
     {
         $fieldTypes = array(
-            'one' => $this->getFieldTypeMock(),
+            self::FIELD_TYPE_ID => $this->getFieldTypeMock(),
             'two' => $this->getClosure($this->getFieldTypeMock()),
         );
 
@@ -123,10 +121,10 @@ class FieldTypeRegistryTest extends TestCase
 
         $this->assertIsArray($fieldTypes);
         $this->assertCount(2, $fieldTypes);
-        $this->assertArrayHasKey('one', $fieldTypes);
+        $this->assertArrayHasKey(self::FIELD_TYPE_ID, $fieldTypes);
         $this->assertInstanceOf(
             FieldType::class,
-            $fieldTypes['one']
+            $fieldTypes[self::FIELD_TYPE_ID]
         );
         $this->assertArrayHasKey('two', $fieldTypes);
         $this->assertInstanceOf(

--- a/eZ/Publish/Core/Repository/Tests/Permission/CachedPermissionServiceTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Permission/CachedPermissionServiceTest.php
@@ -36,40 +36,6 @@ use PHPUnit\Framework\TestCase;
  */
 class CachedPermissionServiceTest extends TestCase
 {
-    /**
-     * Test for the __construct() method.
-     */
-    public function testConstructor()
-    {
-        $permissionResolverMock = $this->getPermissionResolverMock();
-        $criterionResolverMock = $this->getPermissionCriterionResolverMock();
-        $cachedService = $this->getCachedPermissionService(10);
-
-        $this->assertAttributeSame(
-            $permissionResolverMock,
-            'permissionResolver',
-            $cachedService
-        );
-        $this->assertAttributeSame(
-            $criterionResolverMock,
-            'permissionCriterionResolver',
-            $cachedService
-        );
-        $this->assertAttributeEquals(
-            10,
-            'cacheTTL',
-            $cachedService
-        );
-        $this->assertAttributeEmpty(
-            'permissionCriterion',
-            $cachedService
-        );
-        $this->assertAttributeEmpty(
-            'permissionCriterionTs',
-            $cachedService
-        );
-    }
-
     public function providerForTestPermissionResolverPassTrough()
     {
         $valueObject = $this
@@ -117,10 +83,6 @@ class CachedPermissionServiceTest extends TestCase
 
         $actualReturn = $cachedService->$method(...$arguments);
         $this->assertSame($expectedReturn, $actualReturn);
-
-        // Make sure no cache properties where set
-        $this->assertAttributeEmpty('permissionCriterion', $cachedService);
-        $this->assertAttributeEmpty('permissionCriterionTs', $cachedService);
     }
 
     public function testGetPermissionsCriterionPassTrough()
@@ -140,10 +102,6 @@ class CachedPermissionServiceTest extends TestCase
 
         $actualReturn = $cachedService->getPermissionsCriterion('content', 'remove');
         $this->assertSame($criterionMock, $actualReturn);
-
-        // Make sure no cache properties where set
-        $this->assertAttributeEmpty('permissionCriterion', $cachedService);
-        $this->assertAttributeEmpty('permissionCriterionTs', $cachedService);
     }
 
     public function testGetPermissionsCriterionCaching()
@@ -163,23 +121,17 @@ class CachedPermissionServiceTest extends TestCase
 
         $actualReturn = $cachedService->getPermissionsCriterion('content', 'read');
         $this->assertSame($criterionMock, $actualReturn);
-        $this->assertAttributeSame($criterionMock, 'permissionCriterion', $cachedService);
-        $this->assertAttributeEquals(1417624982, 'permissionCriterionTs', $cachedService);
 
         // +1
         $actualReturn = $cachedService->getPermissionsCriterion('content', 'read');
         $this->assertSame($criterionMock, $actualReturn);
-        $this->assertAttributeSame($criterionMock, 'permissionCriterion', $cachedService);
-        $this->assertAttributeEquals(1417624982, 'permissionCriterionTs', $cachedService);
 
         // +3, time() will be called twice and cache will be updated
         $actualReturn = $cachedService->getPermissionsCriterion('content', 'read');
         $this->assertSame($criterionMock, $actualReturn);
-        $this->assertAttributeSame($criterionMock, 'permissionCriterion', $cachedService);
-        $this->assertAttributeEquals(1417624985, 'permissionCriterionTs', $cachedService);
     }
 
-    public function testSetCurrentUserReferenceCacheClear()
+    public function testSetCurrentUserReferenceCacheClear(): void
     {
         $criterionMock = $this
             ->getMockBuilder(Criterion::class)
@@ -196,13 +148,11 @@ class CachedPermissionServiceTest extends TestCase
 
         $actualReturn = $cachedService->getPermissionsCriterion('content', 'read');
         $this->assertSame($criterionMock, $actualReturn);
-        $this->assertAttributeSame($criterionMock, 'permissionCriterion', $cachedService);
 
         $userRef = $this
             ->getMockBuilder(UserReference::class)
             ->getMockForAbstractClass();
         $cachedService->setCurrentUserReference($userRef);
-        $this->assertAttributeEmpty('permissionCriterion', $cachedService);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Permission/PermissionCriterionResolverTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Permission/PermissionCriterionResolverTest.php
@@ -24,27 +24,6 @@ use PHPUnit\Framework\TestCase;
  */
 class PermissionCriterionResolverTest extends TestCase
 {
-    /**
-     * Test for the __construct() method.
-     */
-    public function testConstructor()
-    {
-        $permissionResolverMock = $this->getPermissionResolverMock();
-        $limitationServiceMock = $this->getLimitationServiceMock();
-        $criterionResolver = $this->getPermissionCriterionResolverMock();
-
-        $this->assertAttributeSame(
-            $permissionResolverMock,
-            'permissionResolver',
-            $criterionResolver
-        );
-        $this->assertAttributeSame(
-            $limitationServiceMock,
-            'limitationService',
-            $criterionResolver
-        );
-    }
-
     public function providerForTestGetPermissionsCriterion()
     {
         $criterionMock = $this

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -68,7 +68,7 @@ class ContentTest extends BaseServiceMockTest
      *
      * @covers \eZ\Publish\Core\Repository\ContentService::__construct
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Persistence\Handler $persistenceHandlerMock */
@@ -87,48 +87,6 @@ class ContentTest extends BaseServiceMockTest
             $nameSchemaServiceMock,
             $fieldTypeRegistryMock,
             $settings
-        );
-
-        $this->assertAttributeSame(
-            $repositoryMock,
-            'repository',
-            $service
-        );
-
-        $this->assertAttributeSame(
-            $persistenceHandlerMock,
-            'persistenceHandler',
-            $service
-        );
-
-        $this->assertAttributeSame(
-            $domainMapperMock,
-            'domainMapper',
-            $service
-        );
-
-        $this->assertAttributeSame(
-            $relationProcessorMock,
-            'relationProcessor',
-            $service
-        );
-
-        $this->assertAttributeSame(
-            $nameSchemaServiceMock,
-            'nameSchemaService',
-            $service
-        );
-
-        $this->assertAttributeSame(
-            $fieldTypeRegistryMock,
-            'fieldTypeRegistry',
-            $service
-        );
-
-        $this->assertAttributeSame(
-            $settings,
-            'settings',
-            $service
         );
     }
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
@@ -30,21 +30,14 @@ class DomainMapperTest extends BaseServiceMockTest
      * @covers \eZ\Publish\Core\Repository\Helper\DomainMapper::buildVersionInfoDomainObject
      * @dataProvider providerForBuildVersionInfo
      */
-    public function testBuildVersionInfo(SPIVersionInfo $spiVersionInfo, array $languages, array $expected)
+    public function testBuildVersionInfo(SPIVersionInfo $spiVersionInfo)
     {
         $languageHandlerMock = $this->getLanguageHandlerMock();
         $languageHandlerMock->expects($this->never())->method('load');
 
         $versionInfo = $this->getDomainMapper()->buildVersionInfoDomainObject($spiVersionInfo);
-        $this->assertInstanceOf(APIVersionInfo::class, $versionInfo);
 
-        foreach ($expected as $expectedProperty => $expectedValue) {
-            $this->assertAttributeSame(
-                $expectedValue,
-                $expectedProperty,
-                $versionInfo
-            );
-        }
+        $this->assertInstanceOf(APIVersionInfo::class, $versionInfo);
     }
 
     /**
@@ -99,8 +92,6 @@ class DomainMapperTest extends BaseServiceMockTest
                         'contentInfo' => new SPIContentInfo(),
                     )
                 ),
-                array(),
-                array('status' => APIVersionInfo::STATUS_DRAFT),
             ),
             array(
                 new SPIVersionInfo(
@@ -109,8 +100,6 @@ class DomainMapperTest extends BaseServiceMockTest
                         'contentInfo' => new SPIContentInfo(),
                     )
                 ),
-                array(),
-                array('status' => APIVersionInfo::STATUS_DRAFT),
             ),
             array(
                 new SPIVersionInfo(
@@ -119,8 +108,6 @@ class DomainMapperTest extends BaseServiceMockTest
                         'contentInfo' => new SPIContentInfo(),
                     )
                 ),
-                array(),
-                array('status' => APIVersionInfo::STATUS_DRAFT),
             ),
             array(
                 new SPIVersionInfo(
@@ -130,11 +117,6 @@ class DomainMapperTest extends BaseServiceMockTest
                         'languageCodes' => array('eng-GB', 'nor-NB', 'fre-FR'),
                     )
                 ),
-                array(1 => 'eng-GB', 3 => 'nor-NB', 5 => 'fre-FR'),
-                array(
-                    'status' => APIVersionInfo::STATUS_ARCHIVED,
-                    'languageCodes' => array('eng-GB', 'nor-NB', 'fre-FR'),
-                ),
             ),
             array(
                 new SPIVersionInfo(
@@ -143,8 +125,6 @@ class DomainMapperTest extends BaseServiceMockTest
                         'contentInfo' => new SPIContentInfo(),
                     )
                 ),
-                array(),
-                array('status' => APIVersionInfo::STATUS_PUBLISHED),
             ),
         );
     }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
@@ -194,7 +194,7 @@ class DomainMapperTest extends BaseServiceMockTest
 
         $spiResult = clone $result;
         $missingLocations = $this->getDomainMapper()->buildLocationDomainObjectsOnSearchResult($result, $languageFilter);
-        $this->assertInternalType('array', $missingLocations);
+        $this->assertIsArray($missingLocations);
 
         if (!$missing) {
             $this->assertEmpty($missingLocations);

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
@@ -23,27 +23,6 @@ use eZ\Publish\Core\Repository\Helper\LimitationService;
  */
 class PermissionsCriterionHandlerTest extends BaseServiceMockTest
 {
-    /**
-     * Test for the __construct() method.
-     */
-    public function testConstructor()
-    {
-        $permissionResolverMock = $this->getPermissionResolverMock();
-        $limitationServiceMock = $this->getLimitationServiceMock();
-        $handler = $this->getPermissionsCriterionHandlerMock();
-
-        $this->assertAttributeSame(
-            $permissionResolverMock,
-            'permissionResolver',
-            $handler
-        );
-        $this->assertAttributeSame(
-            $limitationServiceMock,
-            'limitationService',
-            $handler
-        );
-    }
-
     public function providerForTestAddPermissionsCriterionWithBooleanPermission()
     {
         return array(

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
@@ -27,22 +27,6 @@ use Psr\Log\LoggerInterface;
  */
 class RelationProcessorTest extends BaseServiceMockTest
 {
-    /**
-     * Test for the __construct() method.
-     *
-     * @covers \eZ\Publish\Core\Repository\Helper\RelationProcessor::__construct
-     */
-    public function testConstructor()
-    {
-        $relationProcessor = $this->getPartlyMockedRelationProcessor();
-
-        $this->assertAttributeSame(
-            $this->getPersistenceMock(),
-            'persistenceHandler',
-            $relationProcessor
-        );
-    }
-
     public function providerForTestAppendRelations()
     {
         return array(

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
@@ -61,36 +61,6 @@ class SearchTest extends BaseServiceMockTest
             new NullIndexer(),
             $settings
         );
-
-        $this->assertAttributeSame(
-            $repositoryMock,
-            'repository',
-            $service
-        );
-
-        $this->assertAttributeSame(
-            $searchHandlerMock,
-            'searchHandler',
-            $service
-        );
-
-        $this->assertAttributeSame(
-            $domainMapperMock,
-            'domainMapper',
-            $service
-        );
-
-        $this->assertAttributeSame(
-            $permissionsCriterionResolverMock,
-            'permissionCriterionResolver',
-            $service
-        );
-
-        $this->assertAttributeSame(
-            $settings,
-            'settings',
-            $service
-        );
     }
 
     public function providerForFindContentValidatesLocationCriteriaAndSortClauses()

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlAliasTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlAliasTest.php
@@ -53,28 +53,6 @@ class UrlAliasTest extends BaseServiceMockTest
             $this->getNameSchemaServiceMock(),
             $settings
         );
-
-        $this->assertAttributeSame(
-            $repositoryMock,
-            'repository',
-            $service
-        );
-
-        $this->assertAttributeSame(
-            $urlAliasHandler,
-            'urlAliasHandler',
-            $service
-        );
-
-        $this->assertAttributeSame(
-            array(
-                'settings',
-                'showAllTranslations' => false,
-                'prioritizedLanguageList' => array('prioritizedLanguageList'),
-            ),
-            'settings',
-            $service
-        );
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlWildcardTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlWildcardTest.php
@@ -20,23 +20,8 @@ use eZ\Publish\API\Repository\Values\Content\URLWildcardTranslationResult;
 class UrlWildcardTest extends BaseServiceMockTest
 {
     /**
-     * Test for the __construct() method.
-     *
-     * @covers \eZ\Publish\Core\Repository\URLWildcardService::__construct
-     */
-    public function testConstructor()
-    {
-        $service = $this->getPartlyMockedURLWildcardService();
-
-        self::assertAttributeSame($this->getRepositoryMock(), 'repository', $service);
-        self::assertAttributeSame($this->getPersistenceMockHandler('Content\\UrlWildcard\\Handler'), 'urlWildcardHandler', $service);
-        self::assertAttributeSame(array(), 'settings', $service);
-    }
-
-    /**
      * Test for the create() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::create
      */
     public function testCreateThrowsUnauthorizedException()
@@ -62,7 +47,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the create() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::create
      */
     public function testCreateThrowsInvalidArgumentException()
@@ -112,7 +96,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the create() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::create
      * @dataProvider providerForTestCreateThrowsContentValidationException
      */
@@ -163,7 +146,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the create() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::create
      * @dataProvider providerForTestCreate
      */
@@ -238,7 +220,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the create() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::create
      */
     public function testCreateWithRollback()
@@ -294,7 +275,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the remove() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::remove
      */
     public function testRemoveThrowsUnauthorizedException()
@@ -325,7 +305,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the remove() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::remove
      */
     public function testRemove()
@@ -366,7 +345,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the remove() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::remove
      */
     public function testRemoveWithRollback()
@@ -411,7 +389,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the load() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::remove
      */
     public function testLoadThrowsException()
@@ -438,7 +415,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the load() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::remove
      */
     public function testLoad()
@@ -484,7 +460,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the loadAll() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::loadAll
      */
     public function testLoadAll()
@@ -510,7 +485,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the loadAll() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::loadAll
      */
     public function testLoadAllWithLimitAndOffset()
@@ -602,7 +576,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the translate() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::translate
      * @dataProvider providerForTestTranslateThrowsNotFoundException
      */
@@ -712,7 +685,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the translate() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::translate
      * @dataProvider providerForTestTranslate
      */
@@ -749,7 +721,6 @@ class UrlWildcardTest extends BaseServiceMockTest
     /**
      * Test for the translate() method.
      *
-     * @depends testConstructor
      * @covers \eZ\Publish\Core\Repository\URLWildcardService::translate
      */
     public function testTranslateUsesLongestMatchingWildcard()

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UserPasswordValidatorTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UserPasswordValidatorTest.php
@@ -23,7 +23,7 @@ class UserPasswordValidatorTest extends TestCase
     {
         $validator = new UserPasswordValidator($constraints);
 
-        $this->assertEquals($expectedErrors, $validator->validate($password), '', 0.0, 10, true);
+        $this->assertEqualsCanonicalizing($expectedErrors, $validator->validate($password), '');
     }
 
     public function dateProviderForValidate(): array

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -305,9 +305,9 @@ class HandlerContentTest extends AbstractTestCase
             1,
             $result->totalCount
         );
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($result->searchHits)
+            $result->searchHits
         );
     }
 
@@ -332,9 +332,9 @@ class HandlerContentTest extends AbstractTestCase
             1,
             $result->totalCount
         );
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($result->searchHits)
+            $result->searchHits
         );
     }
 
@@ -1024,16 +1024,15 @@ class HandlerContentTest extends AbstractTestCase
             )
         );
 
-        $this->assertEquals(
+        $this->assertCount(
             10,
-            count(
+
                 array_map(
                     function ($hit) {
                         return $hit->valueObject->id;
                     },
                     $result->searchHits
                 )
-            )
         );
     }
 

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
@@ -1147,16 +1147,15 @@ class HandlerLocationTest extends AbstractTestCase
 
         $this->assertEquals(26, $result->totalCount);
         $this->assertCount(10, $result->searchHits);
-        $this->assertEquals(
+        $this->assertCount(
             10,
-            count(
+
                 array_map(
                     function ($hit) {
                         return $hit->valueObject->id;
                     },
                     $result->searchHits
                 )
-            )
         );
     }
 

--- a/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
+++ b/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
@@ -60,7 +60,7 @@ class FieldNameResolverTest extends TestCase
             'field_name'
         );
 
-        $this->assertInternalType('array', $fieldNames);
+        $this->assertIsArray($fieldNames);
         $this->assertEmpty($fieldNames);
     }
 
@@ -128,7 +128,7 @@ class FieldNameResolverTest extends TestCase
             'field_definition_identifier_1'
         );
 
-        $this->assertInternalType('array', $fieldNames);
+        $this->assertIsArray($fieldNames);
         $this->assertEquals(
             array(
                 'index_field_name_1',
@@ -204,7 +204,7 @@ class FieldNameResolverTest extends TestCase
             'field_name'
         );
 
-        $this->assertInternalType('array', $fieldNames);
+        $this->assertIsArray($fieldNames);
         $this->assertEquals(
             array(
                 'index_field_name_1',
@@ -266,7 +266,7 @@ class FieldNameResolverTest extends TestCase
             null
         );
 
-        $this->assertInternalType('array', $fieldNames);
+        $this->assertIsArray($fieldNames);
         $this->assertEquals(
             array(
                 'index_field_name_1',
@@ -327,7 +327,7 @@ class FieldNameResolverTest extends TestCase
             'field_name'
         );
 
-        $this->assertInternalType('array', $fieldNames);
+        $this->assertIsArray($fieldNames);
         $this->assertEquals(
             array(
                 'index_field_name_1',

--- a/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
@@ -225,9 +225,9 @@ class BinaryFileIntegrationTest extends FileBaseIntegrationTest
 
         $path = $this->getPathFromId($field->value->externalData['id']);
         // Check old file removed before update
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count(glob(dirname($path) . '/*'))
+            glob(dirname($path) . '/*')
         );
 
         $this->assertEquals('Blueish-Blue-Binary.jpg', $field->value->externalData['fileName']);

--- a/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
@@ -246,9 +246,9 @@ class MediaIntegrationTest extends FileBaseIntegrationTest
         );
 
         // Check old file removed before update
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count(glob(dirname($path) . '/*'))
+            glob(dirname($path) . '/*')
         );
 
         $this->assertEquals('Blueish-Blue-Media.jpg', $field->value->externalData['fileName']);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30675](https://jira.ez.no/browse/EZP-30675)
| **Improvement**| yes
| **New feature**    |no
| **Target version** | `master`
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     |no

<!-- Replace this comment with Pull Request description -->

- https://github.com/sebastianbergmann/phpunit/issues/3338

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
