### PR TITLE
EZP-30571: Legacy storage column size for default TextField value is too short

### DIFF
--- a/data/update/mysql/dbupdate-7.5.2-to-7.5.3.sql
+++ b/data/update/mysql/dbupdate-7.5.2-to-7.5.3.sql
@@ -1,0 +1,3 @@
+UPDATE ezsite_data SET value='7.5.3' WHERE name='ezpublish-version';
+
+ALTER TABLE ezcontentclass_attribute MODIFY data_text1 VARCHAR(255);

--- a/data/update/postgres/dbupdate-7.5.2-to-7.5.3.sql
+++ b/data/update/postgres/dbupdate-7.5.2-to-7.5.3.sql
@@ -1,0 +1,3 @@
+UPDATE ezsite_data SET value='7.5.3' WHERE name='ezpublish-version';
+
+ALTER TABLE ezcontentclass_attribute ALTER COLUMN data_text1 TYPE varchar(255);

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml
@@ -337,7 +337,7 @@ tables:
             data_int2: { type: integer, nullable: true }
             data_int3: { type: integer, nullable: true }
             data_int4: { type: integer, nullable: true }
-            data_text1: { type: string, nullable: true, length: 50 }
+            data_text1: { type: string, nullable: true, length: 255 }
             data_text2: { type: string, nullable: true, length: 50 }
             data_text3: { type: string, nullable: true, length: 50 }
             data_text4: { type: string, nullable: true, length: 255 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30571](https://jira.ez.no/browse/EZP-30571)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.5`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR increases `data_text1` column length to 255 characters in `ezcontentclass_attribute` table. For more information please refer to mentioned JIRA ticket. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
