### PR TITLE
EZP-30817: Fixed ezplatform:timestamps:to-utc cmd to respect version no.

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/UpdateTimestampsToUTCCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/UpdateTimestampsToUTCCommand.php
@@ -292,7 +292,7 @@ EOT
 
             //failsafe for int field limitation (dates/datetimes after 01/19/2038 @ 4:14am (UTC))
             if ($newTimestamp <= self::MAX_TIMESTAMP_VALUE && !$this->dryRun) {
-                $this->updateTimestampToUTC($timestampBasedField['id'], $newTimestamp);
+                $this->updateTimestampToUTC($timestampBasedField['id'], $timestampBasedField['version'], $newTimestamp);
             }
             ++$this->done;
         }
@@ -308,7 +308,7 @@ EOT
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->select('a.id, a.data_int')
+            ->select('a.id, a.version, a.data_int')
             ->from('ezcontentobject_attribute', 'a')
             ->join('a', 'ezcontentobject_version', 'v', 'a.contentobject_id = v.contentobject_id')
             ->where(
@@ -463,10 +463,12 @@ EOT
 
     /**
      * @param int $contentAttributeId
+     * @param int $contentAttributeVersion
      * @param int $newTimestamp
      */
     protected function updateTimestampToUTC(
         $contentAttributeId,
+        $contentAttributeVersion,
         $newTimestamp
     ) {
         $query = $this->connection->createQueryBuilder();
@@ -475,7 +477,9 @@ EOT
             ->set('a.data_int', $newTimestamp)
             ->set('a.sort_key_int', $newTimestamp)
             ->where('a.id = :id')
-            ->setParameter(':id', $contentAttributeId);
+            ->andWhere('a.version = :version')
+            ->setParameter(':id', $contentAttributeId)
+            ->setParameter(':version', $contentAttributeVersion);
 
         $query->execute();
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30817](https://jira.ez.no/browse/EZP-30817)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

The ezplatform:timestamps:to-utc command doesn't respect the primary keys of ezcontentobject_attribute table and writes field values in all versions. So the times are not correct after update