### PR TITLE
EZP-30832: Fixed wrong usage of hasAccess in URLWildcardService

### DIFF
--- a/eZ/Publish/API/Repository/Tests/URLWildcardServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLWildcardServiceAuthorizationTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+
 /**
  * Test case for operations in the URLWildcardService.
  *
@@ -23,7 +25,6 @@ class URLWildcardServiceAuthorizationTest extends BaseTest
      * @return \eZ\Publish\API\Repository\Values\Content\URLWildcard
      *
      * @see \eZ\Publish\API\Repository\URLWildcardService::create()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @depends eZ\Publish\API\Repository\Tests\URLWildcardServiceTest::testCreate
      */
     public function testCreateThrowsUnauthorizedException()
@@ -38,9 +39,9 @@ class URLWildcardServiceAuthorizationTest extends BaseTest
         $userService = $repository->getUserService();
         $urlWildcardService = $repository->getURLWildcardService();
 
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
-        // This call will fail with an UnauthorizedException
+        $this->expectException(UnauthorizedException::class);
         $urlWildcardService->create('/articles/*', '/content/{1}');
         /* END: Use Case */
     }
@@ -49,7 +50,6 @@ class URLWildcardServiceAuthorizationTest extends BaseTest
      * Test for the remove() method.
      *
      * @see \eZ\Publish\API\Repository\URLWildcardService::remove()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @depends eZ\Publish\API\Repository\Tests\URLWildcardServiceTest::testRemove
      */
     public function testRemoveThrowsUnauthorizedException()
@@ -66,12 +66,12 @@ class URLWildcardServiceAuthorizationTest extends BaseTest
         // Create a new url wildcard
         $urlWildcardId = $urlWildcardService->create('/articles/*', '/content/{1}')->id;
 
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
         // Load newly created url wildcard
         $urlWildcard = $urlWildcardService->load($urlWildcardId);
 
-        // This call will fail with an UnauthorizedException
+        $this->expectException(UnauthorizedException::class);
         $urlWildcardService->remove($urlWildcard);
         /* END: Use Case */
     }

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -646,6 +646,7 @@ class Repository implements RepositoryInterface
         $this->urlWildcardService = new URLWildcardService(
             $this,
             $this->persistenceHandler->urlWildcardHandler(),
+            $this->getPermissionResolver(),
             $this->serviceSettings['urlWildcard']
         );
 

--- a/eZ/Publish/Core/Repository/URLWildcardService.php
+++ b/eZ/Publish/Core/Repository/URLWildcardService.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Repository;
 
+use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\URLWildcardService as URLWildcardServiceInterface;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\SPI\Persistence\Content\UrlWildcard\Handler;
@@ -32,6 +33,9 @@ class URLWildcardService implements URLWildcardServiceInterface
     /** @var \eZ\Publish\SPI\Persistence\Content\UrlWildcard\Handler */
     protected $urlWildcardHandler;
 
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    private $permissionResolver;
+
     /** @var array */
     protected $settings;
 
@@ -40,12 +44,18 @@ class URLWildcardService implements URLWildcardServiceInterface
      *
      * @param \eZ\Publish\API\Repository\Repository $repository
      * @param \eZ\Publish\SPI\Persistence\Content\UrlWildcard\Handler $urlWildcardHandler
+     * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
      * @param array $settings
      */
-    public function __construct(RepositoryInterface $repository, Handler $urlWildcardHandler, array $settings = [])
-    {
+    public function __construct(
+        RepositoryInterface $repository,
+        Handler $urlWildcardHandler,
+        PermissionResolver $permissionResolver,
+        array $settings = []
+    ) {
         $this->repository = $repository;
         $this->urlWildcardHandler = $urlWildcardHandler;
+        $this->permissionResolver = $permissionResolver;
         $this->settings = $settings;
     }
 
@@ -65,7 +75,7 @@ class URLWildcardService implements URLWildcardServiceInterface
      */
     public function create($sourceUrl, $destinationUrl, $forward = false): URLWildcard
     {
-        if ($this->repository->hasAccess('content', 'urltranslator') !== true) {
+        if ($this->permissionResolver->hasAccess('content', 'urltranslator') === false) {
             throw new UnauthorizedException('content', 'urltranslator');
         }
 
@@ -114,7 +124,7 @@ class URLWildcardService implements URLWildcardServiceInterface
      */
     public function remove(URLWildcard $urlWildcard): void
     {
-        if (!$this->repository->canUser('content', 'urltranslator', $urlWildcard)) {
+        if (!$this->permissionResolver->canUser('content', 'urltranslator', $urlWildcard)) {
             throw new UnauthorizedException('content', 'urltranslator');
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30832](https://jira.ez.no/browse/EZP-30832)
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.5` 
| **BC breaks**      |no
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

Fix wrong usage of hasAccess() in repository. This is needed to solve an issue when there is a Role Assignment Limitation. In this case, they will return info to permission system they abstain from "voting" and return an array of Limitations.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
