### PR TITLE
[Travis] Bumped dist to Xenial to use MySQL 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ matrix:
       env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml" JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre/"
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
-      sudo: required
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
 # Disabled as it currently fails, integration tests are not written for language config awareness in Repo, should probably be opt in by test
@@ -80,10 +79,6 @@ before_install:
   # Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
-  # Install openJDK8 as default v11 is too new for SOLR
-  - if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then sudo apt-get install openjdk-8-jdk; fi
-  # Fix for out of memory error for pgsql
-  - if [ "$DB" = "postgresql" ]; then sudo mount -o remount,size=25% /var/ramfs ; fi
 
 install:
   - if [ "$TEST_CONFIG" != "" -o "$CHECK_CS" = "1" ] ; then travis_retry composer install --no-progress --no-interaction --prefer-dist $COMPOSER_FLAGS; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     - php: 7.1
       env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat
     - php: 7.1
-      env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml" JAVA_HOME="/usr/local/lib/jvm/openjdk11/bin/java"
+      env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml" JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre/"
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
     - php: 7.1
@@ -79,6 +79,8 @@ before_install:
   # Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
+  # Install openJDK8 as default v11 is too new for SOLR
+  - if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then sudo apt-get install openjdk-8-jdk; fi
 
 install:
   - if [ "$TEST_CONFIG" != "" -o "$CHECK_CS" = "1" ] ; then travis_retry composer install --no-progress --no-interaction --prefer-dist $COMPOSER_FLAGS; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
       env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml" JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre/"
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
+      sudo: required
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
 # Disabled as it currently fails, integration tests are not written for language config awareness in Repo, should probably be opt in by test
@@ -81,6 +82,8 @@ before_install:
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
   # Install openJDK8 as default v11 is too new for SOLR
   - if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then sudo apt-get install openjdk-8-jdk; fi
+  # Fix for out of memory error for pgsql
+  - if [ "$DB" = "postgresql" ]; then sudo mount -o remount,size=25% /var/ramfs ; fi
 
 install:
   - if [ "$TEST_CONFIG" != "" -o "$CHECK_CS" = "1" ] ; then travis_retry composer install --no-progress --no-interaction --prefer-dist $COMPOSER_FLAGS; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Use trusty for better performance (and avoiding mysql/postgres/solr gone issues on precise and container infra)
-dist: trusty
+dist: xenial
 sudo: required
 
 language: php

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ services:
 addons:
   apt:
     packages:
-    - mysql-server-5.6
-    - mysql-client-core-5.6
-    - mysql-client-5.6
+    - mysql-server-5.7
+    - mysql-client-core-5.7
+    - mysql-client-5.7
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     - php: 7.1
       env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat
     - php: 7.1
-      env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
+      env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml" JAVA_HOME="/usr/local/lib/jvm/openjdk11/bin/java"
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,6 @@ services:
   - postgresql
   - redis-server
 
-# Mysql isn't installed on trusty (only client is), so we need to specifically install it
-addons:
-  apt:
-    packages:
-    - mysql-server-5.7
-    - mysql-client-core-5.7
-    - mysql-client-5.7
-
 cache:
   directories:
     - $HOME/.composer/cache/files

--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -23,10 +23,10 @@ if [ "$DB" = "mysql" ] || [ "$DB" = "mariadb" ] ; then
     # make tmpfs and run MySQL on it for reasonable performance
     sudo mkdir /mnt/ramdisk
     sudo mount -t tmpfs -o size=1024m tmpfs /mnt/ramdisk
-    sudo stop mysql
+    sudo /etc/init.d/mysql stop
     sudo mv /var/lib/mysql /mnt/ramdisk
     sudo ln -s /mnt/ramdisk/mysql /var/lib/mysql
-    sudo start mysql
+    sudo /etc/init.d/mysql start
     # Install test db
     mysql -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;" -uroot
 fi

--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -30,13 +30,17 @@ if [ "$DB" = "mysql" ] || [ "$DB" = "mariadb" ] ; then
     # Install test db
     mysql -e "CREATE DATABASE IF NOT EXISTS testdb DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;" -uroot
 fi
-if [ "$DB" = "postgresql" ] ; then psql -c "CREATE DATABASE testdb;" -U postgres ; psql -c "CREATE EXTENSION pgcrypto;" -U postgres testdb ; fi
+
+# fix memory issue
+if [ "$DB" = "postgresql" ] ; then sudo mount -o remount,size=25% /var/ramfs; psql -c "CREATE DATABASE testdb;" -U postgres ; psql -c "CREATE EXTENSION pgcrypto;" -U postgres testdb ; fi
 
 # Setup GitHub key to avoid api rate limit (pure auth read only key, no rights, for use by ezsystems repos only!)
 composer config -g github-oauth.github.com "d0285ed5c8644f30547572ead2ed897431c1fc09"
 
 # solr package search API integration tests
 if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then
+    # Install openJDK8 as default v11 is too new for SOLR
+    sudo apt-get install openjdk-8-jdk
     echo "> Require ezsystems/ezplatform-solr-search-engine:^1.3.0@dev"
     composer require --no-update ezsystems/ezplatform-solr-search-engine:^1.3.0@dev
 fi


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5` and `master (8.0)`
| **BC breaks**      | no
| **Tests pass**     | TBD
| **Doc needed**     | no

According to the doc [we require at least MySQL 5.7](https://doc.ezplatform.com/en/2.5/getting_started/requirements/#recommended-setups) in version 2.5, so we should align that on Travis as well.

The background reason for this change is faulty default configuration of MySQL 5.6 which leads to unsolvable otherwise false negative test results in #2621.

`Xenial` supports MySQL 5.7 out of the box, so we've decided to bump entire dist. `Trusty` is quite old, so it's the highest time.

**TODO**:
- [x] Wait for Travis to confirm.
- [x] Do a TMP cherry-pick into #2621 to see if that solves the issue
- [x] Ask for Code Review.
