### PR TITLE
[8.0] EZP-30571: Legacy storage column size for default TextField value is too short

### DIFF
--- a/data/update/mysql/dbupdate-7.5.3-to-8.0.0.sql
+++ b/data/update/mysql/dbupdate-7.5.3-to-8.0.0.sql
@@ -1,0 +1,3 @@
+UPDATE ezsite_data SET value='8.0.0' WHERE name='ezpublish-version';
+
+ALTER TABLE ezcontentclass_attribute MODIFY data_text1 VARCHAR(255);

--- a/data/update/mysql/unstable/dbupdate-8.0.0-beta1-to-8.0.0-beta2.sql
+++ b/data/update/mysql/unstable/dbupdate-8.0.0-beta1-to-8.0.0-beta2.sql
@@ -1,0 +1,3 @@
+UPDATE ezsite_data SET value='8.0.0-beta2' WHERE name='ezpublish-version';
+
+ALTER TABLE ezcontentclass_attribute MODIFY data_text1 VARCHAR(255);

--- a/data/update/postgres/dbupdate-7.5.3-to-8.0.0.sql
+++ b/data/update/postgres/dbupdate-7.5.3-to-8.0.0.sql
@@ -1,0 +1,3 @@
+UPDATE ezsite_data SET value='8.0.0' WHERE name='ezpublish-version';
+
+ALTER TABLE ezcontentclass_attribute ALTER COLUMN data_text1 TYPE varchar(255);

--- a/data/update/postgres/unstable/dbupdate-8.0.0-beta1-to-8.0.0-beta2.sql
+++ b/data/update/postgres/unstable/dbupdate-8.0.0-beta1-to-8.0.0-beta2.sql
@@ -1,0 +1,3 @@
+UPDATE ezsite_data SET value='8.0.0-beta2' WHERE name='ezpublish-version';
+
+ALTER TABLE ezcontentclass_attribute ALTER COLUMN data_text1 TYPE varchar(255);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30571](https://jira.ez.no/browse/EZP-30571)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Follow-up for https://github.com/ezsystems/ezpublish-kernel/pull/2702 against `8.0`. For more information please refer to the original PR. 

**TODO**:
- [X] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
