### PR TITLE
Added “nyholm/psr7” to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "jms/translation-bundle": "^1.4",
         "twig/twig": "^2.5",
         "twig/extensions": "^1.5.4",
-        "friendsofsymfony/jsrouting-bundle": "^2.3.0"
+        "friendsofsymfony/jsrouting-bundle": "^2.3.0",
+        "nyholm/psr7": "^1.1"
     },
     "require-dev": {
         "brianium/paratest": "^3.0",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | -
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Added missing `nyholm/psr7` dependency which is required by `kriswallsmith/buzz`: 

> You do also need to install a PSR-17 request/response factory. Buzz uses that factory to create PSR-7 requests and responses. Install one from this list.

Ref. https://github.com/kriswallsmith/buzz#installation

Without it `ezsystems/ezplatform-rest` builds are failing:  https://travis-ci.org/ezsystems/ezplatform-rest/jobs/549685935

**TODO**:
- [X] Implement feature / fix a bug.
- [ ] ~Implement tests.~
- [ ] ~Fix new code according to Coding Standards (`$ composer fix-cs`).~
- [X] Ask for Code Review.
