### PR TITLE
EZP-30733: CleanupVersionsCommand should use new ContentService::loadVersions status argument for better performance

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
@@ -139,7 +139,11 @@ EOT
 
         $status = $input->getOption('status');
 
-        $excludedContentTypeIdentifiers = explode(',', $input->getOption('excluded-content-types'));
+        $excludedContentTypes = (string) $input->getOption('excluded-content-types');
+        if ($excludedContentTypes === '') {
+            $excludedContentTypes = self::DEFAULT_EXCLUDED_CONTENT_TYPES;
+        }
+        $excludedContentTypeIdentifiers = explode(',', $excludedContentTypes);
         $contentIds = $this->getObjectsIds($keep, $status, $excludedContentTypeIdentifiers);
         $contentIdsCount = count($contentIds);
 

--- a/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
@@ -184,10 +184,8 @@ EOT
                 ), OutputInterface::VERBOSITY_VERBOSE);
 
                 if ($removeAll) {
-                    $versions = array_filter($versions, static function ($version) {
-                        if ($version->status !== VersionInfo::STATUS_PUBLISHED) {
-                            return $version;
-                        }
+                    $versions = array_filter($versions, static function (VersionInfo $version) {
+                        return $version->status !== VersionInfo::STATUS_PUBLISHED;
                     });
                 }
 

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -343,7 +343,8 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
      */
     public function listVersions($contentId, $status = null, $limit = -1)
     {
-        $cacheItem = $this->cache->getItem("ez-content-${contentId}-version-list" . ($status ? "-byStatus-${status}" : '') . "-limit-{$limit}");
+        $cacheItem = $this->cache->getItem("ez-content-${contentId}-version-list" . ($status !== null ? "-byStatus-${status}" : '') . "-limit-{$limit}");
+
         if ($cacheItem->isHit()) {
             $this->logger->logCacheHit(['content' => $contentId, 'status' => $status]);
 

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -9,14 +9,14 @@
 namespace eZ\Publish\Core\Persistence\Cache;
 
 use eZ\Publish\API\Repository\Values\Content\Relation as APIRelation;
-use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandlerInterface;
 use eZ\Publish\SPI\Persistence\Content;
-use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\SPI\Persistence\Content\CreateStruct;
-use eZ\Publish\SPI\Persistence\Content\UpdateStruct;
+use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandlerInterface;
 use eZ\Publish\SPI\Persistence\Content\MetadataUpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Relation\CreateStruct as RelationCreateStruct;
+use eZ\Publish\SPI\Persistence\Content\UpdateStruct;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 
 /**
  * @see \eZ\Publish\SPI\Persistence\Content\Handler
@@ -505,10 +505,7 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
      *
      * For use when generating cache, not on invalidation.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
      * @param array $tags Optional, can be used to specify other tags.
-     *
-     * @return array
      */
     private function getCacheTagsForVersion(VersionInfo $versionInfo, array $tags = []): array
     {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30733](https://jira.ez.no/browse/EZP-30733)
| **Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`/`master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR introduces the usage of the new argument of `ContentService::loadVersions()` method (ref: https://github.com/ezsystems/ezpublish-kernel/pull/2652)which should have a significant, positive impact on the performance of CleanupVersionsCommand. 

This PR depends on https://github.com/ezsystems/ezpublish-kernel/pull/2691 which **needs to be** merged first and this one will have to be rebased afterward. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
