### PR TITLE
EZP-30729: Added a possibility to exclude Content Types when running CleanupVersionsCommand

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CleanupVersionsCommand extends Command
 {
     const DEFAULT_REPOSITORY_USER = 'admin';
-    const DEFAULT_EXCLUDED_CONTENT_TYPES = ['user'];
+    const DEFAULT_EXCLUDED_CONTENT_TYPES = 'user';
 
     const BEFORE_RUNNING_HINTS = <<<EOT
 <error>Before you continue:</error>

--- a/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
@@ -260,12 +260,13 @@ EOT;
 
         if ($excludedContentTypeIds) {
             $expr = $query->expr();
-            $query->andWhere(
-                $expr->notIn(
-                    'c.contentclass_id',
-                    $excludedContentTypeIds
-                )
-            );
+            $query
+                ->andWhere(
+                    $expr->notIn(
+                        'c.contentclass_id',
+                        ':contentTypeIds'
+                    )
+                )->setParameter(':contentTypeIds', $excludedContentTypeIds, Connection::PARAM_INT_ARRAY);
         }
 
         $stmt = $query->execute();

--- a/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
@@ -72,6 +72,7 @@ EOT;
 
     protected function configure()
     {
+        $beforeRunningHints = self::BEFORE_RUNNING_HINTS;
         $this
             ->setName('ezplatform:content:cleanup-versions')
             ->setDescription('Remove unwanted content versions. It keeps published version untouched. By default, it keeps also the last archived/draft version.')

--- a/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
@@ -136,13 +136,8 @@ EOT;
 
         $status = $input->getOption('status');
 
-        $contentTypeIds = explode(',', $input->getOption('excluded-content-types'));
-        $excludedContentTypeIds = array_unique(array_merge(
-            self::DEFAULT_EXCLUDED_CONTENT_TYPES,
-            $contentTypeIds)
-        );
-
-        $contentIds = $this->getObjectsIds($keep, $status, $excludedContentTypeIds);
+        $excludedContentTypeIdentifiers = explode(',', $input->getOption('excluded-content-types'));
+        $contentIds = $this->getObjectsIds($keep, $status, $excludedContentTypeIdentifiers);
         $contentIdsCount = count($contentIds);
 
         if ($contentIdsCount === 0) {
@@ -190,7 +185,7 @@ EOT;
                         ($removeDrafts && $version->status === VersionInfo::STATUS_DRAFT) ||
                         ($removeArchived && $version->status === VersionInfo::STATUS_ARCHIVED)
                     ) {
-                        return $version;
+                        return true;
                     }
                 });
 

--- a/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
@@ -107,7 +107,15 @@ EOT;
                 InputOption::VALUE_OPTIONAL,
                 'Comma separated list of ContentType identifiers of which versions should not be removed, for instance `article`.',
                 self::DEFAULT_EXCLUDED_CONTENT_TYPES
-            )->setHelp(self::BEFORE_RUNNING_HINTS);
+            )->setHelp(
+                <<<EOT
+The command <info>%command.name%</info> reduces content versions to a minimum. 
+It keeps published version untouched, and by default it keeps also the last archived/draft version.
+Note: This script can potentially run for a very long time, and in Symfony dev environment it will consume memory exponentially with size of dataset.
+
+{$beforeRunningHints}
+EOT
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -242,7 +242,7 @@ services:
         class: eZ\Bundle\EzPublishCoreBundle\Command\CleanupVersionsCommand
         arguments:
             - "@ezpublish.signalslot.repository"
-            - "@ezpublish.config.resolver"
+            - "@ezpublish.api.repository_configuration_provider"
             - "@ezpublish.persistence.connection"
         tags:
             - { name: console.command }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30729](https://jira.ez.no/browse/EZP-30729)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `6.7`/`6.13`/`7.5`/`master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR adds a possibility to exclude particular ContentTypes of which versions should not be removed. This option **always** includes content objects of default `User` ContentType (ID: `4`, unfortunately, there is no `const` anywhere to use it instead of hardcoding it).

Moreover, I've added a ProgressBar which indicates the progress. In some cases, it takes some time to clean up a huge number of versions so the user might have a wrong impression that nothing is going on. 

A second PR, introducing the usage of `$status` in `ContentService::loadVersions` method (introduced in: https://github.com/ezsystems/ezpublish-kernel/pull/2652) will be done soon, against `7.5` only. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
