### PR TITLE
EZP-30808: Fixed wrong usage of hasAccess in RoleService

### DIFF
--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -257,9 +257,7 @@ interface RoleService
     public function loadRoleByIdentifier($identifier);
 
     /**
-     * Loads all roles.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the roles
+     * Loads all roles, excluding the ones the current user is not allowed to read.
      *
      * @return \eZ\Publish\API\Repository\Values\User\Role[]
      */
@@ -363,12 +361,11 @@ interface RoleService
     public function getRoleAssignments(Role $role);
 
     /**
-     * Returns UserRoleAssignments assigned to the given User.
+     * Returns UserRoleAssignments assigned to the given User, excluding the ones the current user is not allowed to read.
      *
      * If second parameter \$inherited is true then UserGroupRoleAssignment is also returned for UserGroups User is
      * placed in as well as those inherited from parent UserGroups.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the current user is not allowed to read a role
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException On invalid User object
      *
      * @param \eZ\Publish\API\Repository\Values\User\User $user
@@ -379,9 +376,7 @@ interface RoleService
     public function getRoleAssignmentsForUser(User $user, $inherited = false);
 
     /**
-     * Returns the UserGroupRoleAssignments assigned to the given UserGroup.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user group
+     * Returns the UserGroupRoleAssignments assigned to the given UserGroup, excluding the ones the current user is not allowed to read.
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      *

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -577,6 +577,7 @@ abstract class BaseTest extends TestCase
      *
      * @param string $login
      * @param array $policiesData list of policies in the form of <code>[ [ 'module' => 'name', 'function' => 'name'] ]</code>
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation|null $roleLimitation
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
@@ -584,7 +585,7 @@ abstract class BaseTest extends TestCase
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function createUserWithPolicies($login, array $policiesData)
+    public function createUserWithPolicies($login, array $policiesData, RoleLimitation $roleLimitation = null)
     {
         $repository = $this->getRepository(false);
         $roleService = $repository->getRoleService();
@@ -603,7 +604,7 @@ abstract class BaseTest extends TestCase
             $user = $userService->createUser($userCreateStruct, [$userService->loadUserGroup(4)]);
 
             $role = $this->createRoleWithPolicies(uniqid('role_for_' . $login . '_', true), $policiesData);
-            $roleService->assignRoleToUser($role, $user);
+            $roleService->assignRoleToUser($role, $user, $roleLimitation);
 
             $repository->commit();
 

--- a/eZ/Publish/API/Repository/Tests/RoleServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/RoleServiceAuthorizationTest.php
@@ -104,11 +104,8 @@ class RoleServiceAuthorizationTest extends BaseTest
      * Test for the loadRoles() method.
      *
      * @see \eZ\Publish\API\Repository\RoleService::loadRoles()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testLoadRoles
-     * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testCreateUser
      */
-    public function testLoadRolesThrowsUnauthorizedException()
+    public function testLoadRolesLoadsEmptyListForAnonymousUser()
     {
         $repository = $this->getRepository();
 
@@ -120,10 +117,39 @@ class RoleServiceAuthorizationTest extends BaseTest
 
         // Get the role service
         $roleService = $repository->getRoleService();
-
-        // This call will fail with an "UnauthorizedException"
-        $roleService->loadRoles();
         /* END: Use Case */
+
+        $this->assertEquals([], $roleService->loadRoles());
+    }
+
+    /**
+     * Test for the loadRoles() method.
+     *
+     * @see \eZ\Publish\API\Repository\RoleService::loadRoles()
+     */
+    public function testLoadRolesForUserWithSubtreeLimitation()
+    {
+        $repository = $this->getRepository();
+        $roleService = $repository->getRoleService();
+
+        /* BEGIN: Use Case */
+        // create user that can read/create/delete but cannot edit or content
+        $this->createRoleWithPolicies('roleReader', [
+            ['module' => 'role', 'function' => 'read'],
+        ]);
+
+        $user = $this->createCustomUserWithLogin(
+            'user',
+            'user@example.com',
+            'roleReaders',
+            'roleReader',
+            new SubtreeLimitation(['limitationValues' => ['/1/2/']])
+        );
+
+        $repository->getPermissionResolver()->setCurrentUserReference($user);
+        /* END: Use Case */
+
+        $this->assertCount(6, $roleService->loadRoles());
     }
 
     /**
@@ -547,11 +573,8 @@ class RoleServiceAuthorizationTest extends BaseTest
      * Test for the getRoleAssignmentsForUser() method.
      *
      * @see \eZ\Publish\API\Repository\RoleService::getRoleAssignmentsForUser()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testGetRoleAssignmentsForUserEmpty
-     * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testCreateUser
      */
-    public function testGetRoleAssignmentsForUserThrowsUnauthorizedException()
+    public function testGetRoleAssignmentsForUserLoadsEmptyListForAnonymousUser()
     {
         $repository = $this->getRepository();
         $roleService = $repository->getRoleService();
@@ -562,11 +585,39 @@ class RoleServiceAuthorizationTest extends BaseTest
         $this->createRole();
 
         // Set "Editor" user as current user.
-        $repository->setCurrentUser($user);
-
-        // This call will fail with an "UnauthorizedException"
-        $roleService->getRoleAssignmentsForUser($user);
+        $repository->getPermissionResolver()->setCurrentUserReference($user);
         /* END: Use Case */
+
+        $this->assertSame([], $roleService->getRoleAssignmentsForUser($user));
+    }
+
+    /**
+     * Test for the getRoleAssignmentsForUser() method.
+     *
+     * @see \eZ\Publish\API\Repository\RoleService::getRoleAssignmentsForUser()
+     */
+    public function testGetRoleAssignmentsForUserWithSubtreeLimitation()
+    {
+        $repository = $this->getRepository();
+        $roleService = $repository->getRoleService();
+
+        /* BEGIN: Use Case */
+        $user = $this->createUserWithPolicies(
+            'trash_test_user',
+            [
+                ['module' => 'role', 'function' => 'read'],
+            ],
+            new SubtreeLimitation(['limitationValues' => ['/1/2/']])
+        );
+
+        $repository->getPermissionResolver()->setCurrentUserReference($user);
+        /* END: Use Case */
+
+        $roleAssignments = $roleService->getRoleAssignmentsForUser($user);
+        $this->assertCount(1, $roleAssignments);
+
+        $roleAssignment = $roleAssignments[0];
+        $this->assertSame($user, $roleAssignment->user);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/RoleService.php
+++ b/eZ/Publish/Core/REST/Client/RoleService.php
@@ -542,9 +542,7 @@ class RoleService implements APIRoleService, Sessionable
     }
 
     /**
-     * Loads all roles.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the roles
+     * Loads all roles, excluding the ones the current user is not allowed to read.
      *
      * @return \eZ\Publish\API\Repository\Values\User\Role[]
      */
@@ -813,9 +811,7 @@ class RoleService implements APIRoleService, Sessionable
     }
 
     /**
-     * Returns the roles assigned to the given user group.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user group
+     * Returns the roles assigned to the given user group, excluding the ones the current user is not allowed to read.
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      *

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -8,10 +8,10 @@
  */
 namespace eZ\Publish\Core\Repository;
 
+use Exception;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\RoleService as RoleServiceInterface;
-use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\Policy as APIPolicy;
 use eZ\Publish\API\Repository\Values\User\PolicyCreateStruct as APIPolicyCreateStruct;
@@ -28,19 +28,15 @@ use eZ\Publish\Core\Base\Exceptions\BadStateException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 use eZ\Publish\Core\Base\Exceptions\LimitationValidationException;
-use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\NotFound\LimitationNotFoundException;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
-use eZ\Publish\Core\Repository\Values\User\Policy;
 use eZ\Publish\Core\Repository\Values\User\PolicyCreateStruct;
 use eZ\Publish\Core\Repository\Values\User\PolicyUpdateStruct;
 use eZ\Publish\Core\Repository\Values\User\Role;
 use eZ\Publish\Core\Repository\Values\User\RoleCreateStruct;
-use eZ\Publish\Core\Repository\Values\User\RoleDraft;
 use eZ\Publish\SPI\Persistence\User\Handler;
 use eZ\Publish\SPI\Persistence\User\Role as SPIRole;
 use eZ\Publish\SPI\Persistence\User\RoleUpdateStruct as SPIRoleUpdateStruct;
-use Exception;
 
 /**
  * This service provides methods for managing Roles and Policies.
@@ -61,6 +57,9 @@ class RoleService implements RoleServiceInterface
 
     /** @var array */
     protected $settings;
+
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    private $permissionResolver;
 
     /**
      * Setups service with reference to repository object that created it & corresponding handler.
@@ -83,6 +82,7 @@ class RoleService implements RoleServiceInterface
         $this->limitationService = $limitationService;
         $this->roleDomainMapper = $roleDomainMapper;
         $this->settings = $settings;
+        $this->permissionResolver = $repository->getPermissionResolver();
     }
 
     /**
@@ -106,7 +106,7 @@ class RoleService implements RoleServiceInterface
             throw new InvalidArgumentValue('identifier', $roleCreateStruct->identifier, 'RoleCreateStruct');
         }
 
-        if (!$this->repository->canUser('role', 'create', $roleCreateStruct)) {
+        if (!$this->permissionResolver->canUser('role', 'create', $roleCreateStruct)) {
             throw new UnauthorizedException('role', 'create');
         }
 
@@ -155,7 +155,7 @@ class RoleService implements RoleServiceInterface
      */
     public function createRoleDraft(APIRole $role)
     {
-        if (!$this->repository->canUser('role', 'create', $role)) {
+        if (!$this->permissionResolver->canUser('role', 'create', $role)) {
             throw new UnauthorizedException('role', 'create');
         }
 
@@ -199,7 +199,7 @@ class RoleService implements RoleServiceInterface
 
         $role = $this->roleDomainMapper->buildDomainRoleDraftObject($spiRole);
 
-        if (!$this->repository->canUser('role', 'read', $role)) {
+        if (!$this->permissionResolver->canUser('role', 'read', $role)) {
             throw new UnauthorizedException('role', 'read');
         }
 
@@ -222,7 +222,7 @@ class RoleService implements RoleServiceInterface
 
         $role = $this->roleDomainMapper->buildDomainRoleDraftObject($spiRole);
 
-        if (!$this->repository->canUser('role', 'read', $role)) {
+        if (!$this->permissionResolver->canUser('role', 'read', $role)) {
             throw new UnauthorizedException('role', 'read');
         }
 
@@ -250,7 +250,7 @@ class RoleService implements RoleServiceInterface
 
         $loadedRoleDraft = $this->loadRoleDraft($roleDraft->id);
 
-        if (!$this->repository->canUser('role', 'update', $loadedRoleDraft)) {
+        if (!$this->permissionResolver->canUser('role', 'update', $loadedRoleDraft)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -322,7 +322,7 @@ class RoleService implements RoleServiceInterface
             throw new InvalidArgumentValue('module', $policyCreateStruct->module, 'PolicyCreateStruct');
         }
 
-        if (!$this->repository->canUser('role', 'update', $roleDraft)) {
+        if (!$this->permissionResolver->canUser('role', 'update', $roleDraft)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -371,7 +371,7 @@ class RoleService implements RoleServiceInterface
      */
     public function removePolicyByRoleDraft(APIRoleDraft $roleDraft, PolicyDraft $policyDraft)
     {
-        if (!$this->repository->canUser('role', 'update', $roleDraft)) {
+        if (!$this->permissionResolver->canUser('role', 'update', $roleDraft)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -411,7 +411,7 @@ class RoleService implements RoleServiceInterface
             throw new InvalidArgumentValue('function', $policy->function, 'Policy');
         }
 
-        if (!$this->repository->canUser('role', 'update', $roleDraft)) {
+        if (!$this->permissionResolver->canUser('role', 'update', $roleDraft)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -485,7 +485,7 @@ class RoleService implements RoleServiceInterface
      */
     public function publishRoleDraft(APIRoleDraft $roleDraft)
     {
-        if (!$this->repository->canUser('role', 'update', $roleDraft)) {
+        if (!$this->permissionResolver->canUser('role', 'update', $roleDraft)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -530,7 +530,7 @@ class RoleService implements RoleServiceInterface
 
         $loadedRole = $this->loadRole($role->id);
 
-        if (!$this->repository->canUser('role', 'update', $role)) {
+        if (!$this->permissionResolver->canUser('role', 'update', $role)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -597,7 +597,7 @@ class RoleService implements RoleServiceInterface
             throw new InvalidArgumentValue('module', $policyCreateStruct->module, 'PolicyCreateStruct');
         }
 
-        if (!$this->repository->canUser('role', 'update', $role)) {
+        if (!$this->permissionResolver->canUser('role', 'update', $role)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -645,7 +645,7 @@ class RoleService implements RoleServiceInterface
         $spiRole = $this->userHandler->loadRole($policy->roleId);
         $role = $this->roleDomainMapper->buildDomainRoleObject($spiRole);
 
-        if (!$this->repository->canUser('role', 'update', $role)) {
+        if (!$this->permissionResolver->canUser('role', 'update', $role)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -697,10 +697,7 @@ class RoleService implements RoleServiceInterface
             throw new InvalidArgumentValue('function', $policy->function, 'Policy');
         }
 
-        $spiRole = $this->userHandler->loadRole($policy->roleId);
-        $role = $this->roleDomainMapper->buildDomainRoleObject($spiRole);
-
-        if (!$this->repository->canUser('role', 'update', $role)) {
+        if (!$this->permissionResolver->canUser('role', 'update', $policy)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -750,7 +747,7 @@ class RoleService implements RoleServiceInterface
 
         $role = $this->roleDomainMapper->buildDomainRoleObject($spiRole);
 
-        if (!$this->repository->canUser('role', 'read', $role)) {
+        if (!$this->permissionResolver->canUser('role', 'read', $role)) {
             throw new UnauthorizedException('role', 'read');
         }
 
@@ -777,7 +774,7 @@ class RoleService implements RoleServiceInterface
 
         $role = $this->roleDomainMapper->buildDomainRoleObject($spiRole);
 
-        if (!$this->repository->canUser('role', 'read', $role)) {
+        if (!$this->permissionResolver->canUser('role', 'read', $role)) {
             throw new UnauthorizedException('role', 'read');
         }
 
@@ -791,13 +788,21 @@ class RoleService implements RoleServiceInterface
      */
     public function loadRoles()
     {
-        $roles = array_map(function ($spiRole) {
-            return $this->roleDomainMapper->buildDomainRoleObject($spiRole);
-        }, $this->userHandler->loadRoles());
+        $roles = array_map(
+            function ($spiRole) {
+                return $this->roleDomainMapper->buildDomainRoleObject($spiRole);
+            },
+            $this->userHandler->loadRoles()
+        );
 
-        return array_values(array_filter($roles, function ($role) {
-            return $this->repository->canUser('role', 'read', $role);
-        }));
+        return array_values(
+            array_filter(
+                $roles,
+                function ($role) {
+                    return $this->permissionResolver->canUser('role', 'read', $role);
+                }
+            )
+        );
     }
 
     /**
@@ -809,7 +814,7 @@ class RoleService implements RoleServiceInterface
      */
     public function deleteRole(APIRole $role)
     {
-        if (!$this->repository->canUser('role', 'delete', $role)) {
+        if (!$this->permissionResolver->canUser('role', 'delete', $role)) {
             throw new UnauthorizedException('role', 'delete');
         }
 
@@ -863,7 +868,7 @@ class RoleService implements RoleServiceInterface
      */
     public function assignRoleToUserGroup(APIRole $role, UserGroup $userGroup, RoleLimitation $roleLimitation = null)
     {
-        if ($this->repository->canUser('role', 'assign', $userGroup, $role) !== true) {
+        if ($this->permissionResolver->canUser('role', 'assign', $userGroup, [$role]) !== true) {
             throw new UnauthorizedException('role', 'assign');
         }
 
@@ -909,7 +914,7 @@ class RoleService implements RoleServiceInterface
      */
     public function unassignRoleFromUserGroup(APIRole $role, UserGroup $userGroup)
     {
-        if ($this->repository->canUser('role', 'assign', $userGroup, $role) !== true) {
+        if ($this->permissionResolver->canUser('role', 'assign', $userGroup, [$role]) !== true) {
             throw new UnauthorizedException('role', 'assign');
         }
 
@@ -952,7 +957,7 @@ class RoleService implements RoleServiceInterface
      */
     public function assignRoleToUser(APIRole $role, User $user, RoleLimitation $roleLimitation = null)
     {
-        if ($this->repository->canUser('role', 'assign', $user, $role) !== true) {
+        if ($this->permissionResolver->canUser('role', 'assign', $user, [$role]) !== true) {
             throw new UnauthorizedException('role', 'assign');
         }
 
@@ -998,7 +1003,7 @@ class RoleService implements RoleServiceInterface
      */
     public function unassignRoleFromUser(APIRole $role, User $user)
     {
-        if ($this->repository->canUser('role', 'assign', $user, $role) !== true) {
+        if ($this->permissionResolver->canUser('role', 'assign', $user, [$role]) !== true) {
             throw new UnauthorizedException('role', 'assign');
         }
 
@@ -1037,7 +1042,7 @@ class RoleService implements RoleServiceInterface
      */
     public function removeRoleAssignment(RoleAssignment $roleAssignment)
     {
-        if ($this->repository->canUser('role', 'assign', $roleAssignment) !== true) {
+        if ($this->permissionResolver->canUser('role', 'assign', $roleAssignment) !== true) {
             throw new UnauthorizedException('role', 'assign');
         }
 
@@ -1069,7 +1074,7 @@ class RoleService implements RoleServiceInterface
         $userService = $this->repository->getUserService();
         $role = $this->loadRole($spiRoleAssignment->roleId);
 
-        if (!$this->repository->canUser('role', 'read', $role)) {
+        if (!$this->permissionResolver->canUser('role', 'read', $role)) {
             throw new UnauthorizedException('role', 'read');
         }
 
@@ -1111,7 +1116,7 @@ class RoleService implements RoleServiceInterface
      */
     public function getRoleAssignments(APIRole $role)
     {
-        if (!$this->repository->canUser('role', 'read', $role)) {
+        if (!$this->permissionResolver->canUser('role', 'read', $role)) {
             throw new UnauthorizedException('role', 'read');
         }
 
@@ -1156,21 +1161,23 @@ class RoleService implements RoleServiceInterface
         foreach ($spiRoleAssignments as $spiRoleAssignment) {
             $role = $this->loadRole($spiRoleAssignment->roleId);
 
-            if ($this->repository->canUser('role', 'read', $role)) {
-                if (!$inherited || $spiRoleAssignment->contentId == $user->id) {
-                    $roleAssignments[] = $this->roleDomainMapper->buildDomainUserRoleAssignmentObject(
-                        $spiRoleAssignment,
-                        $user,
-                        $role
-                    );
-                } else {
-                    $userGroup = $this->repository->getUserService()->loadUserGroup($spiRoleAssignment->contentId);
-                    $roleAssignments[] = $this->roleDomainMapper->buildDomainUserGroupRoleAssignmentObject(
-                        $spiRoleAssignment,
-                        $userGroup,
-                        $role
-                    );
-                }
+            if (!$this->permissionResolver->canUser('role', 'read', $role)) {
+                continue;
+            }
+
+            if (!$inherited || $spiRoleAssignment->contentId == $user->id) {
+                $roleAssignments[] = $this->roleDomainMapper->buildDomainUserRoleAssignmentObject(
+                    $spiRoleAssignment,
+                    $user,
+                    $role
+                );
+            } else {
+                $userGroup = $this->repository->getUserService()->loadUserGroup($spiRoleAssignment->contentId);
+                $roleAssignments[] = $this->roleDomainMapper->buildDomainUserGroupRoleAssignmentObject(
+                    $spiRoleAssignment,
+                    $userGroup,
+                    $role
+                );
             }
         }
 
@@ -1191,7 +1198,7 @@ class RoleService implements RoleServiceInterface
         foreach ($spiRoleAssignments as $spiRoleAssignment) {
             $role = $this->loadRole($spiRoleAssignment->roleId);
 
-            if ($this->repository->canUser('role', 'read', $role)) {
+            if ($this->permissionResolver->canUser('role', 'read', $role)) {
                 $roleAssignments[] = $this->roleDomainMapper->buildDomainUserGroupRoleAssignmentObject(
                     $spiRoleAssignment,
                     $userGroup,

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -106,7 +106,7 @@ class RoleService implements RoleServiceInterface
             throw new InvalidArgumentValue('identifier', $roleCreateStruct->identifier, 'RoleCreateStruct');
         }
 
-        if ($this->repository->hasAccess('role', 'create') !== true) {
+        if (!$this->repository->canUser('role', 'create', $roleCreateStruct)) {
             throw new UnauthorizedException('role', 'create');
         }
 
@@ -155,7 +155,7 @@ class RoleService implements RoleServiceInterface
      */
     public function createRoleDraft(APIRole $role)
     {
-        if ($this->repository->hasAccess('role', 'create') !== true) {
+        if (!$this->repository->canUser('role', 'create', $role)) {
             throw new UnauthorizedException('role', 'create');
         }
 
@@ -195,13 +195,15 @@ class RoleService implements RoleServiceInterface
      */
     public function loadRoleDraft($id)
     {
-        if ($this->repository->hasAccess('role', 'read') !== true) {
+        $spiRole = $this->userHandler->loadRole($id, Role::STATUS_DRAFT);
+
+        $role = $this->roleDomainMapper->buildDomainRoleDraftObject($spiRole);
+
+        if (!$this->repository->canUser('role', 'read', $role)) {
             throw new UnauthorizedException('role', 'read');
         }
 
-        $spiRole = $this->userHandler->loadRole($id, Role::STATUS_DRAFT);
-
-        return $this->roleDomainMapper->buildDomainRoleDraftObject($spiRole);
+        return $role;
     }
 
     /**
@@ -216,13 +218,15 @@ class RoleService implements RoleServiceInterface
      */
     public function loadRoleDraftByRoleId($roleId)
     {
-        if ($this->repository->hasAccess('role', 'read') !== true) {
+        $spiRole = $this->userHandler->loadRoleDraftByRoleId($roleId);
+
+        $role = $this->roleDomainMapper->buildDomainRoleDraftObject($spiRole);
+
+        if (!$this->repository->canUser('role', 'read', $role)) {
             throw new UnauthorizedException('role', 'read');
         }
 
-        $spiRole = $this->userHandler->loadRoleDraftByRoleId($roleId);
-
-        return $this->roleDomainMapper->buildDomainRoleDraftObject($spiRole);
+        return $role;
     }
 
     /**
@@ -246,7 +250,7 @@ class RoleService implements RoleServiceInterface
 
         $loadedRoleDraft = $this->loadRoleDraft($roleDraft->id);
 
-        if ($this->repository->hasAccess('role', 'update') !== true) {
+        if (!$this->repository->canUser('role', 'update', $loadedRoleDraft)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -318,7 +322,7 @@ class RoleService implements RoleServiceInterface
             throw new InvalidArgumentValue('module', $policyCreateStruct->module, 'PolicyCreateStruct');
         }
 
-        if ($this->repository->hasAccess('role', 'update') !== true) {
+        if (!$this->repository->canUser('role', 'update', $roleDraft)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -367,7 +371,7 @@ class RoleService implements RoleServiceInterface
      */
     public function removePolicyByRoleDraft(APIRoleDraft $roleDraft, PolicyDraft $policyDraft)
     {
-        if ($this->repository->hasAccess('role', 'update') !== true) {
+        if (!$this->repository->canUser('role', 'update', $roleDraft)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -407,7 +411,7 @@ class RoleService implements RoleServiceInterface
             throw new InvalidArgumentValue('function', $policy->function, 'Policy');
         }
 
-        if ($this->repository->hasAccess('role', 'update') !== true) {
+        if (!$this->repository->canUser('role', 'update', $roleDraft)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -481,7 +485,7 @@ class RoleService implements RoleServiceInterface
      */
     public function publishRoleDraft(APIRoleDraft $roleDraft)
     {
-        if ($this->repository->hasAccess('role', 'update') !== true) {
+        if (!$this->repository->canUser('role', 'update', $roleDraft)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -526,7 +530,7 @@ class RoleService implements RoleServiceInterface
 
         $loadedRole = $this->loadRole($role->id);
 
-        if ($this->repository->hasAccess('role', 'update') !== true) {
+        if (!$this->repository->canUser('role', 'update', $role)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -593,7 +597,7 @@ class RoleService implements RoleServiceInterface
             throw new InvalidArgumentValue('module', $policyCreateStruct->module, 'PolicyCreateStruct');
         }
 
-        if ($this->repository->hasAccess('role', 'update') !== true) {
+        if (!$this->repository->canUser('role', 'update', $role)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -638,7 +642,10 @@ class RoleService implements RoleServiceInterface
      */
     public function deletePolicy(APIPolicy $policy)
     {
-        if ($this->repository->hasAccess('role', 'update') !== true) {
+        $spiRole = $this->userHandler->loadRole($policy->roleId);
+        $role = $this->roleDomainMapper->buildDomainRoleObject($spiRole);
+
+        if (!$this->repository->canUser('role', 'update', $role)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -690,7 +697,10 @@ class RoleService implements RoleServiceInterface
             throw new InvalidArgumentValue('function', $policy->function, 'Policy');
         }
 
-        if ($this->repository->hasAccess('role', 'update') !== true) {
+        $spiRole = $this->userHandler->loadRole($policy->roleId);
+        $role = $this->roleDomainMapper->buildDomainRoleObject($spiRole);
+
+        if (!$this->repository->canUser('role', 'update', $role)) {
             throw new UnauthorizedException('role', 'update');
         }
 
@@ -736,13 +746,15 @@ class RoleService implements RoleServiceInterface
      */
     public function loadRole($id)
     {
-        if ($this->repository->hasAccess('role', 'read') !== true) {
+        $spiRole = $this->userHandler->loadRole($id);
+
+        $role = $this->roleDomainMapper->buildDomainRoleObject($spiRole);
+
+        if (!$this->repository->canUser('role', 'read', $role)) {
             throw new UnauthorizedException('role', 'read');
         }
 
-        $spiRole = $this->userHandler->loadRole($id);
-
-        return $this->roleDomainMapper->buildDomainRoleObject($spiRole);
+        return $role;
     }
 
     /**
@@ -761,36 +773,31 @@ class RoleService implements RoleServiceInterface
             throw new InvalidArgumentValue('identifier', $identifier);
         }
 
-        if ($this->repository->hasAccess('role', 'read') !== true) {
+        $spiRole = $this->userHandler->loadRoleByIdentifier($identifier);
+
+        $role = $this->roleDomainMapper->buildDomainRoleObject($spiRole);
+
+        if (!$this->repository->canUser('role', 'read', $role)) {
             throw new UnauthorizedException('role', 'read');
         }
 
-        $spiRole = $this->userHandler->loadRoleByIdentifier($identifier);
-
-        return $this->roleDomainMapper->buildDomainRoleObject($spiRole);
+        return $role;
     }
 
     /**
-     * Loads all roles.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the roles
+     * Loads all roles, excluding the ones the current user is not allowed to read.
      *
      * @return \eZ\Publish\API\Repository\Values\User\Role[]
      */
     public function loadRoles()
     {
-        if ($this->repository->hasAccess('role', 'read') !== true) {
-            throw new UnauthorizedException('role', 'read');
-        }
+        $roles = array_map(function ($spiRole) {
+            return $this->roleDomainMapper->buildDomainRoleObject($spiRole);
+        }, $this->userHandler->loadRoles());
 
-        $spiRoles = $this->userHandler->loadRoles();
-
-        $roles = [];
-        foreach ($spiRoles as $spiRole) {
-            $roles[] = $this->roleDomainMapper->buildDomainRoleObject($spiRole);
-        }
-
-        return $roles;
+        return array_values(array_filter($roles, function ($role) {
+            return $this->repository->canUser('role', 'read', $role);
+        }));
     }
 
     /**
@@ -802,7 +809,7 @@ class RoleService implements RoleServiceInterface
      */
     public function deleteRole(APIRole $role)
     {
-        if ($this->repository->hasAccess('role', 'delete') !== true) {
+        if (!$this->repository->canUser('role', 'delete', $role)) {
             throw new UnauthorizedException('role', 'delete');
         }
 
@@ -1058,13 +1065,14 @@ class RoleService implements RoleServiceInterface
      */
     public function loadRoleAssignment($roleAssignmentId)
     {
-        if ($this->repository->hasAccess('role', 'read') !== true) {
-            throw new UnauthorizedException('role', 'read');
-        }
-
         $spiRoleAssignment = $this->userHandler->loadRoleAssignment($roleAssignmentId);
         $userService = $this->repository->getUserService();
         $role = $this->loadRole($spiRoleAssignment->roleId);
+
+        if (!$this->repository->canUser('role', 'read', $role)) {
+            throw new UnauthorizedException('role', 'read');
+        }
+
         $roleAssignment = null;
 
         // First check if the Role is assigned to a User
@@ -1103,7 +1111,7 @@ class RoleService implements RoleServiceInterface
      */
     public function getRoleAssignments(APIRole $role)
     {
-        if ($this->repository->hasAccess('role', 'read') !== true) {
+        if (!$this->repository->canUser('role', 'read', $role)) {
             throw new UnauthorizedException('role', 'read');
         }
 
@@ -1143,27 +1151,26 @@ class RoleService implements RoleServiceInterface
      */
     public function getRoleAssignmentsForUser(User $user, $inherited = false)
     {
-        if ($this->repository->hasAccess('role', 'read') !== true) {
-            throw new UnauthorizedException('role', 'read');
-        }
-
         $roleAssignments = [];
         $spiRoleAssignments = $this->userHandler->loadRoleAssignmentsByGroupId($user->id, $inherited);
         foreach ($spiRoleAssignments as $spiRoleAssignment) {
             $role = $this->loadRole($spiRoleAssignment->roleId);
-            if (!$inherited || $spiRoleAssignment->contentId == $user->id) {
-                $roleAssignments[] = $this->roleDomainMapper->buildDomainUserRoleAssignmentObject(
-                    $spiRoleAssignment,
-                    $user,
-                    $role
-                );
-            } else {
-                $userGroup = $this->repository->getUserService()->loadUserGroup($spiRoleAssignment->contentId);
-                $roleAssignments[] = $this->roleDomainMapper->buildDomainUserGroupRoleAssignmentObject(
-                    $spiRoleAssignment,
-                    $userGroup,
-                    $role
-                );
+
+            if ($this->repository->canUser('role', 'read', $role)) {
+                if (!$inherited || $spiRoleAssignment->contentId == $user->id) {
+                    $roleAssignments[] = $this->roleDomainMapper->buildDomainUserRoleAssignmentObject(
+                        $spiRoleAssignment,
+                        $user,
+                        $role
+                    );
+                } else {
+                    $userGroup = $this->repository->getUserService()->loadUserGroup($spiRoleAssignment->contentId);
+                    $roleAssignments[] = $this->roleDomainMapper->buildDomainUserGroupRoleAssignmentObject(
+                        $spiRoleAssignment,
+                        $userGroup,
+                        $role
+                    );
+                }
             }
         }
 
@@ -1171,9 +1178,7 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Returns the roles assigned to the given user group.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a role
+     * Returns the roles assigned to the given user group, excluding the ones the current user is not allowed to read.
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      *
@@ -1181,19 +1186,18 @@ class RoleService implements RoleServiceInterface
      */
     public function getRoleAssignmentsForUserGroup(UserGroup $userGroup)
     {
-        if ($this->repository->hasAccess('role', 'read') !== true) {
-            throw new UnauthorizedException('role', 'read');
-        }
-
         $roleAssignments = [];
         $spiRoleAssignments = $this->userHandler->loadRoleAssignmentsByGroupId($userGroup->id);
         foreach ($spiRoleAssignments as $spiRoleAssignment) {
             $role = $this->loadRole($spiRoleAssignment->roleId);
-            $roleAssignments[] = $this->roleDomainMapper->buildDomainUserGroupRoleAssignmentObject(
-                $spiRoleAssignment,
-                $userGroup,
-                $role
-            );
+
+            if ($this->repository->canUser('role', 'read', $role)) {
+                $roleAssignments[] = $this->roleDomainMapper->buildDomainUserGroupRoleAssignmentObject(
+                    $spiRoleAssignment,
+                    $userGroup,
+                    $role
+                );
+            }
         }
 
         return $roleAssignments;

--- a/eZ/Publish/Core/SignalSlot/RoleService.php
+++ b/eZ/Publish/Core/SignalSlot/RoleService.php
@@ -464,9 +464,7 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Loads all roles.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the roles
+     * Loads all roles, excluding the ones the current user is not allowed to read.
      *
      * @return \eZ\Publish\API\Repository\Values\User\Role[]
      */
@@ -667,9 +665,7 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Returns the roles assigned to the given user group.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user group
+     * Returns the roles assigned to the given user group, excluding the ones the current user is not allowed to read.
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      *


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30808](https://jira.ez.no/browse/EZP-30808)
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.5`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

Fix wrong usage of hasAccess() in repository in favor of canUser(). This is needed to solve an issue when there is a Role Assignment Limitation. In this case, they will return info to permission system they abstain from "voting" and return an array of Limitations.

Methods in `RoleService` that threw an exception, but now filter list of returned objects:
- loadRoles
- getRoleAssignmentsForUser
- getRoleAssignmentsForUserGroup


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
