### PR TITLE
TranslateVersionSignal has @deprecated tag in wrong DocBlock

### DIFF
--- a/eZ/Publish/Core/SignalSlot/Signal/ContentService/TranslateVersionSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/ContentService/TranslateVersionSignal.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @deprecated since 7.5. Will be removed in 8.0 as it is no longer used.
  */
 namespace eZ\Publish\Core\SignalSlot\Signal\ContentService;
 

--- a/eZ/Publish/Core/SignalSlot/Signal/ContentService/TranslateVersionSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/ContentService/TranslateVersionSignal.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\SignalSlot\Signal;
 
 /**
  * TranslateVersionSignal class.
+ * @deprecated since 7.5. Will be removed in 8.0 as it is no longer used.
  */
 class TranslateVersionSignal extends Signal
 {


### PR DESCRIPTION
As in the title, moved to the right block.