### PR TITLE
Fixed error when building UserGroup when a user has no access to a parent location

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -577,6 +577,7 @@ abstract class BaseTest extends TestCase
      *
      * @param string $login
      * @param array $policiesData list of policies in the form of <code>[ [ 'module' => 'name', 'function' => 'name'] ]</code>
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation|null $roleLimitation
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
@@ -584,7 +585,7 @@ abstract class BaseTest extends TestCase
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function createUserWithPolicies($login, array $policiesData)
+    public function createUserWithPolicies($login, array $policiesData, RoleLimitation $roleLimitation = null)
     {
         $repository = $this->getRepository(false);
         $roleService = $repository->getRoleService();
@@ -603,7 +604,7 @@ abstract class BaseTest extends TestCase
             $user = $userService->createUser($userCreateStruct, [$userService->loadUserGroup(4)]);
 
             $role = $this->createRoleWithPolicies(uniqid('role_for_' . $login . '_', true), $policiesData);
-            $roleService->assignRoleToUser($role, $user);
+            $roleService->assignRoleToUser($role, $user, $roleLimitation);
 
             $repository->commit();
 

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -54,7 +54,7 @@ class UserServiceTest extends BaseTest
         $userGroup = $userService->loadUserGroup($mainGroupId);
         /* END: Use Case */
 
-        $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup', $userGroup);
+        $this->assertInstanceOf(UserGroup::class, $userGroup);
 
         // User group happens to also be a Content; isUserGroup() should be true and isUser() should be false
         $this->assertTrue($userService->isUserGroup($userGroup), 'isUserGroup() => false on a user group');
@@ -90,12 +90,12 @@ class UserServiceTest extends BaseTest
         $userGroup = $userService->loadUserGroup($mainGroupId);
         /* END: Use Case */
 
-        $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup', $userGroup);
+        $this->assertInstanceOf(UserGroup::class, $userGroup);
 
         // User group happens to also be a Content; isUserGroup() should be true and isUser() should be false
         $this->assertTrue($userService->isUserGroup($userGroup), 'isUserGroup() => false on a user group');
         $this->assertFalse($userService->isUser($userGroup), 'isUser() => true on a user group');
-        $this->assertNull($userGroup->parentId, 'parentId should be null a when user has no access to it');
+        $this->assertSame(0, $userGroup->parentId, 'parentId should be equal `0` because it is top level node');
     }
 
     /**
@@ -139,7 +139,7 @@ class UserServiceTest extends BaseTest
         $subUserGroups = $userService->loadSubUserGroups($userGroup);
         foreach ($subUserGroups as $subUserGroup) {
             // Do something with the $subUserGroup
-            $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup', $subUserGroup);
+            $this->assertInstanceOf(UserGroup::class, $subUserGroup);
         }
         /* END: Use Case */
     }
@@ -278,7 +278,7 @@ class UserServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup',
+            UserGroup::class,
             $userGroup
         );
 
@@ -644,7 +644,7 @@ class UserServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup',
+            UserGroup::class,
             $userGroup
         );
 

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
 use eZ\Publish\API\Repository\Values\User\PasswordValidationContext;
 use eZ\Publish\API\Repository\Values\User\UserGroupUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\UserTokenUpdateStruct;
@@ -58,6 +59,43 @@ class UserServiceTest extends BaseTest
         // User group happens to also be a Content; isUserGroup() should be true and isUser() should be false
         $this->assertTrue($userService->isUserGroup($userGroup), 'isUserGroup() => false on a user group');
         $this->assertFalse($userService->isUser($userGroup), 'isUser() => true on a user group');
+        $this->assertSame(0, $userGroup->parentId, 'parentId should be equal `0` because it is top level node');
+    }
+
+    /**
+     * Test for the loadUserGroup() method to ensure that DomainUserGroupObject is created properly even if a user
+     * has no access to parent of UserGroup.
+     *
+     * @see \eZ\Publish\API\Repository\UserService::loadUserGroup()
+     */
+    public function testLoadUserGroupWithNoAccessToParent()
+    {
+        $repository = $this->getRepository();
+
+        $mainGroupId = $this->generateId('group', 4);
+        /* BEGIN: Use Case */
+        // $mainGroupId is the ID of the main "Users" group
+
+        $userService = $repository->getUserService();
+
+        $user = $this->createUserWithPolicies(
+            'user',
+            [
+                ['module' => 'content', 'function' => 'read'],
+            ],
+            new SubtreeLimitation(['limitationValues' => ['/1/5']])
+        );
+        $repository->getPermissionResolver()->setCurrentUserReference($user);
+
+        $userGroup = $userService->loadUserGroup($mainGroupId);
+        /* END: Use Case */
+
+        $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup', $userGroup);
+
+        // User group happens to also be a Content; isUserGroup() should be true and isUser() should be false
+        $this->assertTrue($userService->isUserGroup($userGroup), 'isUserGroup() => false on a user group');
+        $this->assertFalse($userService->isUser($userGroup), 'isUser() => true on a user group');
+        $this->assertNull($userGroup->parentId, 'parentId should be null a when user has no access to it');
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -603,6 +603,7 @@ class Repository implements RepositoryInterface
         $this->userService = new UserService(
             $this,
             $this->persistenceHandler->userHandler(),
+            $this->persistenceHandler->locationHandler(),
             $this->serviceSettings['user']
         );
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UserTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UserTest.php
@@ -150,6 +150,7 @@ class UserTest extends BaseServiceMockTest
                 [
                     $this->getRepositoryMock(),
                     $this->getPersistenceMock()->userHandler(),
+                    $this->getPersistenceMock()->locationHandler(),
                 ]
             )
             ->getMock();


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30807](https://jira.ez.no/browse/EZP-30807)
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.5` 
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     |no

When a user has `administrator` access but limited do subtree of Users, he is unable to enter Users tab in the Admin section in the top menu. This is because we try to load the parent location in method `buildDomainUserGroupObject`. ~~We can catch `APIUnauthorizedException` and set `parentId` to null because `parentId` in `UserGroup` is nullable and in existed code when we can not access parent location we set `null`~~ We are using a locationHandler to load the Location without checking permission and only return `contentId` of loaded `parentLocation`

To test this user must have separate role with access to role/read without limitation because of another bug [EZP-30783](https://jira.ez.no/browse/EZP-30783)


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
