### PR TITLE
[Composer] Improve install instructions on install splash screen

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -142,7 +142,7 @@ Note:
   - Use PHP's single process, local, HTTP/1 only built-in web server, mainly suitable for testing.
   - Give you the URL to the front end of the installation. TIP: Add "/admin" to reach back end.
 
-For full install instructions with Nginx/Apache for production, remote use, or better performing dev setup:
+See main installation instructions with Nginx/Apache for production, remote, or better performing dev setup in:
 ${installUrl}
 
 EOT

--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -139,7 +139,7 @@ ${installCommandText}
 Note:
 - The instructions assume you execute commands with the CLI user that extracted/installed the software.
 - The "server:run" command will:
-  - Start PHP's built in web server. A single process, local, HTTP/1.x only, mainly suitable for quick demo.
+  - Use PHP's single process, local, HTTP/1 only built-in web server, mainly suitable for testing.
   - Give you the URL to the front end of the installation. TIP: Add "/admin" to reach back end.
 
 For full install instructions with Nginx/Apache for production, remote use, or better performing dev setup:

--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -131,16 +131,16 @@ class ScriptHandler extends DistributionBundleScriptHandler
 
 <fg=cyan>Welcome to ${installName}!</fg=cyan>
 
-<options=bold>Quick install to test in local dev environment:</>
+<options=bold>Quick installation to test in local dev environment:</>
 <comment>    $  export SYMFONY_ENV="dev"</comment>
 ${installCommandText}
 <comment>    $  php ${consoleDir}/console server:run</comment>
 
 Note:
 - Instructions assume CLI user you execute commands with is the same one that extracted/installed the software.
-- "server:run" command will:
+- The "server:run" command will:
   - Start PHP's built in web server. A single process, local, HTTP/1.x only, mainly suitable for quick demo.
-  - Give you the url to the frontend of the installation. TIP: Add "/admin" to reach backend.
+  - Give you the URL to the front end of the installation. TIP: Add "/admin" to reach back end.
 
 For full install instructions with Nginx/Apache for production, remote use, or better performing dev setup:
 ${installUrl}

--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -131,16 +131,18 @@ class ScriptHandler extends DistributionBundleScriptHandler
 
 <fg=cyan>Welcome to ${installName}!</fg=cyan>
 
-<options=bold>Quick dev/test install:</>
+<options=bold>Quick install to test in local dev environment:</>
 <comment>    $  export SYMFONY_ENV="dev"</comment>
 ${installCommandText}
 <comment>    $  php ${consoleDir}/console server:run</comment>
 
 Note:
-- Instructions above assume the CLI user you execute these commands with is the same one that extracted/installed the software.
-- The last command will give you the url to the frontend of the installation, add "/admin" to reach backend.
+- Instructions assume CLI user you execute commands with is the same one that extracted/installed the software.
+- "server:run" command will:
+  - Start PHP's built in web server. A single process, local, HTTP/1.x only, mainly suitable for quick demo.
+  - Give you the url to the frontend of the installation. TIP: Add "/admin" to reach backend.
 
-For full install instructions, both for production and better performing dev setup, see:
+For full install instructions with Nginx/Apache for production, remote use, or better performing dev setup:
 ${installUrl}
 
 EOT

--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -137,7 +137,7 @@ ${installCommandText}
 <comment>    $  php ${consoleDir}/console server:run</comment>
 
 Note:
-- Instructions assume CLI user you execute commands with is the same one that extracted/installed the software.
+- The instructions assume you execute commands with the CLI user that extracted/installed the software.
 - The "server:run" command will:
   - Start PHP's built in web server. A single process, local, HTTP/1.x only, mainly suitable for quick demo.
   - Give you the URL to the front end of the installation. TIP: Add "/admin" to reach back end.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **Bug/Improvement**| yes
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | _maybe_

We had a case where a developer tried to use `server:run` for remote dev server.

This tries to avoid such misunderstandings by:
- mentioning it's local only
- expand on what it is, and its limitations so new devs can better make judgment of when to use it and not.

Also expand on what the alternative specifically is, as most have heard about Nginx/Apache.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
