### PR TITLE
Available languages should not depend on languages order

### DIFF
--- a/eZ/Publish/Core/Helper/Tests/TranslationHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/TranslationHelperTest.php
@@ -337,4 +337,26 @@ class TranslationHelperTest extends TestCase
         $expectedLanguages = ['eng-GB', 'esl-ES', 'fre-FR', 'heb-IL'];
         $this->assertSame($expectedLanguages, $this->translationHelper->getAvailableLanguages());
     }
+
+    public function testGetAvailableLanguagesShouldNotDependOnOrder()
+    {
+        $this->configResolver
+            ->expects($this->any())
+            ->method('getParameter')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['translation_siteaccesses', null, null, []],
+                        ['related_siteaccesses', null, null, ['fre', 'esl', 'heb']],
+                        ['languages', null, null, ['eng-GB']],
+                        ['languages', null, 'fre', ['eng-GB', 'fre-FR']],
+                        ['languages', null, 'esl', ['eng-GB', 'esl-ES', 'fre-FR']],
+                        ['languages', null, 'heb', ['eng-GB', 'heb-IL']],
+                    ]
+                )
+            );
+
+        $expectedLanguages = ['eng-GB', 'esl-ES', 'fre-FR', 'heb-IL'];
+        $this->assertSame($expectedLanguages, $this->translationHelper->getAvailableLanguages());
+    }
 }

--- a/eZ/Publish/Core/Helper/TranslationHelper.php
+++ b/eZ/Publish/Core/Helper/TranslationHelper.php
@@ -279,17 +279,36 @@ class TranslationHelper
         $translationSiteAccesses = $this->configResolver->getParameter('translation_siteaccesses');
         $relatedSiteAccesses = $translationSiteAccesses ?: $this->configResolver->getParameter('related_siteaccesses');
         $availableLanguages = [];
+
         $currentLanguages = $this->configResolver->getParameter('languages');
-        $availableLanguages[] = array_shift($currentLanguages);
+        $availableLanguages = $this->addToAvailableLanguages($availableLanguages, $currentLanguages);
 
         foreach ($relatedSiteAccesses as $sa) {
             $languages = $this->configResolver->getParameter('languages', null, $sa);
-            $availableLanguages[] = array_shift($languages);
+            $availableLanguages = $this->addToAvailableLanguages($availableLanguages, $languages);
         }
+
+        $availableLanguages = array_keys($availableLanguages);
 
         sort($availableLanguages);
 
-        return array_unique($availableLanguages);
+        return $availableLanguages;
+    }
+
+    /**
+     * @param array $availableLanguages
+     * @param array|null $languages
+     * @return mixed
+     */
+    private function addToAvailableLanguages($availableLanguages, $languages)
+    {
+        if (is_array($languages)) {
+            foreach ($languages as $language) {
+                $availableLanguages[$language] = 1;
+            }
+        }
+
+        return $availableLanguages;
     }
 
     /**


### PR DESCRIPTION
Currently translation helper getAvailableLanguages function uses only
the first entry in the languages configuration of a siteaccess

Therefore if we have three site accesses, we need to define the languages
in each of them and with the current language as the first in the array,
although there is no such restriction for the configuration

For such a siteaccess example

    siteaccess:
        list: [en, de, fr, it, admin]
        groups:
            site_group: [en, de, fr, it]
            switzerland: [de, fr, it]

This would work

    en:
        languages: [eng-GB]

    de:
        languages: [ger-DE, fre-FR, ita-IT]

    fr:
        languages: [fre-FR, ger-DE, ita-IT]

    it:
        languages: [ita-IT, fre-FR, ger-DE]

This

    en:
        languages: [eng-GB]

    de:
        languages: [ger-DE, fre-FR, ita-IT]

    fr:
        languages: [ger-DE, fre-FR, ita-IT]

    it:
        languages: [ger-DE, fre-FR, ita-IT]

or more importantly if we define the languages in the sitegroup

    switzerland:
        languages: [ger-DE, fre-FR, ita-IT]
        translation_siteaccesses: [de, fr, it]

the translation helper would only return the first available language in
the list.

Here I have added a test case and the fix for it. Other tests still work
as expected.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-XXXXX](https://jira.ez.no/browse/EZP-XXXXX)
| **Bug/Improvement**| yes/no
| **New feature**    | yes/no
| **Target version** | `6.x`/`7.x` for bug fixes or improvements _(on existing features)_, `master` for features
| **BC breaks**      | yes/no
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
