### PR TITLE
EZP-30697: Fixed content creation under subtree when assignment limitation is used

### DIFF
--- a/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
+++ b/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
@@ -1128,6 +1128,62 @@ class PermissionResolverTest extends BaseTest
     }
 
     /**
+     * If the role limitation is set and policy limitation is not set it should be taken into account.
+     * In this case, role limitation will pass and SectionLimitation should be returned as role limitation
+     * and limitations in LookupPolicyLimitations should be an empty array.
+     *
+     * @see https://jira.ez.no/browse/EZP-30728
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testLookupLimitationsWithRoleLimitationsWithoutPolicyLimitationsHasAccess(): void
+    {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+        $permissionResolver = $repository->getPermissionResolver();
+        $roleService = $repository->getRoleService();
+
+        $module = 'content';
+        $function = 'create';
+
+        /* BEGIN: Use Case */
+        $role = $this->createRoleWithPolicies(
+            'role_' . __FUNCTION__,
+            [
+                ['module' => $module, 'function' => $function, 'limitations' => []],
+                ['module' => 'content', 'function' => 'edit', 'limitations' => []],
+            ]
+        );
+        // create user in root user group to avoid overlapping of existing policies and limitations
+        $user = $this->createUser('user', 'John', 'Doe', $userService->loadUserGroup(4));
+        // SectionLimitation as RoleLimitation will pass
+        $roleLimitation = new Limitation\SectionLimitation(['limitationValues' => [2]]);
+        $roleService->assignRoleToUser($role, $user, $roleLimitation);
+        $permissionResolver->setCurrentUserReference($user);
+        /* END: Use Case */
+
+        $expected = new LookupLimitationResult(
+            true,
+            [$roleLimitation],
+            [
+                new LookupPolicyLimitations(
+                    $role->getPolicies()[0],
+                    []
+                ),
+            ]
+        );
+
+        self::assertEquals(
+            $expected,
+            $permissionResolver->lookupLimitations($module, $function, $this->getContentCreateStruct($repository), [])
+        );
+    }
+
+    /**
      * If the role limitation is set it should be taken into account. In this case, role limitation
      * will not pass and ContentTypeLimitation should not be returned.
      *

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -305,7 +305,7 @@ class PermissionResolver implements PermissionResolverInterface
                     $possibleLimitations = array_filter($possibleLimitations, $limitationFilter);
                 }
 
-                if ($limitationsPass && !empty($possibleLimitations)) {
+                if ($limitationsPass) {
                     $passedLimitations[] = new LookupPolicyLimitations($policy, $possibleLimitations);
                     if (null !== $permissionSet['limitation']) {
                         $passedRoleLimitations[] = $permissionSet['limitation'];

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -288,6 +288,7 @@ class PermissionResolver implements PermissionResolverInterface
 
                 $limitationsPass = true;
                 $possibleLimitations = [];
+                $possibleRoleLimitation = $permissionSet['limitation'];
                 foreach ($policyLimitations as $limitation) {
                     $limitationsPass = $this->isGrantedByLimitation($limitation, $currentUserReference, $object, $targets);
                     if (!$limitationsPass) {
@@ -303,12 +304,15 @@ class PermissionResolver implements PermissionResolverInterface
 
                 if (!empty($limitationsIdentifiers)) {
                     $possibleLimitations = array_filter($possibleLimitations, $limitationFilter);
+                    if (!\in_array($possibleRoleLimitation, $limitationsIdentifiers, true)) {
+                        $possibleRoleLimitation = null;
+                    }
                 }
 
                 if ($limitationsPass) {
                     $passedLimitations[] = new LookupPolicyLimitations($policy, $possibleLimitations);
-                    if (null !== $permissionSet['limitation']) {
-                        $passedRoleLimitations[] = $permissionSet['limitation'];
+                    if (null !== $possibleRoleLimitation) {
+                        $passedRoleLimitations[] = $possibleRoleLimitation;
                     }
                 }
             }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30697](https://jira.ez.no/browse/EZP-30697)
| **Bug**| yes
| **New feature**    |no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     |no

If policy has no limitation and role assignment has limitation incorrect result of hasAccess method was returned. If the limitation is met there is no need to check if policy limitations array is not empty.

Related PR:
 - https://github.com/ezsystems/ezplatform-admin-ui/pull/1039

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
