### PR TITLE
EZP-30722: Make sure siteaccess is loaded before console commands on run

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Console/Application.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Console/Application.php
@@ -8,9 +8,13 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Console;
 
-use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Exception\InvalidSiteAccessException as InvalidSiteAccess;
+use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use Symfony\Bundle\FrameworkBundle\Console\Application as BaseApplication;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -19,11 +23,44 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class Application extends BaseApplication
 {
+    // See doRun()
+    private $kernel;
+
     public function __construct(KernelInterface $kernel)
     {
+        $this->kernel = $kernel;
         parent::__construct($kernel);
         $this->getDefinition()->addOption(
             new InputOption('--siteaccess', null, InputOption::VALUE_OPTIONAL, 'SiteAccess to use for operations. If not provided, default siteaccess will be used')
         );
+    }
+
+    public function doRun(InputInterface $input, OutputInterface $output)
+    {
+        // boot() will be re-executed by parent, but kernel only boots once regardlessly
+        // @todo Contribute a console.init event to Symfony 4 in order to rather use that in v3
+        $this->kernel->boot();
+
+        $container = $this->kernel->getContainer();
+        $siteAccess = $container->get('ezpublish.siteaccess');
+        $siteAccessList = $container->getParameter('ezpublish.siteaccess.list');
+
+        $siteAccess->matchingType = 'cli';
+        $siteAccess->name = $input->getParameterOption(
+            '--siteaccess',
+            $container->getParameter('ezpublish.siteaccess.default')
+        );
+
+
+        if (!in_array($siteAccess->name, $siteAccessList)) {
+            throw new InvalidSiteAccess($siteAccess->name, $siteAccessList, $siteAccess->matchingType, true);
+        }
+
+        $container->get('event_dispatcher')->dispatch(
+            MVCEvents::CONFIG_SCOPE_CHANGE,
+            new ScopeChangeEvent($siteAccess)
+        );
+
+        return parent::doRun($input, $output);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Console/Application.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Console/Application.php
@@ -8,12 +8,9 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Console;
 
-use eZ\Publish\Core\MVC\Exception\InvalidSiteAccessException as InvalidSiteAccess;
 use eZ\Publish\Core\MVC\Symfony\Event\ConsoleInitEvent;
-use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use Symfony\Bundle\FrameworkBundle\Console\Application as BaseApplication;
-use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -51,7 +48,6 @@ class Application extends BaseApplication
             MVCEvents::CONSOLE_INIT,
             new ConsoleInitEvent($input, $output)
         );
-
 
         return parent::doRun($input, $output);
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Console/Application.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Console/Application.php
@@ -23,7 +23,11 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class Application extends BaseApplication
 {
-    // See doRun()
+    /**
+     * @see doRun
+     *
+     * @var \Symfony\Component\HttpKernel\KernelInterface
+     */
     private $kernel;
 
     public function __construct(KernelInterface $kernel)

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ConsoleCommandListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ConsoleCommandListener.php
@@ -9,12 +9,11 @@
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
 
 use eZ\Publish\Core\MVC\Exception\InvalidSiteAccessException;
+use eZ\Publish\Core\MVC\Symfony\Event\ConsoleInitEvent;
 use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
-use Symfony\Component\Console\ConsoleEvents;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -62,13 +61,13 @@ class ConsoleCommandListener implements EventSubscriberInterface, SiteAccessAwar
     public static function getSubscribedEvents()
     {
         return [
-            ConsoleEvents::COMMAND => [
+            MVCEvents::CONSOLE_INIT => [
                 ['onConsoleCommand', -1],
             ],
         ];
     }
 
-    public function onConsoleCommand(ConsoleCommandEvent $event)
+    public function onConsoleCommand(ConsoleInitEvent $event)
     {
         $this->siteAccess->name = $event->getInput()->getParameterOption('--siteaccess', $this->defaultSiteAccessName);
         $this->siteAccess->matchingType = 'cli';

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConsoleCommandListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConsoleCommandListenerTest.php
@@ -14,7 +14,6 @@ use eZ\Publish\Core\MVC\Symfony\Event\ConsoleInitEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConsoleCommandListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConsoleCommandListenerTest.php
@@ -10,11 +10,11 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;
 
 use eZ\Bundle\EzPublishCoreBundle\EventListener\ConsoleCommandListener;
 use eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\TestOutput;
+use eZ\Publish\Core\MVC\Symfony\Event\ConsoleInitEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\ConsoleEvents;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
@@ -49,11 +49,6 @@ class ConsoleCommandListenerTest extends TestCase
     private $inputDefinition;
 
     /**
-     * @var Command
-     */
-    private $command;
-
-    /**
      * @var TestOutput
      */
     private $testOutput;
@@ -66,7 +61,6 @@ class ConsoleCommandListenerTest extends TestCase
         $this->listener = new ConsoleCommandListener('default', $this->siteAccessList, $this->dispatcher);
         $this->listener->setSiteAccess($this->siteAccess);
         $this->dispatcher->addSubscriber($this->listener);
-        $this->command = new Command('test:siteaccess');
         $this->inputDefinition = new InputDefinition([new InputOption('siteaccess', null, InputOption::VALUE_OPTIONAL)]);
         $this->testOutput = new TestOutput(Output::VERBOSITY_QUIET, true);
     }
@@ -75,7 +69,7 @@ class ConsoleCommandListenerTest extends TestCase
     {
         $this->assertSame(
             [
-                ConsoleEvents::COMMAND => [['onConsoleCommand', -1]],
+                MVCEvents::CONSOLE_INIT => [['onConsoleCommand', -1]],
             ],
             $this->listener->getSubscribedEvents()
         );
@@ -90,7 +84,7 @@ class ConsoleCommandListenerTest extends TestCase
         $this->dispatcher->expects($this->never())
             ->method('dispatch');
         $input = new ArrayInput(['--siteaccess' => 'foo'], $this->inputDefinition);
-        $event = new ConsoleCommandEvent($this->command, $input, $this->testOutput);
+        $event = new ConsoleInitEvent($input, $this->testOutput);
         $this->listener->setDebug(true);
         $this->listener->onConsoleCommand($event);
     }
@@ -104,7 +98,7 @@ class ConsoleCommandListenerTest extends TestCase
         $this->dispatcher->expects($this->never())
             ->method('dispatch');
         $input = new ArrayInput(['--siteaccess' => 'foo'], $this->inputDefinition);
-        $event = new ConsoleCommandEvent($this->command, $input, $this->testOutput);
+        $event = new ConsoleInitEvent($input, $this->testOutput);
         $this->listener->setDebug(false);
         $this->listener->onConsoleCommand($event);
     }
@@ -114,7 +108,7 @@ class ConsoleCommandListenerTest extends TestCase
         $this->dispatcher->expects($this->once())
             ->method('dispatch');
         $input = new ArrayInput(['--siteaccess' => 'site1'], $this->inputDefinition);
-        $event = new ConsoleCommandEvent($this->command, $input, $this->testOutput);
+        $event = new ConsoleInitEvent($input, $this->testOutput);
         $this->listener->onConsoleCommand($event);
         $this->assertEquals(new SiteAccess('site1', 'cli'), $this->siteAccess);
     }
@@ -124,7 +118,7 @@ class ConsoleCommandListenerTest extends TestCase
         $this->dispatcher->expects($this->once())
             ->method('dispatch');
         $input = new ArrayInput([], $this->inputDefinition);
-        $event = new ConsoleCommandEvent($this->command, $input, $this->testOutput);
+        $event = new ConsoleInitEvent($input, $this->testOutput);
         $this->listener->onConsoleCommand($event);
         $this->assertEquals(new SiteAccess('default', 'cli'), $this->siteAccess);
     }

--- a/eZ/Publish/Core/MVC/Symfony/Event/ConsoleInitEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/ConsoleInitEvent.php
@@ -17,6 +17,6 @@ class ConsoleInitEvent extends ConsoleEvent
 {
     public function __construct(InputInterface $input, OutputInterface $output)
     {
-        parent::__construct(null,$input, $output);
+        parent::__construct(null, $input, $output);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Event/ConsoleInitEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/ConsoleInitEvent.php
@@ -6,9 +6,11 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Allows to do things before the command is loaded, like configuring system based on input.
@@ -17,6 +19,11 @@ class ConsoleInitEvent extends ConsoleEvent
 {
     public function __construct(InputInterface $input, OutputInterface $output)
     {
-        parent::__construct(null, $input, $output);
+        // Only relevant for 6.x, as in Symfony 2.x command argument is not optional
+        if (Kernel::MAJOR_VERSION < 3) {
+            parent::__construct(new Command('invalid'), $input, $output);
+        } else {
+            parent::__construct(null, $input, $output);
+        }
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Event/ConsoleInitEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/ConsoleInitEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Event;
+
+use Symfony\Component\Console\Event\ConsoleEvent;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Allows to do things before the command is loaded, like configuring system based on input.
+ */
+class ConsoleInitEvent extends ConsoleEvent
+{
+    public function __construct(InputInterface $input, OutputInterface $output)
+    {
+        parent::__construct(null,$input, $output);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/MVCEvents.php
+++ b/eZ/Publish/Core/MVC/Symfony/MVCEvents.php
@@ -85,4 +85,15 @@ final class MVCEvents
      * The event listener method receives a eZ\Publish\Core\MVC\Symfony\Event\ContentCacheClearEvent instance.
      */
     const CACHE_CLEAR_CONTENT = 'ezpublish.cache_clear.content';
+
+    /**
+     * The CONSOLE_INIT event allows you to attach listeners before any command is
+     * loaded by the console. It also allows you react to global arguments before commands are run.
+     *
+     * @Event("eZ\Publish\Core\MVC\Symfony\Event\ConsoleInitEvent")
+     *
+     * @internal For internal use by SiteAccess system on console.
+     * @deprecated Planned for move/contribution to Symfony in the future.
+     */
+    const CONSOLE_INIT = 'ezpublish.console.init';
 }

--- a/eZ/Publish/Core/MVC/Symfony/MVCEvents.php
+++ b/eZ/Publish/Core/MVC/Symfony/MVCEvents.php
@@ -92,7 +92,7 @@ final class MVCEvents
      *
      * @Event("eZ\Publish\Core\MVC\Symfony\Event\ConsoleInitEvent")
      *
-     * @internal For internal use by SiteAccess system on console, might move to symfony in some form in the future.
+     * @internal For internal use by SiteAccess system on console.
      */
     const CONSOLE_INIT = 'ezpublish.console.init';
 }

--- a/eZ/Publish/Core/MVC/Symfony/MVCEvents.php
+++ b/eZ/Publish/Core/MVC/Symfony/MVCEvents.php
@@ -92,8 +92,7 @@ final class MVCEvents
      *
      * @Event("eZ\Publish\Core\MVC\Symfony\Event\ConsoleInitEvent")
      *
-     * @internal For internal use by SiteAccess system on console.
-     * @deprecated Planned for move/contribution to Symfony in the future.
+     * @internal For internal use by SiteAccess system on console, might move to symfony in some form in the future.
      */
     const CONSOLE_INIT = 'ezpublish.console.init';
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30722](https://jira.ez.no/browse/EZP-30722)
| **Bug**| yes
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This fixes the root issue of siteaccess being set after commands are loaded when you run them.

Implies some of the fixes done on 2.5.2 can be reverted, specifically: 
- The once making services lazy _can_ be omitted. 
- Maybe also the once making commands lazy

Changes to drop use of dynamic settings _should_ probably stay as it makes the code more bullet proof also for request scope cases of this, and it aligns code with v3.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
