### PR TITLE
Missing property type in Field DocBlock

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Field.php
@@ -15,7 +15,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  *
  * @property-read mixed $id an internal id of the field
  * @property-read string $fieldDefIdentifier the field definition identifier
- * @property-read $value the value of the field
+ * @property-read mixed $value the value of the field
  * @property-read string $languageCode the language code of the field
  */
 class Field extends ValueObject


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | -
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 6.7
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

PHPStan Error:
```
 Access to protected property                             
         eZ\Publish\API\Repository\Values\Content\Field::$value.
```
