### PR TITLE
EZP-30822: Fixed wrong usage of hasAccess in URLAliasService

### DIFF
--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceAuthorizationTest.php
@@ -8,13 +8,14 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+
 class URLAliasServiceAuthorizationTest extends BaseTest
 {
     /**
      * Test for the createUrlAlias() method.
      *
      * @covers \eZ\Publish\API\Repository\URLAliasService::createUrlAlias()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @depends \eZ\Publish\API\Repository\Tests\URLAliasServiceTest::testCreateUrlAlias
      */
     public function testCreateUrlAliasThrowsUnauthorizedException()
@@ -31,12 +32,13 @@ class URLAliasServiceAuthorizationTest extends BaseTest
         $urlAliasService = $repository->getURLAliasService();
         $locationService = $repository->getLocationService();
 
-        $location = $locationService->newLocationCreateStruct($parentLocationId);
+        $content = $this->createFolder(['eng-GB' => 'Foo'], $parentLocationId);
+        $location = $locationService->loadLocation($content->contentInfo->mainLocationId);
 
         $anonymousUser = $userService->loadUser($anonymousUserId);
         $repository->getPermissionResolver()->setCurrentUserReference($anonymousUser);
 
-        // This call will fail with an UnauthorizedException
+        $this->expectException(UnauthorizedException::class);
         $urlAliasService->createUrlAlias($location, '/Home/My-New-Site', 'eng-US');
         /* END: Use Case */
     }

--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
@@ -87,7 +87,7 @@ class URLAliasServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+            URLAlias::class,
             $createdUrlAlias
         );
 
@@ -144,7 +144,7 @@ class URLAliasServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+            URLAlias::class,
             $createdUrlAlias
         );
 
@@ -200,7 +200,7 @@ class URLAliasServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+            URLAlias::class,
             $createdUrlAlias
         );
 
@@ -279,7 +279,7 @@ class URLAliasServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+            URLAlias::class,
             $createdUrlAlias
         );
 
@@ -331,7 +331,7 @@ class URLAliasServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+            URLAlias::class,
             $createdUrlAlias
         );
 
@@ -384,7 +384,7 @@ class URLAliasServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+            URLAlias::class,
             $createdUrlAlias
         );
 
@@ -443,7 +443,7 @@ class URLAliasServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+            URLAlias::class,
             $createdUrlAlias
         );
 
@@ -478,7 +478,7 @@ class URLAliasServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+            URLAlias::class,
             $createdUrlAlias
         );
 
@@ -569,13 +569,10 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listLocationAliases($location);
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
-        );
+        $this->assertIsArray($loadedAliases);
 
         // Only 1 non-history alias
-        $this->assertEquals(1, count($loadedAliases));
+        $this->assertCount(1, $loadedAliases);
 
         return [$loadedAliases, $location];
     }
@@ -591,7 +588,7 @@ class URLAliasServiceTest extends BaseTest
 
         foreach ($loadedAliases as $loadedAlias) {
             $this->assertInstanceOf(
-                'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+                URLAlias::class,
                 $loadedAlias
             );
             $this->assertEquals(
@@ -626,11 +623,8 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listLocationAliases($location, false, 'eng-US');
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
-        );
-        $this->assertEquals(1, count($loadedAliases));
+        $this->assertIsArray($loadedAliases);
+        $this->assertCount(1, $loadedAliases);
     }
 
     /**
@@ -657,11 +651,8 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listLocationAliases($location, true, 'eng-US');
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
-        );
-        $this->assertEquals(1, count($loadedAliases));
+        $this->assertIsArray($loadedAliases);
+        $this->assertCount(1, $loadedAliases);
     }
 
     /**
@@ -683,11 +674,8 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listGlobalAliases();
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
-        );
-        $this->assertEquals(3, count($loadedAliases));
+        $this->assertIsArray($loadedAliases);
+        $this->assertCount(3, $loadedAliases);
     }
 
     /**
@@ -736,11 +724,8 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listGlobalAliases('eng-US');
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
-        );
-        $this->assertEquals(2, count($loadedAliases));
+        $this->assertIsArray($loadedAliases);
+        $this->assertCount(2, $loadedAliases);
     }
 
     /**
@@ -762,11 +747,8 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listGlobalAliases(null, 1);
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
-        );
-        $this->assertEquals(2, count($loadedAliases));
+        $this->assertIsArray($loadedAliases);
+        $this->assertCount(2, $loadedAliases);
     }
 
     /**
@@ -788,11 +770,8 @@ class URLAliasServiceTest extends BaseTest
         $loadedAliases = $urlAliasService->listGlobalAliases(null, 0, 1);
         /* END: Use Case */
 
-        $this->assertInternalType(
-            'array',
-            $loadedAliases
-        );
-        $this->assertEquals(1, count($loadedAliases));
+        $this->assertIsArray($loadedAliases);
+        $this->assertCount(1, $loadedAliases);
     }
 
     /**
@@ -876,11 +855,11 @@ class URLAliasServiceTest extends BaseTest
         /* BEGIN: Use Case */
         $urlAliasService = $repository->getURLAliasService();
 
-        $loadedAlias = $urlAliasService->lookUp('/Setup2');
+        $loadedAlias = $urlAliasService->lookup('/Setup2');
         /* END: Use Case */
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+            URLAlias::class,
             $loadedAlias
         );
 
@@ -902,11 +881,11 @@ class URLAliasServiceTest extends BaseTest
         // Create aliases in multiple languages
         $this->createGlobalAliases();
 
-        $loadedAlias = $urlAliasService->lookUp('/My/Special-Support', 'eng-US');
+        $loadedAlias = $urlAliasService->lookup('/My/Special-Support', 'eng-US');
         /* END: Use Case */
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+            URLAlias::class,
             $loadedAlias
         );
         $this->assertEquals(
@@ -929,7 +908,7 @@ class URLAliasServiceTest extends BaseTest
         $urlAliasService = $repository->getURLAliasService();
 
         // Throws NotFoundException
-        $loadedAlias = $urlAliasService->lookUp('/non-existent-url');
+        $urlAliasService->lookup('/non-existent-url');
         /* END: Use Case */
     }
 
@@ -947,7 +926,7 @@ class URLAliasServiceTest extends BaseTest
         $urlAliasService = $repository->getURLAliasService();
 
         // Throws NotFoundException
-        $loadedAlias = $urlAliasService->lookUp('/Contact-Us', 'ger-DE');
+        $urlAliasService->lookup('/Contact-Us', 'ger-DE');
         /* END: Use Case */
     }
 
@@ -965,7 +944,7 @@ class URLAliasServiceTest extends BaseTest
         $urlAliasService = $repository->getURLAliasService();
 
         // Throws InvalidArgumentException
-        $loadedAlias = $urlAliasService->lookUp(str_repeat('/1', 99), 'ger-DE');
+        $loadedAlias = $urlAliasService->lookup(str_repeat('/1', 99), 'ger-DE');
         /* END: Use Case */
     }
 

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -626,6 +626,7 @@ class Repository implements RepositoryInterface
             $this,
             $this->persistenceHandler->urlAliasHandler(),
             $this->getNameSchemaService(),
+            $this->getPermissionResolver(),
             $this->serviceSettings['urlAlias']
         );
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30822](https://jira.ez.no/browse/EZP-30822)
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.5` 
| **BC breaks**      |no
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

Fix wrong usage of hasAccess() in repository in favor of canUser(). This is needed to solve an issue when there is a Role Assignment Limitation. In this case, they will return info to permission system they abstain from "voting" and return an array of Limitations.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
