### PR TITLE
EZP-30831: Fixed wrong usage of hasAccess in TrashService

### DIFF
--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -19,6 +19,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\Trash\SearchResult;
 use eZ\Publish\API\Repository\Values\Content\TrashItem as APITrashItem;
+use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
 use eZ\Publish\Core\Repository\Values\Content\TrashItem;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use DateTime;
@@ -754,6 +755,55 @@ class TrashServiceTest extends BaseTrashServiceTest
         /* END: Use Case */
 
         $this->assertEquals(0, $searchResult->count);
+
+        // Try to load content
+        $this->expectException(NotFoundException::class);
+        $contentService->loadContent($trashItem->contentId);
+    }
+
+    /**
+     * Test for the emptyTrash() method with user which has subtree limitations.
+     *
+     * @see \eZ\Publish\API\Repository\TrashService::emptyTrash()
+     * @depends eZ\Publish\API\Repository\Tests\TrashServiceTest::testFindTrashItems
+     */
+    public function testEmptyTrashForUserWithSubtreeLimitation()
+    {
+        $repository = $this->getRepository();
+        $trashService = $repository->getTrashService();
+        $contentService = $repository->getContentService();
+
+        /* BEGIN: Use Case */
+        $trashItem = $this->createTrashItem();
+
+        $this->createRoleWithPolicies('roleTrashCleaner', [
+            ['module' => 'content', 'function' => 'cleantrash'],
+            ['module' => 'content', 'function' => 'read'],
+        ]);
+        $user = $this->createCustomUserWithLogin(
+            'user',
+            'user@example.com',
+            'roleTrashCleaners',
+            'roleTrashCleaner',
+            new SubtreeLimitation(['limitationValues' => ['/1/2/']])
+        );
+        $repository->getPermissionResolver()->setCurrentUserReference($user);
+
+        // Empty the trash
+        $trashService->emptyTrash();
+
+        // Create a search query for all trashed items
+        $query = new Query();
+        $query->filter = new Criterion\LogicalAnd(
+            [
+                new Criterion\Field('title', Criterion\Operator::LIKE, '*'),
+            ]
+        );
+        // Load all trashed locations, search result should be empty
+        $searchResult = $trashService->findTrashItems($query);
+        /* END: Use Case */
+
+        $this->assertEquals(0, $searchResult->totalCount);
 
         // Try to load content
         $this->expectException(NotFoundException::class);

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -225,10 +225,7 @@ class TrashService implements TrashServiceInterface
      */
     public function emptyTrash()
     {
-        // Will throw if you have Role assignment limitation where you have content/cleantrash permission.
-        // This is by design and means you can only delete one and one trash item, or you'll need to change how
-        // permissions is assigned to be on separate role with no Role assignment limitation.
-        if ($this->repository->hasAccess('content', 'cleantrash') !== true) {
+        if ($this->repository->hasAccess('content', 'cleantrash') === false) {
             throw new UnauthorizedException('content', 'cleantrash');
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30831](https://jira.ez.no/browse/EZP-30831)
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | yes

Fix wrong usage of hasAccess() in repository. This is needed to solve an issue when there is a Role Assignment Limitation. In this case, they will return info to permission system they abstain from "voting" and return an array of Limitations. 

To avoid enforce an administrator to create dedicated Role only to allow empty the Trash an exception will be returned only when the user has no access to perform this action.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
