### PR TITLE
Removed wrong return doc

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/PolicyProviderInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/PolicyProviderInterface.php
@@ -59,8 +59,6 @@ interface PolicyProviderInterface
      *     custom_function_1: ~
      *     custom_function_2: [CustomLimitation]
      * ```
-     *
-     * @return array
      */
     public function addPolicies(ConfigBuilderInterface $configBuilder);
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | none
| **Improvement**| yes
| **New feature**    | yes
| **Target version** | `master` for features
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | no

This PR removed return from PHP Doc comment. Implementation expects `ConfigBuilderInterface` argument to be updated, instead of returning an array with policies.
