### PR TITLE
EZP-30749: Passed explicitly event name to dispatcher

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LanguageServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LanguageServiceTest.php
@@ -264,13 +264,13 @@ class LanguageServiceTest extends BaseTest
     public function testUpdateLanguageNameThrowsInvalidArgumentException()
     {
         $this->expectException(\eZ\Publish\API\Repository\Exceptions\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Argument \'newName\' is invalid: \'1\' is wrong value');
+        $this->expectExceptionMessage('Argument \'newName\' is invalid: \'\' is wrong value');
 
         $repository = $this->getRepository();
         $languageService = $repository->getContentLanguageService();
 
         $language = $languageService->loadLanguage('eng-GB');
-        $languageService->updateLanguageName($language, 1);
+        $languageService->updateLanguageName($language, '');
     }
 
     /**

--- a/eZ/Publish/Core/Event/BookmarkService.php
+++ b/eZ/Publish/Core/Event/BookmarkService.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\Event;
 
 use eZ\Publish\API\Repository\BookmarkService as BookmarkServiceInterface;
+use eZ\Publish\API\Repository\Events\Bookmark\BeforeCreateBookmarkEvent as BeforeCreateBookmarkEventInterface;
+use eZ\Publish\API\Repository\Events\Bookmark\BeforeDeleteBookmarkEvent as BeforeDeleteBookmarkEventInterface;
+use eZ\Publish\API\Repository\Events\Bookmark\CreateBookmarkEvent as CreateBookmarkEventInterface;
+use eZ\Publish\API\Repository\Events\Bookmark\DeleteBookmarkEvent as DeleteBookmarkEventInterface;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Event\Bookmark\BeforeCreateBookmarkEvent;
 use eZ\Publish\Core\Event\Bookmark\BeforeDeleteBookmarkEvent;
@@ -36,13 +40,15 @@ class BookmarkService extends BookmarkServiceDecorator
         $eventData = [$location];
 
         $beforeEvent = new BeforeCreateBookmarkEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateBookmarkEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->createBookmark($location);
 
-        $this->eventDispatcher->dispatch(new CreateBookmarkEvent(...$eventData));
+        $this->eventDispatcher->dispatch(new CreateBookmarkEvent(...$eventData), CreateBookmarkEventInterface::class);
     }
 
     public function deleteBookmark(Location $location): void
@@ -50,12 +56,14 @@ class BookmarkService extends BookmarkServiceDecorator
         $eventData = [$location];
 
         $beforeEvent = new BeforeDeleteBookmarkEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteBookmarkEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteBookmark($location);
 
-        $this->eventDispatcher->dispatch(new DeleteBookmarkEvent(...$eventData));
+        $this->eventDispatcher->dispatch(new DeleteBookmarkEvent(...$eventData), DeleteBookmarkEventInterface::class);
     }
 }

--- a/eZ/Publish/Core/Event/ContentService.php
+++ b/eZ/Publish/Core/Event/ContentService.php
@@ -9,6 +9,32 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\Event;
 
 use eZ\Publish\API\Repository\ContentService as ContentServiceInterface;
+use eZ\Publish\API\Repository\Events\Content\AddRelationEvent as AddRelationEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforeAddRelationEvent as BeforeAddRelationEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforeCopyContentEvent as BeforeCopyContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforeCreateContentDraftEvent as BeforeCreateContentDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforeCreateContentEvent as BeforeCreateContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforeDeleteContentEvent as BeforeDeleteContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforeDeleteRelationEvent as BeforeDeleteRelationEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforeDeleteTranslationEvent as BeforeDeleteTranslationEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforeDeleteVersionEvent as BeforeDeleteVersionEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforeHideContentEvent as BeforeHideContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforePublishVersionEvent as BeforePublishVersionEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforeRevealContentEvent as BeforeRevealContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforeUpdateContentEvent as BeforeUpdateContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\BeforeUpdateContentMetadataEvent as BeforeUpdateContentMetadataEventInterface;
+use eZ\Publish\API\Repository\Events\Content\CopyContentEvent as CopyContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\CreateContentDraftEvent as CreateContentDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Content\CreateContentEvent as CreateContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\DeleteContentEvent as DeleteContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\DeleteRelationEvent as DeleteRelationEventInterface;
+use eZ\Publish\API\Repository\Events\Content\DeleteTranslationEvent as DeleteTranslationEventInterface;
+use eZ\Publish\API\Repository\Events\Content\DeleteVersionEvent as DeleteVersionEventInterface;
+use eZ\Publish\API\Repository\Events\Content\HideContentEvent as HideContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\PublishVersionEvent as PublishVersionEventInterface;
+use eZ\Publish\API\Repository\Events\Content\RevealContentEvent as RevealContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\UpdateContentEvent as UpdateContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\UpdateContentMetadataEvent as UpdateContentMetadataEventInterface;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -72,7 +98,9 @@ class ContentService extends ContentServiceDecorator
         ];
 
         $beforeEvent = new BeforeCreateContentEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateContentEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getContent();
         }
 
@@ -80,7 +108,10 @@ class ContentService extends ContentServiceDecorator
             ? $beforeEvent->getContent()
             : $this->innerService->createContent($contentCreateStruct, $locationCreateStructs);
 
-        $this->eventDispatcher->dispatch(new CreateContentEvent($content, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateContentEvent($content, ...$eventData),
+            CreateContentEventInterface::class
+        );
 
         return $content;
     }
@@ -95,7 +126,9 @@ class ContentService extends ContentServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateContentMetadataEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateContentMetadataEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getContent();
         }
 
@@ -103,7 +136,10 @@ class ContentService extends ContentServiceDecorator
             ? $beforeEvent->getContent()
             : $this->innerService->updateContentMetadata($contentInfo, $contentMetadataUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateContentMetadataEvent($content, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateContentMetadataEvent($content, ...$eventData),
+            UpdateContentMetadataEventInterface::class
+        );
 
         return $content;
     }
@@ -113,7 +149,9 @@ class ContentService extends ContentServiceDecorator
         $eventData = [$contentInfo];
 
         $beforeEvent = new BeforeDeleteContentEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteContentEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getLocations();
         }
 
@@ -121,7 +159,10 @@ class ContentService extends ContentServiceDecorator
             ? $beforeEvent->getLocations()
             : $this->innerService->deleteContent($contentInfo);
 
-        $this->eventDispatcher->dispatch(new DeleteContentEvent($locations, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteContentEvent($locations, ...$eventData),
+            DeleteContentEventInterface::class
+        );
 
         return $locations;
     }
@@ -138,7 +179,9 @@ class ContentService extends ContentServiceDecorator
         ];
 
         $beforeEvent = new BeforeCreateContentDraftEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateContentDraftEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getContentDraft();
         }
 
@@ -146,7 +189,10 @@ class ContentService extends ContentServiceDecorator
             ? $beforeEvent->getContentDraft()
             : $this->innerService->createContentDraft($contentInfo, $versionInfo, $creator);
 
-        $this->eventDispatcher->dispatch(new CreateContentDraftEvent($contentDraft, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateContentDraftEvent($contentDraft, ...$eventData),
+            CreateContentDraftEventInterface::class
+        );
 
         return $contentDraft;
     }
@@ -161,7 +207,9 @@ class ContentService extends ContentServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateContentEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateContentEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getContent();
         }
 
@@ -169,7 +217,10 @@ class ContentService extends ContentServiceDecorator
             ? $beforeEvent->getContent()
             : $this->innerService->updateContent($versionInfo, $contentUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateContentEvent($content, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateContentEvent($content, ...$eventData),
+            UpdateContentEventInterface::class
+        );
 
         return $content;
     }
@@ -182,7 +233,9 @@ class ContentService extends ContentServiceDecorator
         ];
 
         $beforeEvent = new BeforePublishVersionEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforePublishVersionEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getContent();
         }
 
@@ -190,7 +243,10 @@ class ContentService extends ContentServiceDecorator
             ? $beforeEvent->getContent()
             : $this->innerService->publishVersion($versionInfo, $translations);
 
-        $this->eventDispatcher->dispatch(new PublishVersionEvent($content, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new PublishVersionEvent($content, ...$eventData),
+            PublishVersionEventInterface::class
+        );
 
         return $content;
     }
@@ -200,13 +256,18 @@ class ContentService extends ContentServiceDecorator
         $eventData = [$versionInfo];
 
         $beforeEvent = new BeforeDeleteVersionEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteVersionEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteVersion($versionInfo);
 
-        $this->eventDispatcher->dispatch(new DeleteVersionEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteVersionEvent(...$eventData),
+            DeleteVersionEventInterface::class
+        );
     }
 
     public function copyContent(
@@ -221,7 +282,9 @@ class ContentService extends ContentServiceDecorator
         ];
 
         $beforeEvent = new BeforeCopyContentEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCopyContentEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getContent();
         }
 
@@ -229,7 +292,10 @@ class ContentService extends ContentServiceDecorator
             ? $beforeEvent->getContent()
             : $this->innerService->copyContent($contentInfo, $destinationLocationCreateStruct, $versionInfo);
 
-        $this->eventDispatcher->dispatch(new CopyContentEvent($content, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CopyContentEvent($content, ...$eventData),
+            CopyContentEventInterface::class
+        );
 
         return $content;
     }
@@ -244,7 +310,9 @@ class ContentService extends ContentServiceDecorator
         ];
 
         $beforeEvent = new BeforeAddRelationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeAddRelationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getRelation();
         }
 
@@ -252,7 +320,10 @@ class ContentService extends ContentServiceDecorator
             ? $beforeEvent->getRelation()
             : $this->innerService->addRelation($sourceVersion, $destinationContent);
 
-        $this->eventDispatcher->dispatch(new AddRelationEvent($relation, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new AddRelationEvent($relation, ...$eventData),
+            AddRelationEventInterface::class
+        );
 
         return $relation;
     }
@@ -267,13 +338,18 @@ class ContentService extends ContentServiceDecorator
         ];
 
         $beforeEvent = new BeforeDeleteRelationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteRelationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteRelation($sourceVersion, $destinationContent);
 
-        $this->eventDispatcher->dispatch(new DeleteRelationEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteRelationEvent(...$eventData),
+            DeleteRelationEventInterface::class
+        );
     }
 
     public function deleteTranslation(
@@ -286,13 +362,18 @@ class ContentService extends ContentServiceDecorator
         ];
 
         $beforeEvent = new BeforeDeleteTranslationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteTranslationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteTranslation($contentInfo, $languageCode);
 
-        $this->eventDispatcher->dispatch(new DeleteTranslationEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteTranslationEvent(...$eventData),
+            DeleteTranslationEventInterface::class
+        );
     }
 
     public function hideContent(ContentInfo $contentInfo): void
@@ -300,13 +381,18 @@ class ContentService extends ContentServiceDecorator
         $eventData = [$contentInfo];
 
         $beforeEvent = new BeforeHideContentEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeHideContentEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->hideContent($contentInfo);
 
-        $this->eventDispatcher->dispatch(new HideContentEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new HideContentEvent(...$eventData),
+            HideContentEventInterface::class
+        );
     }
 
     public function revealContent(ContentInfo $contentInfo): void
@@ -314,12 +400,17 @@ class ContentService extends ContentServiceDecorator
         $eventData = [$contentInfo];
 
         $beforeEvent = new BeforeRevealContentEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeRevealContentEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->revealContent($contentInfo);
 
-        $this->eventDispatcher->dispatch(new RevealContentEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new RevealContentEvent(...$eventData),
+            RevealContentEventInterface::class
+        );
     }
 }

--- a/eZ/Publish/Core/Event/ContentTypeService.php
+++ b/eZ/Publish/Core/Event/ContentTypeService.php
@@ -9,6 +9,36 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\Event;
 
 use eZ\Publish\API\Repository\ContentTypeService as ContentTypeServiceInterface;
+use eZ\Publish\API\Repository\Events\ContentType\AddFieldDefinitionEvent as AddFieldDefinitionEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\AssignContentTypeGroupEvent as AssignContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeAddFieldDefinitionEvent as BeforeAddFieldDefinitionEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeAssignContentTypeGroupEvent as BeforeAssignContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeCopyContentTypeEvent as BeforeCopyContentTypeEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeCreateContentTypeDraftEvent as BeforeCreateContentTypeDraftEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeCreateContentTypeEvent as BeforeCreateContentTypeEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeCreateContentTypeGroupEvent as BeforeCreateContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeDeleteContentTypeEvent as BeforeDeleteContentTypeEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeDeleteContentTypeGroupEvent as BeforeDeleteContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforePublishContentTypeDraftEvent as BeforePublishContentTypeDraftEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeRemoveContentTypeTranslationEvent as BeforeRemoveContentTypeTranslationEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeRemoveFieldDefinitionEvent as BeforeRemoveFieldDefinitionEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeUnassignContentTypeGroupEvent as BeforeUnassignContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeUpdateContentTypeDraftEvent as BeforeUpdateContentTypeDraftEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeUpdateContentTypeGroupEvent as BeforeUpdateContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\BeforeUpdateFieldDefinitionEvent as BeforeUpdateFieldDefinitionEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\CopyContentTypeEvent as CopyContentTypeEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\CreateContentTypeDraftEvent as CreateContentTypeDraftEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\CreateContentTypeEvent as CreateContentTypeEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\CreateContentTypeGroupEvent as CreateContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\DeleteContentTypeEvent as DeleteContentTypeEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\DeleteContentTypeGroupEvent as DeleteContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\PublishContentTypeDraftEvent as PublishContentTypeDraftEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\RemoveContentTypeTranslationEvent as RemoveContentTypeTranslationEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\RemoveFieldDefinitionEvent as RemoveFieldDefinitionEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\UnassignContentTypeGroupEvent as UnassignContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\UpdateContentTypeDraftEvent as UpdateContentTypeDraftEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\UpdateContentTypeGroupEvent as UpdateContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\UpdateFieldDefinitionEvent as UpdateFieldDefinitionEventInterface;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeCreateStruct;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft;
@@ -72,7 +102,9 @@ class ContentTypeService extends ContentTypeServiceDecorator
         $eventData = [$contentTypeGroupCreateStruct];
 
         $beforeEvent = new BeforeCreateContentTypeGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateContentTypeGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getContentTypeGroup();
         }
 
@@ -80,7 +112,10 @@ class ContentTypeService extends ContentTypeServiceDecorator
             ? $beforeEvent->getContentTypeGroup()
             : $this->innerService->createContentTypeGroup($contentTypeGroupCreateStruct);
 
-        $this->eventDispatcher->dispatch(new CreateContentTypeGroupEvent($contentTypeGroup, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateContentTypeGroupEvent($contentTypeGroup, ...$eventData),
+            CreateContentTypeGroupEventInterface::class
+        );
 
         return $contentTypeGroup;
     }
@@ -95,13 +130,18 @@ class ContentTypeService extends ContentTypeServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateContentTypeGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateContentTypeGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->updateContentTypeGroup($contentTypeGroup, $contentTypeGroupUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateContentTypeGroupEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateContentTypeGroupEvent(...$eventData),
+            UpdateContentTypeGroupEventInterface::class
+        );
     }
 
     public function deleteContentTypeGroup(ContentTypeGroup $contentTypeGroup): void
@@ -109,13 +149,18 @@ class ContentTypeService extends ContentTypeServiceDecorator
         $eventData = [$contentTypeGroup];
 
         $beforeEvent = new BeforeDeleteContentTypeGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteContentTypeGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteContentTypeGroup($contentTypeGroup);
 
-        $this->eventDispatcher->dispatch(new DeleteContentTypeGroupEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteContentTypeGroupEvent(...$eventData),
+            DeleteContentTypeGroupEventInterface::class
+        );
     }
 
     public function createContentType(
@@ -128,7 +173,9 @@ class ContentTypeService extends ContentTypeServiceDecorator
         ];
 
         $beforeEvent = new BeforeCreateContentTypeEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateContentTypeEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getContentTypeDraft();
         }
 
@@ -136,7 +183,10 @@ class ContentTypeService extends ContentTypeServiceDecorator
             ? $beforeEvent->getContentTypeDraft()
             : $this->innerService->createContentType($contentTypeCreateStruct, $contentTypeGroups);
 
-        $this->eventDispatcher->dispatch(new CreateContentTypeEvent($contentTypeDraft, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateContentTypeEvent($contentTypeDraft, ...$eventData),
+            CreateContentTypeEventInterface::class
+        );
 
         return $contentTypeDraft;
     }
@@ -146,7 +196,9 @@ class ContentTypeService extends ContentTypeServiceDecorator
         $eventData = [$contentType];
 
         $beforeEvent = new BeforeCreateContentTypeDraftEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateContentTypeDraftEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getContentTypeDraft();
         }
 
@@ -154,7 +206,10 @@ class ContentTypeService extends ContentTypeServiceDecorator
             ? $beforeEvent->getContentTypeDraft()
             : $this->innerService->createContentTypeDraft($contentType);
 
-        $this->eventDispatcher->dispatch(new CreateContentTypeDraftEvent($contentTypeDraft, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateContentTypeDraftEvent($contentTypeDraft, ...$eventData),
+            CreateContentTypeDraftEventInterface::class
+        );
 
         return $contentTypeDraft;
     }
@@ -169,13 +224,18 @@ class ContentTypeService extends ContentTypeServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateContentTypeDraftEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateContentTypeDraftEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->updateContentTypeDraft($contentTypeDraft, $contentTypeUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateContentTypeDraftEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateContentTypeDraftEvent(...$eventData),
+            UpdateContentTypeDraftEventInterface::class
+        );
     }
 
     public function deleteContentType(ContentType $contentType): void
@@ -183,13 +243,18 @@ class ContentTypeService extends ContentTypeServiceDecorator
         $eventData = [$contentType];
 
         $beforeEvent = new BeforeDeleteContentTypeEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteContentTypeEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteContentType($contentType);
 
-        $this->eventDispatcher->dispatch(new DeleteContentTypeEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteContentTypeEvent(...$eventData),
+            DeleteContentTypeEventInterface::class
+        );
     }
 
     public function copyContentType(
@@ -202,7 +267,9 @@ class ContentTypeService extends ContentTypeServiceDecorator
         ];
 
         $beforeEvent = new BeforeCopyContentTypeEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCopyContentTypeEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getContentTypeCopy();
         }
 
@@ -210,7 +277,10 @@ class ContentTypeService extends ContentTypeServiceDecorator
             ? $beforeEvent->getContentTypeCopy()
             : $this->innerService->copyContentType($contentType, $creator);
 
-        $this->eventDispatcher->dispatch(new CopyContentTypeEvent($contentTypeCopy, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CopyContentTypeEvent($contentTypeCopy, ...$eventData),
+            CopyContentTypeEventInterface::class
+        );
 
         return $contentTypeCopy;
     }
@@ -225,13 +295,18 @@ class ContentTypeService extends ContentTypeServiceDecorator
         ];
 
         $beforeEvent = new BeforeAssignContentTypeGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeAssignContentTypeGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->assignContentTypeGroup($contentType, $contentTypeGroup);
 
-        $this->eventDispatcher->dispatch(new AssignContentTypeGroupEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new AssignContentTypeGroupEvent(...$eventData),
+            AssignContentTypeGroupEventInterface::class
+        );
     }
 
     public function unassignContentTypeGroup(
@@ -244,13 +319,18 @@ class ContentTypeService extends ContentTypeServiceDecorator
         ];
 
         $beforeEvent = new BeforeUnassignContentTypeGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUnassignContentTypeGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->unassignContentTypeGroup($contentType, $contentTypeGroup);
 
-        $this->eventDispatcher->dispatch(new UnassignContentTypeGroupEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UnassignContentTypeGroupEvent(...$eventData),
+            UnassignContentTypeGroupEventInterface::class
+        );
     }
 
     public function addFieldDefinition(
@@ -263,13 +343,18 @@ class ContentTypeService extends ContentTypeServiceDecorator
         ];
 
         $beforeEvent = new BeforeAddFieldDefinitionEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeAddFieldDefinitionEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->addFieldDefinition($contentTypeDraft, $fieldDefinitionCreateStruct);
 
-        $this->eventDispatcher->dispatch(new AddFieldDefinitionEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new AddFieldDefinitionEvent(...$eventData),
+            AddFieldDefinitionEventInterface::class
+        );
     }
 
     public function removeFieldDefinition(
@@ -282,13 +367,18 @@ class ContentTypeService extends ContentTypeServiceDecorator
         ];
 
         $beforeEvent = new BeforeRemoveFieldDefinitionEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeRemoveFieldDefinitionEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->removeFieldDefinition($contentTypeDraft, $fieldDefinition);
 
-        $this->eventDispatcher->dispatch(new RemoveFieldDefinitionEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new RemoveFieldDefinitionEvent(...$eventData),
+            RemoveFieldDefinitionEventInterface::class
+        );
     }
 
     public function updateFieldDefinition(
@@ -303,13 +393,18 @@ class ContentTypeService extends ContentTypeServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateFieldDefinitionEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateFieldDefinitionEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->updateFieldDefinition($contentTypeDraft, $fieldDefinition, $fieldDefinitionUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateFieldDefinitionEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateFieldDefinitionEvent(...$eventData),
+            UpdateFieldDefinitionEventInterface::class
+        );
     }
 
     public function publishContentTypeDraft(ContentTypeDraft $contentTypeDraft): void
@@ -317,13 +412,18 @@ class ContentTypeService extends ContentTypeServiceDecorator
         $eventData = [$contentTypeDraft];
 
         $beforeEvent = new BeforePublishContentTypeDraftEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforePublishContentTypeDraftEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->publishContentTypeDraft($contentTypeDraft);
 
-        $this->eventDispatcher->dispatch(new PublishContentTypeDraftEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new PublishContentTypeDraftEvent(...$eventData),
+            PublishContentTypeDraftEventInterface::class
+        );
     }
 
     public function removeContentTypeTranslation(
@@ -336,7 +436,9 @@ class ContentTypeService extends ContentTypeServiceDecorator
         ];
 
         $beforeEvent = new BeforeRemoveContentTypeTranslationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeRemoveContentTypeTranslationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getNewContentTypeDraft();
         }
 
@@ -344,7 +446,10 @@ class ContentTypeService extends ContentTypeServiceDecorator
             ? $beforeEvent->getNewContentTypeDraft()
             : $this->innerService->removeContentTypeTranslation($contentTypeDraft, $languageCode);
 
-        $this->eventDispatcher->dispatch(new RemoveContentTypeTranslationEvent($newContentTypeDraft, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new RemoveContentTypeTranslationEvent($newContentTypeDraft, ...$eventData),
+            RemoveContentTypeTranslationEventInterface::class
+        );
 
         return $newContentTypeDraft;
     }

--- a/eZ/Publish/Core/Event/LanguageService.php
+++ b/eZ/Publish/Core/Event/LanguageService.php
@@ -8,6 +8,16 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Event;
 
+use eZ\Publish\API\Repository\Events\Language\BeforeCreateLanguageEvent as BeforeCreateLanguageEventInterface;
+use eZ\Publish\API\Repository\Events\Language\BeforeDeleteLanguageEvent as BeforeDeleteLanguageEventInterface;
+use eZ\Publish\API\Repository\Events\Language\BeforeDisableLanguageEvent as BeforeDisableLanguageEventInterface;
+use eZ\Publish\API\Repository\Events\Language\BeforeEnableLanguageEvent as BeforeEnableLanguageEventInterface;
+use eZ\Publish\API\Repository\Events\Language\BeforeUpdateLanguageNameEvent as BeforeUpdateLanguageNameEventInterface;
+use eZ\Publish\API\Repository\Events\Language\CreateLanguageEvent as CreateLanguageEventInterface;
+use eZ\Publish\API\Repository\Events\Language\DeleteLanguageEvent as DeleteLanguageEventInterface;
+use eZ\Publish\API\Repository\Events\Language\DisableLanguageEvent as DisableLanguageEventInterface;
+use eZ\Publish\API\Repository\Events\Language\EnableLanguageEvent as EnableLanguageEventInterface;
+use eZ\Publish\API\Repository\Events\Language\UpdateLanguageNameEvent as UpdateLanguageNameEventInterface;
 use eZ\Publish\API\Repository\LanguageService as LanguageServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\LanguageCreateStruct;
@@ -43,7 +53,9 @@ class LanguageService extends LanguageServiceDecorator
         $eventData = [$languageCreateStruct];
 
         $beforeEvent = new BeforeCreateLanguageEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateLanguageEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getLanguage();
         }
 
@@ -51,7 +63,10 @@ class LanguageService extends LanguageServiceDecorator
             ? $beforeEvent->getLanguage()
             : $this->innerService->createLanguage($languageCreateStruct);
 
-        $this->eventDispatcher->dispatch(new CreateLanguageEvent($language, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateLanguageEvent($language, ...$eventData),
+            CreateLanguageEventInterface::class
+        );
 
         return $language;
     }
@@ -66,7 +81,9 @@ class LanguageService extends LanguageServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateLanguageNameEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateLanguageNameEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedLanguage();
         }
 
@@ -74,7 +91,10 @@ class LanguageService extends LanguageServiceDecorator
             ? $beforeEvent->getUpdatedLanguage()
             : $this->innerService->updateLanguageName($language, $newName);
 
-        $this->eventDispatcher->dispatch(new UpdateLanguageNameEvent($updatedLanguage, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateLanguageNameEvent($updatedLanguage, ...$eventData),
+            UpdateLanguageNameEventInterface::class
+        );
 
         return $updatedLanguage;
     }
@@ -84,7 +104,9 @@ class LanguageService extends LanguageServiceDecorator
         $eventData = [$language];
 
         $beforeEvent = new BeforeEnableLanguageEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeEnableLanguageEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getEnabledLanguage();
         }
 
@@ -92,7 +114,10 @@ class LanguageService extends LanguageServiceDecorator
             ? $beforeEvent->getEnabledLanguage()
             : $this->innerService->enableLanguage($language);
 
-        $this->eventDispatcher->dispatch(new EnableLanguageEvent($enabledLanguage, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new EnableLanguageEvent($enabledLanguage, ...$eventData),
+            EnableLanguageEventInterface::class
+        );
 
         return $enabledLanguage;
     }
@@ -102,7 +127,9 @@ class LanguageService extends LanguageServiceDecorator
         $eventData = [$language];
 
         $beforeEvent = new BeforeDisableLanguageEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDisableLanguageEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getDisabledLanguage();
         }
 
@@ -110,7 +137,10 @@ class LanguageService extends LanguageServiceDecorator
             ? $beforeEvent->getDisabledLanguage()
             : $this->innerService->disableLanguage($language);
 
-        $this->eventDispatcher->dispatch(new DisableLanguageEvent($disabledLanguage, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DisableLanguageEvent($disabledLanguage, ...$eventData),
+            DisableLanguageEventInterface::class
+        );
 
         return $disabledLanguage;
     }
@@ -120,12 +150,17 @@ class LanguageService extends LanguageServiceDecorator
         $eventData = [$language];
 
         $beforeEvent = new BeforeDeleteLanguageEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteLanguageEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteLanguage($language);
 
-        $this->eventDispatcher->dispatch(new DeleteLanguageEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteLanguageEvent(...$eventData),
+            DeleteLanguageEventInterface::class
+        );
     }
 }

--- a/eZ/Publish/Core/Event/LocationService.php
+++ b/eZ/Publish/Core/Event/LocationService.php
@@ -8,6 +8,22 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Event;
 
+use eZ\Publish\API\Repository\Events\Location\BeforeCopySubtreeEvent as BeforeCopySubtreeEventInterface;
+use eZ\Publish\API\Repository\Events\Location\BeforeCreateLocationEvent as BeforeCreateLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\BeforeDeleteLocationEvent as BeforeDeleteLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\BeforeHideLocationEvent as BeforeHideLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\BeforeMoveSubtreeEvent as BeforeMoveSubtreeEventInterface;
+use eZ\Publish\API\Repository\Events\Location\BeforeSwapLocationEvent as BeforeSwapLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\BeforeUnhideLocationEvent as BeforeUnhideLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\BeforeUpdateLocationEvent as BeforeUpdateLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\CopySubtreeEvent as CopySubtreeEventInterface;
+use eZ\Publish\API\Repository\Events\Location\CreateLocationEvent as CreateLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\DeleteLocationEvent as DeleteLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\HideLocationEvent as HideLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\MoveSubtreeEvent as MoveSubtreeEventInterface;
+use eZ\Publish\API\Repository\Events\Location\SwapLocationEvent as SwapLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\UnhideLocationEvent as UnhideLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\UpdateLocationEvent as UpdateLocationEventInterface;
 use eZ\Publish\API\Repository\LocationService as LocationServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
@@ -56,7 +72,9 @@ class LocationService extends LocationServiceDecorator
         ];
 
         $beforeEvent = new BeforeCopySubtreeEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCopySubtreeEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getLocation();
         }
 
@@ -64,7 +82,10 @@ class LocationService extends LocationServiceDecorator
             ? $beforeEvent->getLocation()
             : $this->innerService->copySubtree($subtree, $targetParentLocation);
 
-        $this->eventDispatcher->dispatch(new CopySubtreeEvent($location, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CopySubtreeEvent($location, ...$eventData),
+            CopySubtreeEventInterface::class
+        );
 
         return $location;
     }
@@ -79,7 +100,9 @@ class LocationService extends LocationServiceDecorator
         ];
 
         $beforeEvent = new BeforeCreateLocationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateLocationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getLocation();
         }
 
@@ -87,7 +110,10 @@ class LocationService extends LocationServiceDecorator
             ? $beforeEvent->getLocation()
             : $this->innerService->createLocation($contentInfo, $locationCreateStruct);
 
-        $this->eventDispatcher->dispatch(new CreateLocationEvent($location, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateLocationEvent($location, ...$eventData),
+            CreateLocationEventInterface::class
+        );
 
         return $location;
     }
@@ -102,7 +128,9 @@ class LocationService extends LocationServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateLocationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateLocationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedLocation();
         }
 
@@ -110,7 +138,10 @@ class LocationService extends LocationServiceDecorator
             ? $beforeEvent->getUpdatedLocation()
             : $this->innerService->updateLocation($location, $locationUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateLocationEvent($updatedLocation, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateLocationEvent($updatedLocation, ...$eventData),
+            UpdateLocationEventInterface::class
+        );
 
         return $updatedLocation;
     }
@@ -125,13 +156,18 @@ class LocationService extends LocationServiceDecorator
         ];
 
         $beforeEvent = new BeforeSwapLocationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeSwapLocationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->swapLocation($location1, $location2);
 
-        $this->eventDispatcher->dispatch(new SwapLocationEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new SwapLocationEvent(...$eventData),
+            SwapLocationEventInterface::class
+        );
     }
 
     public function hideLocation(Location $location): Location
@@ -139,7 +175,9 @@ class LocationService extends LocationServiceDecorator
         $eventData = [$location];
 
         $beforeEvent = new BeforeHideLocationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeHideLocationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getHiddenLocation();
         }
 
@@ -147,7 +185,10 @@ class LocationService extends LocationServiceDecorator
             ? $beforeEvent->getHiddenLocation()
             : $this->innerService->hideLocation($location);
 
-        $this->eventDispatcher->dispatch(new HideLocationEvent($hiddenLocation, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new HideLocationEvent($hiddenLocation, ...$eventData),
+            HideLocationEventInterface::class
+        );
 
         return $hiddenLocation;
     }
@@ -157,7 +198,9 @@ class LocationService extends LocationServiceDecorator
         $eventData = [$location];
 
         $beforeEvent = new BeforeUnhideLocationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUnhideLocationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getRevealedLocation();
         }
 
@@ -165,7 +208,10 @@ class LocationService extends LocationServiceDecorator
             ? $beforeEvent->getRevealedLocation()
             : $this->innerService->unhideLocation($location);
 
-        $this->eventDispatcher->dispatch(new UnhideLocationEvent($revealedLocation, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UnhideLocationEvent($revealedLocation, ...$eventData),
+            UnhideLocationEventInterface::class
+        );
 
         return $revealedLocation;
     }
@@ -180,13 +226,18 @@ class LocationService extends LocationServiceDecorator
         ];
 
         $beforeEvent = new BeforeMoveSubtreeEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeMoveSubtreeEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->moveSubtree($location, $newParentLocation);
 
-        $this->eventDispatcher->dispatch(new MoveSubtreeEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new MoveSubtreeEvent(...$eventData),
+            MoveSubtreeEventInterface::class
+        );
     }
 
     public function deleteLocation(Location $location): void
@@ -194,12 +245,17 @@ class LocationService extends LocationServiceDecorator
         $eventData = [$location];
 
         $beforeEvent = new BeforeDeleteLocationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteLocationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteLocation($location);
 
-        $this->eventDispatcher->dispatch(new DeleteLocationEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteLocationEvent(...$eventData),
+            DeleteLocationEventInterface::class
+        );
     }
 }

--- a/eZ/Publish/Core/Event/NotificationService.php
+++ b/eZ/Publish/Core/Event/NotificationService.php
@@ -8,6 +8,12 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Event;
 
+use eZ\Publish\API\Repository\Events\Notification\BeforeCreateNotificationEvent as BeforeCreateNotificationEventInterface;
+use eZ\Publish\API\Repository\Events\Notification\BeforeDeleteNotificationEvent as BeforeDeleteNotificationEventInterface;
+use eZ\Publish\API\Repository\Events\Notification\BeforeMarkNotificationAsReadEvent as BeforeMarkNotificationAsReadEventInterface;
+use eZ\Publish\API\Repository\Events\Notification\CreateNotificationEvent as CreateNotificationEventInterface;
+use eZ\Publish\API\Repository\Events\Notification\DeleteNotificationEvent as DeleteNotificationEventInterface;
+use eZ\Publish\API\Repository\Events\Notification\MarkNotificationAsReadEvent as MarkNotificationAsReadEventInterface;
 use eZ\Publish\API\Repository\NotificationService as NotificationServiceInterface;
 use eZ\Publish\API\Repository\Values\Notification\CreateStruct;
 use eZ\Publish\API\Repository\Values\Notification\Notification;
@@ -39,13 +45,18 @@ class NotificationService extends NotificationServiceDecorator
         $eventData = [$notification];
 
         $beforeEvent = new BeforeMarkNotificationAsReadEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeMarkNotificationAsReadEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->markNotificationAsRead($notification);
 
-        $this->eventDispatcher->dispatch(new MarkNotificationAsReadEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new MarkNotificationAsReadEvent(...$eventData),
+            MarkNotificationAsReadEventInterface::class
+        );
     }
 
     public function createNotification(CreateStruct $createStruct): Notification
@@ -53,7 +64,9 @@ class NotificationService extends NotificationServiceDecorator
         $eventData = [$createStruct];
 
         $beforeEvent = new BeforeCreateNotificationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateNotificationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getNotification();
         }
 
@@ -61,7 +74,10 @@ class NotificationService extends NotificationServiceDecorator
             ? $beforeEvent->getNotification()
             : $this->innerService->createNotification($createStruct);
 
-        $this->eventDispatcher->dispatch(new CreateNotificationEvent($notification, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateNotificationEvent($notification, ...$eventData),
+            CreateNotificationEventInterface::class
+        );
 
         return $notification;
     }
@@ -71,12 +87,17 @@ class NotificationService extends NotificationServiceDecorator
         $eventData = [$notification];
 
         $beforeEvent = new BeforeDeleteNotificationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteNotificationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteNotification($notification);
 
-        $this->eventDispatcher->dispatch(new DeleteNotificationEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteNotificationEvent(...$eventData),
+            DeleteNotificationEventInterface::class
+        );
     }
 }

--- a/eZ/Publish/Core/Event/ObjectStateService.php
+++ b/eZ/Publish/Core/Event/ObjectStateService.php
@@ -8,6 +8,22 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Event;
 
+use eZ\Publish\API\Repository\Events\ObjectState\BeforeCreateObjectStateEvent as BeforeCreateObjectStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\BeforeCreateObjectStateGroupEvent as BeforeCreateObjectStateGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\BeforeDeleteObjectStateEvent as BeforeDeleteObjectStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\BeforeDeleteObjectStateGroupEvent as BeforeDeleteObjectStateGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\BeforeSetContentStateEvent as BeforeSetContentStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\BeforeSetPriorityOfObjectStateEvent as BeforeSetPriorityOfObjectStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\BeforeUpdateObjectStateEvent as BeforeUpdateObjectStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\BeforeUpdateObjectStateGroupEvent as BeforeUpdateObjectStateGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\CreateObjectStateEvent as CreateObjectStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\CreateObjectStateGroupEvent as CreateObjectStateGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\DeleteObjectStateEvent as DeleteObjectStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\DeleteObjectStateGroupEvent as DeleteObjectStateGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\SetContentStateEvent as SetContentStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\SetPriorityOfObjectStateEvent as SetPriorityOfObjectStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\UpdateObjectStateEvent as UpdateObjectStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\UpdateObjectStateGroupEvent as UpdateObjectStateGroupEventInterface;
 use eZ\Publish\API\Repository\ObjectStateService as ObjectStateServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
@@ -54,7 +70,9 @@ class ObjectStateService extends ObjectStateServiceDecorator
         $eventData = [$objectStateGroupCreateStruct];
 
         $beforeEvent = new BeforeCreateObjectStateGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateObjectStateGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getObjectStateGroup();
         }
 
@@ -62,7 +80,10 @@ class ObjectStateService extends ObjectStateServiceDecorator
             ? $beforeEvent->getObjectStateGroup()
             : $this->innerService->createObjectStateGroup($objectStateGroupCreateStruct);
 
-        $this->eventDispatcher->dispatch(new CreateObjectStateGroupEvent($objectStateGroup, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateObjectStateGroupEvent($objectStateGroup, ...$eventData),
+            CreateObjectStateGroupEventInterface::class
+        );
 
         return $objectStateGroup;
     }
@@ -77,7 +98,9 @@ class ObjectStateService extends ObjectStateServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateObjectStateGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateObjectStateGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedObjectStateGroup();
         }
 
@@ -85,7 +108,10 @@ class ObjectStateService extends ObjectStateServiceDecorator
             ? $beforeEvent->getUpdatedObjectStateGroup()
             : $this->innerService->updateObjectStateGroup($objectStateGroup, $objectStateGroupUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateObjectStateGroupEvent($updatedObjectStateGroup, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateObjectStateGroupEvent($updatedObjectStateGroup, ...$eventData),
+            UpdateObjectStateGroupEventInterface::class
+        );
 
         return $updatedObjectStateGroup;
     }
@@ -95,13 +121,18 @@ class ObjectStateService extends ObjectStateServiceDecorator
         $eventData = [$objectStateGroup];
 
         $beforeEvent = new BeforeDeleteObjectStateGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteObjectStateGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteObjectStateGroup($objectStateGroup);
 
-        $this->eventDispatcher->dispatch(new DeleteObjectStateGroupEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteObjectStateGroupEvent(...$eventData),
+            DeleteObjectStateGroupEventInterface::class
+        );
     }
 
     public function createObjectState(
@@ -114,7 +145,9 @@ class ObjectStateService extends ObjectStateServiceDecorator
         ];
 
         $beforeEvent = new BeforeCreateObjectStateEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateObjectStateEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getObjectState();
         }
 
@@ -122,7 +155,10 @@ class ObjectStateService extends ObjectStateServiceDecorator
             ? $beforeEvent->getObjectState()
             : $this->innerService->createObjectState($objectStateGroup, $objectStateCreateStruct);
 
-        $this->eventDispatcher->dispatch(new CreateObjectStateEvent($objectState, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateObjectStateEvent($objectState, ...$eventData),
+            CreateObjectStateEventInterface::class
+        );
 
         return $objectState;
     }
@@ -137,7 +173,9 @@ class ObjectStateService extends ObjectStateServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateObjectStateEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateObjectStateEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedObjectState();
         }
 
@@ -145,7 +183,10 @@ class ObjectStateService extends ObjectStateServiceDecorator
             ? $beforeEvent->getUpdatedObjectState()
             : $this->innerService->updateObjectState($objectState, $objectStateUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateObjectStateEvent($updatedObjectState, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateObjectStateEvent($updatedObjectState, ...$eventData),
+            UpdateObjectStateEventInterface::class
+        );
 
         return $updatedObjectState;
     }
@@ -160,13 +201,18 @@ class ObjectStateService extends ObjectStateServiceDecorator
         ];
 
         $beforeEvent = new BeforeSetPriorityOfObjectStateEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeSetPriorityOfObjectStateEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->setPriorityOfObjectState($objectState, $priority);
 
-        $this->eventDispatcher->dispatch(new SetPriorityOfObjectStateEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new SetPriorityOfObjectStateEvent(...$eventData),
+            SetPriorityOfObjectStateEventInterface::class
+        );
     }
 
     public function deleteObjectState(ObjectState $objectState): void
@@ -174,13 +220,18 @@ class ObjectStateService extends ObjectStateServiceDecorator
         $eventData = [$objectState];
 
         $beforeEvent = new BeforeDeleteObjectStateEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteObjectStateEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteObjectState($objectState);
 
-        $this->eventDispatcher->dispatch(new DeleteObjectStateEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteObjectStateEvent(...$eventData),
+            DeleteObjectStateEventInterface::class
+        );
     }
 
     public function setContentState(
@@ -195,12 +246,17 @@ class ObjectStateService extends ObjectStateServiceDecorator
         ];
 
         $beforeEvent = new BeforeSetContentStateEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeSetContentStateEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->setContentState($contentInfo, $objectStateGroup, $objectState);
 
-        $this->eventDispatcher->dispatch(new SetContentStateEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new SetContentStateEvent(...$eventData),
+            SetContentStateEventInterface::class
+        );
     }
 }

--- a/eZ/Publish/Core/Event/Repository.php
+++ b/eZ/Publish/Core/Event/Repository.php
@@ -2,11 +2,6 @@
 
 namespace eZ\Publish\Core\Event;
 
-use eZ\Publish\API\Repository\PermissionResolver;
-use eZ\Publish\API\Repository\Repository as RepositoryInterface;
-use eZ\Publish\API\Repository\Values\User\User;
-use eZ\Publish\API\Repository\Values\User\UserReference;
-use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\BookmarkService as BookmarkServiceInterface;
 use eZ\Publish\API\Repository\ContentService as ContentServiceInterface;
 use eZ\Publish\API\Repository\ContentTypeService as ContentTypeServiceInterface;
@@ -15,6 +10,8 @@ use eZ\Publish\API\Repository\LanguageService as LanguageServiceInterface;
 use eZ\Publish\API\Repository\LocationService as LocationServiceInterface;
 use eZ\Publish\API\Repository\NotificationService as NotificationServiceInterface;
 use eZ\Publish\API\Repository\ObjectStateService as ObjectStateServiceInterface;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\RoleService as RoleServiceInterface;
 use eZ\Publish\API\Repository\SearchService as SearchServiceInterface;
 use eZ\Publish\API\Repository\SectionService as SectionServiceInterface;
@@ -24,6 +21,9 @@ use eZ\Publish\API\Repository\URLService as URLServiceInterface;
 use eZ\Publish\API\Repository\URLWildcardService as URLWildcardServiceInterface;
 use eZ\Publish\API\Repository\UserPreferenceService as UserPreferenceServiceInterface;
 use eZ\Publish\API\Repository\UserService as UserServiceInterface;
+use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\API\Repository\Values\User\UserReference;
+use eZ\Publish\API\Repository\Values\ValueObject;
 
 final class Repository implements RepositoryInterface
 {

--- a/eZ/Publish/Core/Event/RoleService.php
+++ b/eZ/Publish/Core/Event/RoleService.php
@@ -8,6 +8,42 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Event;
 
+use eZ\Publish\API\Repository\Events\Role\AddPolicyByRoleDraftEvent as AddPolicyByRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\AddPolicyEvent as AddPolicyEventInterface;
+use eZ\Publish\API\Repository\Events\Role\AssignRoleToUserEvent as AssignRoleToUserEventInterface;
+use eZ\Publish\API\Repository\Events\Role\AssignRoleToUserGroupEvent as AssignRoleToUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeAddPolicyByRoleDraftEvent as BeforeAddPolicyByRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeAddPolicyEvent as BeforeAddPolicyEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeAssignRoleToUserEvent as BeforeAssignRoleToUserEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeAssignRoleToUserGroupEvent as BeforeAssignRoleToUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeCreateRoleDraftEvent as BeforeCreateRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeCreateRoleEvent as BeforeCreateRoleEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeDeletePolicyEvent as BeforeDeletePolicyEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeDeleteRoleDraftEvent as BeforeDeleteRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeDeleteRoleEvent as BeforeDeleteRoleEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforePublishRoleDraftEvent as BeforePublishRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeRemovePolicyByRoleDraftEvent as BeforeRemovePolicyByRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeRemoveRoleAssignmentEvent as BeforeRemoveRoleAssignmentEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeUnassignRoleFromUserEvent as BeforeUnassignRoleFromUserEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeUnassignRoleFromUserGroupEvent as BeforeUnassignRoleFromUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeUpdatePolicyByRoleDraftEvent as BeforeUpdatePolicyByRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeUpdatePolicyEvent as BeforeUpdatePolicyEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeUpdateRoleDraftEvent as BeforeUpdateRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\BeforeUpdateRoleEvent as BeforeUpdateRoleEventInterface;
+use eZ\Publish\API\Repository\Events\Role\CreateRoleDraftEvent as CreateRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\CreateRoleEvent as CreateRoleEventInterface;
+use eZ\Publish\API\Repository\Events\Role\DeletePolicyEvent as DeletePolicyEventInterface;
+use eZ\Publish\API\Repository\Events\Role\DeleteRoleDraftEvent as DeleteRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\DeleteRoleEvent as DeleteRoleEventInterface;
+use eZ\Publish\API\Repository\Events\Role\PublishRoleDraftEvent as PublishRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\RemovePolicyByRoleDraftEvent as RemovePolicyByRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\RemoveRoleAssignmentEvent as RemoveRoleAssignmentEventInterface;
+use eZ\Publish\API\Repository\Events\Role\UnassignRoleFromUserEvent as UnassignRoleFromUserEventInterface;
+use eZ\Publish\API\Repository\Events\Role\UnassignRoleFromUserGroupEvent as UnassignRoleFromUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\Role\UpdatePolicyByRoleDraftEvent as UpdatePolicyByRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\UpdatePolicyEvent as UpdatePolicyEventInterface;
+use eZ\Publish\API\Repository\Events\Role\UpdateRoleDraftEvent as UpdateRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\UpdateRoleEvent as UpdateRoleEventInterface;
 use eZ\Publish\API\Repository\RoleService as RoleServiceInterface;
 use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\Policy;
@@ -79,7 +115,9 @@ class RoleService extends RoleServiceDecorator
         $eventData = [$roleCreateStruct];
 
         $beforeEvent = new BeforeCreateRoleEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateRoleEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getRoleDraft();
         }
 
@@ -87,7 +125,10 @@ class RoleService extends RoleServiceDecorator
             ? $beforeEvent->getRoleDraft()
             : $this->innerService->createRole($roleCreateStruct);
 
-        $this->eventDispatcher->dispatch(new CreateRoleEvent($roleDraft, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateRoleEvent($roleDraft, ...$eventData),
+            CreateRoleEventInterface::class
+        );
 
         return $roleDraft;
     }
@@ -97,7 +138,9 @@ class RoleService extends RoleServiceDecorator
         $eventData = [$role];
 
         $beforeEvent = new BeforeCreateRoleDraftEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateRoleDraftEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getRoleDraft();
         }
 
@@ -105,7 +148,10 @@ class RoleService extends RoleServiceDecorator
             ? $beforeEvent->getRoleDraft()
             : $this->innerService->createRoleDraft($role);
 
-        $this->eventDispatcher->dispatch(new CreateRoleDraftEvent($roleDraft, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateRoleDraftEvent($roleDraft, ...$eventData),
+            CreateRoleDraftEventInterface::class
+        );
 
         return $roleDraft;
     }
@@ -120,7 +166,9 @@ class RoleService extends RoleServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateRoleDraftEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateRoleDraftEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedRoleDraft();
         }
 
@@ -128,7 +176,10 @@ class RoleService extends RoleServiceDecorator
             ? $beforeEvent->getUpdatedRoleDraft()
             : $this->innerService->updateRoleDraft($roleDraft, $roleUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateRoleDraftEvent($updatedRoleDraft, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateRoleDraftEvent($updatedRoleDraft, ...$eventData),
+            UpdateRoleDraftEventInterface::class
+        );
 
         return $updatedRoleDraft;
     }
@@ -143,7 +194,9 @@ class RoleService extends RoleServiceDecorator
         ];
 
         $beforeEvent = new BeforeAddPolicyByRoleDraftEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeAddPolicyByRoleDraftEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedRoleDraft();
         }
 
@@ -151,7 +204,10 @@ class RoleService extends RoleServiceDecorator
             ? $beforeEvent->getUpdatedRoleDraft()
             : $this->innerService->addPolicyByRoleDraft($roleDraft, $policyCreateStruct);
 
-        $this->eventDispatcher->dispatch(new AddPolicyByRoleDraftEvent($updatedRoleDraft, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new AddPolicyByRoleDraftEvent($updatedRoleDraft, ...$eventData),
+            AddPolicyByRoleDraftEventInterface::class
+        );
 
         return $updatedRoleDraft;
     }
@@ -166,7 +222,9 @@ class RoleService extends RoleServiceDecorator
         ];
 
         $beforeEvent = new BeforeRemovePolicyByRoleDraftEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeRemovePolicyByRoleDraftEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedRoleDraft();
         }
 
@@ -174,7 +232,10 @@ class RoleService extends RoleServiceDecorator
             ? $beforeEvent->getUpdatedRoleDraft()
             : $this->innerService->removePolicyByRoleDraft($roleDraft, $policyDraft);
 
-        $this->eventDispatcher->dispatch(new RemovePolicyByRoleDraftEvent($updatedRoleDraft, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new RemovePolicyByRoleDraftEvent($updatedRoleDraft, ...$eventData),
+            RemovePolicyByRoleDraftEventInterface::class
+        );
 
         return $updatedRoleDraft;
     }
@@ -191,7 +252,9 @@ class RoleService extends RoleServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdatePolicyByRoleDraftEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdatePolicyByRoleDraftEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedPolicyDraft();
         }
 
@@ -199,7 +262,10 @@ class RoleService extends RoleServiceDecorator
             ? $beforeEvent->getUpdatedPolicyDraft()
             : $this->innerService->updatePolicyByRoleDraft($roleDraft, $policy, $policyUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdatePolicyByRoleDraftEvent($updatedPolicyDraft, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdatePolicyByRoleDraftEvent($updatedPolicyDraft, ...$eventData),
+            UpdatePolicyByRoleDraftEventInterface::class
+        );
 
         return $updatedPolicyDraft;
     }
@@ -209,13 +275,18 @@ class RoleService extends RoleServiceDecorator
         $eventData = [$roleDraft];
 
         $beforeEvent = new BeforeDeleteRoleDraftEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteRoleDraftEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteRoleDraft($roleDraft);
 
-        $this->eventDispatcher->dispatch(new DeleteRoleDraftEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteRoleDraftEvent(...$eventData),
+            DeleteRoleDraftEventInterface::class
+        );
     }
 
     public function publishRoleDraft(RoleDraft $roleDraft): void
@@ -223,13 +294,18 @@ class RoleService extends RoleServiceDecorator
         $eventData = [$roleDraft];
 
         $beforeEvent = new BeforePublishRoleDraftEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforePublishRoleDraftEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->publishRoleDraft($roleDraft);
 
-        $this->eventDispatcher->dispatch(new PublishRoleDraftEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new PublishRoleDraftEvent(...$eventData),
+            PublishRoleDraftEventInterface::class
+        );
     }
 
     public function updateRole(
@@ -242,7 +318,9 @@ class RoleService extends RoleServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateRoleEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateRoleEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedRole();
         }
 
@@ -250,7 +328,10 @@ class RoleService extends RoleServiceDecorator
             ? $beforeEvent->getUpdatedRole()
             : $this->innerService->updateRole($role, $roleUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateRoleEvent($updatedRole, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateRoleEvent($updatedRole, ...$eventData),
+            UpdateRoleEventInterface::class
+        );
 
         return $updatedRole;
     }
@@ -265,7 +346,9 @@ class RoleService extends RoleServiceDecorator
         ];
 
         $beforeEvent = new BeforeAddPolicyEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeAddPolicyEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedRole();
         }
 
@@ -273,7 +356,10 @@ class RoleService extends RoleServiceDecorator
             ? $beforeEvent->getUpdatedRole()
             : $this->innerService->addPolicy($role, $policyCreateStruct);
 
-        $this->eventDispatcher->dispatch(new AddPolicyEvent($updatedRole, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new AddPolicyEvent($updatedRole, ...$eventData),
+            AddPolicyEventInterface::class
+        );
 
         return $updatedRole;
     }
@@ -283,13 +369,18 @@ class RoleService extends RoleServiceDecorator
         $eventData = [$policy];
 
         $beforeEvent = new BeforeDeletePolicyEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeletePolicyEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deletePolicy($policy);
 
-        $this->eventDispatcher->dispatch(new DeletePolicyEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeletePolicyEvent(...$eventData),
+            DeletePolicyEventInterface::class
+        );
     }
 
     public function updatePolicy(
@@ -302,7 +393,9 @@ class RoleService extends RoleServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdatePolicyEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdatePolicyEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedPolicy();
         }
 
@@ -310,7 +403,10 @@ class RoleService extends RoleServiceDecorator
             ? $beforeEvent->getUpdatedPolicy()
             : $this->innerService->updatePolicy($policy, $policyUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdatePolicyEvent($updatedPolicy, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdatePolicyEvent($updatedPolicy, ...$eventData),
+            UpdatePolicyEventInterface::class
+        );
 
         return $updatedPolicy;
     }
@@ -320,13 +416,18 @@ class RoleService extends RoleServiceDecorator
         $eventData = [$role];
 
         $beforeEvent = new BeforeDeleteRoleEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteRoleEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteRole($role);
 
-        $this->eventDispatcher->dispatch(new DeleteRoleEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteRoleEvent(...$eventData),
+            DeleteRoleEventInterface::class
+        );
     }
 
     public function assignRoleToUserGroup(
@@ -341,13 +442,18 @@ class RoleService extends RoleServiceDecorator
         ];
 
         $beforeEvent = new BeforeAssignRoleToUserGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeAssignRoleToUserGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->assignRoleToUserGroup($role, $userGroup, $roleLimitation);
 
-        $this->eventDispatcher->dispatch(new AssignRoleToUserGroupEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new AssignRoleToUserGroupEvent(...$eventData),
+            AssignRoleToUserGroupEventInterface::class
+        );
     }
 
     public function unassignRoleFromUserGroup(
@@ -360,13 +466,18 @@ class RoleService extends RoleServiceDecorator
         ];
 
         $beforeEvent = new BeforeUnassignRoleFromUserGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUnassignRoleFromUserGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->unassignRoleFromUserGroup($role, $userGroup);
 
-        $this->eventDispatcher->dispatch(new UnassignRoleFromUserGroupEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UnassignRoleFromUserGroupEvent(...$eventData),
+            UnassignRoleFromUserGroupEventInterface::class
+        );
     }
 
     public function assignRoleToUser(
@@ -381,13 +492,18 @@ class RoleService extends RoleServiceDecorator
         ];
 
         $beforeEvent = new BeforeAssignRoleToUserEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeAssignRoleToUserEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->assignRoleToUser($role, $user, $roleLimitation);
 
-        $this->eventDispatcher->dispatch(new AssignRoleToUserEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new AssignRoleToUserEvent(...$eventData),
+            AssignRoleToUserEventInterface::class
+        );
     }
 
     public function unassignRoleFromUser(
@@ -400,13 +516,18 @@ class RoleService extends RoleServiceDecorator
         ];
 
         $beforeEvent = new BeforeUnassignRoleFromUserEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUnassignRoleFromUserEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->unassignRoleFromUser($role, $user);
 
-        $this->eventDispatcher->dispatch(new UnassignRoleFromUserEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UnassignRoleFromUserEvent(...$eventData),
+            UnassignRoleFromUserEventInterface::class
+        );
     }
 
     public function removeRoleAssignment(RoleAssignment $roleAssignment): void
@@ -414,12 +535,17 @@ class RoleService extends RoleServiceDecorator
         $eventData = [$roleAssignment];
 
         $beforeEvent = new BeforeRemoveRoleAssignmentEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeRemoveRoleAssignmentEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->removeRoleAssignment($roleAssignment);
 
-        $this->eventDispatcher->dispatch(new RemoveRoleAssignmentEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new RemoveRoleAssignmentEvent(...$eventData),
+            RemoveRoleAssignmentEventInterface::class
+        );
     }
 }

--- a/eZ/Publish/Core/Event/SectionService.php
+++ b/eZ/Publish/Core/Event/SectionService.php
@@ -8,6 +8,16 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Event;
 
+use eZ\Publish\API\Repository\Events\Section\AssignSectionEvent as AssignSectionEventInterface;
+use eZ\Publish\API\Repository\Events\Section\AssignSectionToSubtreeEvent as AssignSectionToSubtreeEventInterface;
+use eZ\Publish\API\Repository\Events\Section\BeforeAssignSectionEvent as BeforeAssignSectionEventInterface;
+use eZ\Publish\API\Repository\Events\Section\BeforeAssignSectionToSubtreeEvent as BeforeAssignSectionToSubtreeEventInterface;
+use eZ\Publish\API\Repository\Events\Section\BeforeCreateSectionEvent as BeforeCreateSectionEventInterface;
+use eZ\Publish\API\Repository\Events\Section\BeforeDeleteSectionEvent as BeforeDeleteSectionEventInterface;
+use eZ\Publish\API\Repository\Events\Section\BeforeUpdateSectionEvent as BeforeUpdateSectionEventInterface;
+use eZ\Publish\API\Repository\Events\Section\CreateSectionEvent as CreateSectionEventInterface;
+use eZ\Publish\API\Repository\Events\Section\DeleteSectionEvent as DeleteSectionEventInterface;
+use eZ\Publish\API\Repository\Events\Section\UpdateSectionEvent as UpdateSectionEventInterface;
 use eZ\Publish\API\Repository\SectionService as SectionServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
@@ -46,7 +56,9 @@ class SectionService extends SectionServiceDecorator
         $eventData = [$sectionCreateStruct];
 
         $beforeEvent = new BeforeCreateSectionEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateSectionEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getSection();
         }
 
@@ -54,7 +66,10 @@ class SectionService extends SectionServiceDecorator
             ? $beforeEvent->getSection()
             : $this->innerService->createSection($sectionCreateStruct);
 
-        $this->eventDispatcher->dispatch(new CreateSectionEvent($section, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateSectionEvent($section, ...$eventData),
+            CreateSectionEventInterface::class
+        );
 
         return $section;
     }
@@ -69,7 +84,9 @@ class SectionService extends SectionServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateSectionEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateSectionEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedSection();
         }
 
@@ -77,7 +94,10 @@ class SectionService extends SectionServiceDecorator
             ? $beforeEvent->getUpdatedSection()
             : $this->innerService->updateSection($section, $sectionUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateSectionEvent($updatedSection, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateSectionEvent($updatedSection, ...$eventData),
+            UpdateSectionEventInterface::class
+        );
 
         return $updatedSection;
     }
@@ -92,13 +112,18 @@ class SectionService extends SectionServiceDecorator
         ];
 
         $beforeEvent = new BeforeAssignSectionEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeAssignSectionEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->assignSection($contentInfo, $section);
 
-        $this->eventDispatcher->dispatch(new AssignSectionEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new AssignSectionEvent(...$eventData),
+            AssignSectionEventInterface::class
+        );
     }
 
     public function assignSectionToSubtree(
@@ -111,13 +136,18 @@ class SectionService extends SectionServiceDecorator
         ];
 
         $beforeEvent = new BeforeAssignSectionToSubtreeEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeAssignSectionToSubtreeEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->assignSectionToSubtree($location, $section);
 
-        $this->eventDispatcher->dispatch(new AssignSectionToSubtreeEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new AssignSectionToSubtreeEvent(...$eventData),
+            AssignSectionToSubtreeEventInterface::class
+        );
     }
 
     public function deleteSection(Section $section): void
@@ -125,12 +155,17 @@ class SectionService extends SectionServiceDecorator
         $eventData = [$section];
 
         $beforeEvent = new BeforeDeleteSectionEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteSectionEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->deleteSection($section);
 
-        $this->eventDispatcher->dispatch(new DeleteSectionEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteSectionEvent(...$eventData),
+            DeleteSectionEventInterface::class
+        );
     }
 }

--- a/eZ/Publish/Core/Event/Tests/BookmarkServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/BookmarkServiceTest.php
@@ -9,11 +9,9 @@ namespace eZ\Publish\Core\Event\Tests;
 use eZ\Publish\API\Repository\BookmarkService as BookmarkServiceInterface;
 use eZ\Publish\API\Repository\Events\Bookmark\BeforeCreateBookmarkEvent as BeforeCreateBookmarkEventInterface;
 use eZ\Publish\API\Repository\Events\Bookmark\BeforeDeleteBookmarkEvent as BeforeDeleteBookmarkEventInterface;
+use eZ\Publish\API\Repository\Events\Bookmark\CreateBookmarkEvent as CreateBookmarkEventInterface;
+use eZ\Publish\API\Repository\Events\Bookmark\DeleteBookmarkEvent as DeleteBookmarkEventInterface;
 use eZ\Publish\API\Repository\Values\Content\Location;
-use eZ\Publish\Core\Event\Bookmark\BeforeCreateBookmarkEvent;
-use eZ\Publish\Core\Event\Bookmark\BeforeDeleteBookmarkEvent;
-use eZ\Publish\Core\Event\Bookmark\CreateBookmarkEvent;
-use eZ\Publish\Core\Event\Bookmark\DeleteBookmarkEvent;
 use eZ\Publish\Core\Event\BookmarkService;
 
 class BookmarkServiceTest extends AbstractServiceTest
@@ -21,8 +19,8 @@ class BookmarkServiceTest extends AbstractServiceTest
     public function testCreateBookmarkEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateBookmarkEvent::class,
-            CreateBookmarkEvent::class
+            BeforeCreateBookmarkEventInterface::class,
+            CreateBookmarkEventInterface::class
         );
 
         $parameters = [
@@ -37,8 +35,8 @@ class BookmarkServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeCreateBookmarkEvent::class, 0],
-            [CreateBookmarkEvent::class, 0],
+            [BeforeCreateBookmarkEventInterface::class, 0],
+            [CreateBookmarkEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -46,8 +44,8 @@ class BookmarkServiceTest extends AbstractServiceTest
     public function testCreateBookmarkStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateBookmarkEvent::class,
-            CreateBookmarkEvent::class
+            BeforeCreateBookmarkEventInterface::class,
+            CreateBookmarkEventInterface::class
         );
 
         $parameters = [
@@ -56,7 +54,7 @@ class BookmarkServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(BookmarkServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeCreateBookmarkEvent::class, function (BeforeCreateBookmarkEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeCreateBookmarkEventInterface::class, function (BeforeCreateBookmarkEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -67,19 +65,19 @@ class BookmarkServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeCreateBookmarkEvent::class, 10],
+            [BeforeCreateBookmarkEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateBookmarkEvent::class, 0],
-            [CreateBookmarkEvent::class, 0],
+            [BeforeCreateBookmarkEventInterface::class, 0],
+            [CreateBookmarkEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteBookmarkEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteBookmarkEvent::class,
-            DeleteBookmarkEvent::class
+            BeforeDeleteBookmarkEventInterface::class,
+            DeleteBookmarkEventInterface::class
         );
 
         $parameters = [
@@ -94,8 +92,8 @@ class BookmarkServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteBookmarkEvent::class, 0],
-            [DeleteBookmarkEvent::class, 0],
+            [BeforeDeleteBookmarkEventInterface::class, 0],
+            [DeleteBookmarkEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -103,8 +101,8 @@ class BookmarkServiceTest extends AbstractServiceTest
     public function testDeleteBookmarkStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteBookmarkEvent::class,
-            DeleteBookmarkEvent::class
+            BeforeDeleteBookmarkEventInterface::class,
+            DeleteBookmarkEventInterface::class
         );
 
         $parameters = [
@@ -113,7 +111,7 @@ class BookmarkServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(BookmarkServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteBookmarkEvent::class, function (BeforeDeleteBookmarkEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteBookmarkEventInterface::class, function (BeforeDeleteBookmarkEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -124,11 +122,11 @@ class BookmarkServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteBookmarkEvent::class, 10],
+            [BeforeDeleteBookmarkEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteBookmarkEvent::class, 0],
-            [DeleteBookmarkEvent::class, 0],
+            [BeforeDeleteBookmarkEventInterface::class, 0],
+            [DeleteBookmarkEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/ContentServiceTest.php
@@ -7,6 +7,7 @@
 namespace eZ\Publish\Core\Event\Tests;
 
 use eZ\Publish\API\Repository\ContentService as ContentServiceInterface;
+use eZ\Publish\API\Repository\Events\Content\AddRelationEvent as AddRelationEventInterface;
 use eZ\Publish\API\Repository\Events\Content\BeforeAddRelationEvent as BeforeAddRelationEventInterface;
 use eZ\Publish\API\Repository\Events\Content\BeforeCopyContentEvent as BeforeCopyContentEventInterface;
 use eZ\Publish\API\Repository\Events\Content\BeforeCreateContentDraftEvent as BeforeCreateContentDraftEventInterface;
@@ -20,6 +21,18 @@ use eZ\Publish\API\Repository\Events\Content\BeforePublishVersionEvent as Before
 use eZ\Publish\API\Repository\Events\Content\BeforeRevealContentEvent as BeforeRevealContentEventInterface;
 use eZ\Publish\API\Repository\Events\Content\BeforeUpdateContentEvent as BeforeUpdateContentEventInterface;
 use eZ\Publish\API\Repository\Events\Content\BeforeUpdateContentMetadataEvent as BeforeUpdateContentMetadataEventInterface;
+use eZ\Publish\API\Repository\Events\Content\CopyContentEvent as CopyContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\CreateContentDraftEvent as CreateContentDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Content\CreateContentEvent as CreateContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\DeleteContentEvent as DeleteContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\DeleteRelationEvent as DeleteRelationEventInterface;
+use eZ\Publish\API\Repository\Events\Content\DeleteTranslationEvent as DeleteTranslationEventInterface;
+use eZ\Publish\API\Repository\Events\Content\DeleteVersionEvent as DeleteVersionEventInterface;
+use eZ\Publish\API\Repository\Events\Content\HideContentEvent as HideContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\PublishVersionEvent as PublishVersionEventInterface;
+use eZ\Publish\API\Repository\Events\Content\RevealContentEvent as RevealContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\UpdateContentEvent as UpdateContentEventInterface;
+use eZ\Publish\API\Repository\Events\Content\UpdateContentMetadataEvent as UpdateContentMetadataEventInterface;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -29,32 +42,6 @@ use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\Relation;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\User\User;
-use eZ\Publish\Core\Event\Content\AddRelationEvent;
-use eZ\Publish\Core\Event\Content\BeforeAddRelationEvent;
-use eZ\Publish\Core\Event\Content\BeforeCopyContentEvent;
-use eZ\Publish\Core\Event\Content\BeforeCreateContentDraftEvent;
-use eZ\Publish\Core\Event\Content\BeforeCreateContentEvent;
-use eZ\Publish\Core\Event\Content\BeforeDeleteContentEvent;
-use eZ\Publish\Core\Event\Content\BeforeDeleteRelationEvent;
-use eZ\Publish\Core\Event\Content\BeforeDeleteTranslationEvent;
-use eZ\Publish\Core\Event\Content\BeforeDeleteVersionEvent;
-use eZ\Publish\Core\Event\Content\BeforeHideContentEvent;
-use eZ\Publish\Core\Event\Content\BeforePublishVersionEvent;
-use eZ\Publish\Core\Event\Content\BeforeRevealContentEvent;
-use eZ\Publish\Core\Event\Content\BeforeUpdateContentEvent;
-use eZ\Publish\Core\Event\Content\BeforeUpdateContentMetadataEvent;
-use eZ\Publish\Core\Event\Content\CopyContentEvent;
-use eZ\Publish\Core\Event\Content\CreateContentDraftEvent;
-use eZ\Publish\Core\Event\Content\CreateContentEvent;
-use eZ\Publish\Core\Event\Content\DeleteContentEvent;
-use eZ\Publish\Core\Event\Content\DeleteRelationEvent;
-use eZ\Publish\Core\Event\Content\DeleteTranslationEvent;
-use eZ\Publish\Core\Event\Content\DeleteVersionEvent;
-use eZ\Publish\Core\Event\Content\HideContentEvent;
-use eZ\Publish\Core\Event\Content\PublishVersionEvent;
-use eZ\Publish\Core\Event\Content\RevealContentEvent;
-use eZ\Publish\Core\Event\Content\UpdateContentEvent;
-use eZ\Publish\Core\Event\Content\UpdateContentMetadataEvent;
 use eZ\Publish\Core\Event\ContentService;
 
 class ContentServiceTest extends AbstractServiceTest
@@ -62,8 +49,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testDeleteContentEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteContentEvent::class,
-            DeleteContentEvent::class
+            BeforeDeleteContentEventInterface::class,
+            DeleteContentEventInterface::class
         );
 
         $parameters = [
@@ -81,8 +68,8 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($locations, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDeleteContentEvent::class, 0],
-            [DeleteContentEvent::class, 0],
+            [BeforeDeleteContentEventInterface::class, 0],
+            [DeleteContentEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -90,8 +77,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testReturnDeleteContentResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteContentEvent::class,
-            DeleteContentEvent::class
+            BeforeDeleteContentEventInterface::class,
+            DeleteContentEventInterface::class
         );
 
         $parameters = [
@@ -103,7 +90,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('deleteContent')->willReturn($locations);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteContentEvent::class, function (BeforeDeleteContentEventInterface $event) use ($eventLocations) {
+        $traceableEventDispatcher->addListener(BeforeDeleteContentEventInterface::class, function (BeforeDeleteContentEventInterface $event) use ($eventLocations) {
             $event->setLocations($eventLocations);
         }, 10);
 
@@ -114,9 +101,9 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLocations, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDeleteContentEvent::class, 10],
-            [BeforeDeleteContentEvent::class, 0],
-            [DeleteContentEvent::class, 0],
+            [BeforeDeleteContentEventInterface::class, 10],
+            [BeforeDeleteContentEventInterface::class, 0],
+            [DeleteContentEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -124,8 +111,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testDeleteContentStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteContentEvent::class,
-            DeleteContentEvent::class
+            BeforeDeleteContentEventInterface::class,
+            DeleteContentEventInterface::class
         );
 
         $parameters = [
@@ -137,7 +124,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('deleteContent')->willReturn($locations);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteContentEvent::class, function (BeforeDeleteContentEventInterface $event) use ($eventLocations) {
+        $traceableEventDispatcher->addListener(BeforeDeleteContentEventInterface::class, function (BeforeDeleteContentEventInterface $event) use ($eventLocations) {
             $event->setLocations($eventLocations);
             $event->stopPropagation();
         }, 10);
@@ -150,19 +137,19 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLocations, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDeleteContentEvent::class, 10],
+            [BeforeDeleteContentEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteContentEvent::class, 0],
-            [DeleteContentEvent::class, 0],
+            [BeforeDeleteContentEventInterface::class, 0],
+            [DeleteContentEventInterface::class, 0],
         ]);
     }
 
     public function testCopyContentEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCopyContentEvent::class,
-            CopyContentEvent::class
+            BeforeCopyContentEventInterface::class,
+            CopyContentEventInterface::class
         );
 
         $parameters = [
@@ -182,8 +169,8 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($content, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCopyContentEvent::class, 0],
-            [CopyContentEvent::class, 0],
+            [BeforeCopyContentEventInterface::class, 0],
+            [CopyContentEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -191,8 +178,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testReturnCopyContentResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCopyContentEvent::class,
-            CopyContentEvent::class
+            BeforeCopyContentEventInterface::class,
+            CopyContentEventInterface::class
         );
 
         $parameters = [
@@ -206,7 +193,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('copyContent')->willReturn($content);
 
-        $traceableEventDispatcher->addListener(BeforeCopyContentEvent::class, function (BeforeCopyContentEventInterface $event) use ($eventContent) {
+        $traceableEventDispatcher->addListener(BeforeCopyContentEventInterface::class, function (BeforeCopyContentEventInterface $event) use ($eventContent) {
             $event->setContent($eventContent);
         }, 10);
 
@@ -217,9 +204,9 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContent, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCopyContentEvent::class, 10],
-            [BeforeCopyContentEvent::class, 0],
-            [CopyContentEvent::class, 0],
+            [BeforeCopyContentEventInterface::class, 10],
+            [BeforeCopyContentEventInterface::class, 0],
+            [CopyContentEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -227,8 +214,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testCopyContentStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCopyContentEvent::class,
-            CopyContentEvent::class
+            BeforeCopyContentEventInterface::class,
+            CopyContentEventInterface::class
         );
 
         $parameters = [
@@ -242,7 +229,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('copyContent')->willReturn($content);
 
-        $traceableEventDispatcher->addListener(BeforeCopyContentEvent::class, function (BeforeCopyContentEventInterface $event) use ($eventContent) {
+        $traceableEventDispatcher->addListener(BeforeCopyContentEventInterface::class, function (BeforeCopyContentEventInterface $event) use ($eventContent) {
             $event->setContent($eventContent);
             $event->stopPropagation();
         }, 10);
@@ -255,19 +242,19 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContent, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCopyContentEvent::class, 10],
+            [BeforeCopyContentEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCopyContentEvent::class, 0],
-            [CopyContentEvent::class, 0],
+            [BeforeCopyContentEventInterface::class, 0],
+            [CopyContentEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateContentEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateContentEvent::class,
-            UpdateContentEvent::class
+            BeforeUpdateContentEventInterface::class,
+            UpdateContentEventInterface::class
         );
 
         $parameters = [
@@ -286,8 +273,8 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($content, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateContentEvent::class, 0],
-            [UpdateContentEvent::class, 0],
+            [BeforeUpdateContentEventInterface::class, 0],
+            [UpdateContentEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -295,8 +282,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testReturnUpdateContentResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateContentEvent::class,
-            UpdateContentEvent::class
+            BeforeUpdateContentEventInterface::class,
+            UpdateContentEventInterface::class
         );
 
         $parameters = [
@@ -309,7 +296,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('updateContent')->willReturn($content);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateContentEvent::class, function (BeforeUpdateContentEventInterface $event) use ($eventContent) {
+        $traceableEventDispatcher->addListener(BeforeUpdateContentEventInterface::class, function (BeforeUpdateContentEventInterface $event) use ($eventContent) {
             $event->setContent($eventContent);
         }, 10);
 
@@ -320,9 +307,9 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContent, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateContentEvent::class, 10],
-            [BeforeUpdateContentEvent::class, 0],
-            [UpdateContentEvent::class, 0],
+            [BeforeUpdateContentEventInterface::class, 10],
+            [BeforeUpdateContentEventInterface::class, 0],
+            [UpdateContentEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -330,8 +317,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testUpdateContentStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateContentEvent::class,
-            UpdateContentEvent::class
+            BeforeUpdateContentEventInterface::class,
+            UpdateContentEventInterface::class
         );
 
         $parameters = [
@@ -344,7 +331,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('updateContent')->willReturn($content);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateContentEvent::class, function (BeforeUpdateContentEventInterface $event) use ($eventContent) {
+        $traceableEventDispatcher->addListener(BeforeUpdateContentEventInterface::class, function (BeforeUpdateContentEventInterface $event) use ($eventContent) {
             $event->setContent($eventContent);
             $event->stopPropagation();
         }, 10);
@@ -357,19 +344,19 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContent, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateContentEvent::class, 10],
+            [BeforeUpdateContentEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateContentEvent::class, 0],
-            [UpdateContentEvent::class, 0],
+            [BeforeUpdateContentEventInterface::class, 0],
+            [UpdateContentEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteRelationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteRelationEvent::class,
-            DeleteRelationEvent::class
+            BeforeDeleteRelationEventInterface::class,
+            DeleteRelationEventInterface::class
         );
 
         $parameters = [
@@ -385,8 +372,8 @@ class ContentServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteRelationEvent::class, 0],
-            [DeleteRelationEvent::class, 0],
+            [BeforeDeleteRelationEventInterface::class, 0],
+            [DeleteRelationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -394,8 +381,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testDeleteRelationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteRelationEvent::class,
-            DeleteRelationEvent::class
+            BeforeDeleteRelationEventInterface::class,
+            DeleteRelationEventInterface::class
         );
 
         $parameters = [
@@ -405,7 +392,7 @@ class ContentServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteRelationEvent::class, function (BeforeDeleteRelationEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteRelationEventInterface::class, function (BeforeDeleteRelationEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -416,19 +403,19 @@ class ContentServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteRelationEvent::class, 10],
+            [BeforeDeleteRelationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteRelationEvent::class, 0],
-            [DeleteRelationEvent::class, 0],
+            [BeforeDeleteRelationEventInterface::class, 0],
+            [DeleteRelationEventInterface::class, 0],
         ]);
     }
 
     public function testCreateContentEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentEvent::class,
-            CreateContentEvent::class
+            BeforeCreateContentEventInterface::class,
+            CreateContentEventInterface::class
         );
 
         $parameters = [
@@ -447,8 +434,8 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($content, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentEvent::class, 0],
-            [CreateContentEvent::class, 0],
+            [BeforeCreateContentEventInterface::class, 0],
+            [CreateContentEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -456,8 +443,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testReturnCreateContentResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentEvent::class,
-            CreateContentEvent::class
+            BeforeCreateContentEventInterface::class,
+            CreateContentEventInterface::class
         );
 
         $parameters = [
@@ -470,7 +457,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('createContent')->willReturn($content);
 
-        $traceableEventDispatcher->addListener(BeforeCreateContentEvent::class, function (BeforeCreateContentEventInterface $event) use ($eventContent) {
+        $traceableEventDispatcher->addListener(BeforeCreateContentEventInterface::class, function (BeforeCreateContentEventInterface $event) use ($eventContent) {
             $event->setContent($eventContent);
         }, 10);
 
@@ -481,9 +468,9 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContent, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentEvent::class, 10],
-            [BeforeCreateContentEvent::class, 0],
-            [CreateContentEvent::class, 0],
+            [BeforeCreateContentEventInterface::class, 10],
+            [BeforeCreateContentEventInterface::class, 0],
+            [CreateContentEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -491,8 +478,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testCreateContentStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentEvent::class,
-            CreateContentEvent::class
+            BeforeCreateContentEventInterface::class,
+            CreateContentEventInterface::class
         );
 
         $parameters = [
@@ -505,7 +492,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('createContent')->willReturn($content);
 
-        $traceableEventDispatcher->addListener(BeforeCreateContentEvent::class, function (BeforeCreateContentEventInterface $event) use ($eventContent) {
+        $traceableEventDispatcher->addListener(BeforeCreateContentEventInterface::class, function (BeforeCreateContentEventInterface $event) use ($eventContent) {
             $event->setContent($eventContent);
             $event->stopPropagation();
         }, 10);
@@ -518,19 +505,19 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContent, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentEvent::class, 10],
+            [BeforeCreateContentEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateContentEvent::class, 0],
-            [CreateContentEvent::class, 0],
+            [BeforeCreateContentEventInterface::class, 0],
+            [CreateContentEventInterface::class, 0],
         ]);
     }
 
     public function testHideContentEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeHideContentEvent::class,
-            HideContentEvent::class
+            BeforeHideContentEventInterface::class,
+            HideContentEventInterface::class
         );
 
         $parameters = [
@@ -545,8 +532,8 @@ class ContentServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeHideContentEvent::class, 0],
-            [HideContentEvent::class, 0],
+            [BeforeHideContentEventInterface::class, 0],
+            [HideContentEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -554,8 +541,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testHideContentStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeHideContentEvent::class,
-            HideContentEvent::class
+            BeforeHideContentEventInterface::class,
+            HideContentEventInterface::class
         );
 
         $parameters = [
@@ -564,7 +551,7 @@ class ContentServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeHideContentEvent::class, function (BeforeHideContentEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeHideContentEventInterface::class, function (BeforeHideContentEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -575,19 +562,19 @@ class ContentServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeHideContentEvent::class, 10],
+            [BeforeHideContentEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeHideContentEvent::class, 0],
-            [HideContentEvent::class, 0],
+            [BeforeHideContentEventInterface::class, 0],
+            [HideContentEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteVersionEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteVersionEvent::class,
-            DeleteVersionEvent::class
+            BeforeDeleteVersionEventInterface::class,
+            DeleteVersionEventInterface::class
         );
 
         $parameters = [
@@ -602,8 +589,8 @@ class ContentServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteVersionEvent::class, 0],
-            [DeleteVersionEvent::class, 0],
+            [BeforeDeleteVersionEventInterface::class, 0],
+            [DeleteVersionEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -611,8 +598,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testDeleteVersionStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteVersionEvent::class,
-            DeleteVersionEvent::class
+            BeforeDeleteVersionEventInterface::class,
+            DeleteVersionEventInterface::class
         );
 
         $parameters = [
@@ -621,7 +608,7 @@ class ContentServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteVersionEvent::class, function (BeforeDeleteVersionEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteVersionEventInterface::class, function (BeforeDeleteVersionEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -632,19 +619,19 @@ class ContentServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteVersionEvent::class, 10],
+            [BeforeDeleteVersionEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteVersionEvent::class, 0],
-            [DeleteVersionEvent::class, 0],
+            [BeforeDeleteVersionEventInterface::class, 0],
+            [DeleteVersionEventInterface::class, 0],
         ]);
     }
 
     public function testAddRelationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAddRelationEvent::class,
-            AddRelationEvent::class
+            BeforeAddRelationEventInterface::class,
+            AddRelationEventInterface::class
         );
 
         $parameters = [
@@ -663,8 +650,8 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($relation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeAddRelationEvent::class, 0],
-            [AddRelationEvent::class, 0],
+            [BeforeAddRelationEventInterface::class, 0],
+            [AddRelationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -672,8 +659,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testReturnAddRelationResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAddRelationEvent::class,
-            AddRelationEvent::class
+            BeforeAddRelationEventInterface::class,
+            AddRelationEventInterface::class
         );
 
         $parameters = [
@@ -686,7 +673,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('addRelation')->willReturn($relation);
 
-        $traceableEventDispatcher->addListener(BeforeAddRelationEvent::class, function (BeforeAddRelationEventInterface $event) use ($eventRelation) {
+        $traceableEventDispatcher->addListener(BeforeAddRelationEventInterface::class, function (BeforeAddRelationEventInterface $event) use ($eventRelation) {
             $event->setRelation($eventRelation);
         }, 10);
 
@@ -697,9 +684,9 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventRelation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeAddRelationEvent::class, 10],
-            [BeforeAddRelationEvent::class, 0],
-            [AddRelationEvent::class, 0],
+            [BeforeAddRelationEventInterface::class, 10],
+            [BeforeAddRelationEventInterface::class, 0],
+            [AddRelationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -707,8 +694,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testAddRelationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAddRelationEvent::class,
-            AddRelationEvent::class
+            BeforeAddRelationEventInterface::class,
+            AddRelationEventInterface::class
         );
 
         $parameters = [
@@ -721,7 +708,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('addRelation')->willReturn($relation);
 
-        $traceableEventDispatcher->addListener(BeforeAddRelationEvent::class, function (BeforeAddRelationEventInterface $event) use ($eventRelation) {
+        $traceableEventDispatcher->addListener(BeforeAddRelationEventInterface::class, function (BeforeAddRelationEventInterface $event) use ($eventRelation) {
             $event->setRelation($eventRelation);
             $event->stopPropagation();
         }, 10);
@@ -734,19 +721,19 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventRelation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeAddRelationEvent::class, 10],
+            [BeforeAddRelationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [AddRelationEvent::class, 0],
-            [BeforeAddRelationEvent::class, 0],
+            [AddRelationEventInterface::class, 0],
+            [BeforeAddRelationEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateContentMetadataEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateContentMetadataEvent::class,
-            UpdateContentMetadataEvent::class
+            BeforeUpdateContentMetadataEventInterface::class,
+            UpdateContentMetadataEventInterface::class
         );
 
         $parameters = [
@@ -765,8 +752,8 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($content, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateContentMetadataEvent::class, 0],
-            [UpdateContentMetadataEvent::class, 0],
+            [BeforeUpdateContentMetadataEventInterface::class, 0],
+            [UpdateContentMetadataEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -774,8 +761,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testReturnUpdateContentMetadataResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateContentMetadataEvent::class,
-            UpdateContentMetadataEvent::class
+            BeforeUpdateContentMetadataEventInterface::class,
+            UpdateContentMetadataEventInterface::class
         );
 
         $parameters = [
@@ -788,7 +775,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('updateContentMetadata')->willReturn($content);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateContentMetadataEvent::class, function (BeforeUpdateContentMetadataEventInterface $event) use ($eventContent) {
+        $traceableEventDispatcher->addListener(BeforeUpdateContentMetadataEventInterface::class, function (BeforeUpdateContentMetadataEventInterface $event) use ($eventContent) {
             $event->setContent($eventContent);
         }, 10);
 
@@ -799,9 +786,9 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContent, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateContentMetadataEvent::class, 10],
-            [BeforeUpdateContentMetadataEvent::class, 0],
-            [UpdateContentMetadataEvent::class, 0],
+            [BeforeUpdateContentMetadataEventInterface::class, 10],
+            [BeforeUpdateContentMetadataEventInterface::class, 0],
+            [UpdateContentMetadataEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -809,8 +796,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testUpdateContentMetadataStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateContentMetadataEvent::class,
-            UpdateContentMetadataEvent::class
+            BeforeUpdateContentMetadataEventInterface::class,
+            UpdateContentMetadataEventInterface::class
         );
 
         $parameters = [
@@ -823,7 +810,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('updateContentMetadata')->willReturn($content);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateContentMetadataEvent::class, function (BeforeUpdateContentMetadataEventInterface $event) use ($eventContent) {
+        $traceableEventDispatcher->addListener(BeforeUpdateContentMetadataEventInterface::class, function (BeforeUpdateContentMetadataEventInterface $event) use ($eventContent) {
             $event->setContent($eventContent);
             $event->stopPropagation();
         }, 10);
@@ -836,19 +823,19 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContent, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateContentMetadataEvent::class, 10],
+            [BeforeUpdateContentMetadataEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateContentMetadataEvent::class, 0],
-            [UpdateContentMetadataEvent::class, 0],
+            [BeforeUpdateContentMetadataEventInterface::class, 0],
+            [UpdateContentMetadataEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteTranslationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteTranslationEvent::class,
-            DeleteTranslationEvent::class
+            BeforeDeleteTranslationEventInterface::class,
+            DeleteTranslationEventInterface::class
         );
 
         $parameters = [
@@ -864,8 +851,8 @@ class ContentServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteTranslationEvent::class, 0],
-            [DeleteTranslationEvent::class, 0],
+            [BeforeDeleteTranslationEventInterface::class, 0],
+            [DeleteTranslationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -873,8 +860,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testDeleteTranslationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteTranslationEvent::class,
-            DeleteTranslationEvent::class
+            BeforeDeleteTranslationEventInterface::class,
+            DeleteTranslationEventInterface::class
         );
 
         $parameters = [
@@ -884,7 +871,7 @@ class ContentServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteTranslationEvent::class, function (BeforeDeleteTranslationEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteTranslationEventInterface::class, function (BeforeDeleteTranslationEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -895,19 +882,19 @@ class ContentServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteTranslationEvent::class, 10],
+            [BeforeDeleteTranslationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteTranslationEvent::class, 0],
-            [DeleteTranslationEvent::class, 0],
+            [BeforeDeleteTranslationEventInterface::class, 0],
+            [DeleteTranslationEventInterface::class, 0],
         ]);
     }
 
     public function testPublishVersionEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforePublishVersionEvent::class,
-            PublishVersionEvent::class
+            BeforePublishVersionEventInterface::class,
+            PublishVersionEventInterface::class
         );
 
         $parameters = [
@@ -926,8 +913,8 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($content, $result);
         $this->assertSame($calledListeners, [
-            [BeforePublishVersionEvent::class, 0],
-            [PublishVersionEvent::class, 0],
+            [BeforePublishVersionEventInterface::class, 0],
+            [PublishVersionEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -935,8 +922,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testReturnPublishVersionResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforePublishVersionEvent::class,
-            PublishVersionEvent::class
+            BeforePublishVersionEventInterface::class,
+            PublishVersionEventInterface::class
         );
 
         $parameters = [
@@ -949,7 +936,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('publishVersion')->willReturn($content);
 
-        $traceableEventDispatcher->addListener(BeforePublishVersionEvent::class, function (BeforePublishVersionEventInterface $event) use ($eventContent) {
+        $traceableEventDispatcher->addListener(BeforePublishVersionEventInterface::class, function (BeforePublishVersionEventInterface $event) use ($eventContent) {
             $event->setContent($eventContent);
         }, 10);
 
@@ -960,9 +947,9 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContent, $result);
         $this->assertSame($calledListeners, [
-            [BeforePublishVersionEvent::class, 10],
-            [BeforePublishVersionEvent::class, 0],
-            [PublishVersionEvent::class, 0],
+            [BeforePublishVersionEventInterface::class, 10],
+            [BeforePublishVersionEventInterface::class, 0],
+            [PublishVersionEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -970,8 +957,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testPublishVersionStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforePublishVersionEvent::class,
-            PublishVersionEvent::class
+            BeforePublishVersionEventInterface::class,
+            PublishVersionEventInterface::class
         );
 
         $parameters = [
@@ -984,7 +971,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('publishVersion')->willReturn($content);
 
-        $traceableEventDispatcher->addListener(BeforePublishVersionEvent::class, function (BeforePublishVersionEventInterface $event) use ($eventContent) {
+        $traceableEventDispatcher->addListener(BeforePublishVersionEventInterface::class, function (BeforePublishVersionEventInterface $event) use ($eventContent) {
             $event->setContent($eventContent);
             $event->stopPropagation();
         }, 10);
@@ -997,19 +984,19 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContent, $result);
         $this->assertSame($calledListeners, [
-            [BeforePublishVersionEvent::class, 10],
+            [BeforePublishVersionEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforePublishVersionEvent::class, 0],
-            [PublishVersionEvent::class, 0],
+            [BeforePublishVersionEventInterface::class, 0],
+            [PublishVersionEventInterface::class, 0],
         ]);
     }
 
     public function testCreateContentDraftEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentDraftEvent::class,
-            CreateContentDraftEvent::class
+            BeforeCreateContentDraftEventInterface::class,
+            CreateContentDraftEventInterface::class
         );
 
         $parameters = [
@@ -1029,8 +1016,8 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($contentDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentDraftEvent::class, 0],
-            [CreateContentDraftEvent::class, 0],
+            [BeforeCreateContentDraftEventInterface::class, 0],
+            [CreateContentDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1038,8 +1025,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testReturnCreateContentDraftResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentDraftEvent::class,
-            CreateContentDraftEvent::class
+            BeforeCreateContentDraftEventInterface::class,
+            CreateContentDraftEventInterface::class
         );
 
         $parameters = [
@@ -1053,7 +1040,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('createContentDraft')->willReturn($contentDraft);
 
-        $traceableEventDispatcher->addListener(BeforeCreateContentDraftEvent::class, function (BeforeCreateContentDraftEventInterface $event) use ($eventContentDraft) {
+        $traceableEventDispatcher->addListener(BeforeCreateContentDraftEventInterface::class, function (BeforeCreateContentDraftEventInterface $event) use ($eventContentDraft) {
             $event->setContentDraft($eventContentDraft);
         }, 10);
 
@@ -1064,9 +1051,9 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContentDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentDraftEvent::class, 10],
-            [BeforeCreateContentDraftEvent::class, 0],
-            [CreateContentDraftEvent::class, 0],
+            [BeforeCreateContentDraftEventInterface::class, 10],
+            [BeforeCreateContentDraftEventInterface::class, 0],
+            [CreateContentDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1074,8 +1061,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testCreateContentDraftStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentDraftEvent::class,
-            CreateContentDraftEvent::class
+            BeforeCreateContentDraftEventInterface::class,
+            CreateContentDraftEventInterface::class
         );
 
         $parameters = [
@@ -1089,7 +1076,7 @@ class ContentServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
         $innerServiceMock->method('createContentDraft')->willReturn($contentDraft);
 
-        $traceableEventDispatcher->addListener(BeforeCreateContentDraftEvent::class, function (BeforeCreateContentDraftEventInterface $event) use ($eventContentDraft) {
+        $traceableEventDispatcher->addListener(BeforeCreateContentDraftEventInterface::class, function (BeforeCreateContentDraftEventInterface $event) use ($eventContentDraft) {
             $event->setContentDraft($eventContentDraft);
             $event->stopPropagation();
         }, 10);
@@ -1102,19 +1089,19 @@ class ContentServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContentDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentDraftEvent::class, 10],
+            [BeforeCreateContentDraftEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateContentDraftEvent::class, 0],
-            [CreateContentDraftEvent::class, 0],
+            [BeforeCreateContentDraftEventInterface::class, 0],
+            [CreateContentDraftEventInterface::class, 0],
         ]);
     }
 
     public function testRevealContentEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRevealContentEvent::class,
-            RevealContentEvent::class
+            BeforeRevealContentEventInterface::class,
+            RevealContentEventInterface::class
         );
 
         $parameters = [
@@ -1129,8 +1116,8 @@ class ContentServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeRevealContentEvent::class, 0],
-            [RevealContentEvent::class, 0],
+            [BeforeRevealContentEventInterface::class, 0],
+            [RevealContentEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1138,8 +1125,8 @@ class ContentServiceTest extends AbstractServiceTest
     public function testRevealContentStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRevealContentEvent::class,
-            RevealContentEvent::class
+            BeforeRevealContentEventInterface::class,
+            RevealContentEventInterface::class
         );
 
         $parameters = [
@@ -1148,7 +1135,7 @@ class ContentServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeRevealContentEvent::class, function (BeforeRevealContentEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeRevealContentEventInterface::class, function (BeforeRevealContentEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -1159,11 +1146,11 @@ class ContentServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeRevealContentEvent::class, 10],
+            [BeforeRevealContentEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeRevealContentEvent::class, 0],
-            [RevealContentEvent::class, 0],
+            [BeforeRevealContentEventInterface::class, 0],
+            [RevealContentEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/ContentTypeServiceTest.php
@@ -7,6 +7,8 @@
 namespace eZ\Publish\Core\Event\Tests;
 
 use eZ\Publish\API\Repository\ContentTypeService as ContentTypeServiceInterface;
+use eZ\Publish\API\Repository\Events\ContentType\AddFieldDefinitionEvent as AddFieldDefinitionEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\AssignContentTypeGroupEvent as AssignContentTypeGroupEventInterface;
 use eZ\Publish\API\Repository\Events\ContentType\BeforeAddFieldDefinitionEvent as BeforeAddFieldDefinitionEventInterface;
 use eZ\Publish\API\Repository\Events\ContentType\BeforeAssignContentTypeGroupEvent as BeforeAssignContentTypeGroupEventInterface;
 use eZ\Publish\API\Repository\Events\ContentType\BeforeCopyContentTypeEvent as BeforeCopyContentTypeEventInterface;
@@ -22,6 +24,19 @@ use eZ\Publish\API\Repository\Events\ContentType\BeforeUnassignContentTypeGroupE
 use eZ\Publish\API\Repository\Events\ContentType\BeforeUpdateContentTypeDraftEvent as BeforeUpdateContentTypeDraftEventInterface;
 use eZ\Publish\API\Repository\Events\ContentType\BeforeUpdateContentTypeGroupEvent as BeforeUpdateContentTypeGroupEventInterface;
 use eZ\Publish\API\Repository\Events\ContentType\BeforeUpdateFieldDefinitionEvent as BeforeUpdateFieldDefinitionEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\CopyContentTypeEvent as CopyContentTypeEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\CreateContentTypeDraftEvent as CreateContentTypeDraftEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\CreateContentTypeEvent as CreateContentTypeEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\CreateContentTypeGroupEvent as CreateContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\DeleteContentTypeEvent as DeleteContentTypeEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\DeleteContentTypeGroupEvent as DeleteContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\PublishContentTypeDraftEvent as PublishContentTypeDraftEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\RemoveContentTypeTranslationEvent as RemoveContentTypeTranslationEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\RemoveFieldDefinitionEvent as RemoveFieldDefinitionEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\UnassignContentTypeGroupEvent as UnassignContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\UpdateContentTypeDraftEvent as UpdateContentTypeDraftEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\UpdateContentTypeGroupEvent as UpdateContentTypeGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ContentType\UpdateFieldDefinitionEvent as UpdateFieldDefinitionEventInterface;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeCreateStruct;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft;
@@ -33,36 +48,6 @@ use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\User;
-use eZ\Publish\Core\Event\ContentType\AddFieldDefinitionEvent;
-use eZ\Publish\Core\Event\ContentType\AssignContentTypeGroupEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeAddFieldDefinitionEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeAssignContentTypeGroupEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeCopyContentTypeEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeCreateContentTypeDraftEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeCreateContentTypeEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeCreateContentTypeGroupEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeDeleteContentTypeEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeDeleteContentTypeGroupEvent;
-use eZ\Publish\Core\Event\ContentType\BeforePublishContentTypeDraftEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeRemoveContentTypeTranslationEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeRemoveFieldDefinitionEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeUnassignContentTypeGroupEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeUpdateContentTypeDraftEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeUpdateContentTypeGroupEvent;
-use eZ\Publish\Core\Event\ContentType\BeforeUpdateFieldDefinitionEvent;
-use eZ\Publish\Core\Event\ContentType\CopyContentTypeEvent;
-use eZ\Publish\Core\Event\ContentType\CreateContentTypeDraftEvent;
-use eZ\Publish\Core\Event\ContentType\CreateContentTypeEvent;
-use eZ\Publish\Core\Event\ContentType\CreateContentTypeGroupEvent;
-use eZ\Publish\Core\Event\ContentType\DeleteContentTypeEvent;
-use eZ\Publish\Core\Event\ContentType\DeleteContentTypeGroupEvent;
-use eZ\Publish\Core\Event\ContentType\PublishContentTypeDraftEvent;
-use eZ\Publish\Core\Event\ContentType\RemoveContentTypeTranslationEvent;
-use eZ\Publish\Core\Event\ContentType\RemoveFieldDefinitionEvent;
-use eZ\Publish\Core\Event\ContentType\UnassignContentTypeGroupEvent;
-use eZ\Publish\Core\Event\ContentType\UpdateContentTypeDraftEvent;
-use eZ\Publish\Core\Event\ContentType\UpdateContentTypeGroupEvent;
-use eZ\Publish\Core\Event\ContentType\UpdateFieldDefinitionEvent;
 use eZ\Publish\Core\Event\ContentTypeService;
 
 class ContentTypeServiceTest extends AbstractServiceTest
@@ -70,8 +55,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testAddFieldDefinitionEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAddFieldDefinitionEvent::class,
-            AddFieldDefinitionEvent::class
+            BeforeAddFieldDefinitionEventInterface::class,
+            AddFieldDefinitionEventInterface::class
         );
 
         $parameters = [
@@ -87,8 +72,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAddFieldDefinitionEvent::class, 0],
-            [AddFieldDefinitionEvent::class, 0],
+            [BeforeAddFieldDefinitionEventInterface::class, 0],
+            [AddFieldDefinitionEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -96,8 +81,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testAddFieldDefinitionStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAddFieldDefinitionEvent::class,
-            AddFieldDefinitionEvent::class
+            BeforeAddFieldDefinitionEventInterface::class,
+            AddFieldDefinitionEventInterface::class
         );
 
         $parameters = [
@@ -107,7 +92,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeAddFieldDefinitionEvent::class, function (BeforeAddFieldDefinitionEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeAddFieldDefinitionEventInterface::class, function (BeforeAddFieldDefinitionEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -118,19 +103,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAddFieldDefinitionEvent::class, 10],
+            [BeforeAddFieldDefinitionEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [AddFieldDefinitionEvent::class, 0],
-            [BeforeAddFieldDefinitionEvent::class, 0],
+            [AddFieldDefinitionEventInterface::class, 0],
+            [BeforeAddFieldDefinitionEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteContentTypeGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteContentTypeGroupEvent::class,
-            DeleteContentTypeGroupEvent::class
+            BeforeDeleteContentTypeGroupEventInterface::class,
+            DeleteContentTypeGroupEventInterface::class
         );
 
         $parameters = [
@@ -145,8 +130,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteContentTypeGroupEvent::class, 0],
-            [DeleteContentTypeGroupEvent::class, 0],
+            [BeforeDeleteContentTypeGroupEventInterface::class, 0],
+            [DeleteContentTypeGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -154,8 +139,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testDeleteContentTypeGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteContentTypeGroupEvent::class,
-            DeleteContentTypeGroupEvent::class
+            BeforeDeleteContentTypeGroupEventInterface::class,
+            DeleteContentTypeGroupEventInterface::class
         );
 
         $parameters = [
@@ -164,7 +149,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteContentTypeGroupEvent::class, function (BeforeDeleteContentTypeGroupEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteContentTypeGroupEventInterface::class, function (BeforeDeleteContentTypeGroupEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -175,19 +160,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteContentTypeGroupEvent::class, 10],
+            [BeforeDeleteContentTypeGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteContentTypeGroupEvent::class, 0],
-            [DeleteContentTypeGroupEvent::class, 0],
+            [BeforeDeleteContentTypeGroupEventInterface::class, 0],
+            [DeleteContentTypeGroupEventInterface::class, 0],
         ]);
     }
 
     public function testCreateContentTypeDraftEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentTypeDraftEvent::class,
-            CreateContentTypeDraftEvent::class
+            BeforeCreateContentTypeDraftEventInterface::class,
+            CreateContentTypeDraftEventInterface::class
         );
 
         $parameters = [
@@ -205,8 +190,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($contentTypeDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentTypeDraftEvent::class, 0],
-            [CreateContentTypeDraftEvent::class, 0],
+            [BeforeCreateContentTypeDraftEventInterface::class, 0],
+            [CreateContentTypeDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -214,8 +199,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testReturnCreateContentTypeDraftResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentTypeDraftEvent::class,
-            CreateContentTypeDraftEvent::class
+            BeforeCreateContentTypeDraftEventInterface::class,
+            CreateContentTypeDraftEventInterface::class
         );
 
         $parameters = [
@@ -227,7 +212,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
         $innerServiceMock->method('createContentTypeDraft')->willReturn($contentTypeDraft);
 
-        $traceableEventDispatcher->addListener(BeforeCreateContentTypeDraftEvent::class, function (BeforeCreateContentTypeDraftEventInterface $event) use ($eventContentTypeDraft) {
+        $traceableEventDispatcher->addListener(BeforeCreateContentTypeDraftEventInterface::class, function (BeforeCreateContentTypeDraftEventInterface $event) use ($eventContentTypeDraft) {
             $event->setContentTypeDraft($eventContentTypeDraft);
         }, 10);
 
@@ -238,9 +223,9 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContentTypeDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentTypeDraftEvent::class, 10],
-            [BeforeCreateContentTypeDraftEvent::class, 0],
-            [CreateContentTypeDraftEvent::class, 0],
+            [BeforeCreateContentTypeDraftEventInterface::class, 10],
+            [BeforeCreateContentTypeDraftEventInterface::class, 0],
+            [CreateContentTypeDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -248,8 +233,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testCreateContentTypeDraftStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentTypeDraftEvent::class,
-            CreateContentTypeDraftEvent::class
+            BeforeCreateContentTypeDraftEventInterface::class,
+            CreateContentTypeDraftEventInterface::class
         );
 
         $parameters = [
@@ -261,7 +246,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
         $innerServiceMock->method('createContentTypeDraft')->willReturn($contentTypeDraft);
 
-        $traceableEventDispatcher->addListener(BeforeCreateContentTypeDraftEvent::class, function (BeforeCreateContentTypeDraftEventInterface $event) use ($eventContentTypeDraft) {
+        $traceableEventDispatcher->addListener(BeforeCreateContentTypeDraftEventInterface::class, function (BeforeCreateContentTypeDraftEventInterface $event) use ($eventContentTypeDraft) {
             $event->setContentTypeDraft($eventContentTypeDraft);
             $event->stopPropagation();
         }, 10);
@@ -274,19 +259,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContentTypeDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentTypeDraftEvent::class, 10],
+            [BeforeCreateContentTypeDraftEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateContentTypeDraftEvent::class, 0],
-            [CreateContentTypeDraftEvent::class, 0],
+            [BeforeCreateContentTypeDraftEventInterface::class, 0],
+            [CreateContentTypeDraftEventInterface::class, 0],
         ]);
     }
 
     public function testCreateContentTypeGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentTypeGroupEvent::class,
-            CreateContentTypeGroupEvent::class
+            BeforeCreateContentTypeGroupEventInterface::class,
+            CreateContentTypeGroupEventInterface::class
         );
 
         $parameters = [
@@ -304,8 +289,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($contentTypeGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentTypeGroupEvent::class, 0],
-            [CreateContentTypeGroupEvent::class, 0],
+            [BeforeCreateContentTypeGroupEventInterface::class, 0],
+            [CreateContentTypeGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -313,8 +298,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testReturnCreateContentTypeGroupResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentTypeGroupEvent::class,
-            CreateContentTypeGroupEvent::class
+            BeforeCreateContentTypeGroupEventInterface::class,
+            CreateContentTypeGroupEventInterface::class
         );
 
         $parameters = [
@@ -326,7 +311,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
         $innerServiceMock->method('createContentTypeGroup')->willReturn($contentTypeGroup);
 
-        $traceableEventDispatcher->addListener(BeforeCreateContentTypeGroupEvent::class, function (BeforeCreateContentTypeGroupEventInterface $event) use ($eventContentTypeGroup) {
+        $traceableEventDispatcher->addListener(BeforeCreateContentTypeGroupEventInterface::class, function (BeforeCreateContentTypeGroupEventInterface $event) use ($eventContentTypeGroup) {
             $event->setContentTypeGroup($eventContentTypeGroup);
         }, 10);
 
@@ -337,9 +322,9 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContentTypeGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentTypeGroupEvent::class, 10],
-            [BeforeCreateContentTypeGroupEvent::class, 0],
-            [CreateContentTypeGroupEvent::class, 0],
+            [BeforeCreateContentTypeGroupEventInterface::class, 10],
+            [BeforeCreateContentTypeGroupEventInterface::class, 0],
+            [CreateContentTypeGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -347,8 +332,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testCreateContentTypeGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentTypeGroupEvent::class,
-            CreateContentTypeGroupEvent::class
+            BeforeCreateContentTypeGroupEventInterface::class,
+            CreateContentTypeGroupEventInterface::class
         );
 
         $parameters = [
@@ -360,7 +345,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
         $innerServiceMock->method('createContentTypeGroup')->willReturn($contentTypeGroup);
 
-        $traceableEventDispatcher->addListener(BeforeCreateContentTypeGroupEvent::class, function (BeforeCreateContentTypeGroupEventInterface $event) use ($eventContentTypeGroup) {
+        $traceableEventDispatcher->addListener(BeforeCreateContentTypeGroupEventInterface::class, function (BeforeCreateContentTypeGroupEventInterface $event) use ($eventContentTypeGroup) {
             $event->setContentTypeGroup($eventContentTypeGroup);
             $event->stopPropagation();
         }, 10);
@@ -373,19 +358,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContentTypeGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentTypeGroupEvent::class, 10],
+            [BeforeCreateContentTypeGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateContentTypeGroupEvent::class, 0],
-            [CreateContentTypeGroupEvent::class, 0],
+            [BeforeCreateContentTypeGroupEventInterface::class, 0],
+            [CreateContentTypeGroupEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateContentTypeGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateContentTypeGroupEvent::class,
-            UpdateContentTypeGroupEvent::class
+            BeforeUpdateContentTypeGroupEventInterface::class,
+            UpdateContentTypeGroupEventInterface::class
         );
 
         $parameters = [
@@ -401,8 +386,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUpdateContentTypeGroupEvent::class, 0],
-            [UpdateContentTypeGroupEvent::class, 0],
+            [BeforeUpdateContentTypeGroupEventInterface::class, 0],
+            [UpdateContentTypeGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -410,8 +395,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testUpdateContentTypeGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateContentTypeGroupEvent::class,
-            UpdateContentTypeGroupEvent::class
+            BeforeUpdateContentTypeGroupEventInterface::class,
+            UpdateContentTypeGroupEventInterface::class
         );
 
         $parameters = [
@@ -421,7 +406,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateContentTypeGroupEvent::class, function (BeforeUpdateContentTypeGroupEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeUpdateContentTypeGroupEventInterface::class, function (BeforeUpdateContentTypeGroupEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -432,19 +417,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUpdateContentTypeGroupEvent::class, 10],
+            [BeforeUpdateContentTypeGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateContentTypeGroupEvent::class, 0],
-            [UpdateContentTypeGroupEvent::class, 0],
+            [BeforeUpdateContentTypeGroupEventInterface::class, 0],
+            [UpdateContentTypeGroupEventInterface::class, 0],
         ]);
     }
 
     public function testCreateContentTypeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentTypeEvent::class,
-            CreateContentTypeEvent::class
+            BeforeCreateContentTypeEventInterface::class,
+            CreateContentTypeEventInterface::class
         );
 
         $parameters = [
@@ -463,8 +448,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($contentTypeDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentTypeEvent::class, 0],
-            [CreateContentTypeEvent::class, 0],
+            [BeforeCreateContentTypeEventInterface::class, 0],
+            [CreateContentTypeEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -472,8 +457,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testReturnCreateContentTypeResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentTypeEvent::class,
-            CreateContentTypeEvent::class
+            BeforeCreateContentTypeEventInterface::class,
+            CreateContentTypeEventInterface::class
         );
 
         $parameters = [
@@ -486,7 +471,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
         $innerServiceMock->method('createContentType')->willReturn($contentTypeDraft);
 
-        $traceableEventDispatcher->addListener(BeforeCreateContentTypeEvent::class, function (BeforeCreateContentTypeEventInterface $event) use ($eventContentTypeDraft) {
+        $traceableEventDispatcher->addListener(BeforeCreateContentTypeEventInterface::class, function (BeforeCreateContentTypeEventInterface $event) use ($eventContentTypeDraft) {
             $event->setContentTypeDraft($eventContentTypeDraft);
         }, 10);
 
@@ -497,9 +482,9 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContentTypeDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentTypeEvent::class, 10],
-            [BeforeCreateContentTypeEvent::class, 0],
-            [CreateContentTypeEvent::class, 0],
+            [BeforeCreateContentTypeEventInterface::class, 10],
+            [BeforeCreateContentTypeEventInterface::class, 0],
+            [CreateContentTypeEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -507,8 +492,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testCreateContentTypeStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateContentTypeEvent::class,
-            CreateContentTypeEvent::class
+            BeforeCreateContentTypeEventInterface::class,
+            CreateContentTypeEventInterface::class
         );
 
         $parameters = [
@@ -521,7 +506,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
         $innerServiceMock->method('createContentType')->willReturn($contentTypeDraft);
 
-        $traceableEventDispatcher->addListener(BeforeCreateContentTypeEvent::class, function (BeforeCreateContentTypeEventInterface $event) use ($eventContentTypeDraft) {
+        $traceableEventDispatcher->addListener(BeforeCreateContentTypeEventInterface::class, function (BeforeCreateContentTypeEventInterface $event) use ($eventContentTypeDraft) {
             $event->setContentTypeDraft($eventContentTypeDraft);
             $event->stopPropagation();
         }, 10);
@@ -534,19 +519,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContentTypeDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateContentTypeEvent::class, 10],
+            [BeforeCreateContentTypeEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateContentTypeEvent::class, 0],
-            [CreateContentTypeEvent::class, 0],
+            [BeforeCreateContentTypeEventInterface::class, 0],
+            [CreateContentTypeEventInterface::class, 0],
         ]);
     }
 
     public function testRemoveContentTypeTranslationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemoveContentTypeTranslationEvent::class,
-            RemoveContentTypeTranslationEvent::class
+            BeforeRemoveContentTypeTranslationEventInterface::class,
+            RemoveContentTypeTranslationEventInterface::class
         );
 
         $parameters = [
@@ -565,8 +550,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($newContentTypeDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeRemoveContentTypeTranslationEvent::class, 0],
-            [RemoveContentTypeTranslationEvent::class, 0],
+            [BeforeRemoveContentTypeTranslationEventInterface::class, 0],
+            [RemoveContentTypeTranslationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -574,8 +559,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testReturnRemoveContentTypeTranslationResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemoveContentTypeTranslationEvent::class,
-            RemoveContentTypeTranslationEvent::class
+            BeforeRemoveContentTypeTranslationEventInterface::class,
+            RemoveContentTypeTranslationEventInterface::class
         );
 
         $parameters = [
@@ -588,7 +573,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
         $innerServiceMock->method('removeContentTypeTranslation')->willReturn($newContentTypeDraft);
 
-        $traceableEventDispatcher->addListener(BeforeRemoveContentTypeTranslationEvent::class, function (BeforeRemoveContentTypeTranslationEventInterface $event) use ($eventNewContentTypeDraft) {
+        $traceableEventDispatcher->addListener(BeforeRemoveContentTypeTranslationEventInterface::class, function (BeforeRemoveContentTypeTranslationEventInterface $event) use ($eventNewContentTypeDraft) {
             $event->setNewContentTypeDraft($eventNewContentTypeDraft);
         }, 10);
 
@@ -599,9 +584,9 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventNewContentTypeDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeRemoveContentTypeTranslationEvent::class, 10],
-            [BeforeRemoveContentTypeTranslationEvent::class, 0],
-            [RemoveContentTypeTranslationEvent::class, 0],
+            [BeforeRemoveContentTypeTranslationEventInterface::class, 10],
+            [BeforeRemoveContentTypeTranslationEventInterface::class, 0],
+            [RemoveContentTypeTranslationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -609,8 +594,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testRemoveContentTypeTranslationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemoveContentTypeTranslationEvent::class,
-            RemoveContentTypeTranslationEvent::class
+            BeforeRemoveContentTypeTranslationEventInterface::class,
+            RemoveContentTypeTranslationEventInterface::class
         );
 
         $parameters = [
@@ -623,7 +608,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
         $innerServiceMock->method('removeContentTypeTranslation')->willReturn($newContentTypeDraft);
 
-        $traceableEventDispatcher->addListener(BeforeRemoveContentTypeTranslationEvent::class, function (BeforeRemoveContentTypeTranslationEventInterface $event) use ($eventNewContentTypeDraft) {
+        $traceableEventDispatcher->addListener(BeforeRemoveContentTypeTranslationEventInterface::class, function (BeforeRemoveContentTypeTranslationEventInterface $event) use ($eventNewContentTypeDraft) {
             $event->setNewContentTypeDraft($eventNewContentTypeDraft);
             $event->stopPropagation();
         }, 10);
@@ -636,19 +621,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventNewContentTypeDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeRemoveContentTypeTranslationEvent::class, 10],
+            [BeforeRemoveContentTypeTranslationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeRemoveContentTypeTranslationEvent::class, 0],
-            [RemoveContentTypeTranslationEvent::class, 0],
+            [BeforeRemoveContentTypeTranslationEventInterface::class, 0],
+            [RemoveContentTypeTranslationEventInterface::class, 0],
         ]);
     }
 
     public function testUnassignContentTypeGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUnassignContentTypeGroupEvent::class,
-            UnassignContentTypeGroupEvent::class
+            BeforeUnassignContentTypeGroupEventInterface::class,
+            UnassignContentTypeGroupEventInterface::class
         );
 
         $parameters = [
@@ -664,8 +649,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUnassignContentTypeGroupEvent::class, 0],
-            [UnassignContentTypeGroupEvent::class, 0],
+            [BeforeUnassignContentTypeGroupEventInterface::class, 0],
+            [UnassignContentTypeGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -673,8 +658,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testUnassignContentTypeGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUnassignContentTypeGroupEvent::class,
-            UnassignContentTypeGroupEvent::class
+            BeforeUnassignContentTypeGroupEventInterface::class,
+            UnassignContentTypeGroupEventInterface::class
         );
 
         $parameters = [
@@ -684,7 +669,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeUnassignContentTypeGroupEvent::class, function (BeforeUnassignContentTypeGroupEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeUnassignContentTypeGroupEventInterface::class, function (BeforeUnassignContentTypeGroupEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -695,19 +680,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUnassignContentTypeGroupEvent::class, 10],
+            [BeforeUnassignContentTypeGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUnassignContentTypeGroupEvent::class, 0],
-            [UnassignContentTypeGroupEvent::class, 0],
+            [BeforeUnassignContentTypeGroupEventInterface::class, 0],
+            [UnassignContentTypeGroupEventInterface::class, 0],
         ]);
     }
 
     public function testPublishContentTypeDraftEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforePublishContentTypeDraftEvent::class,
-            PublishContentTypeDraftEvent::class
+            BeforePublishContentTypeDraftEventInterface::class,
+            PublishContentTypeDraftEventInterface::class
         );
 
         $parameters = [
@@ -722,8 +707,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforePublishContentTypeDraftEvent::class, 0],
-            [PublishContentTypeDraftEvent::class, 0],
+            [BeforePublishContentTypeDraftEventInterface::class, 0],
+            [PublishContentTypeDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -731,8 +716,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testPublishContentTypeDraftStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforePublishContentTypeDraftEvent::class,
-            PublishContentTypeDraftEvent::class
+            BeforePublishContentTypeDraftEventInterface::class,
+            PublishContentTypeDraftEventInterface::class
         );
 
         $parameters = [
@@ -741,7 +726,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforePublishContentTypeDraftEvent::class, function (BeforePublishContentTypeDraftEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforePublishContentTypeDraftEventInterface::class, function (BeforePublishContentTypeDraftEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -752,19 +737,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforePublishContentTypeDraftEvent::class, 10],
+            [BeforePublishContentTypeDraftEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforePublishContentTypeDraftEvent::class, 0],
-            [PublishContentTypeDraftEvent::class, 0],
+            [BeforePublishContentTypeDraftEventInterface::class, 0],
+            [PublishContentTypeDraftEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateFieldDefinitionEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateFieldDefinitionEvent::class,
-            UpdateFieldDefinitionEvent::class
+            BeforeUpdateFieldDefinitionEventInterface::class,
+            UpdateFieldDefinitionEventInterface::class
         );
 
         $parameters = [
@@ -781,8 +766,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUpdateFieldDefinitionEvent::class, 0],
-            [UpdateFieldDefinitionEvent::class, 0],
+            [BeforeUpdateFieldDefinitionEventInterface::class, 0],
+            [UpdateFieldDefinitionEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -790,8 +775,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testUpdateFieldDefinitionStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateFieldDefinitionEvent::class,
-            UpdateFieldDefinitionEvent::class
+            BeforeUpdateFieldDefinitionEventInterface::class,
+            UpdateFieldDefinitionEventInterface::class
         );
 
         $parameters = [
@@ -802,7 +787,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateFieldDefinitionEvent::class, function (BeforeUpdateFieldDefinitionEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeUpdateFieldDefinitionEventInterface::class, function (BeforeUpdateFieldDefinitionEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -813,19 +798,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUpdateFieldDefinitionEvent::class, 10],
+            [BeforeUpdateFieldDefinitionEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateFieldDefinitionEvent::class, 0],
-            [UpdateFieldDefinitionEvent::class, 0],
+            [BeforeUpdateFieldDefinitionEventInterface::class, 0],
+            [UpdateFieldDefinitionEventInterface::class, 0],
         ]);
     }
 
     public function testRemoveFieldDefinitionEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemoveFieldDefinitionEvent::class,
-            RemoveFieldDefinitionEvent::class
+            BeforeRemoveFieldDefinitionEventInterface::class,
+            RemoveFieldDefinitionEventInterface::class
         );
 
         $parameters = [
@@ -841,8 +826,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeRemoveFieldDefinitionEvent::class, 0],
-            [RemoveFieldDefinitionEvent::class, 0],
+            [BeforeRemoveFieldDefinitionEventInterface::class, 0],
+            [RemoveFieldDefinitionEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -850,8 +835,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testRemoveFieldDefinitionStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemoveFieldDefinitionEvent::class,
-            RemoveFieldDefinitionEvent::class
+            BeforeRemoveFieldDefinitionEventInterface::class,
+            RemoveFieldDefinitionEventInterface::class
         );
 
         $parameters = [
@@ -861,7 +846,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeRemoveFieldDefinitionEvent::class, function (BeforeRemoveFieldDefinitionEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeRemoveFieldDefinitionEventInterface::class, function (BeforeRemoveFieldDefinitionEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -872,19 +857,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeRemoveFieldDefinitionEvent::class, 10],
+            [BeforeRemoveFieldDefinitionEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeRemoveFieldDefinitionEvent::class, 0],
-            [RemoveFieldDefinitionEvent::class, 0],
+            [BeforeRemoveFieldDefinitionEventInterface::class, 0],
+            [RemoveFieldDefinitionEventInterface::class, 0],
         ]);
     }
 
     public function testAssignContentTypeGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAssignContentTypeGroupEvent::class,
-            AssignContentTypeGroupEvent::class
+            BeforeAssignContentTypeGroupEventInterface::class,
+            AssignContentTypeGroupEventInterface::class
         );
 
         $parameters = [
@@ -900,8 +885,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAssignContentTypeGroupEvent::class, 0],
-            [AssignContentTypeGroupEvent::class, 0],
+            [BeforeAssignContentTypeGroupEventInterface::class, 0],
+            [AssignContentTypeGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -909,8 +894,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testAssignContentTypeGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAssignContentTypeGroupEvent::class,
-            AssignContentTypeGroupEvent::class
+            BeforeAssignContentTypeGroupEventInterface::class,
+            AssignContentTypeGroupEventInterface::class
         );
 
         $parameters = [
@@ -920,7 +905,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeAssignContentTypeGroupEvent::class, function (BeforeAssignContentTypeGroupEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeAssignContentTypeGroupEventInterface::class, function (BeforeAssignContentTypeGroupEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -931,19 +916,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAssignContentTypeGroupEvent::class, 10],
+            [BeforeAssignContentTypeGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [AssignContentTypeGroupEvent::class, 0],
-            [BeforeAssignContentTypeGroupEvent::class, 0],
+            [AssignContentTypeGroupEventInterface::class, 0],
+            [BeforeAssignContentTypeGroupEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateContentTypeDraftEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateContentTypeDraftEvent::class,
-            UpdateContentTypeDraftEvent::class
+            BeforeUpdateContentTypeDraftEventInterface::class,
+            UpdateContentTypeDraftEventInterface::class
         );
 
         $parameters = [
@@ -959,8 +944,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUpdateContentTypeDraftEvent::class, 0],
-            [UpdateContentTypeDraftEvent::class, 0],
+            [BeforeUpdateContentTypeDraftEventInterface::class, 0],
+            [UpdateContentTypeDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -968,8 +953,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testUpdateContentTypeDraftStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateContentTypeDraftEvent::class,
-            UpdateContentTypeDraftEvent::class
+            BeforeUpdateContentTypeDraftEventInterface::class,
+            UpdateContentTypeDraftEventInterface::class
         );
 
         $parameters = [
@@ -979,7 +964,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateContentTypeDraftEvent::class, function (BeforeUpdateContentTypeDraftEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeUpdateContentTypeDraftEventInterface::class, function (BeforeUpdateContentTypeDraftEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -990,19 +975,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUpdateContentTypeDraftEvent::class, 10],
+            [BeforeUpdateContentTypeDraftEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateContentTypeDraftEvent::class, 0],
-            [UpdateContentTypeDraftEvent::class, 0],
+            [BeforeUpdateContentTypeDraftEventInterface::class, 0],
+            [UpdateContentTypeDraftEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteContentTypeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteContentTypeEvent::class,
-            DeleteContentTypeEvent::class
+            BeforeDeleteContentTypeEventInterface::class,
+            DeleteContentTypeEventInterface::class
         );
 
         $parameters = [
@@ -1017,8 +1002,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteContentTypeEvent::class, 0],
-            [DeleteContentTypeEvent::class, 0],
+            [BeforeDeleteContentTypeEventInterface::class, 0],
+            [DeleteContentTypeEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1026,8 +1011,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testDeleteContentTypeStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteContentTypeEvent::class,
-            DeleteContentTypeEvent::class
+            BeforeDeleteContentTypeEventInterface::class,
+            DeleteContentTypeEventInterface::class
         );
 
         $parameters = [
@@ -1036,7 +1021,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteContentTypeEvent::class, function (BeforeDeleteContentTypeEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteContentTypeEventInterface::class, function (BeforeDeleteContentTypeEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -1047,19 +1032,19 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteContentTypeEvent::class, 10],
+            [BeforeDeleteContentTypeEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteContentTypeEvent::class, 0],
-            [DeleteContentTypeEvent::class, 0],
+            [BeforeDeleteContentTypeEventInterface::class, 0],
+            [DeleteContentTypeEventInterface::class, 0],
         ]);
     }
 
     public function testCopyContentTypeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCopyContentTypeEvent::class,
-            CopyContentTypeEvent::class
+            BeforeCopyContentTypeEventInterface::class,
+            CopyContentTypeEventInterface::class
         );
 
         $parameters = [
@@ -1078,8 +1063,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($contentTypeCopy, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCopyContentTypeEvent::class, 0],
-            [CopyContentTypeEvent::class, 0],
+            [BeforeCopyContentTypeEventInterface::class, 0],
+            [CopyContentTypeEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1087,8 +1072,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testReturnCopyContentTypeResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCopyContentTypeEvent::class,
-            CopyContentTypeEvent::class
+            BeforeCopyContentTypeEventInterface::class,
+            CopyContentTypeEventInterface::class
         );
 
         $parameters = [
@@ -1101,7 +1086,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
         $innerServiceMock->method('copyContentType')->willReturn($contentTypeCopy);
 
-        $traceableEventDispatcher->addListener(BeforeCopyContentTypeEvent::class, function (BeforeCopyContentTypeEventInterface $event) use ($eventContentTypeCopy) {
+        $traceableEventDispatcher->addListener(BeforeCopyContentTypeEventInterface::class, function (BeforeCopyContentTypeEventInterface $event) use ($eventContentTypeCopy) {
             $event->setContentTypeCopy($eventContentTypeCopy);
         }, 10);
 
@@ -1112,9 +1097,9 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContentTypeCopy, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCopyContentTypeEvent::class, 10],
-            [BeforeCopyContentTypeEvent::class, 0],
-            [CopyContentTypeEvent::class, 0],
+            [BeforeCopyContentTypeEventInterface::class, 10],
+            [BeforeCopyContentTypeEventInterface::class, 0],
+            [CopyContentTypeEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1122,8 +1107,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
     public function testCopyContentTypeStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCopyContentTypeEvent::class,
-            CopyContentTypeEvent::class
+            BeforeCopyContentTypeEventInterface::class,
+            CopyContentTypeEventInterface::class
         );
 
         $parameters = [
@@ -1136,7 +1121,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ContentTypeServiceInterface::class);
         $innerServiceMock->method('copyContentType')->willReturn($contentTypeCopy);
 
-        $traceableEventDispatcher->addListener(BeforeCopyContentTypeEvent::class, function (BeforeCopyContentTypeEventInterface $event) use ($eventContentTypeCopy) {
+        $traceableEventDispatcher->addListener(BeforeCopyContentTypeEventInterface::class, function (BeforeCopyContentTypeEventInterface $event) use ($eventContentTypeCopy) {
             $event->setContentTypeCopy($eventContentTypeCopy);
             $event->stopPropagation();
         }, 10);
@@ -1149,11 +1134,11 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventContentTypeCopy, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCopyContentTypeEvent::class, 10],
+            [BeforeCopyContentTypeEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCopyContentTypeEvent::class, 0],
-            [CopyContentTypeEvent::class, 0],
+            [BeforeCopyContentTypeEventInterface::class, 0],
+            [CopyContentTypeEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/LanguageServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/LanguageServiceTest.php
@@ -11,19 +11,14 @@ use eZ\Publish\API\Repository\Events\Language\BeforeDeleteLanguageEvent as Befor
 use eZ\Publish\API\Repository\Events\Language\BeforeDisableLanguageEvent as BeforeDisableLanguageEventInterface;
 use eZ\Publish\API\Repository\Events\Language\BeforeEnableLanguageEvent as BeforeEnableLanguageEventInterface;
 use eZ\Publish\API\Repository\Events\Language\BeforeUpdateLanguageNameEvent as BeforeUpdateLanguageNameEventInterface;
+use eZ\Publish\API\Repository\Events\Language\CreateLanguageEvent as CreateLanguageEventInterface;
+use eZ\Publish\API\Repository\Events\Language\DeleteLanguageEvent as DeleteLanguageEventInterface;
+use eZ\Publish\API\Repository\Events\Language\DisableLanguageEvent as DisableLanguageEventInterface;
+use eZ\Publish\API\Repository\Events\Language\EnableLanguageEvent as EnableLanguageEventInterface;
+use eZ\Publish\API\Repository\Events\Language\UpdateLanguageNameEvent as UpdateLanguageNameEventInterface;
 use eZ\Publish\API\Repository\LanguageService as LanguageServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\LanguageCreateStruct;
-use eZ\Publish\Core\Event\Language\BeforeCreateLanguageEvent;
-use eZ\Publish\Core\Event\Language\BeforeDeleteLanguageEvent;
-use eZ\Publish\Core\Event\Language\BeforeDisableLanguageEvent;
-use eZ\Publish\Core\Event\Language\BeforeEnableLanguageEvent;
-use eZ\Publish\Core\Event\Language\BeforeUpdateLanguageNameEvent;
-use eZ\Publish\Core\Event\Language\CreateLanguageEvent;
-use eZ\Publish\Core\Event\Language\DeleteLanguageEvent;
-use eZ\Publish\Core\Event\Language\DisableLanguageEvent;
-use eZ\Publish\Core\Event\Language\EnableLanguageEvent;
-use eZ\Publish\Core\Event\Language\UpdateLanguageNameEvent;
 use eZ\Publish\Core\Event\LanguageService;
 
 class LanguageServiceTest extends AbstractServiceTest
@@ -31,8 +26,8 @@ class LanguageServiceTest extends AbstractServiceTest
     public function testDeleteLanguageEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteLanguageEvent::class,
-            DeleteLanguageEvent::class
+            BeforeDeleteLanguageEventInterface::class,
+            DeleteLanguageEventInterface::class
         );
 
         $parameters = [
@@ -47,8 +42,8 @@ class LanguageServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteLanguageEvent::class, 0],
-            [DeleteLanguageEvent::class, 0],
+            [BeforeDeleteLanguageEventInterface::class, 0],
+            [DeleteLanguageEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -56,8 +51,8 @@ class LanguageServiceTest extends AbstractServiceTest
     public function testDeleteLanguageStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteLanguageEvent::class,
-            DeleteLanguageEvent::class
+            BeforeDeleteLanguageEventInterface::class,
+            DeleteLanguageEventInterface::class
         );
 
         $parameters = [
@@ -66,7 +61,7 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(LanguageServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteLanguageEvent::class, function (BeforeDeleteLanguageEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteLanguageEventInterface::class, function (BeforeDeleteLanguageEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -77,19 +72,19 @@ class LanguageServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteLanguageEvent::class, 10],
+            [BeforeDeleteLanguageEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteLanguageEvent::class, 0],
-            [DeleteLanguageEvent::class, 0],
+            [BeforeDeleteLanguageEventInterface::class, 0],
+            [DeleteLanguageEventInterface::class, 0],
         ]);
     }
 
     public function testCreateLanguageEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateLanguageEvent::class,
-            CreateLanguageEvent::class
+            BeforeCreateLanguageEventInterface::class,
+            CreateLanguageEventInterface::class
         );
 
         $parameters = [
@@ -107,8 +102,8 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $this->assertSame($language, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateLanguageEvent::class, 0],
-            [CreateLanguageEvent::class, 0],
+            [BeforeCreateLanguageEventInterface::class, 0],
+            [CreateLanguageEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -116,8 +111,8 @@ class LanguageServiceTest extends AbstractServiceTest
     public function testReturnCreateLanguageResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateLanguageEvent::class,
-            CreateLanguageEvent::class
+            BeforeCreateLanguageEventInterface::class,
+            CreateLanguageEventInterface::class
         );
 
         $parameters = [
@@ -129,7 +124,7 @@ class LanguageServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LanguageServiceInterface::class);
         $innerServiceMock->method('createLanguage')->willReturn($language);
 
-        $traceableEventDispatcher->addListener(BeforeCreateLanguageEvent::class, function (BeforeCreateLanguageEventInterface $event) use ($eventLanguage) {
+        $traceableEventDispatcher->addListener(BeforeCreateLanguageEventInterface::class, function (BeforeCreateLanguageEventInterface $event) use ($eventLanguage) {
             $event->setLanguage($eventLanguage);
         }, 10);
 
@@ -140,9 +135,9 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLanguage, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateLanguageEvent::class, 10],
-            [BeforeCreateLanguageEvent::class, 0],
-            [CreateLanguageEvent::class, 0],
+            [BeforeCreateLanguageEventInterface::class, 10],
+            [BeforeCreateLanguageEventInterface::class, 0],
+            [CreateLanguageEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -150,8 +145,8 @@ class LanguageServiceTest extends AbstractServiceTest
     public function testCreateLanguageStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateLanguageEvent::class,
-            CreateLanguageEvent::class
+            BeforeCreateLanguageEventInterface::class,
+            CreateLanguageEventInterface::class
         );
 
         $parameters = [
@@ -163,7 +158,7 @@ class LanguageServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LanguageServiceInterface::class);
         $innerServiceMock->method('createLanguage')->willReturn($language);
 
-        $traceableEventDispatcher->addListener(BeforeCreateLanguageEvent::class, function (BeforeCreateLanguageEventInterface $event) use ($eventLanguage) {
+        $traceableEventDispatcher->addListener(BeforeCreateLanguageEventInterface::class, function (BeforeCreateLanguageEventInterface $event) use ($eventLanguage) {
             $event->setLanguage($eventLanguage);
             $event->stopPropagation();
         }, 10);
@@ -176,19 +171,19 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLanguage, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateLanguageEvent::class, 10],
+            [BeforeCreateLanguageEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateLanguageEvent::class, 0],
-            [CreateLanguageEvent::class, 0],
+            [BeforeCreateLanguageEventInterface::class, 0],
+            [CreateLanguageEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateLanguageNameEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateLanguageNameEvent::class,
-            UpdateLanguageNameEvent::class
+            BeforeUpdateLanguageNameEventInterface::class,
+            UpdateLanguageNameEventInterface::class
         );
 
         $parameters = [
@@ -207,8 +202,8 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedLanguage, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateLanguageNameEvent::class, 0],
-            [UpdateLanguageNameEvent::class, 0],
+            [BeforeUpdateLanguageNameEventInterface::class, 0],
+            [UpdateLanguageNameEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -216,8 +211,8 @@ class LanguageServiceTest extends AbstractServiceTest
     public function testReturnUpdateLanguageNameResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateLanguageNameEvent::class,
-            UpdateLanguageNameEvent::class
+            BeforeUpdateLanguageNameEventInterface::class,
+            UpdateLanguageNameEventInterface::class
         );
 
         $parameters = [
@@ -230,7 +225,7 @@ class LanguageServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LanguageServiceInterface::class);
         $innerServiceMock->method('updateLanguageName')->willReturn($updatedLanguage);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateLanguageNameEvent::class, function (BeforeUpdateLanguageNameEventInterface $event) use ($eventUpdatedLanguage) {
+        $traceableEventDispatcher->addListener(BeforeUpdateLanguageNameEventInterface::class, function (BeforeUpdateLanguageNameEventInterface $event) use ($eventUpdatedLanguage) {
             $event->setUpdatedLanguage($eventUpdatedLanguage);
         }, 10);
 
@@ -241,9 +236,9 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedLanguage, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateLanguageNameEvent::class, 10],
-            [BeforeUpdateLanguageNameEvent::class, 0],
-            [UpdateLanguageNameEvent::class, 0],
+            [BeforeUpdateLanguageNameEventInterface::class, 10],
+            [BeforeUpdateLanguageNameEventInterface::class, 0],
+            [UpdateLanguageNameEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -251,8 +246,8 @@ class LanguageServiceTest extends AbstractServiceTest
     public function testUpdateLanguageNameStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateLanguageNameEvent::class,
-            UpdateLanguageNameEvent::class
+            BeforeUpdateLanguageNameEventInterface::class,
+            UpdateLanguageNameEventInterface::class
         );
 
         $parameters = [
@@ -265,7 +260,7 @@ class LanguageServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LanguageServiceInterface::class);
         $innerServiceMock->method('updateLanguageName')->willReturn($updatedLanguage);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateLanguageNameEvent::class, function (BeforeUpdateLanguageNameEventInterface $event) use ($eventUpdatedLanguage) {
+        $traceableEventDispatcher->addListener(BeforeUpdateLanguageNameEventInterface::class, function (BeforeUpdateLanguageNameEventInterface $event) use ($eventUpdatedLanguage) {
             $event->setUpdatedLanguage($eventUpdatedLanguage);
             $event->stopPropagation();
         }, 10);
@@ -278,19 +273,19 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedLanguage, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateLanguageNameEvent::class, 10],
+            [BeforeUpdateLanguageNameEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateLanguageNameEvent::class, 0],
-            [UpdateLanguageNameEvent::class, 0],
+            [BeforeUpdateLanguageNameEventInterface::class, 0],
+            [UpdateLanguageNameEventInterface::class, 0],
         ]);
     }
 
     public function testDisableLanguageEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDisableLanguageEvent::class,
-            DisableLanguageEvent::class
+            BeforeDisableLanguageEventInterface::class,
+            DisableLanguageEventInterface::class
         );
 
         $parameters = [
@@ -308,8 +303,8 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $this->assertSame($disabledLanguage, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDisableLanguageEvent::class, 0],
-            [DisableLanguageEvent::class, 0],
+            [BeforeDisableLanguageEventInterface::class, 0],
+            [DisableLanguageEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -317,8 +312,8 @@ class LanguageServiceTest extends AbstractServiceTest
     public function testReturnDisableLanguageResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDisableLanguageEvent::class,
-            DisableLanguageEvent::class
+            BeforeDisableLanguageEventInterface::class,
+            DisableLanguageEventInterface::class
         );
 
         $parameters = [
@@ -330,7 +325,7 @@ class LanguageServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LanguageServiceInterface::class);
         $innerServiceMock->method('disableLanguage')->willReturn($disabledLanguage);
 
-        $traceableEventDispatcher->addListener(BeforeDisableLanguageEvent::class, function (BeforeDisableLanguageEventInterface $event) use ($eventDisabledLanguage) {
+        $traceableEventDispatcher->addListener(BeforeDisableLanguageEventInterface::class, function (BeforeDisableLanguageEventInterface $event) use ($eventDisabledLanguage) {
             $event->setDisabledLanguage($eventDisabledLanguage);
         }, 10);
 
@@ -341,9 +336,9 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventDisabledLanguage, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDisableLanguageEvent::class, 10],
-            [BeforeDisableLanguageEvent::class, 0],
-            [DisableLanguageEvent::class, 0],
+            [BeforeDisableLanguageEventInterface::class, 10],
+            [BeforeDisableLanguageEventInterface::class, 0],
+            [DisableLanguageEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -351,8 +346,8 @@ class LanguageServiceTest extends AbstractServiceTest
     public function testDisableLanguageStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDisableLanguageEvent::class,
-            DisableLanguageEvent::class
+            BeforeDisableLanguageEventInterface::class,
+            DisableLanguageEventInterface::class
         );
 
         $parameters = [
@@ -364,7 +359,7 @@ class LanguageServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LanguageServiceInterface::class);
         $innerServiceMock->method('disableLanguage')->willReturn($disabledLanguage);
 
-        $traceableEventDispatcher->addListener(BeforeDisableLanguageEvent::class, function (BeforeDisableLanguageEventInterface $event) use ($eventDisabledLanguage) {
+        $traceableEventDispatcher->addListener(BeforeDisableLanguageEventInterface::class, function (BeforeDisableLanguageEventInterface $event) use ($eventDisabledLanguage) {
             $event->setDisabledLanguage($eventDisabledLanguage);
             $event->stopPropagation();
         }, 10);
@@ -377,19 +372,19 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventDisabledLanguage, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDisableLanguageEvent::class, 10],
+            [BeforeDisableLanguageEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDisableLanguageEvent::class, 0],
-            [DisableLanguageEvent::class, 0],
+            [BeforeDisableLanguageEventInterface::class, 0],
+            [DisableLanguageEventInterface::class, 0],
         ]);
     }
 
     public function testEnableLanguageEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeEnableLanguageEvent::class,
-            EnableLanguageEvent::class
+            BeforeEnableLanguageEventInterface::class,
+            EnableLanguageEventInterface::class
         );
 
         $parameters = [
@@ -407,8 +402,8 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $this->assertSame($enabledLanguage, $result);
         $this->assertSame($calledListeners, [
-            [BeforeEnableLanguageEvent::class, 0],
-            [EnableLanguageEvent::class, 0],
+            [BeforeEnableLanguageEventInterface::class, 0],
+            [EnableLanguageEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -416,8 +411,8 @@ class LanguageServiceTest extends AbstractServiceTest
     public function testReturnEnableLanguageResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeEnableLanguageEvent::class,
-            EnableLanguageEvent::class
+            BeforeEnableLanguageEventInterface::class,
+            EnableLanguageEventInterface::class
         );
 
         $parameters = [
@@ -429,7 +424,7 @@ class LanguageServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LanguageServiceInterface::class);
         $innerServiceMock->method('enableLanguage')->willReturn($enabledLanguage);
 
-        $traceableEventDispatcher->addListener(BeforeEnableLanguageEvent::class, function (BeforeEnableLanguageEventInterface $event) use ($eventEnabledLanguage) {
+        $traceableEventDispatcher->addListener(BeforeEnableLanguageEventInterface::class, function (BeforeEnableLanguageEventInterface $event) use ($eventEnabledLanguage) {
             $event->setEnabledLanguage($eventEnabledLanguage);
         }, 10);
 
@@ -440,9 +435,9 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventEnabledLanguage, $result);
         $this->assertSame($calledListeners, [
-            [BeforeEnableLanguageEvent::class, 10],
-            [BeforeEnableLanguageEvent::class, 0],
-            [EnableLanguageEvent::class, 0],
+            [BeforeEnableLanguageEventInterface::class, 10],
+            [BeforeEnableLanguageEventInterface::class, 0],
+            [EnableLanguageEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -450,8 +445,8 @@ class LanguageServiceTest extends AbstractServiceTest
     public function testEnableLanguageStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeEnableLanguageEvent::class,
-            EnableLanguageEvent::class
+            BeforeEnableLanguageEventInterface::class,
+            EnableLanguageEventInterface::class
         );
 
         $parameters = [
@@ -463,7 +458,7 @@ class LanguageServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LanguageServiceInterface::class);
         $innerServiceMock->method('enableLanguage')->willReturn($enabledLanguage);
 
-        $traceableEventDispatcher->addListener(BeforeEnableLanguageEvent::class, function (BeforeEnableLanguageEventInterface $event) use ($eventEnabledLanguage) {
+        $traceableEventDispatcher->addListener(BeforeEnableLanguageEventInterface::class, function (BeforeEnableLanguageEventInterface $event) use ($eventEnabledLanguage) {
             $event->setEnabledLanguage($eventEnabledLanguage);
             $event->stopPropagation();
         }, 10);
@@ -476,11 +471,11 @@ class LanguageServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventEnabledLanguage, $result);
         $this->assertSame($calledListeners, [
-            [BeforeEnableLanguageEvent::class, 10],
+            [BeforeEnableLanguageEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeEnableLanguageEvent::class, 0],
-            [EnableLanguageEvent::class, 0],
+            [BeforeEnableLanguageEventInterface::class, 0],
+            [EnableLanguageEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/LocationServiceTest.php
@@ -14,27 +14,19 @@ use eZ\Publish\API\Repository\Events\Location\BeforeMoveSubtreeEvent as BeforeMo
 use eZ\Publish\API\Repository\Events\Location\BeforeSwapLocationEvent as BeforeSwapLocationEventInterface;
 use eZ\Publish\API\Repository\Events\Location\BeforeUnhideLocationEvent as BeforeUnhideLocationEventInterface;
 use eZ\Publish\API\Repository\Events\Location\BeforeUpdateLocationEvent as BeforeUpdateLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\CopySubtreeEvent as CopySubtreeEventInterface;
+use eZ\Publish\API\Repository\Events\Location\CreateLocationEvent as CreateLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\DeleteLocationEvent as DeleteLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\HideLocationEvent as HideLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\MoveSubtreeEvent as MoveSubtreeEventInterface;
+use eZ\Publish\API\Repository\Events\Location\SwapLocationEvent as SwapLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\UnhideLocationEvent as UnhideLocationEventInterface;
+use eZ\Publish\API\Repository\Events\Location\UpdateLocationEvent as UpdateLocationEventInterface;
 use eZ\Publish\API\Repository\LocationService as LocationServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct;
-use eZ\Publish\Core\Event\Location\BeforeCopySubtreeEvent;
-use eZ\Publish\Core\Event\Location\BeforeCreateLocationEvent;
-use eZ\Publish\Core\Event\Location\BeforeDeleteLocationEvent;
-use eZ\Publish\Core\Event\Location\BeforeHideLocationEvent;
-use eZ\Publish\Core\Event\Location\BeforeMoveSubtreeEvent;
-use eZ\Publish\Core\Event\Location\BeforeSwapLocationEvent;
-use eZ\Publish\Core\Event\Location\BeforeUnhideLocationEvent;
-use eZ\Publish\Core\Event\Location\BeforeUpdateLocationEvent;
-use eZ\Publish\Core\Event\Location\CopySubtreeEvent;
-use eZ\Publish\Core\Event\Location\CreateLocationEvent;
-use eZ\Publish\Core\Event\Location\DeleteLocationEvent;
-use eZ\Publish\Core\Event\Location\HideLocationEvent;
-use eZ\Publish\Core\Event\Location\MoveSubtreeEvent;
-use eZ\Publish\Core\Event\Location\SwapLocationEvent;
-use eZ\Publish\Core\Event\Location\UnhideLocationEvent;
-use eZ\Publish\Core\Event\Location\UpdateLocationEvent;
 use eZ\Publish\Core\Event\LocationService;
 
 class LocationServiceTest extends AbstractServiceTest
@@ -42,8 +34,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testCopySubtreeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCopySubtreeEvent::class,
-            CopySubtreeEvent::class
+            BeforeCopySubtreeEventInterface::class,
+            CopySubtreeEventInterface::class
         );
 
         $parameters = [
@@ -62,8 +54,8 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($location, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCopySubtreeEvent::class, 0],
-            [CopySubtreeEvent::class, 0],
+            [BeforeCopySubtreeEventInterface::class, 0],
+            [CopySubtreeEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -71,8 +63,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testReturnCopySubtreeResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCopySubtreeEvent::class,
-            CopySubtreeEvent::class
+            BeforeCopySubtreeEventInterface::class,
+            CopySubtreeEventInterface::class
         );
 
         $parameters = [
@@ -85,7 +77,7 @@ class LocationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
         $innerServiceMock->method('copySubtree')->willReturn($location);
 
-        $traceableEventDispatcher->addListener(BeforeCopySubtreeEvent::class, function (BeforeCopySubtreeEventInterface $event) use ($eventLocation) {
+        $traceableEventDispatcher->addListener(BeforeCopySubtreeEventInterface::class, function (BeforeCopySubtreeEventInterface $event) use ($eventLocation) {
             $event->setLocation($eventLocation);
         }, 10);
 
@@ -96,9 +88,9 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCopySubtreeEvent::class, 10],
-            [BeforeCopySubtreeEvent::class, 0],
-            [CopySubtreeEvent::class, 0],
+            [BeforeCopySubtreeEventInterface::class, 10],
+            [BeforeCopySubtreeEventInterface::class, 0],
+            [CopySubtreeEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -106,8 +98,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testCopySubtreeStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCopySubtreeEvent::class,
-            CopySubtreeEvent::class
+            BeforeCopySubtreeEventInterface::class,
+            CopySubtreeEventInterface::class
         );
 
         $parameters = [
@@ -120,7 +112,7 @@ class LocationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
         $innerServiceMock->method('copySubtree')->willReturn($location);
 
-        $traceableEventDispatcher->addListener(BeforeCopySubtreeEvent::class, function (BeforeCopySubtreeEventInterface $event) use ($eventLocation) {
+        $traceableEventDispatcher->addListener(BeforeCopySubtreeEventInterface::class, function (BeforeCopySubtreeEventInterface $event) use ($eventLocation) {
             $event->setLocation($eventLocation);
             $event->stopPropagation();
         }, 10);
@@ -133,19 +125,19 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCopySubtreeEvent::class, 10],
+            [BeforeCopySubtreeEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCopySubtreeEvent::class, 0],
-            [CopySubtreeEvent::class, 0],
+            [BeforeCopySubtreeEventInterface::class, 0],
+            [CopySubtreeEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteLocationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteLocationEvent::class,
-            DeleteLocationEvent::class
+            BeforeDeleteLocationEventInterface::class,
+            DeleteLocationEventInterface::class
         );
 
         $parameters = [
@@ -160,8 +152,8 @@ class LocationServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteLocationEvent::class, 0],
-            [DeleteLocationEvent::class, 0],
+            [BeforeDeleteLocationEventInterface::class, 0],
+            [DeleteLocationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -169,8 +161,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testDeleteLocationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteLocationEvent::class,
-            DeleteLocationEvent::class
+            BeforeDeleteLocationEventInterface::class,
+            DeleteLocationEventInterface::class
         );
 
         $parameters = [
@@ -179,7 +171,7 @@ class LocationServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteLocationEvent::class, function (BeforeDeleteLocationEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteLocationEventInterface::class, function (BeforeDeleteLocationEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -190,19 +182,19 @@ class LocationServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteLocationEvent::class, 10],
+            [BeforeDeleteLocationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteLocationEvent::class, 0],
-            [DeleteLocationEvent::class, 0],
+            [BeforeDeleteLocationEventInterface::class, 0],
+            [DeleteLocationEventInterface::class, 0],
         ]);
     }
 
     public function testUnhideLocationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUnhideLocationEvent::class,
-            UnhideLocationEvent::class
+            BeforeUnhideLocationEventInterface::class,
+            UnhideLocationEventInterface::class
         );
 
         $parameters = [
@@ -220,8 +212,8 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($revealedLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUnhideLocationEvent::class, 0],
-            [UnhideLocationEvent::class, 0],
+            [BeforeUnhideLocationEventInterface::class, 0],
+            [UnhideLocationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -229,8 +221,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testReturnUnhideLocationResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUnhideLocationEvent::class,
-            UnhideLocationEvent::class
+            BeforeUnhideLocationEventInterface::class,
+            UnhideLocationEventInterface::class
         );
 
         $parameters = [
@@ -242,7 +234,7 @@ class LocationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
         $innerServiceMock->method('unhideLocation')->willReturn($revealedLocation);
 
-        $traceableEventDispatcher->addListener(BeforeUnhideLocationEvent::class, function (BeforeUnhideLocationEventInterface $event) use ($eventRevealedLocation) {
+        $traceableEventDispatcher->addListener(BeforeUnhideLocationEventInterface::class, function (BeforeUnhideLocationEventInterface $event) use ($eventRevealedLocation) {
             $event->setRevealedLocation($eventRevealedLocation);
         }, 10);
 
@@ -253,9 +245,9 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventRevealedLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUnhideLocationEvent::class, 10],
-            [BeforeUnhideLocationEvent::class, 0],
-            [UnhideLocationEvent::class, 0],
+            [BeforeUnhideLocationEventInterface::class, 10],
+            [BeforeUnhideLocationEventInterface::class, 0],
+            [UnhideLocationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -263,8 +255,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testUnhideLocationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUnhideLocationEvent::class,
-            UnhideLocationEvent::class
+            BeforeUnhideLocationEventInterface::class,
+            UnhideLocationEventInterface::class
         );
 
         $parameters = [
@@ -276,7 +268,7 @@ class LocationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
         $innerServiceMock->method('unhideLocation')->willReturn($revealedLocation);
 
-        $traceableEventDispatcher->addListener(BeforeUnhideLocationEvent::class, function (BeforeUnhideLocationEventInterface $event) use ($eventRevealedLocation) {
+        $traceableEventDispatcher->addListener(BeforeUnhideLocationEventInterface::class, function (BeforeUnhideLocationEventInterface $event) use ($eventRevealedLocation) {
             $event->setRevealedLocation($eventRevealedLocation);
             $event->stopPropagation();
         }, 10);
@@ -289,19 +281,19 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventRevealedLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUnhideLocationEvent::class, 10],
+            [BeforeUnhideLocationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUnhideLocationEvent::class, 0],
-            [UnhideLocationEvent::class, 0],
+            [BeforeUnhideLocationEventInterface::class, 0],
+            [UnhideLocationEventInterface::class, 0],
         ]);
     }
 
     public function testHideLocationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeHideLocationEvent::class,
-            HideLocationEvent::class
+            BeforeHideLocationEventInterface::class,
+            HideLocationEventInterface::class
         );
 
         $parameters = [
@@ -319,8 +311,8 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($hiddenLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeHideLocationEvent::class, 0],
-            [HideLocationEvent::class, 0],
+            [BeforeHideLocationEventInterface::class, 0],
+            [HideLocationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -328,8 +320,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testReturnHideLocationResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeHideLocationEvent::class,
-            HideLocationEvent::class
+            BeforeHideLocationEventInterface::class,
+            HideLocationEventInterface::class
         );
 
         $parameters = [
@@ -341,7 +333,7 @@ class LocationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
         $innerServiceMock->method('hideLocation')->willReturn($hiddenLocation);
 
-        $traceableEventDispatcher->addListener(BeforeHideLocationEvent::class, function (BeforeHideLocationEventInterface $event) use ($eventHiddenLocation) {
+        $traceableEventDispatcher->addListener(BeforeHideLocationEventInterface::class, function (BeforeHideLocationEventInterface $event) use ($eventHiddenLocation) {
             $event->setHiddenLocation($eventHiddenLocation);
         }, 10);
 
@@ -352,9 +344,9 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventHiddenLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeHideLocationEvent::class, 10],
-            [BeforeHideLocationEvent::class, 0],
-            [HideLocationEvent::class, 0],
+            [BeforeHideLocationEventInterface::class, 10],
+            [BeforeHideLocationEventInterface::class, 0],
+            [HideLocationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -362,8 +354,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testHideLocationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeHideLocationEvent::class,
-            HideLocationEvent::class
+            BeforeHideLocationEventInterface::class,
+            HideLocationEventInterface::class
         );
 
         $parameters = [
@@ -375,7 +367,7 @@ class LocationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
         $innerServiceMock->method('hideLocation')->willReturn($hiddenLocation);
 
-        $traceableEventDispatcher->addListener(BeforeHideLocationEvent::class, function (BeforeHideLocationEventInterface $event) use ($eventHiddenLocation) {
+        $traceableEventDispatcher->addListener(BeforeHideLocationEventInterface::class, function (BeforeHideLocationEventInterface $event) use ($eventHiddenLocation) {
             $event->setHiddenLocation($eventHiddenLocation);
             $event->stopPropagation();
         }, 10);
@@ -388,19 +380,19 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventHiddenLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeHideLocationEvent::class, 10],
+            [BeforeHideLocationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeHideLocationEvent::class, 0],
-            [HideLocationEvent::class, 0],
+            [BeforeHideLocationEventInterface::class, 0],
+            [HideLocationEventInterface::class, 0],
         ]);
     }
 
     public function testSwapLocationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeSwapLocationEvent::class,
-            SwapLocationEvent::class
+            BeforeSwapLocationEventInterface::class,
+            SwapLocationEventInterface::class
         );
 
         $parameters = [
@@ -416,8 +408,8 @@ class LocationServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeSwapLocationEvent::class, 0],
-            [SwapLocationEvent::class, 0],
+            [BeforeSwapLocationEventInterface::class, 0],
+            [SwapLocationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -425,8 +417,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testSwapLocationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeSwapLocationEvent::class,
-            SwapLocationEvent::class
+            BeforeSwapLocationEventInterface::class,
+            SwapLocationEventInterface::class
         );
 
         $parameters = [
@@ -436,7 +428,7 @@ class LocationServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeSwapLocationEvent::class, function (BeforeSwapLocationEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeSwapLocationEventInterface::class, function (BeforeSwapLocationEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -447,19 +439,19 @@ class LocationServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeSwapLocationEvent::class, 10],
+            [BeforeSwapLocationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeSwapLocationEvent::class, 0],
-            [SwapLocationEvent::class, 0],
+            [BeforeSwapLocationEventInterface::class, 0],
+            [SwapLocationEventInterface::class, 0],
         ]);
     }
 
     public function testMoveSubtreeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeMoveSubtreeEvent::class,
-            MoveSubtreeEvent::class
+            BeforeMoveSubtreeEventInterface::class,
+            MoveSubtreeEventInterface::class
         );
 
         $parameters = [
@@ -475,8 +467,8 @@ class LocationServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeMoveSubtreeEvent::class, 0],
-            [MoveSubtreeEvent::class, 0],
+            [BeforeMoveSubtreeEventInterface::class, 0],
+            [MoveSubtreeEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -484,8 +476,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testMoveSubtreeStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeMoveSubtreeEvent::class,
-            MoveSubtreeEvent::class
+            BeforeMoveSubtreeEventInterface::class,
+            MoveSubtreeEventInterface::class
         );
 
         $parameters = [
@@ -495,7 +487,7 @@ class LocationServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeMoveSubtreeEvent::class, function (BeforeMoveSubtreeEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeMoveSubtreeEventInterface::class, function (BeforeMoveSubtreeEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -506,19 +498,19 @@ class LocationServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeMoveSubtreeEvent::class, 10],
+            [BeforeMoveSubtreeEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeMoveSubtreeEvent::class, 0],
-            [MoveSubtreeEvent::class, 0],
+            [BeforeMoveSubtreeEventInterface::class, 0],
+            [MoveSubtreeEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateLocationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateLocationEvent::class,
-            UpdateLocationEvent::class
+            BeforeUpdateLocationEventInterface::class,
+            UpdateLocationEventInterface::class
         );
 
         $parameters = [
@@ -537,8 +529,8 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateLocationEvent::class, 0],
-            [UpdateLocationEvent::class, 0],
+            [BeforeUpdateLocationEventInterface::class, 0],
+            [UpdateLocationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -546,8 +538,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testReturnUpdateLocationResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateLocationEvent::class,
-            UpdateLocationEvent::class
+            BeforeUpdateLocationEventInterface::class,
+            UpdateLocationEventInterface::class
         );
 
         $parameters = [
@@ -560,7 +552,7 @@ class LocationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
         $innerServiceMock->method('updateLocation')->willReturn($updatedLocation);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateLocationEvent::class, function (BeforeUpdateLocationEventInterface $event) use ($eventUpdatedLocation) {
+        $traceableEventDispatcher->addListener(BeforeUpdateLocationEventInterface::class, function (BeforeUpdateLocationEventInterface $event) use ($eventUpdatedLocation) {
             $event->setUpdatedLocation($eventUpdatedLocation);
         }, 10);
 
@@ -571,9 +563,9 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateLocationEvent::class, 10],
-            [BeforeUpdateLocationEvent::class, 0],
-            [UpdateLocationEvent::class, 0],
+            [BeforeUpdateLocationEventInterface::class, 10],
+            [BeforeUpdateLocationEventInterface::class, 0],
+            [UpdateLocationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -581,8 +573,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testUpdateLocationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateLocationEvent::class,
-            UpdateLocationEvent::class
+            BeforeUpdateLocationEventInterface::class,
+            UpdateLocationEventInterface::class
         );
 
         $parameters = [
@@ -595,7 +587,7 @@ class LocationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
         $innerServiceMock->method('updateLocation')->willReturn($updatedLocation);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateLocationEvent::class, function (BeforeUpdateLocationEventInterface $event) use ($eventUpdatedLocation) {
+        $traceableEventDispatcher->addListener(BeforeUpdateLocationEventInterface::class, function (BeforeUpdateLocationEventInterface $event) use ($eventUpdatedLocation) {
             $event->setUpdatedLocation($eventUpdatedLocation);
             $event->stopPropagation();
         }, 10);
@@ -608,19 +600,19 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateLocationEvent::class, 10],
+            [BeforeUpdateLocationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateLocationEvent::class, 0],
-            [UpdateLocationEvent::class, 0],
+            [BeforeUpdateLocationEventInterface::class, 0],
+            [UpdateLocationEventInterface::class, 0],
         ]);
     }
 
     public function testCreateLocationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateLocationEvent::class,
-            CreateLocationEvent::class
+            BeforeCreateLocationEventInterface::class,
+            CreateLocationEventInterface::class
         );
 
         $parameters = [
@@ -639,8 +631,8 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($location, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateLocationEvent::class, 0],
-            [CreateLocationEvent::class, 0],
+            [BeforeCreateLocationEventInterface::class, 0],
+            [CreateLocationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -648,8 +640,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testReturnCreateLocationResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateLocationEvent::class,
-            CreateLocationEvent::class
+            BeforeCreateLocationEventInterface::class,
+            CreateLocationEventInterface::class
         );
 
         $parameters = [
@@ -662,7 +654,7 @@ class LocationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
         $innerServiceMock->method('createLocation')->willReturn($location);
 
-        $traceableEventDispatcher->addListener(BeforeCreateLocationEvent::class, function (BeforeCreateLocationEventInterface $event) use ($eventLocation) {
+        $traceableEventDispatcher->addListener(BeforeCreateLocationEventInterface::class, function (BeforeCreateLocationEventInterface $event) use ($eventLocation) {
             $event->setLocation($eventLocation);
         }, 10);
 
@@ -673,9 +665,9 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateLocationEvent::class, 10],
-            [BeforeCreateLocationEvent::class, 0],
-            [CreateLocationEvent::class, 0],
+            [BeforeCreateLocationEventInterface::class, 10],
+            [BeforeCreateLocationEventInterface::class, 0],
+            [CreateLocationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -683,8 +675,8 @@ class LocationServiceTest extends AbstractServiceTest
     public function testCreateLocationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateLocationEvent::class,
-            CreateLocationEvent::class
+            BeforeCreateLocationEventInterface::class,
+            CreateLocationEventInterface::class
         );
 
         $parameters = [
@@ -697,7 +689,7 @@ class LocationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(LocationServiceInterface::class);
         $innerServiceMock->method('createLocation')->willReturn($location);
 
-        $traceableEventDispatcher->addListener(BeforeCreateLocationEvent::class, function (BeforeCreateLocationEventInterface $event) use ($eventLocation) {
+        $traceableEventDispatcher->addListener(BeforeCreateLocationEventInterface::class, function (BeforeCreateLocationEventInterface $event) use ($eventLocation) {
             $event->setLocation($eventLocation);
             $event->stopPropagation();
         }, 10);
@@ -710,11 +702,11 @@ class LocationServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateLocationEvent::class, 10],
+            [BeforeCreateLocationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateLocationEvent::class, 0],
-            [CreateLocationEvent::class, 0],
+            [BeforeCreateLocationEventInterface::class, 0],
+            [CreateLocationEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/NotificationServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/NotificationServiceTest.php
@@ -9,15 +9,12 @@ namespace eZ\Publish\Core\Event\Tests;
 use eZ\Publish\API\Repository\Events\Notification\BeforeCreateNotificationEvent as BeforeCreateNotificationEventInterface;
 use eZ\Publish\API\Repository\Events\Notification\BeforeDeleteNotificationEvent as BeforeDeleteNotificationEventInterface;
 use eZ\Publish\API\Repository\Events\Notification\BeforeMarkNotificationAsReadEvent as BeforeMarkNotificationAsReadEventInterface;
+use eZ\Publish\API\Repository\Events\Notification\CreateNotificationEvent as CreateNotificationEventInterface;
+use eZ\Publish\API\Repository\Events\Notification\DeleteNotificationEvent as DeleteNotificationEventInterface;
+use eZ\Publish\API\Repository\Events\Notification\MarkNotificationAsReadEvent as MarkNotificationAsReadEventInterface;
 use eZ\Publish\API\Repository\NotificationService as NotificationServiceInterface;
 use eZ\Publish\API\Repository\Values\Notification\CreateStruct;
 use eZ\Publish\API\Repository\Values\Notification\Notification;
-use eZ\Publish\Core\Event\Notification\BeforeCreateNotificationEvent;
-use eZ\Publish\Core\Event\Notification\BeforeDeleteNotificationEvent;
-use eZ\Publish\Core\Event\Notification\BeforeMarkNotificationAsReadEvent;
-use eZ\Publish\Core\Event\Notification\CreateNotificationEvent;
-use eZ\Publish\Core\Event\Notification\DeleteNotificationEvent;
-use eZ\Publish\Core\Event\Notification\MarkNotificationAsReadEvent;
 use eZ\Publish\Core\Event\NotificationService;
 
 class NotificationServiceTest extends AbstractServiceTest
@@ -25,8 +22,8 @@ class NotificationServiceTest extends AbstractServiceTest
     public function testCreateNotificationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateNotificationEvent::class,
-            CreateNotificationEvent::class
+            BeforeCreateNotificationEventInterface::class,
+            CreateNotificationEventInterface::class
         );
 
         $parameters = [
@@ -44,8 +41,8 @@ class NotificationServiceTest extends AbstractServiceTest
 
         $this->assertSame($notification, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateNotificationEvent::class, 0],
-            [CreateNotificationEvent::class, 0],
+            [BeforeCreateNotificationEventInterface::class, 0],
+            [CreateNotificationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -53,8 +50,8 @@ class NotificationServiceTest extends AbstractServiceTest
     public function testReturnCreateNotificationResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateNotificationEvent::class,
-            CreateNotificationEvent::class
+            BeforeCreateNotificationEventInterface::class,
+            CreateNotificationEventInterface::class
         );
 
         $parameters = [
@@ -66,7 +63,7 @@ class NotificationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(NotificationServiceInterface::class);
         $innerServiceMock->method('createNotification')->willReturn($notification);
 
-        $traceableEventDispatcher->addListener(BeforeCreateNotificationEvent::class, function (BeforeCreateNotificationEventInterface $event) use ($eventNotification) {
+        $traceableEventDispatcher->addListener(BeforeCreateNotificationEventInterface::class, function (BeforeCreateNotificationEventInterface $event) use ($eventNotification) {
             $event->setNotification($eventNotification);
         }, 10);
 
@@ -77,9 +74,9 @@ class NotificationServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventNotification, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateNotificationEvent::class, 10],
-            [BeforeCreateNotificationEvent::class, 0],
-            [CreateNotificationEvent::class, 0],
+            [BeforeCreateNotificationEventInterface::class, 10],
+            [BeforeCreateNotificationEventInterface::class, 0],
+            [CreateNotificationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -87,8 +84,8 @@ class NotificationServiceTest extends AbstractServiceTest
     public function testCreateNotificationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateNotificationEvent::class,
-            CreateNotificationEvent::class
+            BeforeCreateNotificationEventInterface::class,
+            CreateNotificationEventInterface::class
         );
 
         $parameters = [
@@ -100,7 +97,7 @@ class NotificationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(NotificationServiceInterface::class);
         $innerServiceMock->method('createNotification')->willReturn($notification);
 
-        $traceableEventDispatcher->addListener(BeforeCreateNotificationEvent::class, function (BeforeCreateNotificationEventInterface $event) use ($eventNotification) {
+        $traceableEventDispatcher->addListener(BeforeCreateNotificationEventInterface::class, function (BeforeCreateNotificationEventInterface $event) use ($eventNotification) {
             $event->setNotification($eventNotification);
             $event->stopPropagation();
         }, 10);
@@ -113,19 +110,19 @@ class NotificationServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventNotification, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateNotificationEvent::class, 10],
+            [BeforeCreateNotificationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateNotificationEvent::class, 0],
-            [CreateNotificationEvent::class, 0],
+            [BeforeCreateNotificationEventInterface::class, 0],
+            [CreateNotificationEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteNotificationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteNotificationEvent::class,
-            DeleteNotificationEvent::class
+            BeforeDeleteNotificationEventInterface::class,
+            DeleteNotificationEventInterface::class
         );
 
         $parameters = [
@@ -140,8 +137,8 @@ class NotificationServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteNotificationEvent::class, 0],
-            [DeleteNotificationEvent::class, 0],
+            [BeforeDeleteNotificationEventInterface::class, 0],
+            [DeleteNotificationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -149,8 +146,8 @@ class NotificationServiceTest extends AbstractServiceTest
     public function testDeleteNotificationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteNotificationEvent::class,
-            DeleteNotificationEvent::class
+            BeforeDeleteNotificationEventInterface::class,
+            DeleteNotificationEventInterface::class
         );
 
         $parameters = [
@@ -159,7 +156,7 @@ class NotificationServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(NotificationServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteNotificationEvent::class, function (BeforeDeleteNotificationEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteNotificationEventInterface::class, function (BeforeDeleteNotificationEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -170,19 +167,19 @@ class NotificationServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteNotificationEvent::class, 10],
+            [BeforeDeleteNotificationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteNotificationEvent::class, 0],
-            [DeleteNotificationEvent::class, 0],
+            [BeforeDeleteNotificationEventInterface::class, 0],
+            [DeleteNotificationEventInterface::class, 0],
         ]);
     }
 
     public function testMarkNotificationAsReadEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeMarkNotificationAsReadEvent::class,
-            MarkNotificationAsReadEvent::class
+            BeforeMarkNotificationAsReadEventInterface::class,
+            MarkNotificationAsReadEventInterface::class
         );
 
         $parameters = [
@@ -197,8 +194,8 @@ class NotificationServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeMarkNotificationAsReadEvent::class, 0],
-            [MarkNotificationAsReadEvent::class, 0],
+            [BeforeMarkNotificationAsReadEventInterface::class, 0],
+            [MarkNotificationAsReadEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -206,8 +203,8 @@ class NotificationServiceTest extends AbstractServiceTest
     public function testMarkNotificationAsReadStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeMarkNotificationAsReadEvent::class,
-            MarkNotificationAsReadEvent::class
+            BeforeMarkNotificationAsReadEventInterface::class,
+            MarkNotificationAsReadEventInterface::class
         );
 
         $parameters = [
@@ -216,7 +213,7 @@ class NotificationServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(NotificationServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeMarkNotificationAsReadEvent::class, function (BeforeMarkNotificationAsReadEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeMarkNotificationAsReadEventInterface::class, function (BeforeMarkNotificationAsReadEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -227,11 +224,11 @@ class NotificationServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeMarkNotificationAsReadEvent::class, 10],
+            [BeforeMarkNotificationAsReadEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeMarkNotificationAsReadEvent::class, 0],
-            [MarkNotificationAsReadEvent::class, 0],
+            [BeforeMarkNotificationAsReadEventInterface::class, 0],
+            [MarkNotificationAsReadEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/ObjectStateServiceTest.php
@@ -14,6 +14,14 @@ use eZ\Publish\API\Repository\Events\ObjectState\BeforeSetContentStateEvent as B
 use eZ\Publish\API\Repository\Events\ObjectState\BeforeSetPriorityOfObjectStateEvent as BeforeSetPriorityOfObjectStateEventInterface;
 use eZ\Publish\API\Repository\Events\ObjectState\BeforeUpdateObjectStateEvent as BeforeUpdateObjectStateEventInterface;
 use eZ\Publish\API\Repository\Events\ObjectState\BeforeUpdateObjectStateGroupEvent as BeforeUpdateObjectStateGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\CreateObjectStateEvent as CreateObjectStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\CreateObjectStateGroupEvent as CreateObjectStateGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\DeleteObjectStateEvent as DeleteObjectStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\DeleteObjectStateGroupEvent as DeleteObjectStateGroupEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\SetContentStateEvent as SetContentStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\SetPriorityOfObjectStateEvent as SetPriorityOfObjectStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\UpdateObjectStateEvent as UpdateObjectStateEventInterface;
+use eZ\Publish\API\Repository\Events\ObjectState\UpdateObjectStateGroupEvent as UpdateObjectStateGroupEventInterface;
 use eZ\Publish\API\Repository\ObjectStateService as ObjectStateServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
@@ -22,22 +30,6 @@ use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroupCreateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroupUpdateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateUpdateStruct;
-use eZ\Publish\Core\Event\ObjectState\BeforeCreateObjectStateEvent;
-use eZ\Publish\Core\Event\ObjectState\BeforeCreateObjectStateGroupEvent;
-use eZ\Publish\Core\Event\ObjectState\BeforeDeleteObjectStateEvent;
-use eZ\Publish\Core\Event\ObjectState\BeforeDeleteObjectStateGroupEvent;
-use eZ\Publish\Core\Event\ObjectState\BeforeSetContentStateEvent;
-use eZ\Publish\Core\Event\ObjectState\BeforeSetPriorityOfObjectStateEvent;
-use eZ\Publish\Core\Event\ObjectState\BeforeUpdateObjectStateEvent;
-use eZ\Publish\Core\Event\ObjectState\BeforeUpdateObjectStateGroupEvent;
-use eZ\Publish\Core\Event\ObjectState\CreateObjectStateEvent;
-use eZ\Publish\Core\Event\ObjectState\CreateObjectStateGroupEvent;
-use eZ\Publish\Core\Event\ObjectState\DeleteObjectStateEvent;
-use eZ\Publish\Core\Event\ObjectState\DeleteObjectStateGroupEvent;
-use eZ\Publish\Core\Event\ObjectState\SetContentStateEvent;
-use eZ\Publish\Core\Event\ObjectState\SetPriorityOfObjectStateEvent;
-use eZ\Publish\Core\Event\ObjectState\UpdateObjectStateEvent;
-use eZ\Publish\Core\Event\ObjectState\UpdateObjectStateGroupEvent;
 use eZ\Publish\Core\Event\ObjectStateService;
 
 class ObjectStateServiceTest extends AbstractServiceTest
@@ -45,8 +37,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testSetContentStateEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeSetContentStateEvent::class,
-            SetContentStateEvent::class
+            BeforeSetContentStateEventInterface::class,
+            SetContentStateEventInterface::class
         );
 
         $parameters = [
@@ -63,8 +55,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeSetContentStateEvent::class, 0],
-            [SetContentStateEvent::class, 0],
+            [BeforeSetContentStateEventInterface::class, 0],
+            [SetContentStateEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -72,8 +64,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testSetContentStateStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeSetContentStateEvent::class,
-            SetContentStateEvent::class
+            BeforeSetContentStateEventInterface::class,
+            SetContentStateEventInterface::class
         );
 
         $parameters = [
@@ -84,7 +76,7 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ObjectStateServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeSetContentStateEvent::class, function (BeforeSetContentStateEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeSetContentStateEventInterface::class, function (BeforeSetContentStateEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -95,19 +87,19 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeSetContentStateEvent::class, 10],
+            [BeforeSetContentStateEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeSetContentStateEvent::class, 0],
-            [SetContentStateEvent::class, 0],
+            [BeforeSetContentStateEventInterface::class, 0],
+            [SetContentStateEventInterface::class, 0],
         ]);
     }
 
     public function testCreateObjectStateGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateObjectStateGroupEvent::class,
-            CreateObjectStateGroupEvent::class
+            BeforeCreateObjectStateGroupEventInterface::class,
+            CreateObjectStateGroupEventInterface::class
         );
 
         $parameters = [
@@ -125,8 +117,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $this->assertSame($objectStateGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateObjectStateGroupEvent::class, 0],
-            [CreateObjectStateGroupEvent::class, 0],
+            [BeforeCreateObjectStateGroupEventInterface::class, 0],
+            [CreateObjectStateGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -134,8 +126,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testReturnCreateObjectStateGroupResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateObjectStateGroupEvent::class,
-            CreateObjectStateGroupEvent::class
+            BeforeCreateObjectStateGroupEventInterface::class,
+            CreateObjectStateGroupEventInterface::class
         );
 
         $parameters = [
@@ -147,7 +139,7 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ObjectStateServiceInterface::class);
         $innerServiceMock->method('createObjectStateGroup')->willReturn($objectStateGroup);
 
-        $traceableEventDispatcher->addListener(BeforeCreateObjectStateGroupEvent::class, function (BeforeCreateObjectStateGroupEventInterface $event) use ($eventObjectStateGroup) {
+        $traceableEventDispatcher->addListener(BeforeCreateObjectStateGroupEventInterface::class, function (BeforeCreateObjectStateGroupEventInterface $event) use ($eventObjectStateGroup) {
             $event->setObjectStateGroup($eventObjectStateGroup);
         }, 10);
 
@@ -158,9 +150,9 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventObjectStateGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateObjectStateGroupEvent::class, 10],
-            [BeforeCreateObjectStateGroupEvent::class, 0],
-            [CreateObjectStateGroupEvent::class, 0],
+            [BeforeCreateObjectStateGroupEventInterface::class, 10],
+            [BeforeCreateObjectStateGroupEventInterface::class, 0],
+            [CreateObjectStateGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -168,8 +160,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testCreateObjectStateGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateObjectStateGroupEvent::class,
-            CreateObjectStateGroupEvent::class
+            BeforeCreateObjectStateGroupEventInterface::class,
+            CreateObjectStateGroupEventInterface::class
         );
 
         $parameters = [
@@ -181,7 +173,7 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ObjectStateServiceInterface::class);
         $innerServiceMock->method('createObjectStateGroup')->willReturn($objectStateGroup);
 
-        $traceableEventDispatcher->addListener(BeforeCreateObjectStateGroupEvent::class, function (BeforeCreateObjectStateGroupEventInterface $event) use ($eventObjectStateGroup) {
+        $traceableEventDispatcher->addListener(BeforeCreateObjectStateGroupEventInterface::class, function (BeforeCreateObjectStateGroupEventInterface $event) use ($eventObjectStateGroup) {
             $event->setObjectStateGroup($eventObjectStateGroup);
             $event->stopPropagation();
         }, 10);
@@ -194,19 +186,19 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventObjectStateGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateObjectStateGroupEvent::class, 10],
+            [BeforeCreateObjectStateGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateObjectStateGroupEvent::class, 0],
-            [CreateObjectStateGroupEvent::class, 0],
+            [BeforeCreateObjectStateGroupEventInterface::class, 0],
+            [CreateObjectStateGroupEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateObjectStateEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateObjectStateEvent::class,
-            UpdateObjectStateEvent::class
+            BeforeUpdateObjectStateEventInterface::class,
+            UpdateObjectStateEventInterface::class
         );
 
         $parameters = [
@@ -225,8 +217,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedObjectState, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateObjectStateEvent::class, 0],
-            [UpdateObjectStateEvent::class, 0],
+            [BeforeUpdateObjectStateEventInterface::class, 0],
+            [UpdateObjectStateEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -234,8 +226,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testReturnUpdateObjectStateResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateObjectStateEvent::class,
-            UpdateObjectStateEvent::class
+            BeforeUpdateObjectStateEventInterface::class,
+            UpdateObjectStateEventInterface::class
         );
 
         $parameters = [
@@ -248,7 +240,7 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ObjectStateServiceInterface::class);
         $innerServiceMock->method('updateObjectState')->willReturn($updatedObjectState);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateObjectStateEvent::class, function (BeforeUpdateObjectStateEventInterface $event) use ($eventUpdatedObjectState) {
+        $traceableEventDispatcher->addListener(BeforeUpdateObjectStateEventInterface::class, function (BeforeUpdateObjectStateEventInterface $event) use ($eventUpdatedObjectState) {
             $event->setUpdatedObjectState($eventUpdatedObjectState);
         }, 10);
 
@@ -259,9 +251,9 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedObjectState, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateObjectStateEvent::class, 10],
-            [BeforeUpdateObjectStateEvent::class, 0],
-            [UpdateObjectStateEvent::class, 0],
+            [BeforeUpdateObjectStateEventInterface::class, 10],
+            [BeforeUpdateObjectStateEventInterface::class, 0],
+            [UpdateObjectStateEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -269,8 +261,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testUpdateObjectStateStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateObjectStateEvent::class,
-            UpdateObjectStateEvent::class
+            BeforeUpdateObjectStateEventInterface::class,
+            UpdateObjectStateEventInterface::class
         );
 
         $parameters = [
@@ -283,7 +275,7 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ObjectStateServiceInterface::class);
         $innerServiceMock->method('updateObjectState')->willReturn($updatedObjectState);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateObjectStateEvent::class, function (BeforeUpdateObjectStateEventInterface $event) use ($eventUpdatedObjectState) {
+        $traceableEventDispatcher->addListener(BeforeUpdateObjectStateEventInterface::class, function (BeforeUpdateObjectStateEventInterface $event) use ($eventUpdatedObjectState) {
             $event->setUpdatedObjectState($eventUpdatedObjectState);
             $event->stopPropagation();
         }, 10);
@@ -296,19 +288,19 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedObjectState, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateObjectStateEvent::class, 10],
+            [BeforeUpdateObjectStateEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateObjectStateEvent::class, 0],
-            [UpdateObjectStateEvent::class, 0],
+            [BeforeUpdateObjectStateEventInterface::class, 0],
+            [UpdateObjectStateEventInterface::class, 0],
         ]);
     }
 
     public function testCreateObjectStateEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateObjectStateEvent::class,
-            CreateObjectStateEvent::class
+            BeforeCreateObjectStateEventInterface::class,
+            CreateObjectStateEventInterface::class
         );
 
         $parameters = [
@@ -327,8 +319,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $this->assertSame($objectState, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateObjectStateEvent::class, 0],
-            [CreateObjectStateEvent::class, 0],
+            [BeforeCreateObjectStateEventInterface::class, 0],
+            [CreateObjectStateEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -336,8 +328,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testReturnCreateObjectStateResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateObjectStateEvent::class,
-            CreateObjectStateEvent::class
+            BeforeCreateObjectStateEventInterface::class,
+            CreateObjectStateEventInterface::class
         );
 
         $parameters = [
@@ -350,7 +342,7 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ObjectStateServiceInterface::class);
         $innerServiceMock->method('createObjectState')->willReturn($objectState);
 
-        $traceableEventDispatcher->addListener(BeforeCreateObjectStateEvent::class, function (BeforeCreateObjectStateEventInterface $event) use ($eventObjectState) {
+        $traceableEventDispatcher->addListener(BeforeCreateObjectStateEventInterface::class, function (BeforeCreateObjectStateEventInterface $event) use ($eventObjectState) {
             $event->setObjectState($eventObjectState);
         }, 10);
 
@@ -361,9 +353,9 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventObjectState, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateObjectStateEvent::class, 10],
-            [BeforeCreateObjectStateEvent::class, 0],
-            [CreateObjectStateEvent::class, 0],
+            [BeforeCreateObjectStateEventInterface::class, 10],
+            [BeforeCreateObjectStateEventInterface::class, 0],
+            [CreateObjectStateEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -371,8 +363,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testCreateObjectStateStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateObjectStateEvent::class,
-            CreateObjectStateEvent::class
+            BeforeCreateObjectStateEventInterface::class,
+            CreateObjectStateEventInterface::class
         );
 
         $parameters = [
@@ -385,7 +377,7 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ObjectStateServiceInterface::class);
         $innerServiceMock->method('createObjectState')->willReturn($objectState);
 
-        $traceableEventDispatcher->addListener(BeforeCreateObjectStateEvent::class, function (BeforeCreateObjectStateEventInterface $event) use ($eventObjectState) {
+        $traceableEventDispatcher->addListener(BeforeCreateObjectStateEventInterface::class, function (BeforeCreateObjectStateEventInterface $event) use ($eventObjectState) {
             $event->setObjectState($eventObjectState);
             $event->stopPropagation();
         }, 10);
@@ -398,19 +390,19 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventObjectState, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateObjectStateEvent::class, 10],
+            [BeforeCreateObjectStateEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateObjectStateEvent::class, 0],
-            [CreateObjectStateEvent::class, 0],
+            [BeforeCreateObjectStateEventInterface::class, 0],
+            [CreateObjectStateEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateObjectStateGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateObjectStateGroupEvent::class,
-            UpdateObjectStateGroupEvent::class
+            BeforeUpdateObjectStateGroupEventInterface::class,
+            UpdateObjectStateGroupEventInterface::class
         );
 
         $parameters = [
@@ -429,8 +421,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedObjectStateGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateObjectStateGroupEvent::class, 0],
-            [UpdateObjectStateGroupEvent::class, 0],
+            [BeforeUpdateObjectStateGroupEventInterface::class, 0],
+            [UpdateObjectStateGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -438,8 +430,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testReturnUpdateObjectStateGroupResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateObjectStateGroupEvent::class,
-            UpdateObjectStateGroupEvent::class
+            BeforeUpdateObjectStateGroupEventInterface::class,
+            UpdateObjectStateGroupEventInterface::class
         );
 
         $parameters = [
@@ -452,7 +444,7 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ObjectStateServiceInterface::class);
         $innerServiceMock->method('updateObjectStateGroup')->willReturn($updatedObjectStateGroup);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateObjectStateGroupEvent::class, function (BeforeUpdateObjectStateGroupEventInterface $event) use ($eventUpdatedObjectStateGroup) {
+        $traceableEventDispatcher->addListener(BeforeUpdateObjectStateGroupEventInterface::class, function (BeforeUpdateObjectStateGroupEventInterface $event) use ($eventUpdatedObjectStateGroup) {
             $event->setUpdatedObjectStateGroup($eventUpdatedObjectStateGroup);
         }, 10);
 
@@ -463,9 +455,9 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedObjectStateGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateObjectStateGroupEvent::class, 10],
-            [BeforeUpdateObjectStateGroupEvent::class, 0],
-            [UpdateObjectStateGroupEvent::class, 0],
+            [BeforeUpdateObjectStateGroupEventInterface::class, 10],
+            [BeforeUpdateObjectStateGroupEventInterface::class, 0],
+            [UpdateObjectStateGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -473,8 +465,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testUpdateObjectStateGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateObjectStateGroupEvent::class,
-            UpdateObjectStateGroupEvent::class
+            BeforeUpdateObjectStateGroupEventInterface::class,
+            UpdateObjectStateGroupEventInterface::class
         );
 
         $parameters = [
@@ -487,7 +479,7 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(ObjectStateServiceInterface::class);
         $innerServiceMock->method('updateObjectStateGroup')->willReturn($updatedObjectStateGroup);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateObjectStateGroupEvent::class, function (BeforeUpdateObjectStateGroupEventInterface $event) use ($eventUpdatedObjectStateGroup) {
+        $traceableEventDispatcher->addListener(BeforeUpdateObjectStateGroupEventInterface::class, function (BeforeUpdateObjectStateGroupEventInterface $event) use ($eventUpdatedObjectStateGroup) {
             $event->setUpdatedObjectStateGroup($eventUpdatedObjectStateGroup);
             $event->stopPropagation();
         }, 10);
@@ -500,19 +492,19 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedObjectStateGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateObjectStateGroupEvent::class, 10],
+            [BeforeUpdateObjectStateGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateObjectStateGroupEvent::class, 0],
-            [UpdateObjectStateGroupEvent::class, 0],
+            [BeforeUpdateObjectStateGroupEventInterface::class, 0],
+            [UpdateObjectStateGroupEventInterface::class, 0],
         ]);
     }
 
     public function testSetPriorityOfObjectStateEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeSetPriorityOfObjectStateEvent::class,
-            SetPriorityOfObjectStateEvent::class
+            BeforeSetPriorityOfObjectStateEventInterface::class,
+            SetPriorityOfObjectStateEventInterface::class
         );
 
         $parameters = [
@@ -528,8 +520,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeSetPriorityOfObjectStateEvent::class, 0],
-            [SetPriorityOfObjectStateEvent::class, 0],
+            [BeforeSetPriorityOfObjectStateEventInterface::class, 0],
+            [SetPriorityOfObjectStateEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -537,8 +529,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testSetPriorityOfObjectStateStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeSetPriorityOfObjectStateEvent::class,
-            SetPriorityOfObjectStateEvent::class
+            BeforeSetPriorityOfObjectStateEventInterface::class,
+            SetPriorityOfObjectStateEventInterface::class
         );
 
         $parameters = [
@@ -548,7 +540,7 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ObjectStateServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeSetPriorityOfObjectStateEvent::class, function (BeforeSetPriorityOfObjectStateEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeSetPriorityOfObjectStateEventInterface::class, function (BeforeSetPriorityOfObjectStateEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -559,19 +551,19 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeSetPriorityOfObjectStateEvent::class, 10],
+            [BeforeSetPriorityOfObjectStateEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeSetPriorityOfObjectStateEvent::class, 0],
-            [SetPriorityOfObjectStateEvent::class, 0],
+            [BeforeSetPriorityOfObjectStateEventInterface::class, 0],
+            [SetPriorityOfObjectStateEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteObjectStateGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteObjectStateGroupEvent::class,
-            DeleteObjectStateGroupEvent::class
+            BeforeDeleteObjectStateGroupEventInterface::class,
+            DeleteObjectStateGroupEventInterface::class
         );
 
         $parameters = [
@@ -586,8 +578,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteObjectStateGroupEvent::class, 0],
-            [DeleteObjectStateGroupEvent::class, 0],
+            [BeforeDeleteObjectStateGroupEventInterface::class, 0],
+            [DeleteObjectStateGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -595,8 +587,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testDeleteObjectStateGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteObjectStateGroupEvent::class,
-            DeleteObjectStateGroupEvent::class
+            BeforeDeleteObjectStateGroupEventInterface::class,
+            DeleteObjectStateGroupEventInterface::class
         );
 
         $parameters = [
@@ -605,7 +597,7 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ObjectStateServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteObjectStateGroupEvent::class, function (BeforeDeleteObjectStateGroupEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteObjectStateGroupEventInterface::class, function (BeforeDeleteObjectStateGroupEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -616,19 +608,19 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteObjectStateGroupEvent::class, 10],
+            [BeforeDeleteObjectStateGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteObjectStateGroupEvent::class, 0],
-            [DeleteObjectStateGroupEvent::class, 0],
+            [BeforeDeleteObjectStateGroupEventInterface::class, 0],
+            [DeleteObjectStateGroupEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteObjectStateEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteObjectStateEvent::class,
-            DeleteObjectStateEvent::class
+            BeforeDeleteObjectStateEventInterface::class,
+            DeleteObjectStateEventInterface::class
         );
 
         $parameters = [
@@ -643,8 +635,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteObjectStateEvent::class, 0],
-            [DeleteObjectStateEvent::class, 0],
+            [BeforeDeleteObjectStateEventInterface::class, 0],
+            [DeleteObjectStateEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -652,8 +644,8 @@ class ObjectStateServiceTest extends AbstractServiceTest
     public function testDeleteObjectStateStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteObjectStateEvent::class,
-            DeleteObjectStateEvent::class
+            BeforeDeleteObjectStateEventInterface::class,
+            DeleteObjectStateEventInterface::class
         );
 
         $parameters = [
@@ -662,7 +654,7 @@ class ObjectStateServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(ObjectStateServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteObjectStateEvent::class, function (BeforeDeleteObjectStateEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteObjectStateEventInterface::class, function (BeforeDeleteObjectStateEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -673,11 +665,11 @@ class ObjectStateServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteObjectStateEvent::class, 10],
+            [BeforeDeleteObjectStateEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteObjectStateEvent::class, 0],
-            [DeleteObjectStateEvent::class, 0],
+            [BeforeDeleteObjectStateEventInterface::class, 0],
+            [DeleteObjectStateEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/RoleServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/RoleServiceTest.php
@@ -6,6 +6,10 @@
  */
 namespace eZ\Publish\Core\Event\Tests;
 
+use eZ\Publish\API\Repository\Events\Role\AddPolicyByRoleDraftEvent as AddPolicyByRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\AddPolicyEvent as AddPolicyEventInterface;
+use eZ\Publish\API\Repository\Events\Role\AssignRoleToUserEvent as AssignRoleToUserEventInterface;
+use eZ\Publish\API\Repository\Events\Role\AssignRoleToUserGroupEvent as AssignRoleToUserGroupEventInterface;
 use eZ\Publish\API\Repository\Events\Role\BeforeAddPolicyByRoleDraftEvent as BeforeAddPolicyByRoleDraftEventInterface;
 use eZ\Publish\API\Repository\Events\Role\BeforeAddPolicyEvent as BeforeAddPolicyEventInterface;
 use eZ\Publish\API\Repository\Events\Role\BeforeAssignRoleToUserEvent as BeforeAssignRoleToUserEventInterface;
@@ -24,6 +28,20 @@ use eZ\Publish\API\Repository\Events\Role\BeforeUpdatePolicyByRoleDraftEvent as 
 use eZ\Publish\API\Repository\Events\Role\BeforeUpdatePolicyEvent as BeforeUpdatePolicyEventInterface;
 use eZ\Publish\API\Repository\Events\Role\BeforeUpdateRoleDraftEvent as BeforeUpdateRoleDraftEventInterface;
 use eZ\Publish\API\Repository\Events\Role\BeforeUpdateRoleEvent as BeforeUpdateRoleEventInterface;
+use eZ\Publish\API\Repository\Events\Role\CreateRoleDraftEvent as CreateRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\CreateRoleEvent as CreateRoleEventInterface;
+use eZ\Publish\API\Repository\Events\Role\DeletePolicyEvent as DeletePolicyEventInterface;
+use eZ\Publish\API\Repository\Events\Role\DeleteRoleDraftEvent as DeleteRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\DeleteRoleEvent as DeleteRoleEventInterface;
+use eZ\Publish\API\Repository\Events\Role\PublishRoleDraftEvent as PublishRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\RemovePolicyByRoleDraftEvent as RemovePolicyByRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\RemoveRoleAssignmentEvent as RemoveRoleAssignmentEventInterface;
+use eZ\Publish\API\Repository\Events\Role\UnassignRoleFromUserEvent as UnassignRoleFromUserEventInterface;
+use eZ\Publish\API\Repository\Events\Role\UnassignRoleFromUserGroupEvent as UnassignRoleFromUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\Role\UpdatePolicyByRoleDraftEvent as UpdatePolicyByRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\UpdatePolicyEvent as UpdatePolicyEventInterface;
+use eZ\Publish\API\Repository\Events\Role\UpdateRoleDraftEvent as UpdateRoleDraftEventInterface;
+use eZ\Publish\API\Repository\Events\Role\UpdateRoleEvent as UpdateRoleEventInterface;
 use eZ\Publish\API\Repository\RoleService as RoleServiceInterface;
 use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\Policy;
@@ -37,42 +55,6 @@ use eZ\Publish\API\Repository\Values\User\RoleDraft;
 use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
-use eZ\Publish\Core\Event\Role\AddPolicyByRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\AddPolicyEvent;
-use eZ\Publish\Core\Event\Role\AssignRoleToUserEvent;
-use eZ\Publish\Core\Event\Role\AssignRoleToUserGroupEvent;
-use eZ\Publish\Core\Event\Role\BeforeAddPolicyByRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\BeforeAddPolicyEvent;
-use eZ\Publish\Core\Event\Role\BeforeAssignRoleToUserEvent;
-use eZ\Publish\Core\Event\Role\BeforeAssignRoleToUserGroupEvent;
-use eZ\Publish\Core\Event\Role\BeforeCreateRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\BeforeCreateRoleEvent;
-use eZ\Publish\Core\Event\Role\BeforeDeletePolicyEvent;
-use eZ\Publish\Core\Event\Role\BeforeDeleteRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\BeforeDeleteRoleEvent;
-use eZ\Publish\Core\Event\Role\BeforePublishRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\BeforeRemovePolicyByRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\BeforeRemoveRoleAssignmentEvent;
-use eZ\Publish\Core\Event\Role\BeforeUnassignRoleFromUserEvent;
-use eZ\Publish\Core\Event\Role\BeforeUnassignRoleFromUserGroupEvent;
-use eZ\Publish\Core\Event\Role\BeforeUpdatePolicyByRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\BeforeUpdatePolicyEvent;
-use eZ\Publish\Core\Event\Role\BeforeUpdateRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\BeforeUpdateRoleEvent;
-use eZ\Publish\Core\Event\Role\CreateRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\CreateRoleEvent;
-use eZ\Publish\Core\Event\Role\DeletePolicyEvent;
-use eZ\Publish\Core\Event\Role\DeleteRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\DeleteRoleEvent;
-use eZ\Publish\Core\Event\Role\PublishRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\RemovePolicyByRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\RemoveRoleAssignmentEvent;
-use eZ\Publish\Core\Event\Role\UnassignRoleFromUserEvent;
-use eZ\Publish\Core\Event\Role\UnassignRoleFromUserGroupEvent;
-use eZ\Publish\Core\Event\Role\UpdatePolicyByRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\UpdatePolicyEvent;
-use eZ\Publish\Core\Event\Role\UpdateRoleDraftEvent;
-use eZ\Publish\Core\Event\Role\UpdateRoleEvent;
 use eZ\Publish\Core\Event\RoleService;
 
 class RoleServiceTest extends AbstractServiceTest
@@ -80,8 +62,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testDeletePolicyEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeletePolicyEvent::class,
-            DeletePolicyEvent::class
+            BeforeDeletePolicyEventInterface::class,
+            DeletePolicyEventInterface::class
         );
 
         $parameters = [
@@ -96,8 +78,8 @@ class RoleServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeletePolicyEvent::class, 0],
-            [DeletePolicyEvent::class, 0],
+            [BeforeDeletePolicyEventInterface::class, 0],
+            [DeletePolicyEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -105,8 +87,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testDeletePolicyStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeletePolicyEvent::class,
-            DeletePolicyEvent::class
+            BeforeDeletePolicyEventInterface::class,
+            DeletePolicyEventInterface::class
         );
 
         $parameters = [
@@ -115,7 +97,7 @@ class RoleServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeletePolicyEvent::class, function (BeforeDeletePolicyEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeletePolicyEventInterface::class, function (BeforeDeletePolicyEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -126,19 +108,19 @@ class RoleServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeletePolicyEvent::class, 10],
+            [BeforeDeletePolicyEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeletePolicyEvent::class, 0],
-            [DeletePolicyEvent::class, 0],
+            [BeforeDeletePolicyEventInterface::class, 0],
+            [DeletePolicyEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateRoleEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateRoleEvent::class,
-            UpdateRoleEvent::class
+            BeforeUpdateRoleEventInterface::class,
+            UpdateRoleEventInterface::class
         );
 
         $parameters = [
@@ -157,8 +139,8 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedRole, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateRoleEvent::class, 0],
-            [UpdateRoleEvent::class, 0],
+            [BeforeUpdateRoleEventInterface::class, 0],
+            [UpdateRoleEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -166,8 +148,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testReturnUpdateRoleResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateRoleEvent::class,
-            UpdateRoleEvent::class
+            BeforeUpdateRoleEventInterface::class,
+            UpdateRoleEventInterface::class
         );
 
         $parameters = [
@@ -180,7 +162,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('updateRole')->willReturn($updatedRole);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateRoleEvent::class, function (BeforeUpdateRoleEventInterface $event) use ($eventUpdatedRole) {
+        $traceableEventDispatcher->addListener(BeforeUpdateRoleEventInterface::class, function (BeforeUpdateRoleEventInterface $event) use ($eventUpdatedRole) {
             $event->setUpdatedRole($eventUpdatedRole);
         }, 10);
 
@@ -191,9 +173,9 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedRole, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateRoleEvent::class, 10],
-            [BeforeUpdateRoleEvent::class, 0],
-            [UpdateRoleEvent::class, 0],
+            [BeforeUpdateRoleEventInterface::class, 10],
+            [BeforeUpdateRoleEventInterface::class, 0],
+            [UpdateRoleEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -201,8 +183,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testUpdateRoleStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateRoleEvent::class,
-            UpdateRoleEvent::class
+            BeforeUpdateRoleEventInterface::class,
+            UpdateRoleEventInterface::class
         );
 
         $parameters = [
@@ -215,7 +197,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('updateRole')->willReturn($updatedRole);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateRoleEvent::class, function (BeforeUpdateRoleEventInterface $event) use ($eventUpdatedRole) {
+        $traceableEventDispatcher->addListener(BeforeUpdateRoleEventInterface::class, function (BeforeUpdateRoleEventInterface $event) use ($eventUpdatedRole) {
             $event->setUpdatedRole($eventUpdatedRole);
             $event->stopPropagation();
         }, 10);
@@ -228,19 +210,19 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedRole, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateRoleEvent::class, 10],
+            [BeforeUpdateRoleEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateRoleEvent::class, 0],
-            [UpdateRoleEvent::class, 0],
+            [BeforeUpdateRoleEventInterface::class, 0],
+            [UpdateRoleEventInterface::class, 0],
         ]);
     }
 
     public function testPublishRoleDraftEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforePublishRoleDraftEvent::class,
-            PublishRoleDraftEvent::class
+            BeforePublishRoleDraftEventInterface::class,
+            PublishRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -255,8 +237,8 @@ class RoleServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforePublishRoleDraftEvent::class, 0],
-            [PublishRoleDraftEvent::class, 0],
+            [BeforePublishRoleDraftEventInterface::class, 0],
+            [PublishRoleDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -264,8 +246,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testPublishRoleDraftStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforePublishRoleDraftEvent::class,
-            PublishRoleDraftEvent::class
+            BeforePublishRoleDraftEventInterface::class,
+            PublishRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -274,7 +256,7 @@ class RoleServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforePublishRoleDraftEvent::class, function (BeforePublishRoleDraftEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforePublishRoleDraftEventInterface::class, function (BeforePublishRoleDraftEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -285,19 +267,19 @@ class RoleServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforePublishRoleDraftEvent::class, 10],
+            [BeforePublishRoleDraftEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforePublishRoleDraftEvent::class, 0],
-            [PublishRoleDraftEvent::class, 0],
+            [BeforePublishRoleDraftEventInterface::class, 0],
+            [PublishRoleDraftEventInterface::class, 0],
         ]);
     }
 
     public function testAssignRoleToUserEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAssignRoleToUserEvent::class,
-            AssignRoleToUserEvent::class
+            BeforeAssignRoleToUserEventInterface::class,
+            AssignRoleToUserEventInterface::class
         );
 
         $parameters = [
@@ -314,8 +296,8 @@ class RoleServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAssignRoleToUserEvent::class, 0],
-            [AssignRoleToUserEvent::class, 0],
+            [BeforeAssignRoleToUserEventInterface::class, 0],
+            [AssignRoleToUserEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -323,8 +305,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testAssignRoleToUserStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAssignRoleToUserEvent::class,
-            AssignRoleToUserEvent::class
+            BeforeAssignRoleToUserEventInterface::class,
+            AssignRoleToUserEventInterface::class
         );
 
         $parameters = [
@@ -335,7 +317,7 @@ class RoleServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeAssignRoleToUserEvent::class, function (BeforeAssignRoleToUserEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeAssignRoleToUserEventInterface::class, function (BeforeAssignRoleToUserEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -346,19 +328,19 @@ class RoleServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAssignRoleToUserEvent::class, 10],
+            [BeforeAssignRoleToUserEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [AssignRoleToUserEvent::class, 0],
-            [BeforeAssignRoleToUserEvent::class, 0],
+            [AssignRoleToUserEventInterface::class, 0],
+            [BeforeAssignRoleToUserEventInterface::class, 0],
         ]);
     }
 
     public function testAddPolicyEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAddPolicyEvent::class,
-            AddPolicyEvent::class
+            BeforeAddPolicyEventInterface::class,
+            AddPolicyEventInterface::class
         );
 
         $parameters = [
@@ -377,8 +359,8 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedRole, $result);
         $this->assertSame($calledListeners, [
-            [BeforeAddPolicyEvent::class, 0],
-            [AddPolicyEvent::class, 0],
+            [BeforeAddPolicyEventInterface::class, 0],
+            [AddPolicyEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -386,8 +368,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testReturnAddPolicyResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAddPolicyEvent::class,
-            AddPolicyEvent::class
+            BeforeAddPolicyEventInterface::class,
+            AddPolicyEventInterface::class
         );
 
         $parameters = [
@@ -400,7 +382,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('addPolicy')->willReturn($updatedRole);
 
-        $traceableEventDispatcher->addListener(BeforeAddPolicyEvent::class, function (BeforeAddPolicyEventInterface $event) use ($eventUpdatedRole) {
+        $traceableEventDispatcher->addListener(BeforeAddPolicyEventInterface::class, function (BeforeAddPolicyEventInterface $event) use ($eventUpdatedRole) {
             $event->setUpdatedRole($eventUpdatedRole);
         }, 10);
 
@@ -411,9 +393,9 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedRole, $result);
         $this->assertSame($calledListeners, [
-            [BeforeAddPolicyEvent::class, 10],
-            [BeforeAddPolicyEvent::class, 0],
-            [AddPolicyEvent::class, 0],
+            [BeforeAddPolicyEventInterface::class, 10],
+            [BeforeAddPolicyEventInterface::class, 0],
+            [AddPolicyEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -421,8 +403,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testAddPolicyStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAddPolicyEvent::class,
-            AddPolicyEvent::class
+            BeforeAddPolicyEventInterface::class,
+            AddPolicyEventInterface::class
         );
 
         $parameters = [
@@ -435,7 +417,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('addPolicy')->willReturn($updatedRole);
 
-        $traceableEventDispatcher->addListener(BeforeAddPolicyEvent::class, function (BeforeAddPolicyEventInterface $event) use ($eventUpdatedRole) {
+        $traceableEventDispatcher->addListener(BeforeAddPolicyEventInterface::class, function (BeforeAddPolicyEventInterface $event) use ($eventUpdatedRole) {
             $event->setUpdatedRole($eventUpdatedRole);
             $event->stopPropagation();
         }, 10);
@@ -448,19 +430,19 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedRole, $result);
         $this->assertSame($calledListeners, [
-            [BeforeAddPolicyEvent::class, 10],
+            [BeforeAddPolicyEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [AddPolicyEvent::class, 0],
-            [BeforeAddPolicyEvent::class, 0],
+            [AddPolicyEventInterface::class, 0],
+            [BeforeAddPolicyEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateRoleDraftEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateRoleDraftEvent::class,
-            UpdateRoleDraftEvent::class
+            BeforeUpdateRoleDraftEventInterface::class,
+            UpdateRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -479,8 +461,8 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateRoleDraftEvent::class, 0],
-            [UpdateRoleDraftEvent::class, 0],
+            [BeforeUpdateRoleDraftEventInterface::class, 0],
+            [UpdateRoleDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -488,8 +470,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testReturnUpdateRoleDraftResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateRoleDraftEvent::class,
-            UpdateRoleDraftEvent::class
+            BeforeUpdateRoleDraftEventInterface::class,
+            UpdateRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -502,7 +484,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('updateRoleDraft')->willReturn($updatedRoleDraft);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateRoleDraftEvent::class, function (BeforeUpdateRoleDraftEventInterface $event) use ($eventUpdatedRoleDraft) {
+        $traceableEventDispatcher->addListener(BeforeUpdateRoleDraftEventInterface::class, function (BeforeUpdateRoleDraftEventInterface $event) use ($eventUpdatedRoleDraft) {
             $event->setUpdatedRoleDraft($eventUpdatedRoleDraft);
         }, 10);
 
@@ -513,9 +495,9 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateRoleDraftEvent::class, 10],
-            [BeforeUpdateRoleDraftEvent::class, 0],
-            [UpdateRoleDraftEvent::class, 0],
+            [BeforeUpdateRoleDraftEventInterface::class, 10],
+            [BeforeUpdateRoleDraftEventInterface::class, 0],
+            [UpdateRoleDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -523,8 +505,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testUpdateRoleDraftStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateRoleDraftEvent::class,
-            UpdateRoleDraftEvent::class
+            BeforeUpdateRoleDraftEventInterface::class,
+            UpdateRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -537,7 +519,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('updateRoleDraft')->willReturn($updatedRoleDraft);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateRoleDraftEvent::class, function (BeforeUpdateRoleDraftEventInterface $event) use ($eventUpdatedRoleDraft) {
+        $traceableEventDispatcher->addListener(BeforeUpdateRoleDraftEventInterface::class, function (BeforeUpdateRoleDraftEventInterface $event) use ($eventUpdatedRoleDraft) {
             $event->setUpdatedRoleDraft($eventUpdatedRoleDraft);
             $event->stopPropagation();
         }, 10);
@@ -550,19 +532,19 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateRoleDraftEvent::class, 10],
+            [BeforeUpdateRoleDraftEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateRoleDraftEvent::class, 0],
-            [UpdateRoleDraftEvent::class, 0],
+            [BeforeUpdateRoleDraftEventInterface::class, 0],
+            [UpdateRoleDraftEventInterface::class, 0],
         ]);
     }
 
     public function testAssignRoleToUserGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAssignRoleToUserGroupEvent::class,
-            AssignRoleToUserGroupEvent::class
+            BeforeAssignRoleToUserGroupEventInterface::class,
+            AssignRoleToUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -579,8 +561,8 @@ class RoleServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAssignRoleToUserGroupEvent::class, 0],
-            [AssignRoleToUserGroupEvent::class, 0],
+            [BeforeAssignRoleToUserGroupEventInterface::class, 0],
+            [AssignRoleToUserGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -588,8 +570,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testAssignRoleToUserGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAssignRoleToUserGroupEvent::class,
-            AssignRoleToUserGroupEvent::class
+            BeforeAssignRoleToUserGroupEventInterface::class,
+            AssignRoleToUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -600,7 +582,7 @@ class RoleServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeAssignRoleToUserGroupEvent::class, function (BeforeAssignRoleToUserGroupEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeAssignRoleToUserGroupEventInterface::class, function (BeforeAssignRoleToUserGroupEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -611,19 +593,19 @@ class RoleServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAssignRoleToUserGroupEvent::class, 10],
+            [BeforeAssignRoleToUserGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [AssignRoleToUserGroupEvent::class, 0],
-            [BeforeAssignRoleToUserGroupEvent::class, 0],
+            [AssignRoleToUserGroupEventInterface::class, 0],
+            [BeforeAssignRoleToUserGroupEventInterface::class, 0],
         ]);
     }
 
     public function testUnassignRoleFromUserEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUnassignRoleFromUserEvent::class,
-            UnassignRoleFromUserEvent::class
+            BeforeUnassignRoleFromUserEventInterface::class,
+            UnassignRoleFromUserEventInterface::class
         );
 
         $parameters = [
@@ -639,8 +621,8 @@ class RoleServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUnassignRoleFromUserEvent::class, 0],
-            [UnassignRoleFromUserEvent::class, 0],
+            [BeforeUnassignRoleFromUserEventInterface::class, 0],
+            [UnassignRoleFromUserEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -648,8 +630,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testUnassignRoleFromUserStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUnassignRoleFromUserEvent::class,
-            UnassignRoleFromUserEvent::class
+            BeforeUnassignRoleFromUserEventInterface::class,
+            UnassignRoleFromUserEventInterface::class
         );
 
         $parameters = [
@@ -659,7 +641,7 @@ class RoleServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeUnassignRoleFromUserEvent::class, function (BeforeUnassignRoleFromUserEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeUnassignRoleFromUserEventInterface::class, function (BeforeUnassignRoleFromUserEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -670,19 +652,19 @@ class RoleServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUnassignRoleFromUserEvent::class, 10],
+            [BeforeUnassignRoleFromUserEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUnassignRoleFromUserEvent::class, 0],
-            [UnassignRoleFromUserEvent::class, 0],
+            [BeforeUnassignRoleFromUserEventInterface::class, 0],
+            [UnassignRoleFromUserEventInterface::class, 0],
         ]);
     }
 
     public function testUpdatePolicyByRoleDraftEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdatePolicyByRoleDraftEvent::class,
-            UpdatePolicyByRoleDraftEvent::class
+            BeforeUpdatePolicyByRoleDraftEventInterface::class,
+            UpdatePolicyByRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -702,8 +684,8 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedPolicyDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdatePolicyByRoleDraftEvent::class, 0],
-            [UpdatePolicyByRoleDraftEvent::class, 0],
+            [BeforeUpdatePolicyByRoleDraftEventInterface::class, 0],
+            [UpdatePolicyByRoleDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -711,8 +693,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testReturnUpdatePolicyByRoleDraftResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdatePolicyByRoleDraftEvent::class,
-            UpdatePolicyByRoleDraftEvent::class
+            BeforeUpdatePolicyByRoleDraftEventInterface::class,
+            UpdatePolicyByRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -726,7 +708,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('updatePolicyByRoleDraft')->willReturn($updatedPolicyDraft);
 
-        $traceableEventDispatcher->addListener(BeforeUpdatePolicyByRoleDraftEvent::class, function (BeforeUpdatePolicyByRoleDraftEventInterface $event) use ($eventUpdatedPolicyDraft) {
+        $traceableEventDispatcher->addListener(BeforeUpdatePolicyByRoleDraftEventInterface::class, function (BeforeUpdatePolicyByRoleDraftEventInterface $event) use ($eventUpdatedPolicyDraft) {
             $event->setUpdatedPolicyDraft($eventUpdatedPolicyDraft);
         }, 10);
 
@@ -737,9 +719,9 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedPolicyDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdatePolicyByRoleDraftEvent::class, 10],
-            [BeforeUpdatePolicyByRoleDraftEvent::class, 0],
-            [UpdatePolicyByRoleDraftEvent::class, 0],
+            [BeforeUpdatePolicyByRoleDraftEventInterface::class, 10],
+            [BeforeUpdatePolicyByRoleDraftEventInterface::class, 0],
+            [UpdatePolicyByRoleDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -747,8 +729,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testUpdatePolicyByRoleDraftStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdatePolicyByRoleDraftEvent::class,
-            UpdatePolicyByRoleDraftEvent::class
+            BeforeUpdatePolicyByRoleDraftEventInterface::class,
+            UpdatePolicyByRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -762,7 +744,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('updatePolicyByRoleDraft')->willReturn($updatedPolicyDraft);
 
-        $traceableEventDispatcher->addListener(BeforeUpdatePolicyByRoleDraftEvent::class, function (BeforeUpdatePolicyByRoleDraftEventInterface $event) use ($eventUpdatedPolicyDraft) {
+        $traceableEventDispatcher->addListener(BeforeUpdatePolicyByRoleDraftEventInterface::class, function (BeforeUpdatePolicyByRoleDraftEventInterface $event) use ($eventUpdatedPolicyDraft) {
             $event->setUpdatedPolicyDraft($eventUpdatedPolicyDraft);
             $event->stopPropagation();
         }, 10);
@@ -775,19 +757,19 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedPolicyDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdatePolicyByRoleDraftEvent::class, 10],
+            [BeforeUpdatePolicyByRoleDraftEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdatePolicyByRoleDraftEvent::class, 0],
-            [UpdatePolicyByRoleDraftEvent::class, 0],
+            [BeforeUpdatePolicyByRoleDraftEventInterface::class, 0],
+            [UpdatePolicyByRoleDraftEventInterface::class, 0],
         ]);
     }
 
     public function testCreateRoleEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateRoleEvent::class,
-            CreateRoleEvent::class
+            BeforeCreateRoleEventInterface::class,
+            CreateRoleEventInterface::class
         );
 
         $parameters = [
@@ -805,8 +787,8 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($roleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateRoleEvent::class, 0],
-            [CreateRoleEvent::class, 0],
+            [BeforeCreateRoleEventInterface::class, 0],
+            [CreateRoleEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -814,8 +796,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testReturnCreateRoleResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateRoleEvent::class,
-            CreateRoleEvent::class
+            BeforeCreateRoleEventInterface::class,
+            CreateRoleEventInterface::class
         );
 
         $parameters = [
@@ -827,7 +809,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('createRole')->willReturn($roleDraft);
 
-        $traceableEventDispatcher->addListener(BeforeCreateRoleEvent::class, function (BeforeCreateRoleEventInterface $event) use ($eventRoleDraft) {
+        $traceableEventDispatcher->addListener(BeforeCreateRoleEventInterface::class, function (BeforeCreateRoleEventInterface $event) use ($eventRoleDraft) {
             $event->setRoleDraft($eventRoleDraft);
         }, 10);
 
@@ -838,9 +820,9 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateRoleEvent::class, 10],
-            [BeforeCreateRoleEvent::class, 0],
-            [CreateRoleEvent::class, 0],
+            [BeforeCreateRoleEventInterface::class, 10],
+            [BeforeCreateRoleEventInterface::class, 0],
+            [CreateRoleEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -848,8 +830,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testCreateRoleStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateRoleEvent::class,
-            CreateRoleEvent::class
+            BeforeCreateRoleEventInterface::class,
+            CreateRoleEventInterface::class
         );
 
         $parameters = [
@@ -861,7 +843,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('createRole')->willReturn($roleDraft);
 
-        $traceableEventDispatcher->addListener(BeforeCreateRoleEvent::class, function (BeforeCreateRoleEventInterface $event) use ($eventRoleDraft) {
+        $traceableEventDispatcher->addListener(BeforeCreateRoleEventInterface::class, function (BeforeCreateRoleEventInterface $event) use ($eventRoleDraft) {
             $event->setRoleDraft($eventRoleDraft);
             $event->stopPropagation();
         }, 10);
@@ -874,19 +856,19 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateRoleEvent::class, 10],
+            [BeforeCreateRoleEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateRoleEvent::class, 0],
-            [CreateRoleEvent::class, 0],
+            [BeforeCreateRoleEventInterface::class, 0],
+            [CreateRoleEventInterface::class, 0],
         ]);
     }
 
     public function testRemovePolicyByRoleDraftEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemovePolicyByRoleDraftEvent::class,
-            RemovePolicyByRoleDraftEvent::class
+            BeforeRemovePolicyByRoleDraftEventInterface::class,
+            RemovePolicyByRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -905,8 +887,8 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeRemovePolicyByRoleDraftEvent::class, 0],
-            [RemovePolicyByRoleDraftEvent::class, 0],
+            [BeforeRemovePolicyByRoleDraftEventInterface::class, 0],
+            [RemovePolicyByRoleDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -914,8 +896,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testReturnRemovePolicyByRoleDraftResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemovePolicyByRoleDraftEvent::class,
-            RemovePolicyByRoleDraftEvent::class
+            BeforeRemovePolicyByRoleDraftEventInterface::class,
+            RemovePolicyByRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -928,7 +910,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('removePolicyByRoleDraft')->willReturn($updatedRoleDraft);
 
-        $traceableEventDispatcher->addListener(BeforeRemovePolicyByRoleDraftEvent::class, function (BeforeRemovePolicyByRoleDraftEventInterface $event) use ($eventUpdatedRoleDraft) {
+        $traceableEventDispatcher->addListener(BeforeRemovePolicyByRoleDraftEventInterface::class, function (BeforeRemovePolicyByRoleDraftEventInterface $event) use ($eventUpdatedRoleDraft) {
             $event->setUpdatedRoleDraft($eventUpdatedRoleDraft);
         }, 10);
 
@@ -939,9 +921,9 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeRemovePolicyByRoleDraftEvent::class, 10],
-            [BeforeRemovePolicyByRoleDraftEvent::class, 0],
-            [RemovePolicyByRoleDraftEvent::class, 0],
+            [BeforeRemovePolicyByRoleDraftEventInterface::class, 10],
+            [BeforeRemovePolicyByRoleDraftEventInterface::class, 0],
+            [RemovePolicyByRoleDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -949,8 +931,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testRemovePolicyByRoleDraftStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemovePolicyByRoleDraftEvent::class,
-            RemovePolicyByRoleDraftEvent::class
+            BeforeRemovePolicyByRoleDraftEventInterface::class,
+            RemovePolicyByRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -963,7 +945,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('removePolicyByRoleDraft')->willReturn($updatedRoleDraft);
 
-        $traceableEventDispatcher->addListener(BeforeRemovePolicyByRoleDraftEvent::class, function (BeforeRemovePolicyByRoleDraftEventInterface $event) use ($eventUpdatedRoleDraft) {
+        $traceableEventDispatcher->addListener(BeforeRemovePolicyByRoleDraftEventInterface::class, function (BeforeRemovePolicyByRoleDraftEventInterface $event) use ($eventUpdatedRoleDraft) {
             $event->setUpdatedRoleDraft($eventUpdatedRoleDraft);
             $event->stopPropagation();
         }, 10);
@@ -976,19 +958,19 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeRemovePolicyByRoleDraftEvent::class, 10],
+            [BeforeRemovePolicyByRoleDraftEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeRemovePolicyByRoleDraftEvent::class, 0],
-            [RemovePolicyByRoleDraftEvent::class, 0],
+            [BeforeRemovePolicyByRoleDraftEventInterface::class, 0],
+            [RemovePolicyByRoleDraftEventInterface::class, 0],
         ]);
     }
 
     public function testAddPolicyByRoleDraftEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAddPolicyByRoleDraftEvent::class,
-            AddPolicyByRoleDraftEvent::class
+            BeforeAddPolicyByRoleDraftEventInterface::class,
+            AddPolicyByRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -1007,8 +989,8 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeAddPolicyByRoleDraftEvent::class, 0],
-            [AddPolicyByRoleDraftEvent::class, 0],
+            [BeforeAddPolicyByRoleDraftEventInterface::class, 0],
+            [AddPolicyByRoleDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1016,8 +998,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testReturnAddPolicyByRoleDraftResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAddPolicyByRoleDraftEvent::class,
-            AddPolicyByRoleDraftEvent::class
+            BeforeAddPolicyByRoleDraftEventInterface::class,
+            AddPolicyByRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -1030,7 +1012,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('addPolicyByRoleDraft')->willReturn($updatedRoleDraft);
 
-        $traceableEventDispatcher->addListener(BeforeAddPolicyByRoleDraftEvent::class, function (BeforeAddPolicyByRoleDraftEventInterface $event) use ($eventUpdatedRoleDraft) {
+        $traceableEventDispatcher->addListener(BeforeAddPolicyByRoleDraftEventInterface::class, function (BeforeAddPolicyByRoleDraftEventInterface $event) use ($eventUpdatedRoleDraft) {
             $event->setUpdatedRoleDraft($eventUpdatedRoleDraft);
         }, 10);
 
@@ -1041,9 +1023,9 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeAddPolicyByRoleDraftEvent::class, 10],
-            [BeforeAddPolicyByRoleDraftEvent::class, 0],
-            [AddPolicyByRoleDraftEvent::class, 0],
+            [BeforeAddPolicyByRoleDraftEventInterface::class, 10],
+            [BeforeAddPolicyByRoleDraftEventInterface::class, 0],
+            [AddPolicyByRoleDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1051,8 +1033,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testAddPolicyByRoleDraftStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAddPolicyByRoleDraftEvent::class,
-            AddPolicyByRoleDraftEvent::class
+            BeforeAddPolicyByRoleDraftEventInterface::class,
+            AddPolicyByRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -1065,7 +1047,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('addPolicyByRoleDraft')->willReturn($updatedRoleDraft);
 
-        $traceableEventDispatcher->addListener(BeforeAddPolicyByRoleDraftEvent::class, function (BeforeAddPolicyByRoleDraftEventInterface $event) use ($eventUpdatedRoleDraft) {
+        $traceableEventDispatcher->addListener(BeforeAddPolicyByRoleDraftEventInterface::class, function (BeforeAddPolicyByRoleDraftEventInterface $event) use ($eventUpdatedRoleDraft) {
             $event->setUpdatedRoleDraft($eventUpdatedRoleDraft);
             $event->stopPropagation();
         }, 10);
@@ -1078,19 +1060,19 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeAddPolicyByRoleDraftEvent::class, 10],
+            [BeforeAddPolicyByRoleDraftEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [AddPolicyByRoleDraftEvent::class, 0],
-            [BeforeAddPolicyByRoleDraftEvent::class, 0],
+            [AddPolicyByRoleDraftEventInterface::class, 0],
+            [BeforeAddPolicyByRoleDraftEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteRoleEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteRoleEvent::class,
-            DeleteRoleEvent::class
+            BeforeDeleteRoleEventInterface::class,
+            DeleteRoleEventInterface::class
         );
 
         $parameters = [
@@ -1105,8 +1087,8 @@ class RoleServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteRoleEvent::class, 0],
-            [DeleteRoleEvent::class, 0],
+            [BeforeDeleteRoleEventInterface::class, 0],
+            [DeleteRoleEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1114,8 +1096,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testDeleteRoleStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteRoleEvent::class,
-            DeleteRoleEvent::class
+            BeforeDeleteRoleEventInterface::class,
+            DeleteRoleEventInterface::class
         );
 
         $parameters = [
@@ -1124,7 +1106,7 @@ class RoleServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteRoleEvent::class, function (BeforeDeleteRoleEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteRoleEventInterface::class, function (BeforeDeleteRoleEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -1135,19 +1117,19 @@ class RoleServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteRoleEvent::class, 10],
+            [BeforeDeleteRoleEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteRoleEvent::class, 0],
-            [DeleteRoleEvent::class, 0],
+            [BeforeDeleteRoleEventInterface::class, 0],
+            [DeleteRoleEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteRoleDraftEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteRoleDraftEvent::class,
-            DeleteRoleDraftEvent::class
+            BeforeDeleteRoleDraftEventInterface::class,
+            DeleteRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -1162,8 +1144,8 @@ class RoleServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteRoleDraftEvent::class, 0],
-            [DeleteRoleDraftEvent::class, 0],
+            [BeforeDeleteRoleDraftEventInterface::class, 0],
+            [DeleteRoleDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1171,8 +1153,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testDeleteRoleDraftStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteRoleDraftEvent::class,
-            DeleteRoleDraftEvent::class
+            BeforeDeleteRoleDraftEventInterface::class,
+            DeleteRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -1181,7 +1163,7 @@ class RoleServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteRoleDraftEvent::class, function (BeforeDeleteRoleDraftEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteRoleDraftEventInterface::class, function (BeforeDeleteRoleDraftEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -1192,19 +1174,19 @@ class RoleServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteRoleDraftEvent::class, 10],
+            [BeforeDeleteRoleDraftEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteRoleDraftEvent::class, 0],
-            [DeleteRoleDraftEvent::class, 0],
+            [BeforeDeleteRoleDraftEventInterface::class, 0],
+            [DeleteRoleDraftEventInterface::class, 0],
         ]);
     }
 
     public function testRemoveRoleAssignmentEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemoveRoleAssignmentEvent::class,
-            RemoveRoleAssignmentEvent::class
+            BeforeRemoveRoleAssignmentEventInterface::class,
+            RemoveRoleAssignmentEventInterface::class
         );
 
         $parameters = [
@@ -1219,8 +1201,8 @@ class RoleServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeRemoveRoleAssignmentEvent::class, 0],
-            [RemoveRoleAssignmentEvent::class, 0],
+            [BeforeRemoveRoleAssignmentEventInterface::class, 0],
+            [RemoveRoleAssignmentEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1228,8 +1210,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testRemoveRoleAssignmentStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemoveRoleAssignmentEvent::class,
-            RemoveRoleAssignmentEvent::class
+            BeforeRemoveRoleAssignmentEventInterface::class,
+            RemoveRoleAssignmentEventInterface::class
         );
 
         $parameters = [
@@ -1238,7 +1220,7 @@ class RoleServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeRemoveRoleAssignmentEvent::class, function (BeforeRemoveRoleAssignmentEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeRemoveRoleAssignmentEventInterface::class, function (BeforeRemoveRoleAssignmentEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -1249,19 +1231,19 @@ class RoleServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeRemoveRoleAssignmentEvent::class, 10],
+            [BeforeRemoveRoleAssignmentEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeRemoveRoleAssignmentEvent::class, 0],
-            [RemoveRoleAssignmentEvent::class, 0],
+            [BeforeRemoveRoleAssignmentEventInterface::class, 0],
+            [RemoveRoleAssignmentEventInterface::class, 0],
         ]);
     }
 
     public function testCreateRoleDraftEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateRoleDraftEvent::class,
-            CreateRoleDraftEvent::class
+            BeforeCreateRoleDraftEventInterface::class,
+            CreateRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -1279,8 +1261,8 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($roleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateRoleDraftEvent::class, 0],
-            [CreateRoleDraftEvent::class, 0],
+            [BeforeCreateRoleDraftEventInterface::class, 0],
+            [CreateRoleDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1288,8 +1270,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testReturnCreateRoleDraftResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateRoleDraftEvent::class,
-            CreateRoleDraftEvent::class
+            BeforeCreateRoleDraftEventInterface::class,
+            CreateRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -1301,7 +1283,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('createRoleDraft')->willReturn($roleDraft);
 
-        $traceableEventDispatcher->addListener(BeforeCreateRoleDraftEvent::class, function (BeforeCreateRoleDraftEventInterface $event) use ($eventRoleDraft) {
+        $traceableEventDispatcher->addListener(BeforeCreateRoleDraftEventInterface::class, function (BeforeCreateRoleDraftEventInterface $event) use ($eventRoleDraft) {
             $event->setRoleDraft($eventRoleDraft);
         }, 10);
 
@@ -1312,9 +1294,9 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateRoleDraftEvent::class, 10],
-            [BeforeCreateRoleDraftEvent::class, 0],
-            [CreateRoleDraftEvent::class, 0],
+            [BeforeCreateRoleDraftEventInterface::class, 10],
+            [BeforeCreateRoleDraftEventInterface::class, 0],
+            [CreateRoleDraftEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1322,8 +1304,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testCreateRoleDraftStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateRoleDraftEvent::class,
-            CreateRoleDraftEvent::class
+            BeforeCreateRoleDraftEventInterface::class,
+            CreateRoleDraftEventInterface::class
         );
 
         $parameters = [
@@ -1335,7 +1317,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('createRoleDraft')->willReturn($roleDraft);
 
-        $traceableEventDispatcher->addListener(BeforeCreateRoleDraftEvent::class, function (BeforeCreateRoleDraftEventInterface $event) use ($eventRoleDraft) {
+        $traceableEventDispatcher->addListener(BeforeCreateRoleDraftEventInterface::class, function (BeforeCreateRoleDraftEventInterface $event) use ($eventRoleDraft) {
             $event->setRoleDraft($eventRoleDraft);
             $event->stopPropagation();
         }, 10);
@@ -1348,19 +1330,19 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventRoleDraft, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateRoleDraftEvent::class, 10],
+            [BeforeCreateRoleDraftEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateRoleDraftEvent::class, 0],
-            [CreateRoleDraftEvent::class, 0],
+            [BeforeCreateRoleDraftEventInterface::class, 0],
+            [CreateRoleDraftEventInterface::class, 0],
         ]);
     }
 
     public function testUpdatePolicyEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdatePolicyEvent::class,
-            UpdatePolicyEvent::class
+            BeforeUpdatePolicyEventInterface::class,
+            UpdatePolicyEventInterface::class
         );
 
         $parameters = [
@@ -1379,8 +1361,8 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedPolicy, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdatePolicyEvent::class, 0],
-            [UpdatePolicyEvent::class, 0],
+            [BeforeUpdatePolicyEventInterface::class, 0],
+            [UpdatePolicyEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1388,8 +1370,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testReturnUpdatePolicyResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdatePolicyEvent::class,
-            UpdatePolicyEvent::class
+            BeforeUpdatePolicyEventInterface::class,
+            UpdatePolicyEventInterface::class
         );
 
         $parameters = [
@@ -1402,7 +1384,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('updatePolicy')->willReturn($updatedPolicy);
 
-        $traceableEventDispatcher->addListener(BeforeUpdatePolicyEvent::class, function (BeforeUpdatePolicyEventInterface $event) use ($eventUpdatedPolicy) {
+        $traceableEventDispatcher->addListener(BeforeUpdatePolicyEventInterface::class, function (BeforeUpdatePolicyEventInterface $event) use ($eventUpdatedPolicy) {
             $event->setUpdatedPolicy($eventUpdatedPolicy);
         }, 10);
 
@@ -1413,9 +1395,9 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedPolicy, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdatePolicyEvent::class, 10],
-            [BeforeUpdatePolicyEvent::class, 0],
-            [UpdatePolicyEvent::class, 0],
+            [BeforeUpdatePolicyEventInterface::class, 10],
+            [BeforeUpdatePolicyEventInterface::class, 0],
+            [UpdatePolicyEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1423,8 +1405,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testUpdatePolicyStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdatePolicyEvent::class,
-            UpdatePolicyEvent::class
+            BeforeUpdatePolicyEventInterface::class,
+            UpdatePolicyEventInterface::class
         );
 
         $parameters = [
@@ -1437,7 +1419,7 @@ class RoleServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
         $innerServiceMock->method('updatePolicy')->willReturn($updatedPolicy);
 
-        $traceableEventDispatcher->addListener(BeforeUpdatePolicyEvent::class, function (BeforeUpdatePolicyEventInterface $event) use ($eventUpdatedPolicy) {
+        $traceableEventDispatcher->addListener(BeforeUpdatePolicyEventInterface::class, function (BeforeUpdatePolicyEventInterface $event) use ($eventUpdatedPolicy) {
             $event->setUpdatedPolicy($eventUpdatedPolicy);
             $event->stopPropagation();
         }, 10);
@@ -1450,19 +1432,19 @@ class RoleServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedPolicy, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdatePolicyEvent::class, 10],
+            [BeforeUpdatePolicyEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdatePolicyEvent::class, 0],
-            [UpdatePolicyEvent::class, 0],
+            [BeforeUpdatePolicyEventInterface::class, 0],
+            [UpdatePolicyEventInterface::class, 0],
         ]);
     }
 
     public function testUnassignRoleFromUserGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUnassignRoleFromUserGroupEvent::class,
-            UnassignRoleFromUserGroupEvent::class
+            BeforeUnassignRoleFromUserGroupEventInterface::class,
+            UnassignRoleFromUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -1478,8 +1460,8 @@ class RoleServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUnassignRoleFromUserGroupEvent::class, 0],
-            [UnassignRoleFromUserGroupEvent::class, 0],
+            [BeforeUnassignRoleFromUserGroupEventInterface::class, 0],
+            [UnassignRoleFromUserGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -1487,8 +1469,8 @@ class RoleServiceTest extends AbstractServiceTest
     public function testUnassignRoleFromUserGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUnassignRoleFromUserGroupEvent::class,
-            UnassignRoleFromUserGroupEvent::class
+            BeforeUnassignRoleFromUserGroupEventInterface::class,
+            UnassignRoleFromUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -1498,7 +1480,7 @@ class RoleServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(RoleServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeUnassignRoleFromUserGroupEvent::class, function (BeforeUnassignRoleFromUserGroupEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeUnassignRoleFromUserGroupEventInterface::class, function (BeforeUnassignRoleFromUserGroupEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -1509,11 +1491,11 @@ class RoleServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUnassignRoleFromUserGroupEvent::class, 10],
+            [BeforeUnassignRoleFromUserGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUnassignRoleFromUserGroupEvent::class, 0],
-            [UnassignRoleFromUserGroupEvent::class, 0],
+            [BeforeUnassignRoleFromUserGroupEventInterface::class, 0],
+            [UnassignRoleFromUserGroupEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/SectionServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/SectionServiceTest.php
@@ -6,27 +6,22 @@
  */
 namespace eZ\Publish\Core\Event\Tests;
 
+use eZ\Publish\API\Repository\Events\Section\AssignSectionEvent as AssignSectionEventInterface;
+use eZ\Publish\API\Repository\Events\Section\AssignSectionToSubtreeEvent as AssignSectionToSubtreeEventInterface;
 use eZ\Publish\API\Repository\Events\Section\BeforeAssignSectionEvent as BeforeAssignSectionEventInterface;
 use eZ\Publish\API\Repository\Events\Section\BeforeAssignSectionToSubtreeEvent as BeforeAssignSectionToSubtreeEventInterface;
 use eZ\Publish\API\Repository\Events\Section\BeforeCreateSectionEvent as BeforeCreateSectionEventInterface;
 use eZ\Publish\API\Repository\Events\Section\BeforeDeleteSectionEvent as BeforeDeleteSectionEventInterface;
 use eZ\Publish\API\Repository\Events\Section\BeforeUpdateSectionEvent as BeforeUpdateSectionEventInterface;
+use eZ\Publish\API\Repository\Events\Section\CreateSectionEvent as CreateSectionEventInterface;
+use eZ\Publish\API\Repository\Events\Section\DeleteSectionEvent as DeleteSectionEventInterface;
+use eZ\Publish\API\Repository\Events\Section\UpdateSectionEvent as UpdateSectionEventInterface;
 use eZ\Publish\API\Repository\SectionService as SectionServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Section;
 use eZ\Publish\API\Repository\Values\Content\SectionCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\SectionUpdateStruct;
-use eZ\Publish\Core\Event\Section\AssignSectionEvent;
-use eZ\Publish\Core\Event\Section\AssignSectionToSubtreeEvent;
-use eZ\Publish\Core\Event\Section\BeforeAssignSectionEvent;
-use eZ\Publish\Core\Event\Section\BeforeAssignSectionToSubtreeEvent;
-use eZ\Publish\Core\Event\Section\BeforeCreateSectionEvent;
-use eZ\Publish\Core\Event\Section\BeforeDeleteSectionEvent;
-use eZ\Publish\Core\Event\Section\BeforeUpdateSectionEvent;
-use eZ\Publish\Core\Event\Section\CreateSectionEvent;
-use eZ\Publish\Core\Event\Section\DeleteSectionEvent;
-use eZ\Publish\Core\Event\Section\UpdateSectionEvent;
 use eZ\Publish\Core\Event\SectionService;
 
 class SectionServiceTest extends AbstractServiceTest
@@ -34,8 +29,8 @@ class SectionServiceTest extends AbstractServiceTest
     public function testAssignSectionEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAssignSectionEvent::class,
-            AssignSectionEvent::class
+            BeforeAssignSectionEventInterface::class,
+            AssignSectionEventInterface::class
         );
 
         $parameters = [
@@ -51,8 +46,8 @@ class SectionServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAssignSectionEvent::class, 0],
-            [AssignSectionEvent::class, 0],
+            [BeforeAssignSectionEventInterface::class, 0],
+            [AssignSectionEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -60,8 +55,8 @@ class SectionServiceTest extends AbstractServiceTest
     public function testAssignSectionStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAssignSectionEvent::class,
-            AssignSectionEvent::class
+            BeforeAssignSectionEventInterface::class,
+            AssignSectionEventInterface::class
         );
 
         $parameters = [
@@ -71,7 +66,7 @@ class SectionServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(SectionServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeAssignSectionEvent::class, function (BeforeAssignSectionEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeAssignSectionEventInterface::class, function (BeforeAssignSectionEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -82,19 +77,19 @@ class SectionServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAssignSectionEvent::class, 10],
+            [BeforeAssignSectionEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [AssignSectionEvent::class, 0],
-            [BeforeAssignSectionEvent::class, 0],
+            [AssignSectionEventInterface::class, 0],
+            [BeforeAssignSectionEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateSectionEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateSectionEvent::class,
-            UpdateSectionEvent::class
+            BeforeUpdateSectionEventInterface::class,
+            UpdateSectionEventInterface::class
         );
 
         $parameters = [
@@ -113,8 +108,8 @@ class SectionServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedSection, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateSectionEvent::class, 0],
-            [UpdateSectionEvent::class, 0],
+            [BeforeUpdateSectionEventInterface::class, 0],
+            [UpdateSectionEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -122,8 +117,8 @@ class SectionServiceTest extends AbstractServiceTest
     public function testReturnUpdateSectionResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateSectionEvent::class,
-            UpdateSectionEvent::class
+            BeforeUpdateSectionEventInterface::class,
+            UpdateSectionEventInterface::class
         );
 
         $parameters = [
@@ -136,7 +131,7 @@ class SectionServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(SectionServiceInterface::class);
         $innerServiceMock->method('updateSection')->willReturn($updatedSection);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateSectionEvent::class, function (BeforeUpdateSectionEventInterface $event) use ($eventUpdatedSection) {
+        $traceableEventDispatcher->addListener(BeforeUpdateSectionEventInterface::class, function (BeforeUpdateSectionEventInterface $event) use ($eventUpdatedSection) {
             $event->setUpdatedSection($eventUpdatedSection);
         }, 10);
 
@@ -147,9 +142,9 @@ class SectionServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedSection, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateSectionEvent::class, 10],
-            [BeforeUpdateSectionEvent::class, 0],
-            [UpdateSectionEvent::class, 0],
+            [BeforeUpdateSectionEventInterface::class, 10],
+            [BeforeUpdateSectionEventInterface::class, 0],
+            [UpdateSectionEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -157,8 +152,8 @@ class SectionServiceTest extends AbstractServiceTest
     public function testUpdateSectionStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateSectionEvent::class,
-            UpdateSectionEvent::class
+            BeforeUpdateSectionEventInterface::class,
+            UpdateSectionEventInterface::class
         );
 
         $parameters = [
@@ -171,7 +166,7 @@ class SectionServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(SectionServiceInterface::class);
         $innerServiceMock->method('updateSection')->willReturn($updatedSection);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateSectionEvent::class, function (BeforeUpdateSectionEventInterface $event) use ($eventUpdatedSection) {
+        $traceableEventDispatcher->addListener(BeforeUpdateSectionEventInterface::class, function (BeforeUpdateSectionEventInterface $event) use ($eventUpdatedSection) {
             $event->setUpdatedSection($eventUpdatedSection);
             $event->stopPropagation();
         }, 10);
@@ -184,19 +179,19 @@ class SectionServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedSection, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateSectionEvent::class, 10],
+            [BeforeUpdateSectionEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateSectionEvent::class, 0],
-            [UpdateSectionEvent::class, 0],
+            [BeforeUpdateSectionEventInterface::class, 0],
+            [UpdateSectionEventInterface::class, 0],
         ]);
     }
 
     public function testAssignSectionToSubtreeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAssignSectionToSubtreeEvent::class,
-            AssignSectionToSubtreeEvent::class
+            BeforeAssignSectionToSubtreeEventInterface::class,
+            AssignSectionToSubtreeEventInterface::class
         );
 
         $parameters = [
@@ -212,8 +207,8 @@ class SectionServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAssignSectionToSubtreeEvent::class, 0],
-            [AssignSectionToSubtreeEvent::class, 0],
+            [BeforeAssignSectionToSubtreeEventInterface::class, 0],
+            [AssignSectionToSubtreeEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -221,8 +216,8 @@ class SectionServiceTest extends AbstractServiceTest
     public function testAssignSectionToSubtreeStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAssignSectionToSubtreeEvent::class,
-            AssignSectionToSubtreeEvent::class
+            BeforeAssignSectionToSubtreeEventInterface::class,
+            AssignSectionToSubtreeEventInterface::class
         );
 
         $parameters = [
@@ -232,7 +227,7 @@ class SectionServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(SectionServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeAssignSectionToSubtreeEvent::class, function (BeforeAssignSectionToSubtreeEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeAssignSectionToSubtreeEventInterface::class, function (BeforeAssignSectionToSubtreeEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -243,19 +238,19 @@ class SectionServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAssignSectionToSubtreeEvent::class, 10],
+            [BeforeAssignSectionToSubtreeEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [AssignSectionToSubtreeEvent::class, 0],
-            [BeforeAssignSectionToSubtreeEvent::class, 0],
+            [AssignSectionToSubtreeEventInterface::class, 0],
+            [BeforeAssignSectionToSubtreeEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteSectionEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteSectionEvent::class,
-            DeleteSectionEvent::class
+            BeforeDeleteSectionEventInterface::class,
+            DeleteSectionEventInterface::class
         );
 
         $parameters = [
@@ -270,8 +265,8 @@ class SectionServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteSectionEvent::class, 0],
-            [DeleteSectionEvent::class, 0],
+            [BeforeDeleteSectionEventInterface::class, 0],
+            [DeleteSectionEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -279,8 +274,8 @@ class SectionServiceTest extends AbstractServiceTest
     public function testDeleteSectionStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteSectionEvent::class,
-            DeleteSectionEvent::class
+            BeforeDeleteSectionEventInterface::class,
+            DeleteSectionEventInterface::class
         );
 
         $parameters = [
@@ -289,7 +284,7 @@ class SectionServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(SectionServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteSectionEvent::class, function (BeforeDeleteSectionEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeDeleteSectionEventInterface::class, function (BeforeDeleteSectionEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -300,19 +295,19 @@ class SectionServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeDeleteSectionEvent::class, 10],
+            [BeforeDeleteSectionEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteSectionEvent::class, 0],
-            [DeleteSectionEvent::class, 0],
+            [BeforeDeleteSectionEventInterface::class, 0],
+            [DeleteSectionEventInterface::class, 0],
         ]);
     }
 
     public function testCreateSectionEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateSectionEvent::class,
-            CreateSectionEvent::class
+            BeforeCreateSectionEventInterface::class,
+            CreateSectionEventInterface::class
         );
 
         $parameters = [
@@ -330,8 +325,8 @@ class SectionServiceTest extends AbstractServiceTest
 
         $this->assertSame($section, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateSectionEvent::class, 0],
-            [CreateSectionEvent::class, 0],
+            [BeforeCreateSectionEventInterface::class, 0],
+            [CreateSectionEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -339,8 +334,8 @@ class SectionServiceTest extends AbstractServiceTest
     public function testReturnCreateSectionResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateSectionEvent::class,
-            CreateSectionEvent::class
+            BeforeCreateSectionEventInterface::class,
+            CreateSectionEventInterface::class
         );
 
         $parameters = [
@@ -352,7 +347,7 @@ class SectionServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(SectionServiceInterface::class);
         $innerServiceMock->method('createSection')->willReturn($section);
 
-        $traceableEventDispatcher->addListener(BeforeCreateSectionEvent::class, function (BeforeCreateSectionEventInterface $event) use ($eventSection) {
+        $traceableEventDispatcher->addListener(BeforeCreateSectionEventInterface::class, function (BeforeCreateSectionEventInterface $event) use ($eventSection) {
             $event->setSection($eventSection);
         }, 10);
 
@@ -363,9 +358,9 @@ class SectionServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventSection, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateSectionEvent::class, 10],
-            [BeforeCreateSectionEvent::class, 0],
-            [CreateSectionEvent::class, 0],
+            [BeforeCreateSectionEventInterface::class, 10],
+            [BeforeCreateSectionEventInterface::class, 0],
+            [CreateSectionEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -373,8 +368,8 @@ class SectionServiceTest extends AbstractServiceTest
     public function testCreateSectionStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateSectionEvent::class,
-            CreateSectionEvent::class
+            BeforeCreateSectionEventInterface::class,
+            CreateSectionEventInterface::class
         );
 
         $parameters = [
@@ -386,7 +381,7 @@ class SectionServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(SectionServiceInterface::class);
         $innerServiceMock->method('createSection')->willReturn($section);
 
-        $traceableEventDispatcher->addListener(BeforeCreateSectionEvent::class, function (BeforeCreateSectionEventInterface $event) use ($eventSection) {
+        $traceableEventDispatcher->addListener(BeforeCreateSectionEventInterface::class, function (BeforeCreateSectionEventInterface $event) use ($eventSection) {
             $event->setSection($eventSection);
             $event->stopPropagation();
         }, 10);
@@ -399,11 +394,11 @@ class SectionServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventSection, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateSectionEvent::class, 10],
+            [BeforeCreateSectionEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateSectionEvent::class, 0],
-            [CreateSectionEvent::class, 0],
+            [BeforeCreateSectionEventInterface::class, 0],
+            [CreateSectionEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/TrashServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/TrashServiceTest.php
@@ -10,19 +10,15 @@ use eZ\Publish\API\Repository\Events\Trash\BeforeDeleteTrashItemEvent as BeforeD
 use eZ\Publish\API\Repository\Events\Trash\BeforeEmptyTrashEvent as BeforeEmptyTrashEventInterface;
 use eZ\Publish\API\Repository\Events\Trash\BeforeRecoverEvent as BeforeRecoverEventInterface;
 use eZ\Publish\API\Repository\Events\Trash\BeforeTrashEvent as BeforeTrashEventInterface;
+use eZ\Publish\API\Repository\Events\Trash\DeleteTrashItemEvent as DeleteTrashItemEventInterface;
+use eZ\Publish\API\Repository\Events\Trash\EmptyTrashEvent as EmptyTrashEventInterface;
+use eZ\Publish\API\Repository\Events\Trash\RecoverEvent as RecoverEventInterface;
+use eZ\Publish\API\Repository\Events\Trash\TrashEvent as TrashEventInterface;
 use eZ\Publish\API\Repository\TrashService as TrashServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResult;
 use eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResultList;
 use eZ\Publish\API\Repository\Values\Content\TrashItem;
-use eZ\Publish\Core\Event\Trash\BeforeDeleteTrashItemEvent;
-use eZ\Publish\Core\Event\Trash\BeforeEmptyTrashEvent;
-use eZ\Publish\Core\Event\Trash\BeforeRecoverEvent;
-use eZ\Publish\Core\Event\Trash\BeforeTrashEvent;
-use eZ\Publish\Core\Event\Trash\DeleteTrashItemEvent;
-use eZ\Publish\Core\Event\Trash\EmptyTrashEvent;
-use eZ\Publish\Core\Event\Trash\RecoverEvent;
-use eZ\Publish\Core\Event\Trash\TrashEvent;
 use eZ\Publish\Core\Event\TrashService;
 
 class TrashServiceTest extends AbstractServiceTest
@@ -30,8 +26,8 @@ class TrashServiceTest extends AbstractServiceTest
     public function testEmptyTrashEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeEmptyTrashEvent::class,
-            EmptyTrashEvent::class
+            BeforeEmptyTrashEventInterface::class,
+            EmptyTrashEventInterface::class
         );
 
         $parameters = [
@@ -48,8 +44,8 @@ class TrashServiceTest extends AbstractServiceTest
 
         $this->assertSame($resultList, $result);
         $this->assertSame($calledListeners, [
-            [BeforeEmptyTrashEvent::class, 0],
-            [EmptyTrashEvent::class, 0],
+            [BeforeEmptyTrashEventInterface::class, 0],
+            [EmptyTrashEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -57,8 +53,8 @@ class TrashServiceTest extends AbstractServiceTest
     public function testReturnEmptyTrashResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeEmptyTrashEvent::class,
-            EmptyTrashEvent::class
+            BeforeEmptyTrashEventInterface::class,
+            EmptyTrashEventInterface::class
         );
 
         $parameters = [
@@ -69,7 +65,7 @@ class TrashServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(TrashServiceInterface::class);
         $innerServiceMock->method('emptyTrash')->willReturn($resultList);
 
-        $traceableEventDispatcher->addListener(BeforeEmptyTrashEvent::class, function (BeforeEmptyTrashEventInterface $event) use ($eventResultList) {
+        $traceableEventDispatcher->addListener(BeforeEmptyTrashEventInterface::class, function (BeforeEmptyTrashEventInterface $event) use ($eventResultList) {
             $event->setResultList($eventResultList);
         }, 10);
 
@@ -80,9 +76,9 @@ class TrashServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventResultList, $result);
         $this->assertSame($calledListeners, [
-            [BeforeEmptyTrashEvent::class, 10],
-            [BeforeEmptyTrashEvent::class, 0],
-            [EmptyTrashEvent::class, 0],
+            [BeforeEmptyTrashEventInterface::class, 10],
+            [BeforeEmptyTrashEventInterface::class, 0],
+            [EmptyTrashEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -90,8 +86,8 @@ class TrashServiceTest extends AbstractServiceTest
     public function testEmptyTrashStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeEmptyTrashEvent::class,
-            EmptyTrashEvent::class
+            BeforeEmptyTrashEventInterface::class,
+            EmptyTrashEventInterface::class
         );
 
         $parameters = [
@@ -102,7 +98,7 @@ class TrashServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(TrashServiceInterface::class);
         $innerServiceMock->method('emptyTrash')->willReturn($resultList);
 
-        $traceableEventDispatcher->addListener(BeforeEmptyTrashEvent::class, function (BeforeEmptyTrashEventInterface $event) use ($eventResultList) {
+        $traceableEventDispatcher->addListener(BeforeEmptyTrashEventInterface::class, function (BeforeEmptyTrashEventInterface $event) use ($eventResultList) {
             $event->setResultList($eventResultList);
             $event->stopPropagation();
         }, 10);
@@ -115,19 +111,19 @@ class TrashServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventResultList, $result);
         $this->assertSame($calledListeners, [
-            [BeforeEmptyTrashEvent::class, 10],
+            [BeforeEmptyTrashEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeEmptyTrashEvent::class, 0],
-            [EmptyTrashEvent::class, 0],
+            [BeforeEmptyTrashEventInterface::class, 0],
+            [EmptyTrashEventInterface::class, 0],
         ]);
     }
 
     public function testTrashEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeTrashEvent::class,
-            TrashEvent::class
+            BeforeTrashEventInterface::class,
+            TrashEventInterface::class
         );
 
         $parameters = [
@@ -145,8 +141,8 @@ class TrashServiceTest extends AbstractServiceTest
 
         $this->assertSame($trashItem, $result);
         $this->assertSame($calledListeners, [
-            [BeforeTrashEvent::class, 0],
-            [TrashEvent::class, 0],
+            [BeforeTrashEventInterface::class, 0],
+            [TrashEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -154,8 +150,8 @@ class TrashServiceTest extends AbstractServiceTest
     public function testReturnTrashResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeTrashEvent::class,
-            TrashEvent::class
+            BeforeTrashEventInterface::class,
+            TrashEventInterface::class
         );
 
         $parameters = [
@@ -167,7 +163,7 @@ class TrashServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(TrashServiceInterface::class);
         $innerServiceMock->method('trash')->willReturn($trashItem);
 
-        $traceableEventDispatcher->addListener(BeforeTrashEvent::class, function (BeforeTrashEventInterface $event) use ($eventTrashItem) {
+        $traceableEventDispatcher->addListener(BeforeTrashEventInterface::class, function (BeforeTrashEventInterface $event) use ($eventTrashItem) {
             $event->setResult($eventTrashItem);
         }, 10);
 
@@ -178,9 +174,9 @@ class TrashServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventTrashItem, $result);
         $this->assertSame($calledListeners, [
-            [BeforeTrashEvent::class, 10],
-            [BeforeTrashEvent::class, 0],
-            [TrashEvent::class, 0],
+            [BeforeTrashEventInterface::class, 10],
+            [BeforeTrashEventInterface::class, 0],
+            [TrashEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -188,8 +184,8 @@ class TrashServiceTest extends AbstractServiceTest
     public function testTrashStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeTrashEvent::class,
-            TrashEvent::class
+            BeforeTrashEventInterface::class,
+            TrashEventInterface::class
         );
 
         $parameters = [
@@ -201,7 +197,7 @@ class TrashServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(TrashServiceInterface::class);
         $innerServiceMock->method('trash')->willReturn($trashItem);
 
-        $traceableEventDispatcher->addListener(BeforeTrashEvent::class, function (BeforeTrashEventInterface $event) use ($eventTrashItem) {
+        $traceableEventDispatcher->addListener(BeforeTrashEventInterface::class, function (BeforeTrashEventInterface $event) use ($eventTrashItem) {
             $event->setResult($eventTrashItem);
             $event->stopPropagation();
         }, 10);
@@ -214,19 +210,19 @@ class TrashServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventTrashItem, $result);
         $this->assertSame($calledListeners, [
-            [BeforeTrashEvent::class, 10],
+            [BeforeTrashEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeTrashEvent::class, 0],
-            [TrashEvent::class, 0],
+            [BeforeTrashEventInterface::class, 0],
+            [TrashEventInterface::class, 0],
         ]);
     }
 
     public function testRecoverEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRecoverEvent::class,
-            RecoverEvent::class
+            BeforeRecoverEventInterface::class,
+            RecoverEventInterface::class
         );
 
         $parameters = [
@@ -245,8 +241,8 @@ class TrashServiceTest extends AbstractServiceTest
 
         $this->assertSame($location, $result);
         $this->assertSame($calledListeners, [
-            [BeforeRecoverEvent::class, 0],
-            [RecoverEvent::class, 0],
+            [BeforeRecoverEventInterface::class, 0],
+            [RecoverEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -254,8 +250,8 @@ class TrashServiceTest extends AbstractServiceTest
     public function testReturnRecoverResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRecoverEvent::class,
-            RecoverEvent::class
+            BeforeRecoverEventInterface::class,
+            RecoverEventInterface::class
         );
 
         $parameters = [
@@ -268,7 +264,7 @@ class TrashServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(TrashServiceInterface::class);
         $innerServiceMock->method('recover')->willReturn($location);
 
-        $traceableEventDispatcher->addListener(BeforeRecoverEvent::class, function (BeforeRecoverEventInterface $event) use ($eventLocation) {
+        $traceableEventDispatcher->addListener(BeforeRecoverEventInterface::class, function (BeforeRecoverEventInterface $event) use ($eventLocation) {
             $event->setLocation($eventLocation);
         }, 10);
 
@@ -279,9 +275,9 @@ class TrashServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeRecoverEvent::class, 10],
-            [BeforeRecoverEvent::class, 0],
-            [RecoverEvent::class, 0],
+            [BeforeRecoverEventInterface::class, 10],
+            [BeforeRecoverEventInterface::class, 0],
+            [RecoverEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -289,8 +285,8 @@ class TrashServiceTest extends AbstractServiceTest
     public function testRecoverStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRecoverEvent::class,
-            RecoverEvent::class
+            BeforeRecoverEventInterface::class,
+            RecoverEventInterface::class
         );
 
         $parameters = [
@@ -303,7 +299,7 @@ class TrashServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(TrashServiceInterface::class);
         $innerServiceMock->method('recover')->willReturn($location);
 
-        $traceableEventDispatcher->addListener(BeforeRecoverEvent::class, function (BeforeRecoverEventInterface $event) use ($eventLocation) {
+        $traceableEventDispatcher->addListener(BeforeRecoverEventInterface::class, function (BeforeRecoverEventInterface $event) use ($eventLocation) {
             $event->setLocation($eventLocation);
             $event->stopPropagation();
         }, 10);
@@ -316,19 +312,19 @@ class TrashServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLocation, $result);
         $this->assertSame($calledListeners, [
-            [BeforeRecoverEvent::class, 10],
+            [BeforeRecoverEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeRecoverEvent::class, 0],
-            [RecoverEvent::class, 0],
+            [BeforeRecoverEventInterface::class, 0],
+            [RecoverEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteTrashItemEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteTrashItemEvent::class,
-            DeleteTrashItemEvent::class
+            BeforeDeleteTrashItemEventInterface::class,
+            DeleteTrashItemEventInterface::class
         );
 
         $parameters = [
@@ -346,8 +342,8 @@ class TrashServiceTest extends AbstractServiceTest
 
         $this->assertSame($result, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDeleteTrashItemEvent::class, 0],
-            [DeleteTrashItemEvent::class, 0],
+            [BeforeDeleteTrashItemEventInterface::class, 0],
+            [DeleteTrashItemEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -355,8 +351,8 @@ class TrashServiceTest extends AbstractServiceTest
     public function testReturnDeleteTrashItemResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteTrashItemEvent::class,
-            DeleteTrashItemEvent::class
+            BeforeDeleteTrashItemEventInterface::class,
+            DeleteTrashItemEventInterface::class
         );
 
         $parameters = [
@@ -368,7 +364,7 @@ class TrashServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(TrashServiceInterface::class);
         $innerServiceMock->method('deleteTrashItem')->willReturn($result);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteTrashItemEvent::class, function (BeforeDeleteTrashItemEventInterface $event) use ($eventResult) {
+        $traceableEventDispatcher->addListener(BeforeDeleteTrashItemEventInterface::class, function (BeforeDeleteTrashItemEventInterface $event) use ($eventResult) {
             $event->setResult($eventResult);
         }, 10);
 
@@ -379,9 +375,9 @@ class TrashServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventResult, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDeleteTrashItemEvent::class, 10],
-            [BeforeDeleteTrashItemEvent::class, 0],
-            [DeleteTrashItemEvent::class, 0],
+            [BeforeDeleteTrashItemEventInterface::class, 10],
+            [BeforeDeleteTrashItemEventInterface::class, 0],
+            [DeleteTrashItemEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -389,8 +385,8 @@ class TrashServiceTest extends AbstractServiceTest
     public function testDeleteTrashItemStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteTrashItemEvent::class,
-            DeleteTrashItemEvent::class
+            BeforeDeleteTrashItemEventInterface::class,
+            DeleteTrashItemEventInterface::class
         );
 
         $parameters = [
@@ -402,7 +398,7 @@ class TrashServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(TrashServiceInterface::class);
         $innerServiceMock->method('deleteTrashItem')->willReturn($result);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteTrashItemEvent::class, function (BeforeDeleteTrashItemEventInterface $event) use ($eventResult) {
+        $traceableEventDispatcher->addListener(BeforeDeleteTrashItemEventInterface::class, function (BeforeDeleteTrashItemEventInterface $event) use ($eventResult) {
             $event->setResult($eventResult);
             $event->stopPropagation();
         }, 10);
@@ -415,11 +411,11 @@ class TrashServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventResult, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDeleteTrashItemEvent::class, 10],
+            [BeforeDeleteTrashItemEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteTrashItemEvent::class, 0],
-            [DeleteTrashItemEvent::class, 0],
+            [BeforeDeleteTrashItemEventInterface::class, 0],
+            [DeleteTrashItemEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/URLAliasServiceTest.php
@@ -10,17 +10,13 @@ use eZ\Publish\API\Repository\Events\URLAlias\BeforeCreateGlobalUrlAliasEvent as
 use eZ\Publish\API\Repository\Events\URLAlias\BeforeCreateUrlAliasEvent as BeforeCreateUrlAliasEventInterface;
 use eZ\Publish\API\Repository\Events\URLAlias\BeforeRefreshSystemUrlAliasesForLocationEvent as BeforeRefreshSystemUrlAliasesForLocationEventInterface;
 use eZ\Publish\API\Repository\Events\URLAlias\BeforeRemoveAliasesEvent as BeforeRemoveAliasesEventInterface;
+use eZ\Publish\API\Repository\Events\URLAlias\CreateGlobalUrlAliasEvent as CreateGlobalUrlAliasEventInterface;
+use eZ\Publish\API\Repository\Events\URLAlias\CreateUrlAliasEvent as CreateUrlAliasEventInterface;
+use eZ\Publish\API\Repository\Events\URLAlias\RefreshSystemUrlAliasesForLocationEvent as RefreshSystemUrlAliasesForLocationEventInterface;
+use eZ\Publish\API\Repository\Events\URLAlias\RemoveAliasesEvent as RemoveAliasesEventInterface;
 use eZ\Publish\API\Repository\URLAliasService as URLAliasServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
-use eZ\Publish\Core\Event\URLAlias\BeforeCreateGlobalUrlAliasEvent;
-use eZ\Publish\Core\Event\URLAlias\BeforeCreateUrlAliasEvent;
-use eZ\Publish\Core\Event\URLAlias\BeforeRefreshSystemUrlAliasesForLocationEvent;
-use eZ\Publish\Core\Event\URLAlias\BeforeRemoveAliasesEvent;
-use eZ\Publish\Core\Event\URLAlias\CreateGlobalUrlAliasEvent;
-use eZ\Publish\Core\Event\URLAlias\CreateUrlAliasEvent;
-use eZ\Publish\Core\Event\URLAlias\RefreshSystemUrlAliasesForLocationEvent;
-use eZ\Publish\Core\Event\URLAlias\RemoveAliasesEvent;
 use eZ\Publish\Core\Event\URLAliasService;
 
 class URLAliasServiceTest extends AbstractServiceTest
@@ -28,8 +24,8 @@ class URLAliasServiceTest extends AbstractServiceTest
     public function testCreateGlobalUrlAliasEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateGlobalUrlAliasEvent::class,
-            CreateGlobalUrlAliasEvent::class
+            BeforeCreateGlobalUrlAliasEventInterface::class,
+            CreateGlobalUrlAliasEventInterface::class
         );
 
         $parameters = [
@@ -51,8 +47,8 @@ class URLAliasServiceTest extends AbstractServiceTest
 
         $this->assertSame($urlAlias, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateGlobalUrlAliasEvent::class, 0],
-            [CreateGlobalUrlAliasEvent::class, 0],
+            [BeforeCreateGlobalUrlAliasEventInterface::class, 0],
+            [CreateGlobalUrlAliasEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -60,8 +56,8 @@ class URLAliasServiceTest extends AbstractServiceTest
     public function testReturnCreateGlobalUrlAliasResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateGlobalUrlAliasEvent::class,
-            CreateGlobalUrlAliasEvent::class
+            BeforeCreateGlobalUrlAliasEventInterface::class,
+            CreateGlobalUrlAliasEventInterface::class
         );
 
         $parameters = [
@@ -77,7 +73,7 @@ class URLAliasServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(URLAliasServiceInterface::class);
         $innerServiceMock->method('createGlobalUrlAlias')->willReturn($urlAlias);
 
-        $traceableEventDispatcher->addListener(BeforeCreateGlobalUrlAliasEvent::class, function (BeforeCreateGlobalUrlAliasEventInterface $event) use ($eventUrlAlias) {
+        $traceableEventDispatcher->addListener(BeforeCreateGlobalUrlAliasEventInterface::class, function (BeforeCreateGlobalUrlAliasEventInterface $event) use ($eventUrlAlias) {
             $event->setUrlAlias($eventUrlAlias);
         }, 10);
 
@@ -88,9 +84,9 @@ class URLAliasServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUrlAlias, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateGlobalUrlAliasEvent::class, 10],
-            [BeforeCreateGlobalUrlAliasEvent::class, 0],
-            [CreateGlobalUrlAliasEvent::class, 0],
+            [BeforeCreateGlobalUrlAliasEventInterface::class, 10],
+            [BeforeCreateGlobalUrlAliasEventInterface::class, 0],
+            [CreateGlobalUrlAliasEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -98,8 +94,8 @@ class URLAliasServiceTest extends AbstractServiceTest
     public function testCreateGlobalUrlAliasStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateGlobalUrlAliasEvent::class,
-            CreateGlobalUrlAliasEvent::class
+            BeforeCreateGlobalUrlAliasEventInterface::class,
+            CreateGlobalUrlAliasEventInterface::class
         );
 
         $parameters = [
@@ -115,7 +111,7 @@ class URLAliasServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(URLAliasServiceInterface::class);
         $innerServiceMock->method('createGlobalUrlAlias')->willReturn($urlAlias);
 
-        $traceableEventDispatcher->addListener(BeforeCreateGlobalUrlAliasEvent::class, function (BeforeCreateGlobalUrlAliasEventInterface $event) use ($eventUrlAlias) {
+        $traceableEventDispatcher->addListener(BeforeCreateGlobalUrlAliasEventInterface::class, function (BeforeCreateGlobalUrlAliasEventInterface $event) use ($eventUrlAlias) {
             $event->setUrlAlias($eventUrlAlias);
             $event->stopPropagation();
         }, 10);
@@ -128,19 +124,19 @@ class URLAliasServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUrlAlias, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateGlobalUrlAliasEvent::class, 10],
+            [BeforeCreateGlobalUrlAliasEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateGlobalUrlAliasEvent::class, 0],
-            [CreateGlobalUrlAliasEvent::class, 0],
+            [BeforeCreateGlobalUrlAliasEventInterface::class, 0],
+            [CreateGlobalUrlAliasEventInterface::class, 0],
         ]);
     }
 
     public function testRefreshSystemUrlAliasesForLocationEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRefreshSystemUrlAliasesForLocationEvent::class,
-            RefreshSystemUrlAliasesForLocationEvent::class
+            BeforeRefreshSystemUrlAliasesForLocationEventInterface::class,
+            RefreshSystemUrlAliasesForLocationEventInterface::class
         );
 
         $parameters = [
@@ -155,8 +151,8 @@ class URLAliasServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeRefreshSystemUrlAliasesForLocationEvent::class, 0],
-            [RefreshSystemUrlAliasesForLocationEvent::class, 0],
+            [BeforeRefreshSystemUrlAliasesForLocationEventInterface::class, 0],
+            [RefreshSystemUrlAliasesForLocationEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -164,8 +160,8 @@ class URLAliasServiceTest extends AbstractServiceTest
     public function testRefreshSystemUrlAliasesForLocationStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRefreshSystemUrlAliasesForLocationEvent::class,
-            RefreshSystemUrlAliasesForLocationEvent::class
+            BeforeRefreshSystemUrlAliasesForLocationEventInterface::class,
+            RefreshSystemUrlAliasesForLocationEventInterface::class
         );
 
         $parameters = [
@@ -174,7 +170,7 @@ class URLAliasServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(URLAliasServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeRefreshSystemUrlAliasesForLocationEvent::class, function (BeforeRefreshSystemUrlAliasesForLocationEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeRefreshSystemUrlAliasesForLocationEventInterface::class, function (BeforeRefreshSystemUrlAliasesForLocationEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -185,19 +181,19 @@ class URLAliasServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeRefreshSystemUrlAliasesForLocationEvent::class, 10],
+            [BeforeRefreshSystemUrlAliasesForLocationEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeRefreshSystemUrlAliasesForLocationEvent::class, 0],
-            [RefreshSystemUrlAliasesForLocationEvent::class, 0],
+            [BeforeRefreshSystemUrlAliasesForLocationEventInterface::class, 0],
+            [RefreshSystemUrlAliasesForLocationEventInterface::class, 0],
         ]);
     }
 
     public function testCreateUrlAliasEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateUrlAliasEvent::class,
-            CreateUrlAliasEvent::class
+            BeforeCreateUrlAliasEventInterface::class,
+            CreateUrlAliasEventInterface::class
         );
 
         $parameters = [
@@ -219,8 +215,8 @@ class URLAliasServiceTest extends AbstractServiceTest
 
         $this->assertSame($urlAlias, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateUrlAliasEvent::class, 0],
-            [CreateUrlAliasEvent::class, 0],
+            [BeforeCreateUrlAliasEventInterface::class, 0],
+            [CreateUrlAliasEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -228,8 +224,8 @@ class URLAliasServiceTest extends AbstractServiceTest
     public function testReturnCreateUrlAliasResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateUrlAliasEvent::class,
-            CreateUrlAliasEvent::class
+            BeforeCreateUrlAliasEventInterface::class,
+            CreateUrlAliasEventInterface::class
         );
 
         $parameters = [
@@ -245,7 +241,7 @@ class URLAliasServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(URLAliasServiceInterface::class);
         $innerServiceMock->method('createUrlAlias')->willReturn($urlAlias);
 
-        $traceableEventDispatcher->addListener(BeforeCreateUrlAliasEvent::class, function (BeforeCreateUrlAliasEventInterface $event) use ($eventUrlAlias) {
+        $traceableEventDispatcher->addListener(BeforeCreateUrlAliasEventInterface::class, function (BeforeCreateUrlAliasEventInterface $event) use ($eventUrlAlias) {
             $event->setUrlAlias($eventUrlAlias);
         }, 10);
 
@@ -256,9 +252,9 @@ class URLAliasServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUrlAlias, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateUrlAliasEvent::class, 10],
-            [BeforeCreateUrlAliasEvent::class, 0],
-            [CreateUrlAliasEvent::class, 0],
+            [BeforeCreateUrlAliasEventInterface::class, 10],
+            [BeforeCreateUrlAliasEventInterface::class, 0],
+            [CreateUrlAliasEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -266,8 +262,8 @@ class URLAliasServiceTest extends AbstractServiceTest
     public function testCreateUrlAliasStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateUrlAliasEvent::class,
-            CreateUrlAliasEvent::class
+            BeforeCreateUrlAliasEventInterface::class,
+            CreateUrlAliasEventInterface::class
         );
 
         $parameters = [
@@ -283,7 +279,7 @@ class URLAliasServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(URLAliasServiceInterface::class);
         $innerServiceMock->method('createUrlAlias')->willReturn($urlAlias);
 
-        $traceableEventDispatcher->addListener(BeforeCreateUrlAliasEvent::class, function (BeforeCreateUrlAliasEventInterface $event) use ($eventUrlAlias) {
+        $traceableEventDispatcher->addListener(BeforeCreateUrlAliasEventInterface::class, function (BeforeCreateUrlAliasEventInterface $event) use ($eventUrlAlias) {
             $event->setUrlAlias($eventUrlAlias);
             $event->stopPropagation();
         }, 10);
@@ -296,19 +292,19 @@ class URLAliasServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUrlAlias, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateUrlAliasEvent::class, 10],
+            [BeforeCreateUrlAliasEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateUrlAliasEvent::class, 0],
-            [CreateUrlAliasEvent::class, 0],
+            [BeforeCreateUrlAliasEventInterface::class, 0],
+            [CreateUrlAliasEventInterface::class, 0],
         ]);
     }
 
     public function testRemoveAliasesEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemoveAliasesEvent::class,
-            RemoveAliasesEvent::class
+            BeforeRemoveAliasesEventInterface::class,
+            RemoveAliasesEventInterface::class
         );
 
         $parameters = [
@@ -323,8 +319,8 @@ class URLAliasServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeRemoveAliasesEvent::class, 0],
-            [RemoveAliasesEvent::class, 0],
+            [BeforeRemoveAliasesEventInterface::class, 0],
+            [RemoveAliasesEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -332,8 +328,8 @@ class URLAliasServiceTest extends AbstractServiceTest
     public function testRemoveAliasesStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemoveAliasesEvent::class,
-            RemoveAliasesEvent::class
+            BeforeRemoveAliasesEventInterface::class,
+            RemoveAliasesEventInterface::class
         );
 
         $parameters = [
@@ -342,7 +338,7 @@ class URLAliasServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(URLAliasServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeRemoveAliasesEvent::class, function (BeforeRemoveAliasesEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeRemoveAliasesEventInterface::class, function (BeforeRemoveAliasesEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -353,11 +349,11 @@ class URLAliasServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeRemoveAliasesEvent::class, 10],
+            [BeforeRemoveAliasesEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeRemoveAliasesEvent::class, 0],
-            [RemoveAliasesEvent::class, 0],
+            [BeforeRemoveAliasesEventInterface::class, 0],
+            [RemoveAliasesEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/URLServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/URLServiceTest.php
@@ -7,11 +7,10 @@
 namespace eZ\Publish\Core\Event\Tests;
 
 use eZ\Publish\API\Repository\Events\URL\BeforeUpdateUrlEvent as BeforeUpdateUrlEventInterface;
+use eZ\Publish\API\Repository\Events\URL\UpdateUrlEvent as UpdateUrlEventInterface;
 use eZ\Publish\API\Repository\URLService as URLServiceInterface;
 use eZ\Publish\API\Repository\Values\URL\URL;
 use eZ\Publish\API\Repository\Values\URL\URLUpdateStruct;
-use eZ\Publish\Core\Event\URL\BeforeUpdateUrlEvent;
-use eZ\Publish\Core\Event\URL\UpdateUrlEvent;
 use eZ\Publish\Core\Event\URLService;
 
 class URLServiceTest extends AbstractServiceTest
@@ -19,8 +18,8 @@ class URLServiceTest extends AbstractServiceTest
     public function testUpdateUrlEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateUrlEvent::class,
-            UpdateUrlEvent::class
+            BeforeUpdateUrlEventInterface::class,
+            UpdateUrlEventInterface::class
         );
 
         $parameters = [
@@ -39,8 +38,8 @@ class URLServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedUrl, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateUrlEvent::class, 0],
-            [UpdateUrlEvent::class, 0],
+            [BeforeUpdateUrlEventInterface::class, 0],
+            [UpdateUrlEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -48,8 +47,8 @@ class URLServiceTest extends AbstractServiceTest
     public function testReturnUpdateUrlResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateUrlEvent::class,
-            UpdateUrlEvent::class
+            BeforeUpdateUrlEventInterface::class,
+            UpdateUrlEventInterface::class
         );
 
         $parameters = [
@@ -62,7 +61,7 @@ class URLServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(URLServiceInterface::class);
         $innerServiceMock->method('updateUrl')->willReturn($updatedUrl);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateUrlEvent::class, function (BeforeUpdateUrlEventInterface $event) use ($eventUpdatedUrl) {
+        $traceableEventDispatcher->addListener(BeforeUpdateUrlEventInterface::class, function (BeforeUpdateUrlEventInterface $event) use ($eventUpdatedUrl) {
             $event->setUpdatedUrl($eventUpdatedUrl);
         }, 10);
 
@@ -73,9 +72,9 @@ class URLServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedUrl, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateUrlEvent::class, 10],
-            [BeforeUpdateUrlEvent::class, 0],
-            [UpdateUrlEvent::class, 0],
+            [BeforeUpdateUrlEventInterface::class, 10],
+            [BeforeUpdateUrlEventInterface::class, 0],
+            [UpdateUrlEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -83,8 +82,8 @@ class URLServiceTest extends AbstractServiceTest
     public function testUpdateUrlStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateUrlEvent::class,
-            UpdateUrlEvent::class
+            BeforeUpdateUrlEventInterface::class,
+            UpdateUrlEventInterface::class
         );
 
         $parameters = [
@@ -97,7 +96,7 @@ class URLServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(URLServiceInterface::class);
         $innerServiceMock->method('updateUrl')->willReturn($updatedUrl);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateUrlEvent::class, function (BeforeUpdateUrlEventInterface $event) use ($eventUpdatedUrl) {
+        $traceableEventDispatcher->addListener(BeforeUpdateUrlEventInterface::class, function (BeforeUpdateUrlEventInterface $event) use ($eventUpdatedUrl) {
             $event->setUpdatedUrl($eventUpdatedUrl);
             $event->stopPropagation();
         }, 10);
@@ -110,11 +109,11 @@ class URLServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedUrl, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateUrlEvent::class, 10],
+            [BeforeUpdateUrlEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateUrlEvent::class, 0],
-            [UpdateUrlEvent::class, 0],
+            [BeforeUpdateUrlEventInterface::class, 0],
+            [UpdateUrlEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/URLWildcardServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/URLWildcardServiceTest.php
@@ -9,15 +9,12 @@ namespace eZ\Publish\Core\Event\Tests;
 use eZ\Publish\API\Repository\Events\URLWildcard\BeforeCreateEvent as BeforeCreateEventInterface;
 use eZ\Publish\API\Repository\Events\URLWildcard\BeforeRemoveEvent as BeforeRemoveEventInterface;
 use eZ\Publish\API\Repository\Events\URLWildcard\BeforeTranslateEvent as BeforeTranslateEventInterface;
+use eZ\Publish\API\Repository\Events\URLWildcard\CreateEvent as CreateEventInterface;
+use eZ\Publish\API\Repository\Events\URLWildcard\RemoveEvent as RemoveEventInterface;
+use eZ\Publish\API\Repository\Events\URLWildcard\TranslateEvent as TranslateEventInterface;
 use eZ\Publish\API\Repository\URLWildcardService as URLWildcardServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\URLWildcard;
 use eZ\Publish\API\Repository\Values\Content\URLWildcardTranslationResult;
-use eZ\Publish\Core\Event\URLWildcard\BeforeCreateEvent;
-use eZ\Publish\Core\Event\URLWildcard\BeforeRemoveEvent;
-use eZ\Publish\Core\Event\URLWildcard\BeforeTranslateEvent;
-use eZ\Publish\Core\Event\URLWildcard\CreateEvent;
-use eZ\Publish\Core\Event\URLWildcard\RemoveEvent;
-use eZ\Publish\Core\Event\URLWildcard\TranslateEvent;
 use eZ\Publish\Core\Event\URLWildcardService;
 
 class URLWildcardServiceTest extends AbstractServiceTest
@@ -25,8 +22,8 @@ class URLWildcardServiceTest extends AbstractServiceTest
     public function testRemoveEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemoveEvent::class,
-            RemoveEvent::class
+            BeforeRemoveEventInterface::class,
+            RemoveEventInterface::class
         );
 
         $parameters = [
@@ -41,8 +38,8 @@ class URLWildcardServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeRemoveEvent::class, 0],
-            [RemoveEvent::class, 0],
+            [BeforeRemoveEventInterface::class, 0],
+            [RemoveEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -50,8 +47,8 @@ class URLWildcardServiceTest extends AbstractServiceTest
     public function testRemoveStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeRemoveEvent::class,
-            RemoveEvent::class
+            BeforeRemoveEventInterface::class,
+            RemoveEventInterface::class
         );
 
         $parameters = [
@@ -60,7 +57,7 @@ class URLWildcardServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(URLWildcardServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeRemoveEvent::class, function (BeforeRemoveEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeRemoveEventInterface::class, function (BeforeRemoveEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -71,19 +68,19 @@ class URLWildcardServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeRemoveEvent::class, 10],
+            [BeforeRemoveEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeRemoveEvent::class, 0],
-            [RemoveEvent::class, 0],
+            [BeforeRemoveEventInterface::class, 0],
+            [RemoveEventInterface::class, 0],
         ]);
     }
 
     public function testCreateEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateEvent::class,
-            CreateEvent::class
+            BeforeCreateEventInterface::class,
+            CreateEventInterface::class
         );
 
         $parameters = [
@@ -103,8 +100,8 @@ class URLWildcardServiceTest extends AbstractServiceTest
 
         $this->assertSame($urlWildcard, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateEvent::class, 0],
-            [CreateEvent::class, 0],
+            [BeforeCreateEventInterface::class, 0],
+            [CreateEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -112,8 +109,8 @@ class URLWildcardServiceTest extends AbstractServiceTest
     public function testReturnCreateResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateEvent::class,
-            CreateEvent::class
+            BeforeCreateEventInterface::class,
+            CreateEventInterface::class
         );
 
         $parameters = [
@@ -127,7 +124,7 @@ class URLWildcardServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(URLWildcardServiceInterface::class);
         $innerServiceMock->method('create')->willReturn($urlWildcard);
 
-        $traceableEventDispatcher->addListener(BeforeCreateEvent::class, function (BeforeCreateEventInterface $event) use ($eventUrlWildcard) {
+        $traceableEventDispatcher->addListener(BeforeCreateEventInterface::class, function (BeforeCreateEventInterface $event) use ($eventUrlWildcard) {
             $event->setUrlWildcard($eventUrlWildcard);
         }, 10);
 
@@ -138,9 +135,9 @@ class URLWildcardServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUrlWildcard, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateEvent::class, 10],
-            [BeforeCreateEvent::class, 0],
-            [CreateEvent::class, 0],
+            [BeforeCreateEventInterface::class, 10],
+            [BeforeCreateEventInterface::class, 0],
+            [CreateEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -148,8 +145,8 @@ class URLWildcardServiceTest extends AbstractServiceTest
     public function testCreateStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateEvent::class,
-            CreateEvent::class
+            BeforeCreateEventInterface::class,
+            CreateEventInterface::class
         );
 
         $parameters = [
@@ -163,7 +160,7 @@ class URLWildcardServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(URLWildcardServiceInterface::class);
         $innerServiceMock->method('create')->willReturn($urlWildcard);
 
-        $traceableEventDispatcher->addListener(BeforeCreateEvent::class, function (BeforeCreateEventInterface $event) use ($eventUrlWildcard) {
+        $traceableEventDispatcher->addListener(BeforeCreateEventInterface::class, function (BeforeCreateEventInterface $event) use ($eventUrlWildcard) {
             $event->setUrlWildcard($eventUrlWildcard);
             $event->stopPropagation();
         }, 10);
@@ -176,19 +173,19 @@ class URLWildcardServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUrlWildcard, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateEvent::class, 10],
+            [BeforeCreateEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateEvent::class, 0],
-            [CreateEvent::class, 0],
+            [BeforeCreateEventInterface::class, 0],
+            [CreateEventInterface::class, 0],
         ]);
     }
 
     public function testTranslateEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeTranslateEvent::class,
-            TranslateEvent::class
+            BeforeTranslateEventInterface::class,
+            TranslateEventInterface::class
         );
 
         $parameters = [
@@ -206,8 +203,8 @@ class URLWildcardServiceTest extends AbstractServiceTest
 
         $this->assertSame($result, $result);
         $this->assertSame($calledListeners, [
-            [BeforeTranslateEvent::class, 0],
-            [TranslateEvent::class, 0],
+            [BeforeTranslateEventInterface::class, 0],
+            [TranslateEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -215,8 +212,8 @@ class URLWildcardServiceTest extends AbstractServiceTest
     public function testReturnTranslateResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeTranslateEvent::class,
-            TranslateEvent::class
+            BeforeTranslateEventInterface::class,
+            TranslateEventInterface::class
         );
 
         $parameters = [
@@ -228,7 +225,7 @@ class URLWildcardServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(URLWildcardServiceInterface::class);
         $innerServiceMock->method('translate')->willReturn($result);
 
-        $traceableEventDispatcher->addListener(BeforeTranslateEvent::class, function (BeforeTranslateEventInterface $event) use ($eventResult) {
+        $traceableEventDispatcher->addListener(BeforeTranslateEventInterface::class, function (BeforeTranslateEventInterface $event) use ($eventResult) {
             $event->setResult($eventResult);
         }, 10);
 
@@ -239,9 +236,9 @@ class URLWildcardServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventResult, $result);
         $this->assertSame($calledListeners, [
-            [BeforeTranslateEvent::class, 10],
-            [BeforeTranslateEvent::class, 0],
-            [TranslateEvent::class, 0],
+            [BeforeTranslateEventInterface::class, 10],
+            [BeforeTranslateEventInterface::class, 0],
+            [TranslateEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -249,8 +246,8 @@ class URLWildcardServiceTest extends AbstractServiceTest
     public function testTranslateStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeTranslateEvent::class,
-            TranslateEvent::class
+            BeforeTranslateEventInterface::class,
+            TranslateEventInterface::class
         );
 
         $parameters = [
@@ -262,7 +259,7 @@ class URLWildcardServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(URLWildcardServiceInterface::class);
         $innerServiceMock->method('translate')->willReturn($result);
 
-        $traceableEventDispatcher->addListener(BeforeTranslateEvent::class, function (BeforeTranslateEventInterface $event) use ($eventResult) {
+        $traceableEventDispatcher->addListener(BeforeTranslateEventInterface::class, function (BeforeTranslateEventInterface $event) use ($eventResult) {
             $event->setResult($eventResult);
             $event->stopPropagation();
         }, 10);
@@ -275,11 +272,11 @@ class URLWildcardServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventResult, $result);
         $this->assertSame($calledListeners, [
-            [BeforeTranslateEvent::class, 10],
+            [BeforeTranslateEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeTranslateEvent::class, 0],
-            [TranslateEvent::class, 0],
+            [BeforeTranslateEventInterface::class, 0],
+            [TranslateEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/UserPreferenceServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/UserPreferenceServiceTest.php
@@ -7,9 +7,8 @@
 namespace eZ\Publish\Core\Event\Tests;
 
 use eZ\Publish\API\Repository\Events\UserPreference\BeforeSetUserPreferenceEvent as BeforeSetUserPreferenceEventInterface;
+use eZ\Publish\API\Repository\Events\UserPreference\SetUserPreferenceEvent as SetUserPreferenceEventInterface;
 use eZ\Publish\API\Repository\UserPreferenceService as UserPreferenceServiceInterface;
-use eZ\Publish\Core\Event\UserPreference\BeforeSetUserPreferenceEvent;
-use eZ\Publish\Core\Event\UserPreference\SetUserPreferenceEvent;
 use eZ\Publish\Core\Event\UserPreferenceService;
 
 class UserPreferenceServiceTest extends AbstractServiceTest
@@ -17,8 +16,8 @@ class UserPreferenceServiceTest extends AbstractServiceTest
     public function testSetUserPreferenceEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeSetUserPreferenceEvent::class,
-            SetUserPreferenceEvent::class
+            BeforeSetUserPreferenceEventInterface::class,
+            SetUserPreferenceEventInterface::class
         );
 
         $parameters = [
@@ -33,8 +32,8 @@ class UserPreferenceServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeSetUserPreferenceEvent::class, 0],
-            [SetUserPreferenceEvent::class, 0],
+            [BeforeSetUserPreferenceEventInterface::class, 0],
+            [SetUserPreferenceEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -42,8 +41,8 @@ class UserPreferenceServiceTest extends AbstractServiceTest
     public function testSetUserPreferenceStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeSetUserPreferenceEvent::class,
-            SetUserPreferenceEvent::class
+            BeforeSetUserPreferenceEventInterface::class,
+            SetUserPreferenceEventInterface::class
         );
 
         $parameters = [
@@ -52,7 +51,7 @@ class UserPreferenceServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(UserPreferenceServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeSetUserPreferenceEvent::class, function (BeforeSetUserPreferenceEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeSetUserPreferenceEventInterface::class, function (BeforeSetUserPreferenceEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -63,11 +62,11 @@ class UserPreferenceServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeSetUserPreferenceEvent::class, 10],
+            [BeforeSetUserPreferenceEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeSetUserPreferenceEvent::class, 0],
-            [SetUserPreferenceEvent::class, 0],
+            [BeforeSetUserPreferenceEventInterface::class, 0],
+            [SetUserPreferenceEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/UserServiceTest.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\Event\Tests;
 
+use eZ\Publish\API\Repository\Events\User\AssignUserToUserGroupEvent as AssignUserToUserGroupEventInterface;
 use eZ\Publish\API\Repository\Events\User\BeforeAssignUserToUserGroupEvent as BeforeAssignUserToUserGroupEventInterface;
 use eZ\Publish\API\Repository\Events\User\BeforeCreateUserEvent as BeforeCreateUserEventInterface;
 use eZ\Publish\API\Repository\Events\User\BeforeCreateUserGroupEvent as BeforeCreateUserGroupEventInterface;
@@ -16,6 +17,15 @@ use eZ\Publish\API\Repository\Events\User\BeforeUnAssignUserFromUserGroupEvent a
 use eZ\Publish\API\Repository\Events\User\BeforeUpdateUserEvent as BeforeUpdateUserEventInterface;
 use eZ\Publish\API\Repository\Events\User\BeforeUpdateUserGroupEvent as BeforeUpdateUserGroupEventInterface;
 use eZ\Publish\API\Repository\Events\User\BeforeUpdateUserTokenEvent as BeforeUpdateUserTokenEventInterface;
+use eZ\Publish\API\Repository\Events\User\CreateUserEvent as CreateUserEventInterface;
+use eZ\Publish\API\Repository\Events\User\CreateUserGroupEvent as CreateUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\DeleteUserEvent as DeleteUserEventInterface;
+use eZ\Publish\API\Repository\Events\User\DeleteUserGroupEvent as DeleteUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\MoveUserGroupEvent as MoveUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\UnAssignUserFromUserGroupEvent as UnAssignUserFromUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\UpdateUserEvent as UpdateUserEventInterface;
+use eZ\Publish\API\Repository\Events\User\UpdateUserGroupEvent as UpdateUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\UpdateUserTokenEvent as UpdateUserTokenEventInterface;
 use eZ\Publish\API\Repository\UserService as UserServiceInterface;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserCreateStruct;
@@ -24,26 +34,6 @@ use eZ\Publish\API\Repository\Values\User\UserGroupCreateStruct;
 use eZ\Publish\API\Repository\Values\User\UserGroupUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\UserTokenUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\UserUpdateStruct;
-use eZ\Publish\Core\Event\User\AssignUserToUserGroupEvent;
-use eZ\Publish\Core\Event\User\BeforeAssignUserToUserGroupEvent;
-use eZ\Publish\Core\Event\User\BeforeCreateUserEvent;
-use eZ\Publish\Core\Event\User\BeforeCreateUserGroupEvent;
-use eZ\Publish\Core\Event\User\BeforeDeleteUserEvent;
-use eZ\Publish\Core\Event\User\BeforeDeleteUserGroupEvent;
-use eZ\Publish\Core\Event\User\BeforeMoveUserGroupEvent;
-use eZ\Publish\Core\Event\User\BeforeUnAssignUserFromUserGroupEvent;
-use eZ\Publish\Core\Event\User\BeforeUpdateUserEvent;
-use eZ\Publish\Core\Event\User\BeforeUpdateUserGroupEvent;
-use eZ\Publish\Core\Event\User\BeforeUpdateUserTokenEvent;
-use eZ\Publish\Core\Event\User\CreateUserEvent;
-use eZ\Publish\Core\Event\User\CreateUserGroupEvent;
-use eZ\Publish\Core\Event\User\DeleteUserEvent;
-use eZ\Publish\Core\Event\User\DeleteUserGroupEvent;
-use eZ\Publish\Core\Event\User\MoveUserGroupEvent;
-use eZ\Publish\Core\Event\User\UnAssignUserFromUserGroupEvent;
-use eZ\Publish\Core\Event\User\UpdateUserEvent;
-use eZ\Publish\Core\Event\User\UpdateUserGroupEvent;
-use eZ\Publish\Core\Event\User\UpdateUserTokenEvent;
 use eZ\Publish\Core\Event\UserService;
 
 class UserServiceTest extends AbstractServiceTest
@@ -51,8 +41,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testUpdateUserGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateUserGroupEvent::class,
-            UpdateUserGroupEvent::class
+            BeforeUpdateUserGroupEventInterface::class,
+            UpdateUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -71,8 +61,8 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedUserGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateUserGroupEvent::class, 0],
-            [UpdateUserGroupEvent::class, 0],
+            [BeforeUpdateUserGroupEventInterface::class, 0],
+            [UpdateUserGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -80,8 +70,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testReturnUpdateUserGroupResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateUserGroupEvent::class,
-            UpdateUserGroupEvent::class
+            BeforeUpdateUserGroupEventInterface::class,
+            UpdateUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -94,7 +84,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('updateUserGroup')->willReturn($updatedUserGroup);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateUserGroupEvent::class, function (BeforeUpdateUserGroupEventInterface $event) use ($eventUpdatedUserGroup) {
+        $traceableEventDispatcher->addListener(BeforeUpdateUserGroupEventInterface::class, function (BeforeUpdateUserGroupEventInterface $event) use ($eventUpdatedUserGroup) {
             $event->setUpdatedUserGroup($eventUpdatedUserGroup);
         }, 10);
 
@@ -105,9 +95,9 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedUserGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateUserGroupEvent::class, 10],
-            [BeforeUpdateUserGroupEvent::class, 0],
-            [UpdateUserGroupEvent::class, 0],
+            [BeforeUpdateUserGroupEventInterface::class, 10],
+            [BeforeUpdateUserGroupEventInterface::class, 0],
+            [UpdateUserGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -115,8 +105,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testUpdateUserGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateUserGroupEvent::class,
-            UpdateUserGroupEvent::class
+            BeforeUpdateUserGroupEventInterface::class,
+            UpdateUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -129,7 +119,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('updateUserGroup')->willReturn($updatedUserGroup);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateUserGroupEvent::class, function (BeforeUpdateUserGroupEventInterface $event) use ($eventUpdatedUserGroup) {
+        $traceableEventDispatcher->addListener(BeforeUpdateUserGroupEventInterface::class, function (BeforeUpdateUserGroupEventInterface $event) use ($eventUpdatedUserGroup) {
             $event->setUpdatedUserGroup($eventUpdatedUserGroup);
             $event->stopPropagation();
         }, 10);
@@ -142,19 +132,19 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedUserGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateUserGroupEvent::class, 10],
+            [BeforeUpdateUserGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateUserGroupEvent::class, 0],
-            [UpdateUserGroupEvent::class, 0],
+            [BeforeUpdateUserGroupEventInterface::class, 0],
+            [UpdateUserGroupEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateUserEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateUserEvent::class,
-            UpdateUserEvent::class
+            BeforeUpdateUserEventInterface::class,
+            UpdateUserEventInterface::class
         );
 
         $parameters = [
@@ -173,8 +163,8 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedUser, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateUserEvent::class, 0],
-            [UpdateUserEvent::class, 0],
+            [BeforeUpdateUserEventInterface::class, 0],
+            [UpdateUserEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -182,8 +172,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testReturnUpdateUserResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateUserEvent::class,
-            UpdateUserEvent::class
+            BeforeUpdateUserEventInterface::class,
+            UpdateUserEventInterface::class
         );
 
         $parameters = [
@@ -196,7 +186,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('updateUser')->willReturn($updatedUser);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateUserEvent::class, function (BeforeUpdateUserEventInterface $event) use ($eventUpdatedUser) {
+        $traceableEventDispatcher->addListener(BeforeUpdateUserEventInterface::class, function (BeforeUpdateUserEventInterface $event) use ($eventUpdatedUser) {
             $event->setUpdatedUser($eventUpdatedUser);
         }, 10);
 
@@ -207,9 +197,9 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedUser, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateUserEvent::class, 10],
-            [BeforeUpdateUserEvent::class, 0],
-            [UpdateUserEvent::class, 0],
+            [BeforeUpdateUserEventInterface::class, 10],
+            [BeforeUpdateUserEventInterface::class, 0],
+            [UpdateUserEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -217,8 +207,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testUpdateUserStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateUserEvent::class,
-            UpdateUserEvent::class
+            BeforeUpdateUserEventInterface::class,
+            UpdateUserEventInterface::class
         );
 
         $parameters = [
@@ -231,7 +221,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('updateUser')->willReturn($updatedUser);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateUserEvent::class, function (BeforeUpdateUserEventInterface $event) use ($eventUpdatedUser) {
+        $traceableEventDispatcher->addListener(BeforeUpdateUserEventInterface::class, function (BeforeUpdateUserEventInterface $event) use ($eventUpdatedUser) {
             $event->setUpdatedUser($eventUpdatedUser);
             $event->stopPropagation();
         }, 10);
@@ -244,19 +234,19 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedUser, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateUserEvent::class, 10],
+            [BeforeUpdateUserEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateUserEvent::class, 0],
-            [UpdateUserEvent::class, 0],
+            [BeforeUpdateUserEventInterface::class, 0],
+            [UpdateUserEventInterface::class, 0],
         ]);
     }
 
     public function testUnAssignUserFromUserGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUnAssignUserFromUserGroupEvent::class,
-            UnAssignUserFromUserGroupEvent::class
+            BeforeUnAssignUserFromUserGroupEventInterface::class,
+            UnAssignUserFromUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -272,8 +262,8 @@ class UserServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUnAssignUserFromUserGroupEvent::class, 0],
-            [UnAssignUserFromUserGroupEvent::class, 0],
+            [BeforeUnAssignUserFromUserGroupEventInterface::class, 0],
+            [UnAssignUserFromUserGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -281,8 +271,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testUnAssignUserFromUserGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUnAssignUserFromUserGroupEvent::class,
-            UnAssignUserFromUserGroupEvent::class
+            BeforeUnAssignUserFromUserGroupEventInterface::class,
+            UnAssignUserFromUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -292,7 +282,7 @@ class UserServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeUnAssignUserFromUserGroupEvent::class, function (BeforeUnAssignUserFromUserGroupEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeUnAssignUserFromUserGroupEventInterface::class, function (BeforeUnAssignUserFromUserGroupEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -303,19 +293,19 @@ class UserServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeUnAssignUserFromUserGroupEvent::class, 10],
+            [BeforeUnAssignUserFromUserGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUnAssignUserFromUserGroupEvent::class, 0],
-            [UnAssignUserFromUserGroupEvent::class, 0],
+            [BeforeUnAssignUserFromUserGroupEventInterface::class, 0],
+            [UnAssignUserFromUserGroupEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteUserGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteUserGroupEvent::class,
-            DeleteUserGroupEvent::class
+            BeforeDeleteUserGroupEventInterface::class,
+            DeleteUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -333,8 +323,8 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($locations, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDeleteUserGroupEvent::class, 0],
-            [DeleteUserGroupEvent::class, 0],
+            [BeforeDeleteUserGroupEventInterface::class, 0],
+            [DeleteUserGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -342,8 +332,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testReturnDeleteUserGroupResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteUserGroupEvent::class,
-            DeleteUserGroupEvent::class
+            BeforeDeleteUserGroupEventInterface::class,
+            DeleteUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -355,7 +345,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('deleteUserGroup')->willReturn($locations);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteUserGroupEvent::class, function (BeforeDeleteUserGroupEventInterface $event) use ($eventLocations) {
+        $traceableEventDispatcher->addListener(BeforeDeleteUserGroupEventInterface::class, function (BeforeDeleteUserGroupEventInterface $event) use ($eventLocations) {
             $event->setLocations($eventLocations);
         }, 10);
 
@@ -366,9 +356,9 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLocations, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDeleteUserGroupEvent::class, 10],
-            [BeforeDeleteUserGroupEvent::class, 0],
-            [DeleteUserGroupEvent::class, 0],
+            [BeforeDeleteUserGroupEventInterface::class, 10],
+            [BeforeDeleteUserGroupEventInterface::class, 0],
+            [DeleteUserGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -376,8 +366,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testDeleteUserGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteUserGroupEvent::class,
-            DeleteUserGroupEvent::class
+            BeforeDeleteUserGroupEventInterface::class,
+            DeleteUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -389,7 +379,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('deleteUserGroup')->willReturn($locations);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteUserGroupEvent::class, function (BeforeDeleteUserGroupEventInterface $event) use ($eventLocations) {
+        $traceableEventDispatcher->addListener(BeforeDeleteUserGroupEventInterface::class, function (BeforeDeleteUserGroupEventInterface $event) use ($eventLocations) {
             $event->setLocations($eventLocations);
             $event->stopPropagation();
         }, 10);
@@ -402,19 +392,19 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLocations, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDeleteUserGroupEvent::class, 10],
+            [BeforeDeleteUserGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteUserGroupEvent::class, 0],
-            [DeleteUserGroupEvent::class, 0],
+            [BeforeDeleteUserGroupEventInterface::class, 0],
+            [DeleteUserGroupEventInterface::class, 0],
         ]);
     }
 
     public function testAssignUserToUserGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAssignUserToUserGroupEvent::class,
-            AssignUserToUserGroupEvent::class
+            BeforeAssignUserToUserGroupEventInterface::class,
+            AssignUserToUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -430,8 +420,8 @@ class UserServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAssignUserToUserGroupEvent::class, 0],
-            [AssignUserToUserGroupEvent::class, 0],
+            [BeforeAssignUserToUserGroupEventInterface::class, 0],
+            [AssignUserToUserGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -439,8 +429,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testAssignUserToUserGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeAssignUserToUserGroupEvent::class,
-            AssignUserToUserGroupEvent::class
+            BeforeAssignUserToUserGroupEventInterface::class,
+            AssignUserToUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -450,7 +440,7 @@ class UserServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeAssignUserToUserGroupEvent::class, function (BeforeAssignUserToUserGroupEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeAssignUserToUserGroupEventInterface::class, function (BeforeAssignUserToUserGroupEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -461,19 +451,19 @@ class UserServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeAssignUserToUserGroupEvent::class, 10],
+            [BeforeAssignUserToUserGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [AssignUserToUserGroupEvent::class, 0],
-            [BeforeAssignUserToUserGroupEvent::class, 0],
+            [AssignUserToUserGroupEventInterface::class, 0],
+            [BeforeAssignUserToUserGroupEventInterface::class, 0],
         ]);
     }
 
     public function testDeleteUserEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteUserEvent::class,
-            DeleteUserEvent::class
+            BeforeDeleteUserEventInterface::class,
+            DeleteUserEventInterface::class
         );
 
         $parameters = [
@@ -491,8 +481,8 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($locations, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDeleteUserEvent::class, 0],
-            [DeleteUserEvent::class, 0],
+            [BeforeDeleteUserEventInterface::class, 0],
+            [DeleteUserEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -500,8 +490,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testReturnDeleteUserResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteUserEvent::class,
-            DeleteUserEvent::class
+            BeforeDeleteUserEventInterface::class,
+            DeleteUserEventInterface::class
         );
 
         $parameters = [
@@ -513,7 +503,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('deleteUser')->willReturn($locations);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteUserEvent::class, function (BeforeDeleteUserEventInterface $event) use ($eventLocations) {
+        $traceableEventDispatcher->addListener(BeforeDeleteUserEventInterface::class, function (BeforeDeleteUserEventInterface $event) use ($eventLocations) {
             $event->setLocations($eventLocations);
         }, 10);
 
@@ -524,9 +514,9 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLocations, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDeleteUserEvent::class, 10],
-            [BeforeDeleteUserEvent::class, 0],
-            [DeleteUserEvent::class, 0],
+            [BeforeDeleteUserEventInterface::class, 10],
+            [BeforeDeleteUserEventInterface::class, 0],
+            [DeleteUserEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -534,8 +524,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testDeleteUserStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeDeleteUserEvent::class,
-            DeleteUserEvent::class
+            BeforeDeleteUserEventInterface::class,
+            DeleteUserEventInterface::class
         );
 
         $parameters = [
@@ -547,7 +537,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('deleteUser')->willReturn($locations);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteUserEvent::class, function (BeforeDeleteUserEventInterface $event) use ($eventLocations) {
+        $traceableEventDispatcher->addListener(BeforeDeleteUserEventInterface::class, function (BeforeDeleteUserEventInterface $event) use ($eventLocations) {
             $event->setLocations($eventLocations);
             $event->stopPropagation();
         }, 10);
@@ -560,19 +550,19 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventLocations, $result);
         $this->assertSame($calledListeners, [
-            [BeforeDeleteUserEvent::class, 10],
+            [BeforeDeleteUserEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeDeleteUserEvent::class, 0],
-            [DeleteUserEvent::class, 0],
+            [BeforeDeleteUserEventInterface::class, 0],
+            [DeleteUserEventInterface::class, 0],
         ]);
     }
 
     public function testMoveUserGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeMoveUserGroupEvent::class,
-            MoveUserGroupEvent::class
+            BeforeMoveUserGroupEventInterface::class,
+            MoveUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -588,8 +578,8 @@ class UserServiceTest extends AbstractServiceTest
         $calledListeners = $this->getListenersStack($traceableEventDispatcher->getCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeMoveUserGroupEvent::class, 0],
-            [MoveUserGroupEvent::class, 0],
+            [BeforeMoveUserGroupEventInterface::class, 0],
+            [MoveUserGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -597,8 +587,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testMoveUserGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeMoveUserGroupEvent::class,
-            MoveUserGroupEvent::class
+            BeforeMoveUserGroupEventInterface::class,
+            MoveUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -608,7 +598,7 @@ class UserServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeMoveUserGroupEvent::class, function (BeforeMoveUserGroupEventInterface $event) {
+        $traceableEventDispatcher->addListener(BeforeMoveUserGroupEventInterface::class, function (BeforeMoveUserGroupEventInterface $event) {
             $event->stopPropagation();
         }, 10);
 
@@ -619,19 +609,19 @@ class UserServiceTest extends AbstractServiceTest
         $notCalledListeners = $this->getListenersStack($traceableEventDispatcher->getNotCalledListeners());
 
         $this->assertSame($calledListeners, [
-            [BeforeMoveUserGroupEvent::class, 10],
+            [BeforeMoveUserGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeMoveUserGroupEvent::class, 0],
-            [MoveUserGroupEvent::class, 0],
+            [BeforeMoveUserGroupEventInterface::class, 0],
+            [MoveUserGroupEventInterface::class, 0],
         ]);
     }
 
     public function testCreateUserEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateUserEvent::class,
-            CreateUserEvent::class
+            BeforeCreateUserEventInterface::class,
+            CreateUserEventInterface::class
         );
 
         $parameters = [
@@ -650,8 +640,8 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($user, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateUserEvent::class, 0],
-            [CreateUserEvent::class, 0],
+            [BeforeCreateUserEventInterface::class, 0],
+            [CreateUserEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -659,8 +649,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testReturnCreateUserResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateUserEvent::class,
-            CreateUserEvent::class
+            BeforeCreateUserEventInterface::class,
+            CreateUserEventInterface::class
         );
 
         $parameters = [
@@ -673,7 +663,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('createUser')->willReturn($user);
 
-        $traceableEventDispatcher->addListener(BeforeCreateUserEvent::class, function (BeforeCreateUserEventInterface $event) use ($eventUser) {
+        $traceableEventDispatcher->addListener(BeforeCreateUserEventInterface::class, function (BeforeCreateUserEventInterface $event) use ($eventUser) {
             $event->setUser($eventUser);
         }, 10);
 
@@ -684,9 +674,9 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUser, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateUserEvent::class, 10],
-            [BeforeCreateUserEvent::class, 0],
-            [CreateUserEvent::class, 0],
+            [BeforeCreateUserEventInterface::class, 10],
+            [BeforeCreateUserEventInterface::class, 0],
+            [CreateUserEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -694,8 +684,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testCreateUserStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateUserEvent::class,
-            CreateUserEvent::class
+            BeforeCreateUserEventInterface::class,
+            CreateUserEventInterface::class
         );
 
         $parameters = [
@@ -708,7 +698,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('createUser')->willReturn($user);
 
-        $traceableEventDispatcher->addListener(BeforeCreateUserEvent::class, function (BeforeCreateUserEventInterface $event) use ($eventUser) {
+        $traceableEventDispatcher->addListener(BeforeCreateUserEventInterface::class, function (BeforeCreateUserEventInterface $event) use ($eventUser) {
             $event->setUser($eventUser);
             $event->stopPropagation();
         }, 10);
@@ -721,19 +711,19 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUser, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateUserEvent::class, 10],
+            [BeforeCreateUserEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateUserEvent::class, 0],
-            [CreateUserEvent::class, 0],
+            [BeforeCreateUserEventInterface::class, 0],
+            [CreateUserEventInterface::class, 0],
         ]);
     }
 
     public function testCreateUserGroupEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateUserGroupEvent::class,
-            CreateUserGroupEvent::class
+            BeforeCreateUserGroupEventInterface::class,
+            CreateUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -752,8 +742,8 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($userGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateUserGroupEvent::class, 0],
-            [CreateUserGroupEvent::class, 0],
+            [BeforeCreateUserGroupEventInterface::class, 0],
+            [CreateUserGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -761,8 +751,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testReturnCreateUserGroupResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateUserGroupEvent::class,
-            CreateUserGroupEvent::class
+            BeforeCreateUserGroupEventInterface::class,
+            CreateUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -775,7 +765,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('createUserGroup')->willReturn($userGroup);
 
-        $traceableEventDispatcher->addListener(BeforeCreateUserGroupEvent::class, function (BeforeCreateUserGroupEventInterface $event) use ($eventUserGroup) {
+        $traceableEventDispatcher->addListener(BeforeCreateUserGroupEventInterface::class, function (BeforeCreateUserGroupEventInterface $event) use ($eventUserGroup) {
             $event->setUserGroup($eventUserGroup);
         }, 10);
 
@@ -786,9 +776,9 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUserGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateUserGroupEvent::class, 10],
-            [BeforeCreateUserGroupEvent::class, 0],
-            [CreateUserGroupEvent::class, 0],
+            [BeforeCreateUserGroupEventInterface::class, 10],
+            [BeforeCreateUserGroupEventInterface::class, 0],
+            [CreateUserGroupEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -796,8 +786,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testCreateUserGroupStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeCreateUserGroupEvent::class,
-            CreateUserGroupEvent::class
+            BeforeCreateUserGroupEventInterface::class,
+            CreateUserGroupEventInterface::class
         );
 
         $parameters = [
@@ -810,7 +800,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('createUserGroup')->willReturn($userGroup);
 
-        $traceableEventDispatcher->addListener(BeforeCreateUserGroupEvent::class, function (BeforeCreateUserGroupEventInterface $event) use ($eventUserGroup) {
+        $traceableEventDispatcher->addListener(BeforeCreateUserGroupEventInterface::class, function (BeforeCreateUserGroupEventInterface $event) use ($eventUserGroup) {
             $event->setUserGroup($eventUserGroup);
             $event->stopPropagation();
         }, 10);
@@ -823,19 +813,19 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUserGroup, $result);
         $this->assertSame($calledListeners, [
-            [BeforeCreateUserGroupEvent::class, 10],
+            [BeforeCreateUserGroupEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeCreateUserGroupEvent::class, 0],
-            [CreateUserGroupEvent::class, 0],
+            [BeforeCreateUserGroupEventInterface::class, 0],
+            [CreateUserGroupEventInterface::class, 0],
         ]);
     }
 
     public function testUpdateUserTokenEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateUserTokenEvent::class,
-            UpdateUserTokenEvent::class
+            BeforeUpdateUserTokenEventInterface::class,
+            UpdateUserTokenEventInterface::class
         );
 
         $parameters = [
@@ -854,8 +844,8 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($updatedUser, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateUserTokenEvent::class, 0],
-            [UpdateUserTokenEvent::class, 0],
+            [BeforeUpdateUserTokenEventInterface::class, 0],
+            [UpdateUserTokenEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -863,8 +853,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testReturnUpdateUserTokenResultInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateUserTokenEvent::class,
-            UpdateUserTokenEvent::class
+            BeforeUpdateUserTokenEventInterface::class,
+            UpdateUserTokenEventInterface::class
         );
 
         $parameters = [
@@ -877,7 +867,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('updateUserToken')->willReturn($updatedUser);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateUserTokenEvent::class, function (BeforeUpdateUserTokenEventInterface $event) use ($eventUpdatedUser) {
+        $traceableEventDispatcher->addListener(BeforeUpdateUserTokenEventInterface::class, function (BeforeUpdateUserTokenEventInterface $event) use ($eventUpdatedUser) {
             $event->setUpdatedUser($eventUpdatedUser);
         }, 10);
 
@@ -888,9 +878,9 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedUser, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateUserTokenEvent::class, 10],
-            [BeforeUpdateUserTokenEvent::class, 0],
-            [UpdateUserTokenEvent::class, 0],
+            [BeforeUpdateUserTokenEventInterface::class, 10],
+            [BeforeUpdateUserTokenEventInterface::class, 0],
+            [UpdateUserTokenEventInterface::class, 0],
         ]);
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
@@ -898,8 +888,8 @@ class UserServiceTest extends AbstractServiceTest
     public function testUpdateUserTokenStopPropagationInBeforeEvents()
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
-            BeforeUpdateUserTokenEvent::class,
-            UpdateUserTokenEvent::class
+            BeforeUpdateUserTokenEventInterface::class,
+            UpdateUserTokenEventInterface::class
         );
 
         $parameters = [
@@ -912,7 +902,7 @@ class UserServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(UserServiceInterface::class);
         $innerServiceMock->method('updateUserToken')->willReturn($updatedUser);
 
-        $traceableEventDispatcher->addListener(BeforeUpdateUserTokenEvent::class, function (BeforeUpdateUserTokenEventInterface $event) use ($eventUpdatedUser) {
+        $traceableEventDispatcher->addListener(BeforeUpdateUserTokenEventInterface::class, function (BeforeUpdateUserTokenEventInterface $event) use ($eventUpdatedUser) {
             $event->setUpdatedUser($eventUpdatedUser);
             $event->stopPropagation();
         }, 10);
@@ -925,11 +915,11 @@ class UserServiceTest extends AbstractServiceTest
 
         $this->assertSame($eventUpdatedUser, $result);
         $this->assertSame($calledListeners, [
-            [BeforeUpdateUserTokenEvent::class, 10],
+            [BeforeUpdateUserTokenEventInterface::class, 10],
         ]);
         $this->assertSame($notCalledListeners, [
-            [BeforeUpdateUserTokenEvent::class, 0],
-            [UpdateUserTokenEvent::class, 0],
+            [BeforeUpdateUserTokenEventInterface::class, 0],
+            [UpdateUserTokenEventInterface::class, 0],
         ]);
     }
 }

--- a/eZ/Publish/Core/Event/TrashService.php
+++ b/eZ/Publish/Core/Event/TrashService.php
@@ -8,6 +8,14 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Event;
 
+use eZ\Publish\API\Repository\Events\Trash\BeforeDeleteTrashItemEvent as BeforeDeleteTrashItemEventInterface;
+use eZ\Publish\API\Repository\Events\Trash\BeforeEmptyTrashEvent as BeforeEmptyTrashEventInterface;
+use eZ\Publish\API\Repository\Events\Trash\BeforeRecoverEvent as BeforeRecoverEventInterface;
+use eZ\Publish\API\Repository\Events\Trash\BeforeTrashEvent as BeforeTrashEventInterface;
+use eZ\Publish\API\Repository\Events\Trash\DeleteTrashItemEvent as DeleteTrashItemEventInterface;
+use eZ\Publish\API\Repository\Events\Trash\EmptyTrashEvent as EmptyTrashEventInterface;
+use eZ\Publish\API\Repository\Events\Trash\RecoverEvent as RecoverEventInterface;
+use eZ\Publish\API\Repository\Events\Trash\TrashEvent as TrashEventInterface;
 use eZ\Publish\API\Repository\TrashService as TrashServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\TrashItem;
@@ -41,7 +49,9 @@ class TrashService extends TrashServiceDecorator
         $eventData = [$location];
 
         $beforeEvent = new BeforeTrashEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeTrashEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getResult();
         }
 
@@ -49,7 +59,10 @@ class TrashService extends TrashServiceDecorator
             ? $beforeEvent->getResult()
             : $this->innerService->trash($location);
 
-        $this->eventDispatcher->dispatch(new TrashEvent($trashItem, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new TrashEvent($trashItem, ...$eventData),
+            TrashEventInterface::class
+        );
 
         return $trashItem;
     }
@@ -64,7 +77,9 @@ class TrashService extends TrashServiceDecorator
         ];
 
         $beforeEvent = new BeforeRecoverEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeRecoverEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getLocation();
         }
 
@@ -72,7 +87,10 @@ class TrashService extends TrashServiceDecorator
             ? $beforeEvent->getLocation()
             : $this->innerService->recover($trashItem, $newParentLocation);
 
-        $this->eventDispatcher->dispatch(new RecoverEvent($location, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new RecoverEvent($location, ...$eventData),
+            RecoverEventInterface::class
+        );
 
         return $location;
     }
@@ -80,7 +98,9 @@ class TrashService extends TrashServiceDecorator
     public function emptyTrash()
     {
         $beforeEvent = new BeforeEmptyTrashEvent();
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeEmptyTrashEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getResultList();
         }
 
@@ -88,7 +108,10 @@ class TrashService extends TrashServiceDecorator
             ? $beforeEvent->getResultList()
             : $this->innerService->emptyTrash();
 
-        $this->eventDispatcher->dispatch(new EmptyTrashEvent($resultList));
+        $this->eventDispatcher->dispatch(
+            new EmptyTrashEvent($resultList),
+            EmptyTrashEventInterface::class
+        );
 
         return $resultList;
     }
@@ -98,7 +121,9 @@ class TrashService extends TrashServiceDecorator
         $eventData = [$trashItem];
 
         $beforeEvent = new BeforeDeleteTrashItemEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteTrashItemEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getResult();
         }
 
@@ -106,7 +131,10 @@ class TrashService extends TrashServiceDecorator
             ? $beforeEvent->getResult()
             : $this->innerService->deleteTrashItem($trashItem);
 
-        $this->eventDispatcher->dispatch(new DeleteTrashItemEvent($result, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteTrashItemEvent($result, ...$eventData),
+            DeleteTrashItemEventInterface::class
+        );
 
         return $result;
     }

--- a/eZ/Publish/Core/Event/URLAliasService.php
+++ b/eZ/Publish/Core/Event/URLAliasService.php
@@ -8,6 +8,14 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Event;
 
+use eZ\Publish\API\Repository\Events\URLAlias\BeforeCreateGlobalUrlAliasEvent as BeforeCreateGlobalUrlAliasEventInterface;
+use eZ\Publish\API\Repository\Events\URLAlias\BeforeCreateUrlAliasEvent as BeforeCreateUrlAliasEventInterface;
+use eZ\Publish\API\Repository\Events\URLAlias\BeforeRefreshSystemUrlAliasesForLocationEvent as BeforeRefreshSystemUrlAliasesForLocationEventInterface;
+use eZ\Publish\API\Repository\Events\URLAlias\BeforeRemoveAliasesEvent as BeforeRemoveAliasesEventInterface;
+use eZ\Publish\API\Repository\Events\URLAlias\CreateGlobalUrlAliasEvent as CreateGlobalUrlAliasEventInterface;
+use eZ\Publish\API\Repository\Events\URLAlias\CreateUrlAliasEvent as CreateUrlAliasEventInterface;
+use eZ\Publish\API\Repository\Events\URLAlias\RefreshSystemUrlAliasesForLocationEvent as RefreshSystemUrlAliasesForLocationEventInterface;
+use eZ\Publish\API\Repository\Events\URLAlias\RemoveAliasesEvent as RemoveAliasesEventInterface;
 use eZ\Publish\API\Repository\URLAliasService as URLAliasServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Event\URLAlias\BeforeCreateGlobalUrlAliasEvent;
@@ -51,7 +59,9 @@ class URLAliasService extends URLAliasServiceDecorator
         ];
 
         $beforeEvent = new BeforeCreateUrlAliasEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateUrlAliasEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUrlAlias();
         }
 
@@ -59,7 +69,10 @@ class URLAliasService extends URLAliasServiceDecorator
             ? $beforeEvent->getUrlAlias()
             : $this->innerService->createUrlAlias($location, $path, $languageCode, $forwarding, $alwaysAvailable);
 
-        $this->eventDispatcher->dispatch(new CreateUrlAliasEvent($urlAlias, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateUrlAliasEvent($urlAlias, ...$eventData),
+            CreateUrlAliasEventInterface::class
+        );
 
         return $urlAlias;
     }
@@ -80,7 +93,9 @@ class URLAliasService extends URLAliasServiceDecorator
         ];
 
         $beforeEvent = new BeforeCreateGlobalUrlAliasEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateGlobalUrlAliasEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUrlAlias();
         }
 
@@ -88,7 +103,10 @@ class URLAliasService extends URLAliasServiceDecorator
             ? $beforeEvent->getUrlAlias()
             : $this->innerService->createGlobalUrlAlias($resource, $path, $languageCode, $forwarding, $alwaysAvailable);
 
-        $this->eventDispatcher->dispatch(new CreateGlobalUrlAliasEvent($urlAlias, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateGlobalUrlAliasEvent($urlAlias, ...$eventData),
+            CreateGlobalUrlAliasEventInterface::class
+        );
 
         return $urlAlias;
     }
@@ -98,13 +116,18 @@ class URLAliasService extends URLAliasServiceDecorator
         $eventData = [$aliasList];
 
         $beforeEvent = new BeforeRemoveAliasesEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeRemoveAliasesEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->removeAliases($aliasList);
 
-        $this->eventDispatcher->dispatch(new RemoveAliasesEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new RemoveAliasesEvent(...$eventData),
+            RemoveAliasesEventInterface::class
+        );
     }
 
     public function refreshSystemUrlAliasesForLocation(Location $location): void
@@ -112,12 +135,17 @@ class URLAliasService extends URLAliasServiceDecorator
         $eventData = [$location];
 
         $beforeEvent = new BeforeRefreshSystemUrlAliasesForLocationEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeRefreshSystemUrlAliasesForLocationEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->refreshSystemUrlAliasesForLocation($location);
 
-        $this->eventDispatcher->dispatch(new RefreshSystemUrlAliasesForLocationEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new RefreshSystemUrlAliasesForLocationEvent(...$eventData),
+            RefreshSystemUrlAliasesForLocationEventInterface::class
+        );
     }
 }

--- a/eZ/Publish/Core/Event/URLService.php
+++ b/eZ/Publish/Core/Event/URLService.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Event;
 
+use eZ\Publish\API\Repository\Events\URL\BeforeUpdateUrlEvent as BeforeUpdateUrlEventInterface;
+use eZ\Publish\API\Repository\Events\URL\UpdateUrlEvent as UpdateUrlEventInterface;
 use eZ\Publish\API\Repository\URLService as URLServiceInterface;
 use eZ\Publish\API\Repository\Values\URL\URL;
 use eZ\Publish\API\Repository\Values\URL\URLUpdateStruct;
@@ -40,7 +42,9 @@ class URLService extends URLServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateUrlEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateUrlEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedUrl();
         }
 
@@ -48,7 +52,10 @@ class URLService extends URLServiceDecorator
             ? $beforeEvent->getUpdatedUrl()
             : $this->innerService->updateUrl($url, $struct);
 
-        $this->eventDispatcher->dispatch(new UpdateUrlEvent($updatedUrl, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateUrlEvent($updatedUrl, ...$eventData),
+            UpdateUrlEventInterface::class
+        );
 
         return $updatedUrl;
     }

--- a/eZ/Publish/Core/Event/URLWildcardService.php
+++ b/eZ/Publish/Core/Event/URLWildcardService.php
@@ -8,6 +8,12 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Event;
 
+use eZ\Publish\API\Repository\Events\URLWildcard\BeforeCreateEvent as BeforeCreateEventInterface;
+use eZ\Publish\API\Repository\Events\URLWildcard\BeforeRemoveEvent as BeforeRemoveEventInterface;
+use eZ\Publish\API\Repository\Events\URLWildcard\BeforeTranslateEvent as BeforeTranslateEventInterface;
+use eZ\Publish\API\Repository\Events\URLWildcard\CreateEvent as CreateEventInterface;
+use eZ\Publish\API\Repository\Events\URLWildcard\RemoveEvent as RemoveEventInterface;
+use eZ\Publish\API\Repository\Events\URLWildcard\TranslateEvent as TranslateEventInterface;
 use eZ\Publish\API\Repository\URLWildcardService as URLWildcardServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\URLWildcard;
 use eZ\Publish\Core\Event\URLWildcard\BeforeCreateEvent;
@@ -45,7 +51,9 @@ class URLWildcardService extends URLWildcardServiceDecorator
         ];
 
         $beforeEvent = new BeforeCreateEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUrlWildcard();
         }
 
@@ -53,7 +61,10 @@ class URLWildcardService extends URLWildcardServiceDecorator
             ? $beforeEvent->getUrlWildcard()
             : $this->innerService->create($sourceUrl, $destinationUrl, $forward);
 
-        $this->eventDispatcher->dispatch(new CreateEvent($urlWildcard, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateEvent($urlWildcard, ...$eventData),
+            CreateEventInterface::class
+        );
 
         return $urlWildcard;
     }
@@ -63,13 +74,18 @@ class URLWildcardService extends URLWildcardServiceDecorator
         $eventData = [$urlWildcard];
 
         $beforeEvent = new BeforeRemoveEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeRemoveEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->remove($urlWildcard);
 
-        $this->eventDispatcher->dispatch(new RemoveEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new RemoveEvent(...$eventData),
+            RemoveEventInterface::class
+        );
     }
 
     public function translate($url)
@@ -77,7 +93,9 @@ class URLWildcardService extends URLWildcardServiceDecorator
         $eventData = [$url];
 
         $beforeEvent = new BeforeTranslateEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeTranslateEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getResult();
         }
 
@@ -85,7 +103,10 @@ class URLWildcardService extends URLWildcardServiceDecorator
             ? $beforeEvent->getResult()
             : $this->innerService->translate($url);
 
-        $this->eventDispatcher->dispatch(new TranslateEvent($result, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new TranslateEvent($result, ...$eventData),
+            TranslateEventInterface::class
+        );
 
         return $result;
     }

--- a/eZ/Publish/Core/Event/UserPreferenceService.php
+++ b/eZ/Publish/Core/Event/UserPreferenceService.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Event;
 
+use eZ\Publish\API\Repository\Events\UserPreference\BeforeSetUserPreferenceEvent as BeforeSetUserPreferenceEventInterface;
+use eZ\Publish\API\Repository\Events\UserPreference\SetUserPreferenceEvent as SetUserPreferenceEventInterface;
 use eZ\Publish\API\Repository\UserPreferenceService as UserPreferenceServiceInterface;
 use eZ\Publish\Core\Event\UserPreference\BeforeSetUserPreferenceEvent;
 use eZ\Publish\Core\Event\UserPreference\SetUserPreferenceEvent;
@@ -33,12 +35,17 @@ class UserPreferenceService extends UserPreferenceServiceDecorator
         $eventData = [$userPreferenceSetStructs];
 
         $beforeEvent = new BeforeSetUserPreferenceEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeSetUserPreferenceEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->setUserPreference($userPreferenceSetStructs);
 
-        $this->eventDispatcher->dispatch(new SetUserPreferenceEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new SetUserPreferenceEvent(...$eventData),
+            SetUserPreferenceEventInterface::class
+        );
     }
 }

--- a/eZ/Publish/Core/Event/UserService.php
+++ b/eZ/Publish/Core/Event/UserService.php
@@ -8,6 +8,26 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Event;
 
+use eZ\Publish\API\Repository\Events\User\AssignUserToUserGroupEvent as AssignUserToUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\BeforeAssignUserToUserGroupEvent as BeforeAssignUserToUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\BeforeCreateUserEvent as BeforeCreateUserEventInterface;
+use eZ\Publish\API\Repository\Events\User\BeforeCreateUserGroupEvent as BeforeCreateUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\BeforeDeleteUserEvent as BeforeDeleteUserEventInterface;
+use eZ\Publish\API\Repository\Events\User\BeforeDeleteUserGroupEvent as BeforeDeleteUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\BeforeMoveUserGroupEvent as BeforeMoveUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\BeforeUnAssignUserFromUserGroupEvent as BeforeUnAssignUserFromUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\BeforeUpdateUserEvent as BeforeUpdateUserEventInterface;
+use eZ\Publish\API\Repository\Events\User\BeforeUpdateUserGroupEvent as BeforeUpdateUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\BeforeUpdateUserTokenEvent as BeforeUpdateUserTokenEventInterface;
+use eZ\Publish\API\Repository\Events\User\CreateUserEvent as CreateUserEventInterface;
+use eZ\Publish\API\Repository\Events\User\CreateUserGroupEvent as CreateUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\DeleteUserEvent as DeleteUserEventInterface;
+use eZ\Publish\API\Repository\Events\User\DeleteUserGroupEvent as DeleteUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\MoveUserGroupEvent as MoveUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\UnAssignUserFromUserGroupEvent as UnAssignUserFromUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\UpdateUserEvent as UpdateUserEventInterface;
+use eZ\Publish\API\Repository\Events\User\UpdateUserGroupEvent as UpdateUserGroupEventInterface;
+use eZ\Publish\API\Repository\Events\User\UpdateUserTokenEvent as UpdateUserTokenEventInterface;
 use eZ\Publish\API\Repository\UserService as UserServiceInterface;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserCreateStruct;
@@ -63,7 +83,9 @@ class UserService extends UserServiceDecorator
         ];
 
         $beforeEvent = new BeforeCreateUserGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateUserGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUserGroup();
         }
 
@@ -71,7 +93,10 @@ class UserService extends UserServiceDecorator
             ? $beforeEvent->getUserGroup()
             : $this->innerService->createUserGroup($userGroupCreateStruct, $parentGroup);
 
-        $this->eventDispatcher->dispatch(new CreateUserGroupEvent($userGroup, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateUserGroupEvent($userGroup, ...$eventData),
+            CreateUserGroupEventInterface::class
+        );
 
         return $userGroup;
     }
@@ -81,7 +106,9 @@ class UserService extends UserServiceDecorator
         $eventData = [$userGroup];
 
         $beforeEvent = new BeforeDeleteUserGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteUserGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getLocations();
         }
 
@@ -89,7 +116,10 @@ class UserService extends UserServiceDecorator
             ? $beforeEvent->getLocations()
             : $this->innerService->deleteUserGroup($userGroup);
 
-        $this->eventDispatcher->dispatch(new DeleteUserGroupEvent($locations, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteUserGroupEvent($locations, ...$eventData),
+            DeleteUserGroupEventInterface::class
+        );
 
         return $locations;
     }
@@ -104,13 +134,18 @@ class UserService extends UserServiceDecorator
         ];
 
         $beforeEvent = new BeforeMoveUserGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeMoveUserGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->moveUserGroup($userGroup, $newParent);
 
-        $this->eventDispatcher->dispatch(new MoveUserGroupEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new MoveUserGroupEvent(...$eventData),
+            MoveUserGroupEventInterface::class
+        );
     }
 
     public function updateUserGroup(
@@ -123,7 +158,9 @@ class UserService extends UserServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateUserGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateUserGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedUserGroup();
         }
 
@@ -131,7 +168,10 @@ class UserService extends UserServiceDecorator
             ? $beforeEvent->getUpdatedUserGroup()
             : $this->innerService->updateUserGroup($userGroup, $userGroupUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateUserGroupEvent($updatedUserGroup, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateUserGroupEvent($updatedUserGroup, ...$eventData),
+            UpdateUserGroupEventInterface::class
+        );
 
         return $updatedUserGroup;
     }
@@ -146,7 +186,9 @@ class UserService extends UserServiceDecorator
         ];
 
         $beforeEvent = new BeforeCreateUserEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeCreateUserEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUser();
         }
 
@@ -154,7 +196,10 @@ class UserService extends UserServiceDecorator
             ? $beforeEvent->getUser()
             : $this->innerService->createUser($userCreateStruct, $parentGroups);
 
-        $this->eventDispatcher->dispatch(new CreateUserEvent($user, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new CreateUserEvent($user, ...$eventData),
+            CreateUserEventInterface::class
+        );
 
         return $user;
     }
@@ -164,7 +209,9 @@ class UserService extends UserServiceDecorator
         $eventData = [$user];
 
         $beforeEvent = new BeforeDeleteUserEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeDeleteUserEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getLocations();
         }
 
@@ -172,7 +219,10 @@ class UserService extends UserServiceDecorator
             ? $beforeEvent->getLocations()
             : $this->innerService->deleteUser($user);
 
-        $this->eventDispatcher->dispatch(new DeleteUserEvent($locations, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new DeleteUserEvent($locations, ...$eventData),
+            DeleteUserEventInterface::class
+        );
 
         return $locations;
     }
@@ -187,7 +237,9 @@ class UserService extends UserServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateUserEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateUserEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedUser();
         }
 
@@ -195,7 +247,10 @@ class UserService extends UserServiceDecorator
             ? $beforeEvent->getUpdatedUser()
             : $this->innerService->updateUser($user, $userUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateUserEvent($updatedUser, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateUserEvent($updatedUser, ...$eventData),
+            UpdateUserEventInterface::class
+        );
 
         return $updatedUser;
     }
@@ -210,7 +265,9 @@ class UserService extends UserServiceDecorator
         ];
 
         $beforeEvent = new BeforeUpdateUserTokenEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUpdateUserTokenEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return $beforeEvent->getUpdatedUser();
         }
 
@@ -218,7 +275,10 @@ class UserService extends UserServiceDecorator
             ? $beforeEvent->getUpdatedUser()
             : $this->innerService->updateUserToken($user, $userTokenUpdateStruct);
 
-        $this->eventDispatcher->dispatch(new UpdateUserTokenEvent($updatedUser, ...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UpdateUserTokenEvent($updatedUser, ...$eventData),
+            UpdateUserTokenEventInterface::class
+        );
 
         return $updatedUser;
     }
@@ -233,13 +293,18 @@ class UserService extends UserServiceDecorator
         ];
 
         $beforeEvent = new BeforeAssignUserToUserGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeAssignUserToUserGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->assignUserToUserGroup($user, $userGroup);
 
-        $this->eventDispatcher->dispatch(new AssignUserToUserGroupEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new AssignUserToUserGroupEvent(...$eventData),
+            AssignUserToUserGroupEventInterface::class
+        );
     }
 
     public function unAssignUserFromUserGroup(
@@ -252,12 +317,17 @@ class UserService extends UserServiceDecorator
         ];
 
         $beforeEvent = new BeforeUnAssignUserFromUserGroupEvent(...$eventData);
-        if ($this->eventDispatcher->dispatch($beforeEvent)->isPropagationStopped()) {
+
+        $this->eventDispatcher->dispatch($beforeEvent, BeforeUnAssignUserFromUserGroupEventInterface::class);
+        if ($beforeEvent->isPropagationStopped()) {
             return;
         }
 
         $this->innerService->unAssignUserFromUserGroup($user, $userGroup);
 
-        $this->eventDispatcher->dispatch(new UnAssignUserFromUserGroupEvent(...$eventData));
+        $this->eventDispatcher->dispatch(
+            new UnAssignUserFromUserGroupEvent(...$eventData),
+            UnAssignUserFromUserGroupEventInterface::class
+        );
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30749](https://jira.ez.no/browse/EZP-30749)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     |no

Event names should be passed explicitly to the dispatcher, otherwise subscribers will be forced to use `eZ\Publish\Core\Event\` instead of `eZ\Publish\API\Repository\Events\`

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
