### PR TITLE
EZP-30745: Introduced new names for External Storage service tags

### DIFF
--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/ExternalStorageRegistryPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/ExternalStorageRegistryPassTest.php
@@ -28,11 +28,14 @@ class ExternalStorageRegistryPassTest extends AbstractCompilerPassTestCase
         $container->addCompilerPass(new ExternalStorageRegistryPass());
     }
 
-    public function testRegisterExternalStorageHandler()
+    /**
+     * @dataProvider externalStorageHandlerTagsProvider
+     */
+    public function testRegisterExternalStorageHandler(string $tag)
     {
         $def = new Definition();
         $fieldTypeIdentifier = 'field_type_identifier';
-        $def->addTag('ezpublish.fieldType.externalStorageHandler', ['alias' => $fieldTypeIdentifier]);
+        $def->addTag($tag, ['alias' => $fieldTypeIdentifier]);
         $serviceId = 'some_service_id';
         $this->setDefinition($serviceId, $def);
 
@@ -45,13 +48,16 @@ class ExternalStorageRegistryPassTest extends AbstractCompilerPassTestCase
         );
     }
 
-    public function testRegisterExternalStorageHandlerNoAlias()
+    /**
+     * @dataProvider externalStorageHandlerTagsProvider
+     */
+    public function testRegisterExternalStorageHandlerNoAlias(string $tag)
     {
         $this->expectException(\LogicException::class);
 
         $def = new Definition();
         $fieldTypeIdentifier = 'field_type_identifier';
-        $def->addTag('ezpublish.fieldType.externalStorageHandler');
+        $def->addTag($tag);
         $serviceId = 'some_service_id';
         $this->setDefinition($serviceId, $def);
 
@@ -64,21 +70,26 @@ class ExternalStorageRegistryPassTest extends AbstractCompilerPassTestCase
         );
     }
 
-    public function testRegisterExternalStorageHandlerWithGateway()
+    /**
+     * @dataProvider externalStorageHandlerGatewayTagsProvider
+     */
+    public function testRegisterExternalStorageHandlerWithGateway(string $tag)
     {
         $handlerDef = new Definition();
         $handlerDef->setClass(GatewayBasedStorageHandler::class);
         $fieldTypeIdentifier = 'field_type_identifier';
-        $handlerDef->addTag('ezpublish.fieldType.externalStorageHandler', ['alias' => $fieldTypeIdentifier]);
+        $handlerDef->addTag(ExternalStorageRegistryPass::EXTERNAL_STORAGE_HANDLER_SERVICE_TAG, [
+            'alias' => $fieldTypeIdentifier,
+        ]);
         $storageHandlerServiceId = 'external_storage_handler_id';
         $this->setDefinition($storageHandlerServiceId, $handlerDef);
 
         $gatewayDef = new Definition();
         $gatewayIdentifier = 'LegacyStorage';
-        $gatewayDef->addTag(
-            'ezpublish.fieldType.externalStorageHandler.gateway',
-            ['alias' => $fieldTypeIdentifier, 'identifier' => $gatewayIdentifier]
-        );
+        $gatewayDef->addTag($tag, [
+            'alias' => $fieldTypeIdentifier,
+            'identifier' => $gatewayIdentifier,
+        ]);
         $gatewayServiceId = 'gateway_service';
         $this->setDefinition($gatewayServiceId, $gatewayDef);
 
@@ -97,14 +108,19 @@ class ExternalStorageRegistryPassTest extends AbstractCompilerPassTestCase
         );
     }
 
-    public function testRegisterExternalStorageHandlerWithoutRegisteredGateway()
+    /**
+     * @dataProvider externalStorageHandlerGatewayTagsProvider
+     */
+    public function testRegisterExternalStorageHandlerWithoutRegisteredGateway(string $tag)
     {
         $this->expectException(\LogicException::class);
 
         $handlerDef = new Definition();
         $handlerDef->setClass(GatewayBasedStorageHandler::class);
         $fieldTypeIdentifier = 'field_type_identifier';
-        $handlerDef->addTag('ezpublish.fieldType.externalStorageHandler', ['alias' => $fieldTypeIdentifier]);
+        $handlerDef->addTag($tag, [
+            'alias' => $fieldTypeIdentifier,
+        ]);
         $storageHandlerServiceId = 'external_storage_handler_id';
         $this->setDefinition($storageHandlerServiceId, $handlerDef);
 
@@ -117,20 +133,25 @@ class ExternalStorageRegistryPassTest extends AbstractCompilerPassTestCase
         );
     }
 
-    public function testRegisterExternalStorageHandlerWithGatewayNoAlias()
+    /**
+     * @dataProvider externalStorageHandlerGatewayTagsProvider
+     */
+    public function testRegisterExternalStorageHandlerWithGatewayNoAlias(string $tag)
     {
         $this->expectException(\LogicException::class);
 
         $handlerDef = new Definition();
         $handlerDef->setClass(GatewayBasedStorageHandler::class);
         $fieldTypeIdentifier = 'field_type_identifier';
-        $handlerDef->addTag('ezpublish.fieldType.externalStorageHandler', ['alias' => $fieldTypeIdentifier]);
+        $handlerDef->addTag(ExternalStorageRegistryPass::EXTERNAL_STORAGE_HANDLER_SERVICE_TAG, [
+            'alias' => $fieldTypeIdentifier,
+        ]);
         $storageHandlerServiceId = 'external_storage_handler_id';
         $this->setDefinition($storageHandlerServiceId, $handlerDef);
 
         $gatewayDef = new Definition();
         $gatewayIdentifier = 'LegacyStorage';
-        $gatewayDef->addTag('ezpublish.fieldType.externalStorageHandler.gateway');
+        $gatewayDef->addTag($tag);
         $gatewayServiceId = 'gateway_service';
         $this->setDefinition($gatewayServiceId, $gatewayDef);
 
@@ -143,23 +164,25 @@ class ExternalStorageRegistryPassTest extends AbstractCompilerPassTestCase
         );
     }
 
-    public function testRegisterExternalStorageHandlerWithGatewayNoIdentifier()
+    /**
+     * @dataProvider externalStorageHandlerGatewayTagsProvider
+     */
+    public function testRegisterExternalStorageHandlerWithGatewayNoIdentifier(string $tag)
     {
         $this->expectException(\LogicException::class);
 
         $handlerDef = new Definition();
         $handlerDef->setClass(GatewayBasedStorageHandler::class);
         $fieldTypeIdentifier = 'field_type_identifier';
-        $handlerDef->addTag('ezpublish.fieldType.externalStorageHandler', ['alias' => $fieldTypeIdentifier]);
+        $handlerDef->addTag(ExternalStorageRegistryPass::EXTERNAL_STORAGE_HANDLER_SERVICE_TAG, [
+            'alias' => $fieldTypeIdentifier,
+        ]);
         $storageHandlerServiceId = 'external_storage_handler_id';
         $this->setDefinition($storageHandlerServiceId, $handlerDef);
 
         $gatewayDef = new Definition();
         $gatewayIdentifier = 'LegacyStorage';
-        $gatewayDef->addTag(
-            'ezpublish.fieldType.externalStorageHandler.gateway',
-            ['alias' => $fieldTypeIdentifier]
-        );
+        $gatewayDef->addTag($tag, ['alias' => $fieldTypeIdentifier]);
         $gatewayServiceId = 'gateway_service';
         $this->setDefinition($gatewayServiceId, $gatewayDef);
 
@@ -170,5 +193,21 @@ class ExternalStorageRegistryPassTest extends AbstractCompilerPassTestCase
             'registerExternalStorageHandler',
             [$storageHandlerServiceId, $fieldTypeIdentifier]
         );
+    }
+
+    public function externalStorageHandlerTagsProvider(): array
+    {
+        return [
+            [ExternalStorageRegistryPass::DEPRECATED_EXTERNAL_STORAGE_HANDLER_SERVICE_TAG],
+            [ExternalStorageRegistryPass::EXTERNAL_STORAGE_HANDLER_SERVICE_TAG],
+        ];
+    }
+
+    public function externalStorageHandlerGatewayTagsProvider(): array
+    {
+        return [
+            [ExternalStorageRegistryPass::DEPRECATED_EXTERNAL_STORAGE_HANDLER_GATEWAY_SERVICE_TAG],
+            [ExternalStorageRegistryPass::EXTERNAL_STORAGE_HANDLER_GATEWAY_SERVICE_TAG],
+        ];
     }
 }

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -17,7 +17,7 @@ services:
             - "@ezpublish.fieldType.ezbinaryfile.pathGenerator"
             - "@ezpublish.core.io.mimeTypeDetector"
         tags:
-            - {name: ezpublish.fieldType.externalStorageHandler, alias: ezbinaryfile}
+            - {name: ezplatform.field_type.external_storage_handler, alias: ezbinaryfile}
 
     ezpublish.fieldType.ezimage.externalStorage:
         class: "%ezpublish.fieldType.ezimage.externalStorage.class%"
@@ -30,14 +30,14 @@ services:
             - "@ezpublish.utils.deprecation_warner"
             - "@?ezpublish.image_alias.imagine.alias_cleaner"
         tags:
-            - {name: ezpublish.fieldType.externalStorageHandler, alias: ezimage}
+            - {name: ezplatform.field_type.external_storage_handler, alias: ezimage}
 
     ezpublish.fieldType.ezkeyword.externalStorage:
         class: "%ezpublish.fieldType.ezkeyword.externalStorage.class%"
         public: true # @todo should be private
         arguments: ["@ezpublish.fieldType.ezkeyword.storage_gateway"]
         tags:
-            - {name: ezpublish.fieldType.externalStorageHandler, alias: ezkeyword}
+            - {name: ezplatform.field_type.external_storage_handler, alias: ezkeyword}
 
     ezpublish.fieldType.ezmedia.externalStorage:
         class: "%ezpublish.fieldType.ezmedia.externalStorage.class%"
@@ -48,7 +48,7 @@ services:
             - "@ezpublish.fieldType.ezbinaryfile.pathGenerator"
             - "@ezpublish.core.io.mimeTypeDetector"
         tags:
-            - {name: ezpublish.fieldType.externalStorageHandler, alias: ezmedia}
+            - {name: ezplatform.field_type.external_storage_handler, alias: ezmedia}
 
     ezpublish.fieldType.ezurl.externalStorage:
         class: "%ezpublish.fieldType.ezurl.externalStorage.class%"
@@ -57,21 +57,21 @@ services:
             - "@ezpublish.fieldType.ezurl.storage_gateway"
             - "@?logger"
         tags:
-            - {name: ezpublish.fieldType.externalStorageHandler, alias: ezurl}
+            - {name: ezplatform.field_type.external_storage_handler, alias: ezurl}
 
     ezpublish.fieldType.ezgmaplocation.externalStorage:
         class: "%ezpublish.fieldType.ezgmaplocation.externalStorage.class%"
         public: true # @todo should be private
         arguments: ["@ezpublish.fieldType.externalStorageHandler.ezgmaplocation.gateway"]
         tags:
-            - {name: ezpublish.fieldType.externalStorageHandler, alias: ezgmaplocation}
+            - {name: ezplatform.field_type.external_storage_handler, alias: ezgmaplocation}
 
     ezpublish.fieldType.ezuser.externalStorage:
         class: "%ezpublish.fieldType.ezuser.externalStorage.class%"
         public: true # @todo should be private
         arguments: ["@ezpublish.fieldType.ezuser.storage_gateway"]
         tags:
-            - {name: ezpublish.fieldType.externalStorageHandler, alias: ezuser}
+            - {name: ezplatform.field_type.external_storage_handler, alias: ezuser}
 
     ezpublish.fieldType.metadataHandler.imagesize:
         class: "%ezpublish.core.io.metadataHandler.imageSize.class%"

--- a/eZ/Publish/Core/settings/richtext/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/richtext/fieldtype_external_storages.yml
@@ -7,5 +7,5 @@ services:
         public: true # @todo should be private
         arguments: ["@ezpublish.fieldType.ezrichtext.storage_gateway"]
         tags:
-            - {name: ezpublish.fieldType.externalStorageHandler, alias: ezrichtext}
+            - {name: ezplatform.field_type.external_storage_handler, alias: ezrichtext}
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30745](https://jira.ez.no/browse/EZP-30745)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** |`master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Follow up for #2653: 
* `ezpublish.fieldType.externalStorageHandler` has been deprecated in favour of `ezplatform.field_type.external_storage_handler`
* `ezpublish.fieldType.externalStorageHandler.gateway` has been deprecated in favour of `ezplatform.field_type.external_storage_handler.gateway`

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
