### PR TITLE
Fixed test which fails on PostgreSQL because it depends on items order

### DIFF
--- a/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
+++ b/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use function array_filter;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -1166,12 +1167,16 @@ class PermissionResolverTest extends BaseTest
         $permissionResolver->setCurrentUserReference($user);
         /* END: Use Case */
 
+        $expectedPolicy = array_filter($role->getPolicies(), function ($policy) use ($module, $function) {
+            return $policy->module === $module && $policy->function === $function;
+        })[0] ?? null;
+
         $expected = new LookupLimitationResult(
             true,
             [$roleLimitation],
             [
                 new LookupPolicyLimitations(
-                    $role->getPolicies()[0],
+                    $expectedPolicy,
                     []
                 ),
             ]


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.5`
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     |no

Fixed test which fails on PostgreSQL because it depends on items order in array of expected Policies. In reference to https://jira.ez.no/browse/EZP-30697


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
