### PR TITLE
EZP-30846: Dropped deprecated Symfony\Component\Config\Definition\Builder\TreeBuilder::root method calls

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -45,8 +45,9 @@ class Configuration extends SiteAccessConfiguration
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ezpublish');
+        $treeBuilder = new TreeBuilder('ezpublish');
+
+        $rootNode = $treeBuilder->getRootNode();
 
         $this->addRepositoriesSection($rootNode);
         $this->addSiteaccessSection($rootNode);

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/Configuration.php
@@ -33,8 +33,9 @@ class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ez_io');
+        $treeBuilder = new TreeBuilder('ez_io');
+
+        $rootNode = $treeBuilder->getRootNode();
 
         $this->addHandlersSection(
             $rootNode,


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30846](https://jira.ez.no/browse/EZP-30846)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** |  `master` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Since Symfony 4.3 configuration root name should be passed via constructor instead of using "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method.

More information:
* https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes
* https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#config

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
