### PR TITLE
Fixed random error during the test with PostgreSQL

### DIFF
--- a/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
+++ b/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
@@ -1167,9 +1167,9 @@ class PermissionResolverTest extends BaseTest
         $permissionResolver->setCurrentUserReference($user);
         /* END: Use Case */
 
-        $expectedPolicy = array_filter($role->getPolicies(), function ($policy) use ($module, $function) {
+        $expectedPolicy = current(array_filter($role->getPolicies(), function ($policy) use ($module, $function) {
             return $policy->module === $module && $policy->function === $function;
-        })[0] ?? null;
+        }));
 
         $expected = new LookupLimitationResult(
             true,


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [N/A]
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.5` 
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     |no

Because we want to get the first element of the array and `array_filter` preserve keys we can not get the first element by `[0]`. See [travis](https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/565253192)


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
