### PR TITLE
EZP-30724: Allowed to load content type draft owned by any user via API

### DIFF
--- a/eZ/Publish/API/Repository/ContentTypeService.php
+++ b/eZ/Publish/API/Repository/ContentTypeService.php
@@ -155,11 +155,12 @@ interface ContentTypeService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the content type draft owned by the current user can not be found
      *
-     * @param mixed $contentTypeId
+     * @param int $contentTypeId
+     * @param bool $anyOwner if true, method will return draft even if the owner is different than currently logged in user
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft
      */
-    public function loadContentTypeDraft($contentTypeId);
+    public function loadContentTypeDraft($contentTypeId, bool $anyOwner = false);
 
     /**
      * Bulk-load Content Type objects by ids.

--- a/eZ/Publish/API/Repository/ContentTypeService.php
+++ b/eZ/Publish/API/Repository/ContentTypeService.php
@@ -156,11 +156,11 @@ interface ContentTypeService
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the content type draft owned by the current user can not be found
      *
      * @param int $contentTypeId
-     * @param bool $anyOwner if true, method will return draft even if the owner is different than currently logged in user
+     * @param bool $ignoreOwnership if true, method will return draft even if the owner is different than currently logged in user
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft
      */
-    public function loadContentTypeDraft($contentTypeId, bool $anyOwner = false);
+    public function loadContentTypeDraft($contentTypeId, bool $ignoreOwnership = false);
 
     /**
      * Bulk-load Content Type objects by ids.

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -1238,6 +1238,49 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
     }
 
     /**
+     * Test for the loadContentTypeDraft() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentTypeService::loadContentTypeDraft()
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testLoadContentTypeDraftThrowsNotFoundExceptionIfDiffrentOwner()
+    {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+        $permissionResolver = $repository->getPermissionResolver();
+        $contentTypeService = $repository->getContentTypeService();
+
+        $draft = $this->createContentTypeDraft();
+
+        $anotherUser = $this->createUserVersion1('anotherUser');
+        $permissionResolver->setCurrentUserReference($anotherUser);
+
+        $contentTypeDraft = $contentTypeService->loadContentTypeDraft($draft->id);
+    }
+
+    /**
+     * Test for the loadContentTypeDraft() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentTypeService::loadContentTypeDraft()
+     */
+    public function testCanLoadContentTypeDraftEvenIfDiffrentOwner()
+    {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+        $permissionResolver = $repository->getPermissionResolver();
+        $contentTypeService = $repository->getContentTypeService();
+
+        $draft = $this->createContentTypeDraft();
+
+        $anotherUser = $this->createUserVersion1('anotherUser');
+        $permissionResolver->setCurrentUserReference($anotherUser);
+
+        $loadedDraft = $contentTypeService->loadContentTypeDraft($draft->id, true);
+
+        $this->assertSame((int)$loadedDraft->id, (int)$draft->id);
+    }
+
+    /**
      * Test for the updateContentTypeDraft() method.
      *
      * @see \eZ\Publish\API\Repository\ContentTypeService::updateContentTypeDraft()

--- a/eZ/Publish/Core/REST/Client/ContentTypeService.php
+++ b/eZ/Publish/Core/REST/Client/ContentTypeService.php
@@ -365,7 +365,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft
      */
-    public function loadContentTypeDraft($contentTypeId, bool $ignoreOwnership=false)
+    public function loadContentTypeDraft($contentTypeId, bool $ignoreOwnership = false)
     {
         $response = $this->client->request(
             'GET',

--- a/eZ/Publish/Core/REST/Client/ContentTypeService.php
+++ b/eZ/Publish/Core/REST/Client/ContentTypeService.php
@@ -360,11 +360,12 @@ class ContentTypeService implements APIContentTypeService, Sessionable
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the content type draft owned by the current user can not be found
      *
-     * @param mixed $contentTypeId
+     * @param int $contentTypeId
+     * @param bool $anyOwner not supported yet
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft
      */
-    public function loadContentTypeDraft($contentTypeId)
+    public function loadContentTypeDraft($contentTypeId, bool $anyOwner=false)
     {
         $response = $this->client->request(
             'GET',

--- a/eZ/Publish/Core/REST/Client/ContentTypeService.php
+++ b/eZ/Publish/Core/REST/Client/ContentTypeService.php
@@ -361,11 +361,11 @@ class ContentTypeService implements APIContentTypeService, Sessionable
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the content type draft owned by the current user can not be found
      *
      * @param int $contentTypeId
-     * @param bool $anyOwner not supported yet
+     * @param bool $ignoreOwnership not supported yet
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft
      */
-    public function loadContentTypeDraft($contentTypeId, bool $anyOwner=false)
+    public function loadContentTypeDraft($contentTypeId, bool $ignoreOwnership=false)
     {
         $response = $this->client->request(
             'GET',

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -887,20 +887,20 @@ class ContentTypeService implements ContentTypeServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the content type draft owned by the current user can not be found
      *
      * @param int $contentTypeId
-     * @param bool $anyOwner if true, method will return draft even if the owner is different than currently logged in user
+     * @param bool $ignoreOwnership if true, method will return draft even if the owner is different than currently logged in user
      *
      * @todo Use another exception when user of draft is someone else
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft
      */
-    public function loadContentTypeDraft($contentTypeId, bool $anyOwner = false)
+    public function loadContentTypeDraft($contentTypeId, bool $ignoreOwnership = false)
     {
         $spiContentType = $this->contentTypeHandler->load(
             $contentTypeId,
             SPIContentType::STATUS_DRAFT
         );
 
-        if (!$anyOwner && $spiContentType->modifierId != $this->repository->getCurrentUserReference()->getUserId()) {
+        if (!$ignoreOwnership && $spiContentType->modifierId != $this->repository->getCurrentUserReference()->getUserId()) {
             throw new NotFoundException('ContentType owned by someone else', $contentTypeId);
         }
 

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -886,20 +886,21 @@ class ContentTypeService implements ContentTypeServiceInterface
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the content type draft owned by the current user can not be found
      *
-     * @param mixed $contentTypeId
+     * @param int $contentTypeId
+     * @param bool $anyOwner if true, method will return draft even if the owner is different than currently logged in user
      *
      * @todo Use another exception when user of draft is someone else
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft
      */
-    public function loadContentTypeDraft($contentTypeId)
+    public function loadContentTypeDraft($contentTypeId, bool $anyOwner = false)
     {
         $spiContentType = $this->contentTypeHandler->load(
             $contentTypeId,
             SPIContentType::STATUS_DRAFT
         );
 
-        if ($spiContentType->modifierId != $this->repository->getCurrentUserReference()->getUserId()) {
+        if (!$anyOwner && $spiContentType->modifierId != $this->repository->getCurrentUserReference()->getUserId()) {
             throw new NotFoundException('ContentType owned by someone else', $contentTypeId);
         }
 

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
@@ -109,9 +109,9 @@ class ContentTypeService implements ContentTypeServiceInterface
         return $this->service->loadContentTypeByRemoteId($remoteId, $prioritizedLanguages);
     }
 
-    public function loadContentTypeDraft($contentTypeId)
+    public function loadContentTypeDraft($contentTypeId, bool $anyOwner = false)
     {
-        return $this->service->loadContentTypeDraft($contentTypeId);
+        return $this->service->loadContentTypeDraft($contentTypeId, $anyOwner);
     }
 
     public function loadContentTypeList(array $contentTypeIds, array $prioritizedLanguages = []): iterable

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
@@ -109,9 +109,9 @@ class ContentTypeService implements ContentTypeServiceInterface
         return $this->service->loadContentTypeByRemoteId($remoteId, $prioritizedLanguages);
     }
 
-    public function loadContentTypeDraft($contentTypeId, bool $anyOwner = false)
+    public function loadContentTypeDraft($contentTypeId, bool $ignoreOwnership = false)
     {
-        return $this->service->loadContentTypeDraft($contentTypeId, $anyOwner);
+        return $this->service->loadContentTypeDraft($contentTypeId, $ignoreOwnership);
     }
 
     public function loadContentTypeList(array $contentTypeIds, array $prioritizedLanguages = []): iterable

--- a/eZ/Publish/Core/SignalSlot/ContentTypeService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentTypeService.php
@@ -227,13 +227,14 @@ class ContentTypeService implements ContentTypeServiceInterface
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the content type draft owned by the current user can not be found
      *
-     * @param mixed $contentTypeId
+     * @param int $contentTypeId
+     * @param bool $anyOwner if true, method will return draft even if the owner is different than currently logged in user
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft
      */
-    public function loadContentTypeDraft($contentTypeId)
+    public function loadContentTypeDraft($contentTypeId, bool $anyOwner = false)
     {
-        return $this->service->loadContentTypeDraft($contentTypeId);
+        return $this->service->loadContentTypeDraft($contentTypeId, $anyOwner);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/ContentTypeService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentTypeService.php
@@ -228,13 +228,13 @@ class ContentTypeService implements ContentTypeServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the content type draft owned by the current user can not be found
      *
      * @param int $contentTypeId
-     * @param bool $anyOwner if true, method will return draft even if the owner is different than currently logged in user
+     * @param bool $ignoreOwnership if true, method will return draft even if the owner is different than currently logged in user
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft
      */
-    public function loadContentTypeDraft($contentTypeId, bool $anyOwner = false)
+    public function loadContentTypeDraft($contentTypeId, bool $ignoreOwnership = false)
     {
-        return $this->service->loadContentTypeDraft($contentTypeId, $anyOwner);
+        return $this->service->loadContentTypeDraft($contentTypeId, $ignoreOwnership);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentTypeServiceTest.php
@@ -163,7 +163,13 @@ class ContentTypeServiceTest extends ServiceTest
             ],
             [
                 'loadContentTypeDraft',
-                [$contentType],
+                [$contentType, false],
+                [$contentTypeDraft],
+                0,
+            ],
+            [
+                'loadContentTypeDraft',
+                [$contentType, true],
                 [$contentTypeDraft],
                 0,
             ],


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30724](https://jira.ez.no/browse/EZP-30724)
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `7.5` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Allowed to load content type draft owned by any user via API

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
