### PR TITLE
EZP-30457: FieldType::getSortInfo should be implemented by impl. only if the FT is sortable

### DIFF
--- a/eZ/Publish/Core/FieldType/FieldType.php
+++ b/eZ/Publish/Core/FieldType/FieldType.php
@@ -271,7 +271,7 @@ abstract class FieldType extends SPIFieldType
      */
     protected function getSortInfo(Value $value)
     {
-        return false;
+        return null;
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/FieldType.php
+++ b/eZ/Publish/Core/FieldType/FieldType.php
@@ -271,7 +271,7 @@ abstract class FieldType extends SPIFieldType
      */
     protected function getSortInfo(Value $value)
     {
-        throw new \RuntimeException('Not implemented, yet.');
+        return false;
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30457](https://jira.ez.no/browse/EZP-30457)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     |  no

Method `eZ\Publish\Core\FieldType\FieldType::getSortInfo` should be implemented by Developer only if the FT is sortable.  

Currently, the default implementation throws a `RuntimeException:  "Not implemented, yet."`.  Usually, the developer figures out that something is missing on the first try of adding FT to the CT ...

**TODO**:
- [X] Implement feature / fix a bug.
- [ ] ~Implement tests.~
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
