### PR TITLE
[Tests] Fixed PHPUnit 8.x deprecated assertions warnings

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -3295,17 +3295,17 @@ XML
 
         $this->assertPropertiesCorrect($expectedVersions[0], $versions[0]);
         $this->assertPropertiesCorrect($expectedVersions[1], $versions[1]);
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             $versions[0]->creationDate->getTimestamp(),
             $versions[1]->creationDate->getTimestamp(),
+            2,
             'Creation time did not match within delta of 2 seconds',
-            2
         );
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             $versions[0]->modificationDate->getTimestamp(),
             $versions[1]->modificationDate->getTimestamp(),
+            2,
             'Creation time did not match within delta of 2 seconds',
-            2
         );
         $this->assertTrue($versions[0]->isArchived());
         $this->assertFalse($versions[0]->isDraft());

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1534,7 +1534,7 @@ class LocationServiceTest extends BaseTest
         self::assertCount(count($expectedLocations), $actualLocationsIds);
 
         // perform unordered equality assertion
-        self::assertEquals(
+        self::assertEqualsCanonicalizing(
             $expectedLocationIds,
             $actualLocationsIds,
             sprintf(
@@ -1542,10 +1542,7 @@ class LocationServiceTest extends BaseTest
                 $content->id,
                 implode(', ', $actualLocationsIds),
                 implode(', ', $expectedLocationIds)
-            ),
-            0.0,
-            10,
-            true
+            )
         );
     }
 

--- a/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
@@ -763,8 +763,8 @@ class ObjectStateServiceTest extends BaseTest
             $updatedObjectStateGroup
         );
 
-        $this->assertContains($updatedObjectStateGroup, $allObjectGroups, '', false, false);
-        $this->assertNotContains($loadedObjectStateGroup, $allObjectGroups, '', false, false);
+        $this->assertContainsEquals($updatedObjectStateGroup, $allObjectGroups, '');
+        $this->assertNotContainsEquals($loadedObjectStateGroup, $allObjectGroups, '');
     }
 
     /**
@@ -1394,8 +1394,8 @@ class ObjectStateServiceTest extends BaseTest
             $updatedObjectState->getObjectStateGroup()
         );
 
-        $this->assertContains($updatedObjectState, $allObjectStates, '', false, false);
-        $this->assertNotContains($loadedObjectState, $allObjectStates, '', false, false);
+        $this->assertContainsEquals($updatedObjectState, $allObjectStates, '');
+        $this->assertNotContainsEquals($loadedObjectState, $allObjectStates, '');
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
@@ -1184,11 +1184,11 @@ class SearchServiceLocationTest extends BaseTest
             }
         }
 
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             $fixture,
             $result,
+            .2, // Be quite generous regarding delay -- most important for scores
             'Search results do not match.',
-            .2 // Be quite generous regarding delay -- most important for scores
         );
     }
 

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -3741,11 +3741,11 @@ class SearchServiceTest extends BaseTest
             $this->assertEquals($content->id, $foundContent1->valueObject->id);
 
             $this->simplifySearchResult($result);
-            $this->assertEquals(
+            $this->assertEqualsWithDelta(
                 include $this->getFixtureDir() . '/UserMetadata.php',
                 $result,
+                .1, // Be quite generous regarding delay -- most important for scores
                 'Search results do not match.',
-                .1 // Be quite generous regarding delay -- most important for scores
             );
         }
     }
@@ -3840,11 +3840,11 @@ class SearchServiceTest extends BaseTest
             );
 
             $this->simplifySearchResult($result);
-            $this->assertEquals(
+            $this->assertEqualsWithDelta(
                 include $this->getFixtureDir() . '/UserMetadataLocation.php',
                 $result,
+                .1, // Be quite generous regarding delay -- most important for scores
                 'Search results do not match.',
-                .1 // Be quite generous regarding delay -- most important for scores
             );
         }
     }
@@ -4350,11 +4350,11 @@ class SearchServiceTest extends BaseTest
             }
         }
 
-        $this->assertEquals(
+        $this->assertEqualsWithDelta(
             $fixture,
             $result,
+            .99, // Be quite generous regarding delay -- most important for scores
             'Search results do not match.',
-            .99 // Be quite generous regarding delay -- most important for scores
         );
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | TBD
| **Doc needed**     | no

This PR refactors tests to get rid of some left-over PHPUnit 8.x deprecation warnings.

Handled the following deprecated warnings:
- [x] checking of internal attributes,
- [x] using assertEquals with delta argument,
- [x] using assertEquals with canonicalizing argument,
- [x] checking for object identity when using assert(Not)Contains.

**TODO**:
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Confirm CI agrees.
- [x] Ask for Code Review.
