### PR TITLE
EZP-30790: Introduced strict types for Search supports methods

### DIFF
--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -82,6 +82,13 @@ Changes affecting version compatibility with former or future versions.
 * `ezpublish.core.io.metadata_handler.factory` service was renamed to `ezpublish.core.io.metadata_handler.registry`
 * `ezpublish.core.io.binarydata_handler.factory` service was renamed to `ezpublish.core.io.binarydata_handler.registry`
 
+## Changed features
+
+* The signature of the `\eZ\Publish\API\Repository\SearchService::supports` method was changed to:
+  ```php
+  public function supports(int $capabilityFlag): bool;
+  ```
+
 ## Removed services
 
 * `ezpublish.field_type_collection.factory` has been removed in favor of `eZ\Publish\Core\FieldType\FieldTypeRegistry`

--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -88,6 +88,10 @@ Changes affecting version compatibility with former or future versions.
   ```php
   public function supports(int $capabilityFlag): bool;
   ```
+* The signature of the `\eZ\Publish\SPI\Search\Capable::supports` method was changed to:
+  ```php
+  public function supports(int $capabilityFlag): bool;
+  ```
 
 ## Removed services
 

--- a/eZ/Publish/API/Repository/SearchService.php
+++ b/eZ/Publish/API/Repository/SearchService.php
@@ -194,5 +194,5 @@ interface SearchService
      *
      * @return bool
      */
-    public function supports($capabilityFlag);
+    public function supports(int $capabilityFlag): bool;
 }

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -341,7 +341,7 @@ class SearchService implements SearchServiceInterface
         return true;
     }
 
-    public function supports($capabilityFlag)
+    public function supports(int $capabilityFlag): bool
     {
         if ($this->searchHandler instanceof Capable) {
             return $this->searchHandler->supports($capabilityFlag);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/SearchService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/SearchService.php
@@ -96,7 +96,7 @@ class SearchService implements SearchServiceInterface
         return $this->service->findLocations($query, $languageFilter, $filterOnUserPermissions);
     }
 
-    public function supports($capabilityFlag)
+    public function supports(int $capabilityFlag): bool
     {
         return $this->service->supports($capabilityFlag);
     }

--- a/eZ/Publish/SPI/Repository/Decorator/SearchServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/SearchServiceDecorator.php
@@ -64,7 +64,7 @@ abstract class SearchServiceDecorator implements SearchService
         return $this->innerService->findLocations($query, $languageFilter, $filterOnUserPermissions);
     }
 
-    public function supports($capabilityFlag)
+    public function supports(int $capabilityFlag): bool
     {
         return $this->innerService->supports($capabilityFlag);
     }

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/SearchServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/SearchServiceDecoratorTest.php
@@ -110,15 +110,38 @@ class SearchServiceDecoratorTest extends TestCase
         $decoratedService->findLocations(...$parameters);
     }
 
-    public function testSupportsDecorator()
+    /**
+     * @dataProvider getSearchEngineCapabilities
+     *
+     * @param int $capability
+     */
+    public function testSupportsDecorator(int $capability): void
     {
         $serviceMock = $this->createServiceMock();
         $decoratedService = $this->createDecorator($serviceMock);
 
-        $parameters = ['random_value_5ced05ce17f6c8.39484505'];
+        $serviceMock->expects($this->once())->method('supports')->with($capability);
 
-        $serviceMock->expects($this->once())->method('supports')->with(...$parameters);
+        $decoratedService->supports($capability);
+    }
 
-        $decoratedService->supports(...$parameters);
+    /**
+     * Data provider for testSupportsDecorator.
+     *
+     * @see testSupportsDecorator
+     *
+     * @return array
+     */
+    public function getSearchEngineCapabilities(): array
+    {
+        return [
+            [SearchService::CAPABILITY_SCORING],
+            [SearchService::CAPABILITY_FACETS],
+            [SearchService::CAPABILITY_CUSTOM_FIELDS],
+            [SearchService::CAPABILITY_SPELLCHECK],
+            [SearchService::CAPABILITY_HIGHLIGHT],
+            [SearchService::CAPABILITY_SUGGEST],
+            [SearchService::CAPABILITY_ADVANCED_FULLTEXT],
+        ];
     }
 }

--- a/eZ/Publish/SPI/Search/Capable.php
+++ b/eZ/Publish/SPI/Search/Capable.php
@@ -22,5 +22,5 @@ interface Capable
      *
      * @return bool
      */
-    public function supports($capabilityFlag);
+    public function supports(int $capabilityFlag): bool;
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30790](https://jira.ez.no/browse/EZP-30790)
| **Requires** | ezsystems/ezplatform-solr-search-engine#145
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0)` for eZ Platform `v3.0`
| **BC breaks**      | yes
| **Tests pass**     | yes, Solr fails due to missing PR dependency.
| **Doc needed**     | yes[1]

This PR introduces strict types for the following methods:
- [x] `\eZ\Publish\API\Repository\SearchService::supports`,
- [x] `\eZ\Publish\SPI\Search\Capable::supports`.

I've just seen a call like
```php
$searchService->supports('CAPABILITY_FACETS');
```
so it will be a DX improvement to get here concrete error instead of `false` result.

[1] We should probably improve [this doc](https://doc.ezplatform.com/en/latest/api/public_php_api_search/#difference-between-filter-and-query) to use proper method name (`eZ\Publish\API\Repository\SearchService::supports`) instead of out of context call and add an example showing how to use it.

## QA

- [x] Sanity check for search usage (method is actually not used anywhere, but if anything is wrong, just loading the Service would crash), make sure to use Solr with ezsystems/ezplatform-solr-search-engine#145,
- [ ] Optional: Symfony command which calls the `support` method with some capability flag (`\eZ\Publish\API\Repository\SearchService::CAPABILITY_*`).

**TODO**:
- [x] Add BC doc.
- [x] Fix tests.
- [x] Prepare Solr PR (ezsystems/ezplatform-solr-search-engine#145).
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
