### PR TITLE
EZP-30828: Replaced \Symfony\Component\EventDispatcher\Event usage in favor of Symfony\Contracts\EventDispatcher\Event

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Event/APIContentExceptionEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/APIContentExceptionEvent.php
@@ -8,7 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use eZ\Publish\Core\MVC\Symfony\View\View;
 use Exception;
 

--- a/eZ/Publish/Core/MVC/Symfony/Event/ContentCacheClearEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/ContentCacheClearEvent.php
@@ -10,7 +10,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Event;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class ContentCacheClearEvent.

--- a/eZ/Publish/Core/MVC/Symfony/Event/PostSiteAccessMatchEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/PostSiteAccessMatchEvent.php
@@ -8,7 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 

--- a/eZ/Publish/Core/MVC/Symfony/Event/PreContentViewEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/PreContentViewEvent.php
@@ -9,7 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Event;
 
 use eZ\Publish\Core\MVC\Symfony\View\View;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * The PreContentViewEvent allows you to inject additional parameters to a content view template.

--- a/eZ/Publish/Core/MVC/Symfony/Event/RouteReferenceGenerationEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/RouteReferenceGenerationEvent.php
@@ -9,7 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Event;
 
 use eZ\Publish\Core\MVC\Symfony\Routing\RouteReference;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/eZ/Publish/Core/MVC/Symfony/Event/ScopeChangeEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/ScopeChangeEvent.php
@@ -9,7 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Event;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * This event is sent when configuration scope is changed (e.g. for content preview in a given siteaccess).

--- a/eZ/Publish/Core/MVC/Symfony/View/Event/FilterViewBuilderParametersEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Event/FilterViewBuilderParametersEvent.php
@@ -4,7 +4,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/eZ/Publish/Core/MVC/Symfony/View/Event/FilterViewParametersEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Event/FilterViewParametersEvent.php
@@ -5,7 +5,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\View\Event;
 
 use eZ\Publish\Core\MVC\Symfony\View\View;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
 /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30828](https://jira.ez.no/browse/EZP-30828)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | yes
| **Tests pass**     | ?
| **Doc needed**     | no

Replaced `\Symfony\Component\EventDispatcher\Event` usage in favor of `Symfony\Contracts\EventDispatcher\Event`. 

**TODO**:
- [X] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
