### PR TITLE
EZP-25721: Return to show first service name in resolver warning

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -302,6 +302,7 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
             return;
         }
 
+        $serviceName = '??';
         $firstService = '??';
         $commandName = null;
         $resettableServiceIds = $container->getParameter('ezpublish.config_resolver.resettable_services');

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -302,7 +302,8 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
             return;
         }
 
-        $blame = '??';
+        $firstService = '??';
+        $commandName = null;
         $resettableServiceIds = $container->getParameter('ezpublish.config_resolver.resettable_services');
         $updatableServices = $container->getParameter('ezpublish.config_resolver.updateable_services');
 
@@ -330,20 +331,36 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
                 // Possible exception: Class name based services, can't be resolved as namespace is omitted from
                 // compiled function. In this case we won't know if it was updateable and "safe", so we warn to be sure
                 if (!in_array($serviceName, $resettableServiceIds, true) && !$container->has($serviceName)) {
-                    $blame = $potentialClassName;
+                    $serviceName = $potentialClassName;
                 } else {
-                    $blame = '@' . $serviceName;
+                    $serviceName = '@' . $serviceName;
                 }
 
-                // Detect if we found the command loading the service, if so add info to blame to make it easier to spot
+                // Keep track of the first service loaded
+                if ($firstService === '??') {
+                    $firstService = $serviceName;
+                }
+
+                // Detect if we found the command loading the service, if we track that as lasts service
                 if (PHP_SAPI === 'cli' && isset($t['file']) && \stripos($t['file'], 'CommandService.php') !== false) {
-                    $path = explode('/', $t['file']);
-                    $blame = \substr($path[count($path) - 1], 3, -11) . '(' . $blame . ')';
+                    $path = explode(DIRECTORY_SEPARATOR, $t['file']);
+                    $commandName = \substr($path[count($path) - 1], 3, -11);
                     break;
                 }
             }
         }
 
+        // Skip service name if same as first service
+        if ($serviceName === $firstService) {
+            $serviceName = '';
+        }
+
+        // Add command name if present as the trigger
+        if ($commandName) {
+            $blame = "$commandName($serviceName) -> $firstService";
+        } else {
+            $blame = ($serviceName ? $serviceName . ' -> ' : '') . $firstService;
+        }
         $this->tooEarlyLoadedList[$blame][] = $paramName;
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-2572](https://jira.ez.no/browse/EZP-2572)
| **Bug/Improvement**| yes
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Previous PR changed the logic to show last service to be able to show command name, however it makes it hard to read the error.

Now it becomes:
> 13:42:38 WARNING   [app] ConfigResolver was used by "Console_Command_EzsystemsEzplatformgraphqlCommandGenerateplatformschemacommand(@ezpublish.siteaccessaware.service.content_type) -> @ezpublish.helper.language_resolver" before SiteAccess was initialized, loading parameter(s) "$languages$". As this can cause very hard to debug issues, try to use ConfigResolver lazily, make the affected commands lazy, make the service lazy or see if you can inject another lazy service.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
