### PR TITLE
EZP-30647: Refactored View Matcher Factory to use ConfigResolver

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -75,7 +75,14 @@ services:
         arguments: ["@ezpublish.api.repository", 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased']
         calls:
             - [setContainer, ["@service_container"]]
-            - [setMatchConfig, [$content_view$]]
+
+    ezpublish.content_view.matcher_factory.dynamically_configured:
+        class: eZ\Publish\Core\MVC\Symfony\Matcher\DynamicallyConfiguredMatcherFactoryDecorator
+        decorates: ezpublish.content_view.matcher_factory
+        arguments:
+            $innerConfigurableMatcherFactory: '@ezpublish.content_view.matcher_factory.dynamically_configured.inner'
+            $configResolver: '@ezpublish.config.resolver'
+            $parameterName: content_view
 
     ezpublish.content_view_provider.default_configured:
         class: "%ezpublish.view_provider.configured.class%"
@@ -88,7 +95,14 @@ services:
         arguments: ["@ezpublish.api.repository", 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased']
         calls:
             - [setContainer, ["@service_container"]]
-            - [setMatchConfig, [$content_view_defaults$]]
+
+    ezpublish.content_view.default_matcher_factory.dynamically_configured:
+        class: eZ\Publish\Core\MVC\Symfony\Matcher\DynamicallyConfiguredMatcherFactoryDecorator
+        decorates: ezpublish.content_view.default_matcher_factory
+        arguments:
+            $innerConfigurableMatcherFactory: '@ezpublish.content_view.default_matcher_factory.dynamically_configured.inner'
+            $configResolver: '@ezpublish.config.resolver'
+            $parameterName: content_view_defaults
 
     ezpublish.location_view_provider.configured:
         class: "%ezpublish.view_provider.configured.class%"
@@ -101,7 +115,14 @@ services:
         arguments: ["@ezpublish.api.repository", 'eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased']
         calls:
             - [setContainer, ["@service_container"]]
-            - [setMatchConfig, [$location_view$]]
+
+    ezpublish.location_view.matcher_factory.dynamically_configured:
+        class: eZ\Publish\Core\MVC\Symfony\Matcher\DynamicallyConfiguredMatcherFactoryDecorator
+        decorates: ezpublish.location_view.matcher_factory
+        arguments:
+            $innerConfigurableMatcherFactory: '@ezpublish.location_view.matcher_factory.dynamically_configured.inner'
+            $configResolver: '@ezpublish.config.resolver'
+            $parameterName: location_view
 
     ezpublish.templating.global_helper.core:
         class: "%ezpublish.templating.global_helper.core.class%"

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ClassNameMatcherFactory.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ClassNameMatcherFactory.php
@@ -20,7 +20,7 @@ use InvalidArgumentException;
  * A relative namespace can be defined. If so, getMatcher() will search for the requested matcher
  * inside this namespace if a relative namespace (not starting with '\') is passed.
  */
-class ClassNameMatcherFactory implements MatcherFactoryInterface
+class ClassNameMatcherFactory implements ConfigurableMatcherFactoryInterface
 {
     /**
      * @var \eZ\Publish\API\Repository\Repository
@@ -145,13 +145,9 @@ class ClassNameMatcherFactory implements MatcherFactoryInterface
 
     /**
      * @param array $matchConfig
-     *
-     * @return AbstractMatcherFactory
      */
-    public function setMatchConfig($matchConfig)
+    public function setMatchConfig(array $matchConfig): void
     {
         $this->matchConfig = $matchConfig;
-
-        return $this;
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ConfigurableMatcherFactoryInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ConfigurableMatcherFactoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * File containing the MatcherFactory interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Matcher;
+
+interface ConfigurableMatcherFactoryInterface extends MatcherFactoryInterface
+{
+    public function setMatchConfig(array $matchConfig): void;
+}

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ConfigurableMatcherFactoryInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ConfigurableMatcherFactoryInterface.php
@@ -1,13 +1,14 @@
 <?php
 
 /**
- * File containing the MatcherFactory interface.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher;
 
+/**
+ * @internal
+ */
 interface ConfigurableMatcherFactoryInterface extends MatcherFactoryInterface
 {
     public function setMatchConfig(array $matchConfig): void;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/DynamicallyConfiguredMatcherFactoryDecorator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/DynamicallyConfiguredMatcherFactoryDecorator.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * File containing the AbstractMatcherFactory class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Matcher;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+
+/**
+ * Injects dynamic configuration before every matching operation.
+ */
+class DynamicallyConfiguredMatcherFactoryDecorator implements MatcherFactoryInterface
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface|\eZ\Publish\Core\MVC\Symfony\Matcher\ConfigurableMatcherFactoryInterface */
+    private $innerConfigurableMatcherFactory;
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    /** @var string */
+    private $parameterName;
+
+    /** @var string|null */
+    private $namespace;
+
+    /** @var string|null */
+    private $scope;
+
+    public function __construct(
+        MatcherFactoryInterface $innerConfigurableMatcherFactory,
+        ConfigResolverInterface $configResolver,
+        string $parameterName,
+        ?string $namespace = null,
+        ?string $scope = null
+    ) {
+        $this->innerConfigurableMatcherFactory = $innerConfigurableMatcherFactory;
+        $this->configResolver = $configResolver;
+        $this->parameterName = $parameterName;
+        $this->namespace = $namespace;
+        $this->scope = $scope;
+    }
+
+    public function match(View $view)
+    {
+        $matchConfig = $this->configResolver->getParameter($this->parameterName, $this->namespace, $this->scope);
+        $this->innerConfigurableMatcherFactory->setMatchConfig($matchConfig);
+
+        return $this->innerConfigurableMatcherFactory->match($view);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/DynamicallyConfiguredMatcherFactoryDecoratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/DynamicallyConfiguredMatcherFactoryDecoratorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * File containing the ContentBasedMatcherFactoryTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
+use eZ\Publish\Core\MVC\Symfony\Matcher\ClassNameMatcherFactory;
+use eZ\Publish\Core\MVC\Symfony\Matcher\DynamicallyConfiguredMatcherFactoryDecorator;
+use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use PHPUnit\Framework\TestCase;
+
+class DynamicallyConfiguredMatcherFactoryDecoratorTest extends TestCase
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\Matcher\ConfigurableMatcherFactoryInterface */
+    private $innerMatcherFactory;
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    public function setUp(): void
+    {
+        $innerMatcherFactory = $this->createMock(ClassNameMatcherFactory::class);
+        $configResolver = $this->createMock(ConfigResolver::class);
+
+        $this->innerMatcherFactory = $innerMatcherFactory;
+        $this->configResolver = $configResolver;
+    }
+
+    /**
+     * @dataProvider matchConfigProvider
+     */
+    public function testMatch($parameterName, $namespace, $scope, $viewsConfiguration, $matchedConfig): void
+    {
+        $view = $this->createMock(ContentView::class);
+        $this->configResolver->expects($this->atLeastOnce())->method('getParameter')->with($parameterName, $namespace,
+            $scope)->willReturn($viewsConfiguration);
+        $this->innerMatcherFactory->expects($this->once())->method('match')->with($view)->willReturn($matchedConfig);
+
+        $matcherFactory = new DynamicallyConfiguredMatcherFactoryDecorator(
+            $this->innerMatcherFactory,
+            $this->configResolver,
+            $parameterName,
+            $namespace,
+            $scope
+        );
+
+        $this->assertEquals($matchedConfig, $matcherFactory->match($view));
+    }
+
+    public function matchConfigProvider(): array
+    {
+        return [
+            [
+                'location_view',
+                null,
+                null,
+                [
+                    'full' => [
+                        'test' => [
+                            'template' => 'foo.html.twig',
+                            'match' => [
+                                \stdClass::class => true,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'template' => 'foo.html.twig',
+                    'match' => [
+                        \stdClass::class => true,
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30647](https://jira.ez.no/browse/EZP-30647)
| **Bug/Improvement**| bug
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Due to Dynamic Settings being partially broken in Symfony 4, this fixes related content preview issue by using ConfigResolver. View matching configuration is fetched before matching operation.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
