### PR TITLE
EZP-30821: Fixed wrong usage of hasAccess in URLService

### DIFF
--- a/eZ/Publish/API/Repository/Tests/URLServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLServiceAuthorizationTest.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 use eZ\Publish\API\Repository\Values\URL\URLQuery;
 
@@ -15,7 +16,6 @@ class URLServiceAuthorizationTest extends BaseURLServiceTest
      * Test for the findUrls() method.
      *
      * @see \eZ\Publish\API\Repository\URLService::findUrls
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
     public function testFindUrlsThrowsUnauthorizedException()
     {
@@ -29,12 +29,12 @@ class URLServiceAuthorizationTest extends BaseURLServiceTest
         $userService = $repository->getUserService();
         $urlService = $repository->getURLService();
 
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
         $query = new URLQuery();
         $query->filter = new Criterion\MatchAll();
 
-        // This call will fail with an UnauthorizedException
+        $this->expectException(UnauthorizedException::class);
         $urlService->findUrls($query);
         /* END: Use Case */
     }
@@ -58,7 +58,7 @@ class URLServiceAuthorizationTest extends BaseURLServiceTest
         $userService = $repository->getUserService();
         $urlService = $repository->getURLService();
 
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
         $url = $urlService->loadById($urlId);
         $updateStruct = $urlService->createUpdateStruct();
@@ -88,7 +88,7 @@ class URLServiceAuthorizationTest extends BaseURLServiceTest
         $userService = $repository->getUserService();
         $urlService = $repository->getURLService();
 
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
         // This call will fail with an UnauthorizedException
         $urlService->loadById($urlId);
@@ -115,7 +115,7 @@ class URLServiceAuthorizationTest extends BaseURLServiceTest
         $userService = $repository->getUserService();
         $urlService = $repository->getURLService();
 
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
         // This call will fail with an UnauthorizedException
         $urlService->loadByUrl($url);

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -663,7 +663,8 @@ class Repository implements RepositoryInterface
 
         $this->urlService = new URLService(
             $this,
-            $this->persistenceHandler->urlHandler()
+            $this->persistenceHandler->urlHandler(),
+            $this->getPermissionResolver()
         );
 
         return $this->urlService;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlTest.php
@@ -9,6 +9,7 @@ namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 use DateTime;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\URL\UsageSearchResult;
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -24,22 +25,28 @@ use eZ\Publish\SPI\Persistence\URL\URL as SpiUrl;
 
 class UrlTest extends BaseServiceMockTest
 {
+    private const URL_ID = 12;
+    private const URL_EZ_NO = 'http://ez.no';
+    private const URL_EZ_COM = 'http://ez.com';
+
     /** @var \eZ\Publish\API\Repository\URLService|\PHPUnit\Framework\MockObject\MockObject */
     private $urlHandler;
+
+    /** @var \eZ\Publish\API\Repository\PermissionResolver|\PHPUnit\Framework\MockObject\MockObject */
+    private $permissionResolver;
 
     protected function setUp()
     {
         parent::setUp();
         $this->urlHandler = $this->getPersistenceMockHandler('URL\\Handler');
+        $this->permissionResolver = $this->getPermissionResolverMock();
     }
 
-    /**
-     * @expectedException \eZ\Publish\Core\Base\Exceptions\UnauthorizedException
-     */
     public function testFindUrlsUnauthorized()
     {
-        $this->configureUrlViewPermission(false);
+        $this->configureUrlViewPermissionForHasAccess(false);
 
+        $this->expectException(UnauthorizedException::class);
         $this->createUrlService()->findUrls(new URLQuery());
     }
 
@@ -48,8 +55,6 @@ class UrlTest extends BaseServiceMockTest
      */
     public function testFindUrlsNonNumericOffset()
     {
-        $this->configureUrlViewPermission(true);
-
         $query = new URLQuery();
         $query->offset = 'foo';
 
@@ -61,8 +66,6 @@ class UrlTest extends BaseServiceMockTest
      */
     public function testFindUrlsNonNumericLimit()
     {
-        $this->configureUrlViewPermission(true);
-
         $query = new URLQuery();
         $query->limit = 'foo';
 
@@ -71,11 +74,11 @@ class UrlTest extends BaseServiceMockTest
 
     public function testFindUrls()
     {
-        $this->configureUrlViewPermission(true);
+        $url = $this->getApiUrl();
+
+        $this->configureUrlViewPermissionForHasAccess(true);
 
         $query = new URLQuery();
-
-        $url = $this->getApiUrl();
 
         $results = [
             'count' => 1,
@@ -105,11 +108,7 @@ class UrlTest extends BaseServiceMockTest
     {
         $url = $this->getApiUrl();
 
-        $this->getRepositoryMock()
-            ->expects($this->once())
-            ->method('hasAccess')
-            ->with('url', 'update')
-            ->willReturn(false);
+        $this->configureUrlUpdatePermission($url, false);
 
         $this->createUrlService()->updateUrl($url, new URLUpdateStruct());
     }
@@ -119,11 +118,12 @@ class UrlTest extends BaseServiceMockTest
      */
     public function testUpdateUrlNonUnique()
     {
-        $this->configureUrlUpdatePermission(true);
+        $url = $this->getApiUrl(self::URL_ID, self::URL_EZ_NO);
 
-        $url = $this->getApiUrl(1, 'http://ez.no');
+        $this->configureUrlUpdatePermission($url, true);
+
         $struct = new URLUpdateStruct([
-            'url' => 'http://ez.com',
+            'url' => self::URL_EZ_COM,
         ]);
 
         $urlService = $this->createUrlService(['isUnique']);
@@ -138,17 +138,17 @@ class UrlTest extends BaseServiceMockTest
 
     public function testUpdateUrl()
     {
-        $apiUrl = $this->getApiUrl(1, 'http://ez.no');
+        $apiUrl = $this->getApiUrl(self::URL_ID, self::URL_EZ_NO);
         $apiStruct = new URLUpdateStruct([
-            'url' => 'http://ez.com',
+            'url' => self::URL_EZ_COM,
             'isValid' => false,
             'lastChecked' => new DateTime(),
         ]);
 
         $this->configurePermissions([
-            ['url', 'update', null],
-            ['url', 'view', null],
-            ['url', 'view', null],
+            ['url', 'update', $apiUrl, []],
+            ['url', 'view', $apiUrl, []],
+            ['url', 'view', new URL(['id' => self::URL_ID, 'url' => self::URL_EZ_COM, 'isValid' => true]), []],
         ]);
 
         $urlService = $this->createUrlService(['isUnique']);
@@ -197,16 +197,23 @@ class UrlTest extends BaseServiceMockTest
 
     public function testUpdateUrlStatus()
     {
-        $apiUrl = $this->getApiUrl(1, 'http://ez.no');
+        $apiUrl = $this->getApiUrl(self::URL_ID, self::URL_EZ_NO);
         $apiStruct = new URLUpdateStruct([
             'isValid' => true,
             'lastChecked' => new DateTime('@' . time()),
         ]);
 
+        $urlAfterUpdate = new URL([
+            'id' => self::URL_ID,
+            'url' => self::URL_EZ_NO,
+            'isValid' => true,
+            'lastChecked' => new DateTime('@' . time()),
+        ]);
+
         $this->configurePermissions([
-            ['url', 'update', null],
-            ['url', 'view', null],
-            ['url', 'view', null],
+            ['url', 'update', $apiUrl, []],
+            ['url', 'view', $apiUrl, []],
+            ['url', 'view', $urlAfterUpdate, []],
         ]);
 
         $urlService = $this->createUrlService(['isUnique']);
@@ -258,28 +265,41 @@ class UrlTest extends BaseServiceMockTest
      */
     public function testLoadByIdUnauthorized()
     {
-        $this->configureUrlViewPermission(false);
-
-        $this->createUrlService()->loadById(1);
-    }
-
-    public function testLoadById()
-    {
-        $this->configureUrlViewPermission(true);
-
-        $urlId = 12;
+        $this->configureUrlViewPermission(
+            new URL([
+                'id' => self::URL_ID,
+            ]),
+            false
+        );
 
         $this->urlHandler
             ->expects($this->once())
             ->method('loadById')
-            ->with($urlId)
+            ->with(self::URL_ID)
             ->willReturn(new SpiUrl([
-                'id' => $urlId,
+                'id' => self::URL_ID,
             ]));
 
-        $this->assertEquals(new URL([
-            'id' => $urlId,
-        ]), $this->createUrlService()->loadById($urlId));
+        $this->createUrlService()->loadById(self::URL_ID);
+    }
+
+    public function testLoadById()
+    {
+        $url = new URL([
+            'id' => self::URL_ID,
+        ]);
+
+        $this->configureUrlViewPermission($url, true);
+
+        $this->urlHandler
+            ->expects($this->once())
+            ->method('loadById')
+            ->with(self::URL_ID)
+            ->willReturn(new SpiUrl([
+                'id' => self::URL_ID,
+            ]));
+
+        $this->assertEquals($url, $this->createUrlService()->loadById(self::URL_ID));
     }
 
     /**
@@ -287,16 +307,35 @@ class UrlTest extends BaseServiceMockTest
      */
     public function testLoadByUrlUnauthorized()
     {
-        $this->configureUrlViewPermission(false);
+        $url = self::URL_EZ_NO;
 
-        $this->createUrlService()->loadByUrl('http://ez.no');
+        $this->configureUrlViewPermission(
+            new URL([
+                'id' => self::URL_ID,
+            ]),
+            false
+        );
+
+        $this->urlHandler
+            ->expects($this->once())
+            ->method('loadByUrl')
+            ->with($url)
+            ->willReturn(new SpiUrl([
+                'id' => self::URL_ID,
+            ]));
+
+        $this->createUrlService()->loadByUrl(self::URL_EZ_NO);
     }
 
     public function testLoadByUrl()
     {
-        $this->configureUrlViewPermission(true);
+        $url = self::URL_EZ_NO;
 
-        $url = 'http://ez.no';
+        $apiUrl = new URL([
+            'url' => $url,
+        ]);
+
+        $this->configureUrlViewPermission($apiUrl, true);
 
         $this->urlHandler
             ->expects($this->once())
@@ -306,9 +345,7 @@ class UrlTest extends BaseServiceMockTest
                 'url' => $url,
             ]));
 
-        $this->assertEquals(new URL([
-            'url' => $url,
-        ]), $this->createUrlService()->loadByUrl($url));
+        $this->assertEquals($apiUrl, $this->createUrlService()->loadByUrl($url));
     }
 
     /**
@@ -316,7 +353,7 @@ class UrlTest extends BaseServiceMockTest
      */
     public function testFindUsages($offset, $limit, ContentQuery $expectedQuery, array $usages)
     {
-        $url = $this->getApiUrl(1, 'http://ez.no');
+        $url = $this->getApiUrl(self::URL_ID, self::URL_EZ_NO);
 
         if (!empty($usages)) {
             $searchService = $this->createMock(SearchService::class);
@@ -395,7 +432,7 @@ class UrlTest extends BaseServiceMockTest
         $this->assertEquals(new URLUpdateStruct(), $this->createUrlService()->createUpdateStruct());
     }
 
-    protected function configureUrlViewPermission($hasAccess = false)
+    protected function configureUrlViewPermissionForHasAccess($hasAccess = false)
     {
         $this->getRepositoryMock()
             ->expects($this->once())
@@ -404,20 +441,37 @@ class UrlTest extends BaseServiceMockTest
             ->willReturn($hasAccess);
     }
 
-    protected function configureUrlUpdatePermission($hasAccess = false)
+    protected function configureUrlViewPermission($object, $hasAccess = false)
     {
-        $this->getRepositoryMock()
+        $this->permissionResolver
             ->expects($this->once())
-            ->method('hasAccess')
-            ->with('url', 'update')
-            ->willReturn($hasAccess);
+            ->method('canUser')
+            ->with(
+                $this->equalTo('url'),
+                $this->equalTo('view'),
+                $this->equalTo($object)
+            )
+            ->will($this->returnValue($hasAccess));
+    }
+
+    protected function configureUrlUpdatePermission($object, $hasAccess = false)
+    {
+        $this->permissionResolver
+            ->expects($this->once())
+            ->method('canUser')
+            ->with(
+                $this->equalTo('url'),
+                $this->equalTo('update'),
+                $this->equalTo($object)
+            )
+            ->will($this->returnValue($hasAccess));
     }
 
     protected function configurePermissions(array $permissions)
     {
-        $this->getRepositoryMock()
+        $this->permissionResolver
             ->expects($this->exactly(count($permissions)))
-            ->method('hasAccess')
+            ->method('canUser')
             ->withConsecutive(...$permissions)
             ->willReturn(true);
     }
@@ -429,7 +483,7 @@ class UrlTest extends BaseServiceMockTest
     {
         return $this
             ->getMockBuilder(URLService::class)
-            ->setConstructorArgs([$this->getRepositoryMock(), $this->urlHandler])
+            ->setConstructorArgs([$this->getRepositoryMock(), $this->urlHandler, $this->permissionResolver])
             ->setMethods($methods)
             ->getMock();
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30821](https://jira.ez.no/browse/EZP-30821)
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.5`
| **BC breaks**      |no
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

Fix wrong usage of hasAccess() in repository in favor of canUser(). This is needed to solve an issue when there is a Role Assignment Limitation. In this case, they will return info to permission system they abstain from "voting" and return an array of Limitations.

Methods in `URLService` that threw an exception, but now filter list of returned objects:
- findUrls


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
