### PR TITLE
EZP-30696: Changed Repository::sudo typehint form self to Repository

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -26,6 +26,7 @@ return PhpCsFixer\Config::create()
         'php_unit_construct' => false,
         'standardize_increment' => false,
         'fopen_flags' => false,
+        'self_accessor' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/eZ/Publish/API/Repository/Repository.php
+++ b/eZ/Publish/API/Repository/Repository.php
@@ -103,7 +103,7 @@ interface Repository
      *
      * @return mixed
      */
-    public function sudo(callable $callback, self $outerRepository = null);
+    public function sudo(callable $callback, Repository $outerRepository = null);
 
     /**
      * Get Content Service.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30696](https://jira.ez.no/browse/EZP-30696)
| **Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Current implementation forces descendants to change typehint to `Repository` interface. While it works (because descendants inherits Repository anyway), `self` is invalid in this context. `self` should be used only in case of indicating self-referenced instances, and not for typehinting current interface.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] ~Implement tests~
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
