### PR TITLE
Enable CSRF token in login form by default

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/SessionTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/SessionTest.php
@@ -126,8 +126,8 @@ class SessionTest extends TestCase
         );
         $response = $this->sendHttpRequest($request);
 
-        // Since Session is reused, not created, expect 200 instead of 201
-        self::assertHttpResponseCodeEquals($response, 200);
+        // Session is recreated when using CSRF, expect 201 instead of 200
+        self::assertHttpResponseCodeEquals($response, 201);
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30515](https://jira.ez.no/browse/EZP-30515) (private)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 7.5
| **BC breaks**      | maybe?
| **Tests pass**     | yes, with https://github.com/ezsystems/ezplatform/pull/435
| **Doc needed**     | no

https://github.com/ezsystems/ezplatform/pull/435 enables CSRF token in login forms by default. This is a publicly known security issue which isn't merged yet due to a problem with kernel tests, but users have been warned to enable it. This kernel PR fixes the test.
https://share.ez.no/community-project/security-advisories/ezsa-2019-004-csrf-token-in-login-form-is-disabled-by-default

⚠ SessionTest will fail here, but passes if https://github.com/ezsystems/ezplatform/pull/435 is merged.

Some digging shows that in [CVE-2018-11385](https://symfony.com/blog/cve-2018-11385-session-fixation-issue-for-guard-authentication) in Feb 2018, session migration was "added to all auth listeners to avoid any possible session fixation": https://github.com/symfony/symfony/commit/a5855e8c9700c4f438cfad5e3e2cbf5994298605

So it seems clear that you *should* normally change session on login (with some exceptions, seen in [later commits](https://github.com/symfony/symfony/commit/cca73bb564adae22d0e9dd0c6dafbf1466a555c1)). Not clear yet why it didn't happen before we added CSRF to the login.