### PR TITLE
Remove kriswallsmith/buzz from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "symfony/validator": "^4.3",
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "symfony-cmf/routing": "^2.1",
-        "kriswallsmith/buzz": "^1.0",
         "nelmio/cors-bundle": "^1.5.0",
         "hautelook/templated-uri-bundle": "^2.1",
         "pagerfanta/pagerfanta": "^2.0",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

`kriswallsmith/buzz` is not needed anymore in the kernel as REST has been moved to separate package.