### PR TITLE
EZP-30503: Fixed missing default value for the new page_layout parameter

### DIFF
--- a/doc/specifications/security/authentication_symfony.md
+++ b/doc/specifications/security/authentication_symfony.md
@@ -52,7 +52,7 @@ Base template used is `EzPublishCoreBundle:Security:login.html.twig` and stands 
 {% endblock %}
 ```
 
-The layout used by default is `%ezsettings.default.pagelayout%` but can be configured easily
+The layout used by default is `%ezsettings.default.page_layout%` but can be configured easily
 as well as the login template:
 
 *ezpublish.yml*

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -209,9 +209,13 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
             $contextualizer->setContextualParameter('default_page', $currentScope, '/' . ltrim($scopeSettings['default_page'], '/'));
         }
         if (isset($scopeSettings['pagelayout'])) {
+            // note: "pagelayout" is deprecated, deprecation message is set via Semantic Config Node Builder
             $contextualizer->setContextualParameter('pagelayout', $currentScope, $scopeSettings['pagelayout']);
+            $contextualizer->setContextualParameter('page_layout', $currentScope, $scopeSettings['pagelayout']);
         }
         if (isset($scopeSettings['page_layout'])) {
+            // note: "page_layout" as the new setting always takes precedence
+            $contextualizer->setContextualParameter('pagelayout', $currentScope, $scopeSettings['page_layout']);
             $contextualizer->setContextualParameter('page_layout', $currentScope, $scopeSettings['page_layout']);
         }
     }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -211,6 +211,9 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
         if (isset($scopeSettings['pagelayout'])) {
             $contextualizer->setContextualParameter('pagelayout', $currentScope, $scopeSettings['pagelayout']);
         }
+        if (isset($scopeSettings['page_layout'])) {
+            $contextualizer->setContextualParameter('page_layout', $currentScope, $scopeSettings['page_layout']);
+        }
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -35,6 +35,7 @@ parameters:
         parent_location_id: 51
 
     ezsettings.default.pagelayout: '%ezplatform.default_templates.pagelayout%'
+    ezsettings.default.page_layout: '%ezplatform.default_templates.pagelayout%'
 
     # List of content type identifiers to display as image when embedded
     ezplatform.content_view.image_embed_content_types_identifiers: ['image']
@@ -138,7 +139,7 @@ parameters:
 
     # Security settings
     ezsettings.default.security.login_template: "EzPublishCoreBundle:Security:login.html.twig"
-    ezsettings.default.security.base_layout: "%ezsettings.default.pagelayout%"
+    ezsettings.default.security.base_layout: "%ezsettings.default.page_layout%"
 
     # Image settings
     ezsettings.default.image.temporary_dir: imagetmp

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
@@ -211,7 +211,7 @@ class CommonTest extends AbstractParserTestCase
         $this->load();
         $this->assertConfigResolverParameterValue(
             'security.base_layout',
-            '%ezsettings.default.pagelayout%',
+            '%ezsettings.default.page_layout%',
             'ezdemo_site'
         );
         $this->assertConfigResolverParameterValue(

--- a/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/ViewbaseLayout.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/ViewbaseLayout.php
@@ -33,9 +33,7 @@ class ViewbaseLayout implements EventSubscriberInterface
 
     private function getPageLayout(): string
     {
-        return $this->configResolver->hasParameter('page_layout')
-            ? $this->configResolver->getParameter('page_layout')
-            : $this->configResolver->getParameter('pagelayout');
+        return $this->configResolver->getParameter('page_layout');
     }
 
     public function injectViewbaseLayout(FilterViewParametersEvent $event)


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30503](https://jira.ez.no/browse/EZP-30503)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

https://github.com/ezsystems/ezpublish-kernel/pull/2629 was incomplete. Default value for `page_layout` parameter did not exist.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
