### PR TITLE
EZP-30753: Changed loadSections method to filter available sections

### DIFF
--- a/eZ/Publish/API/Repository/SectionService.php
+++ b/eZ/Publish/API/Repository/SectionService.php
@@ -57,9 +57,7 @@ interface SectionService
     public function loadSection($sectionId);
 
     /**
-     * Loads all sections.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read a section
+     * Loads all sections. If the current user is not allowed to read a section then list are filtered.
      *
      * @return array of {@link \eZ\Publish\API\Repository\Values\Content\Section}
      */

--- a/eZ/Publish/API/Repository/SectionService.php
+++ b/eZ/Publish/API/Repository/SectionService.php
@@ -57,7 +57,7 @@ interface SectionService
     public function loadSection($sectionId);
 
     /**
-     * Loads all sections. If the current user is not allowed to read a section then list are filtered.
+     * Loads all sections, excluding the ones the current user is not allowed to read.
      *
      * @return array of {@link \eZ\Publish\API\Repository\Values\Content\Section}
      */

--- a/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
@@ -124,7 +124,7 @@ class SectionServiceAuthorizationTest extends BaseTest
      * @see \eZ\Publish\API\Repository\SectionService::loadSections()
      * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
      */
-    public function testLoadSectionDidNotThrowAnException()
+    public function testLoadSectionsLoadsEmptyListForAnonymousUser()
     {
         $repository = $this->getRepository();
 
@@ -153,7 +153,6 @@ class SectionServiceAuthorizationTest extends BaseTest
         $sections = $sectionService->loadSections();
         /* END: Use Case */
 
-        // Sections should be filtered to those which user has access
         $this->assertEquals([], $sections);
     }
 
@@ -199,7 +198,7 @@ class SectionServiceAuthorizationTest extends BaseTest
         $sections = $sectionService->loadSections();
         /* END: Use Case */
 
-        // Sections should be filtered to those which user has access
+        // Only Sections the user has access to should be loaded
         $this->assertEquals([$expectedSection], $sections);
     }
 

--- a/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Values\User\Limitation;
+
 /**
  * Test case for operations in the SectionService using in memory storage.
  *
@@ -120,10 +122,9 @@ class SectionServiceAuthorizationTest extends BaseTest
      * Test for the loadSections() method.
      *
      * @see \eZ\Publish\API\Repository\SectionService::loadSections()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
      */
-    public function testLoadSectionsThrowsUnauthorizedException()
+    public function testLoadSectionDidNotThrowAnException()
     {
         $repository = $this->getRepository();
 
@@ -149,9 +150,57 @@ class SectionServiceAuthorizationTest extends BaseTest
         // Set anonymous user
         $repository->setCurrentUser($userService->loadUser($anonymousUserId));
 
-        // This call will fail with a "UnauthorizedException"
-        $sectionService->loadSections();
+        $sections = $sectionService->loadSections();
         /* END: Use Case */
+
+        // Sections should be filtered to those which user has access
+        $this->assertEquals([], $sections);
+    }
+
+    /**
+     * Test for the loadSections() method.
+     *
+     * @see \eZ\Publish\API\Repository\SectionService::loadSections()
+     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
+     */
+    public function testLoadSectionFiltersSections()
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        // Publish demo installation.
+        $sectionService = $repository->getSectionService();
+        // Create some sections
+        $sectionCreateOne = $sectionService->newSectionCreateStruct();
+        $sectionCreateOne->name = 'Test section one';
+        $sectionCreateOne->identifier = 'uniqueKeyOne';
+
+        $sectionCreateTwo = $sectionService->newSectionCreateStruct();
+        $sectionCreateTwo->name = 'Test section two';
+        $sectionCreateTwo->identifier = 'uniqueKeyTwo';
+
+        $expectedSection = $sectionService->createSection($sectionCreateOne);
+        $sectionService->createSection($sectionCreateTwo);
+
+        // Set user
+        $this->createRoleWithPolicies('MediaUser', [
+            ['module' => '*', 'function' => '*'],
+        ]);
+        $mediaUser = $this->createCustomUserWithLogin(
+            'user',
+            'user@example.com',
+            'MediaUser',
+            'MediaUser',
+            new Limitation\SectionLimitation(['limitationValues' => [$expectedSection->id]])
+        );
+
+        $repository->getPermissionResolver()->setCurrentUserReference($mediaUser);
+
+        $sections = $sectionService->loadSections();
+        /* END: Use Case */
+
+        // Sections should be filtered to those which user has access
+        $this->assertEquals([$expectedSection], $sections);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/SectionService.php
+++ b/eZ/Publish/Core/REST/Client/SectionService.php
@@ -156,9 +156,7 @@ class SectionService implements APISectionService, Sessionable
     }
 
     /**
-     * Loads all sections.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read a section
+     * Loads all sections. If the current user is not allowed to read a section then list are filtered.
      *
      * @return array of {@link \eZ\Publish\API\Repository\Values\Content\Section}
      */

--- a/eZ/Publish/Core/REST/Client/SectionService.php
+++ b/eZ/Publish/Core/REST/Client/SectionService.php
@@ -156,7 +156,7 @@ class SectionService implements APISectionService, Sessionable
     }
 
     /**
-     * Loads all sections. If the current user is not allowed to read a section then list are filtered.
+     * Loads all sections, excluding the ones the current user is not allowed to read.
      *
      * @return array of {@link \eZ\Publish\API\Repository\Values\Content\Section}
      */

--- a/eZ/Publish/Core/Repository/SectionService.php
+++ b/eZ/Publish/Core/Repository/SectionService.php
@@ -204,7 +204,7 @@ class SectionService implements SectionServiceInterface
     }
 
     /**
-     * Loads all sections. If the current user is not allowed to read a section then list are filtered.
+     * Loads all sections, excluding the ones the current user is not allowed to read.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Section[]
      */

--- a/eZ/Publish/Core/Repository/SectionService.php
+++ b/eZ/Publish/Core/Repository/SectionService.php
@@ -8,27 +8,28 @@
  */
 namespace eZ\Publish\Core\Repository;
 
+use Exception;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\API\Repository\PermissionCriterionResolver;
+use eZ\Publish\API\Repository\Repository as RepositoryInterface;
+use eZ\Publish\API\Repository\SectionService as SectionServiceInterface;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Query;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree as CriterionSubtree;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd as CriterionLogicalAnd;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalNot as CriterionLogicalNot;
-use eZ\Publish\API\Repository\Values\Content\SectionCreateStruct;
-use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree as CriterionSubtree;
 use eZ\Publish\API\Repository\Values\Content\Section;
+use eZ\Publish\API\Repository\Values\Content\SectionCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\SectionUpdateStruct;
-use eZ\Publish\API\Repository\SectionService as SectionServiceInterface;
-use eZ\Publish\API\Repository\Repository as RepositoryInterface;
-use eZ\Publish\SPI\Persistence\Content\Section\Handler as SectionHandler;
+use eZ\Publish\Core\Base\Exceptions\BadStateException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
 use eZ\Publish\SPI\Persistence\Content\Section as SPISection;
-use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
-use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use eZ\Publish\Core\Base\Exceptions\BadStateException;
-use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
-use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
-use Exception;
+use eZ\Publish\SPI\Persistence\Content\Section\Handler as SectionHandler;
+use function array_filter;
 
 /**
  * Section service, used for section operations.
@@ -203,25 +204,19 @@ class SectionService implements SectionServiceInterface
     }
 
     /**
-     * Loads all sections.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read a section
+     * Loads all sections. If the current user is not allowed to read a section then list are filtered.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Section[]
      */
     public function loadSections()
     {
-        $sections = [];
-        foreach ($this->sectionHandler->loadAll() as $spiSection) {
-            $sections[] = $section = $this->buildDomainSectionObject($spiSection);
+        $sections = array_map(function ($spiSection) {
+            return $this->buildDomainSectionObject($spiSection);
+        }, $this->sectionHandler->loadAll());
 
-            // @todo change API to just filter instead of throwing here
-            if (!$this->permissionResolver->canUser('section', 'view', $section)) {
-                throw new UnauthorizedException('section', 'view');
-            }
-        }
-
-        return $sections;
+        return array_values(array_filter($sections, function ($section) {
+            return $this->permissionResolver->canUser('section', 'view', $section);
+        }));
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/SectionService.php
+++ b/eZ/Publish/Core/SignalSlot/SectionService.php
@@ -119,9 +119,7 @@ class SectionService implements SectionServiceInterface
     }
 
     /**
-     * Loads all sections.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read a section
+     * Loads all sections. If the current user is not allowed to read a section then list are filtered.
      *
      * @return array of {@link \eZ\Publish\API\Repository\Values\Content\Section}
      */

--- a/eZ/Publish/Core/SignalSlot/SectionService.php
+++ b/eZ/Publish/Core/SignalSlot/SectionService.php
@@ -119,7 +119,7 @@ class SectionService implements SectionServiceInterface
     }
 
     /**
-     * Loads all sections. If the current user is not allowed to read a section then list are filtered.
+     * Loads all sections, excluding the ones the current user is not allowed to read.
      *
      * @return array of {@link \eZ\Publish\API\Repository\Values\Content\Section}
      */


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30753](https://jira.ez.no/browse/EZP-30753)
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.5`
| **BC breaks**      | yes
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

Changed `loadSection()` method to filter the available sections and not throw an exception when the user has no permission to all sections. This change is needed to allow display user a list of section available to him in the administration panel.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
