### PR TITLE
EZP-30819: Removed deprecated controller references from routes definitions

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -15,7 +15,7 @@ _ezpublishLocation:
 _ez_content_view_redirect:
     path: /view/content/{contentId}/{language}/{viewType}/{layout}/{locationId}
     defaults:
-        _controller: "FrameworkBundle:Redirect:redirect"
+        _controller: 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction'
         route: _ez_content_view
         permanent: true
         ignoreAttributes: [language]


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30819](https://jira.ez.no/browse/EZP-30819)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no



Referencing controllers with `<Bundle>:<Controller>:<Action>` syntax (aka bundle notation) is deprecated since Symfony 4.1  and generate the following log entries:

```
[2019-08-05 19:39:35] php.INFO: User Deprecated: Referencing controllers with FrameworkBundle:Redirect:redirect is deprecated since Symfony 4.1, use "Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction" instead. {"exception":"[object] (ErrorException(code: 0): User Deprecated: Referencing controllers with FrameworkBundle:Redirect:redirect is deprecated since Symfony 4.1, use \"Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController::redirectAction\" instead. at /home/awojs/eZ/ezplatform-ee-3.0/vendor/symfony/framework-bundle/Routing/DelegatingLoader.php:95)"} []
```

More informations: https://symfony.com/blog/new-in-symfony-4-1-deprecated-the-bundle-notation

**TODO**:
- [X] Implement feature / fix a bug.
- [ ] ~Implement tests.~
- [ ] ~Fix new code according to Coding Standards (`$ composer fix-cs`).~
- [x] Ask for Code Review.
