### PR TITLE
EZP-30681: Fixed double slash in path_identification_string after moveSubtree

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -2332,6 +2332,56 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
+     * Test that Legacy ezcontentobject_tree.path_identification_string field is correctly updated
+     * after moving subtree.
+     *
+     * @covers \eZ\Publish\API\Repository\LocationService::moveSubtree
+     *
+     * @throws \ErrorException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testMoveSubtreeUpdatesPathIdentificationString()
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $topNode = $this->createFolder(['eng-US' => 'top_node'], 2);
+
+        $newParentLocation = $locationService->loadLocation(
+            $this
+                ->createFolder(['eng-US' => 'Parent'], $topNode->contentInfo->mainLocationId)
+                ->contentInfo
+                ->mainLocationId
+        );
+        $location = $locationService->loadLocation(
+            $this
+                ->createFolder(['eng-US' => 'Move Me'], $topNode->contentInfo->mainLocationId)
+                ->contentInfo
+                ->mainLocationId
+        );
+
+        $locationService->moveSubtree($location, $newParentLocation);
+
+        // path location string is not present on API level, so we need to query database
+        $serviceContainer = $this->getSetupFactory()->getServiceContainer();
+        $dbHandler = $serviceContainer->get('ezpublish.api.storage_engine.legacy.dbhandler');
+        $connection = $dbHandler->getConnection();
+        $query = $connection->createQueryBuilder();
+        $query
+            ->select('path_identification_string')
+            ->from('ezcontentobject_tree')
+            ->where('node_id = :nodeId')
+            ->setParameter('nodeId', $location->id);
+
+        self::assertEquals(
+            'top_node/parent/move_me',
+            $query->execute()->fetchColumn()
+        );
+    }
+
+    /**
      * Loads properties from all locations in the $location's subtree.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -320,12 +320,15 @@ class DoctrineDatabase extends Gateway
                 $destinationNodeData['path_string'],
                 'prefix' . $row['path_string']
             );
+            $replace = rtrim($destinationNodeData['path_identification_string'], '/');
+            if (empty($oldParentPathIdentificationString)) {
+                $replace .= '/';
+            }
             $newPathIdentificationString = str_replace(
                 'prefix' . $oldParentPathIdentificationString,
-                $destinationNodeData['path_identification_string'] . '/',
+                $replace,
                 'prefix' . $row['path_identification_string']
             );
-
             $newParentId = $row['parent_node_id'];
             if ($row['path_string'] === $fromPathString) {
                 $newParentId = (int)implode('', array_slice(explode('/', $newPathString), -3, 1));


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30681](https://jira.ez.no/browse/EZP-30681)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Use case:
1. Under "Home" location (#2) create two folders: "Parent" and "Move me".
2. Move "Move me" folder to "Parent".
3. Check `ezcontentobject_tree.path_identification_string` for moved node.

Expected result: `node_2/parent/move_me`
Actual result: `node_2/parent//move_me`

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
