### PR TITLE
EZP-30839: Fixed loading Content of Location for 1st draft in preview

### DIFF
--- a/eZ/Publish/Core/Helper/PreviewLocationProvider.php
+++ b/eZ/Publish/Core/Helper/PreviewLocationProvider.php
@@ -52,8 +52,10 @@ class PreviewLocationProvider
      *
      * If the content doesn't have a location nor a location draft, null is returned.
      *
-     * @deprecated Since 7.5.4, rather use {@see loadMainLocationByContent}.
-     *
+     * @deprecated Since 7.5.4, rather use loadMainLocationByContent.
+     * @see loadMainLocationByContent
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @param mixed $contentId
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Location|null

--- a/eZ/Publish/Core/Helper/PreviewLocationProvider.php
+++ b/eZ/Publish/Core/Helper/PreviewLocationProvider.php
@@ -95,7 +95,7 @@ class PreviewLocationProvider
                 return null;
             }
 
-            // NOTE: Once Repository adds support for draft locations (and draft  location ops), then this can be removed 
+            // NOTE: Once Repository adds support for draft locations (and draft  location ops), then this can be removed
             $location = new Location(
                 [
                     'content' => $content,

--- a/eZ/Publish/Core/Helper/PreviewLocationProvider.php
+++ b/eZ/Publish/Core/Helper/PreviewLocationProvider.php
@@ -95,7 +95,7 @@ class PreviewLocationProvider
                 return null;
             }
 
-            // @TODO: Repository needs to add full support for draft Locations to avoid having to do this
+            // NOTE: Once Repository adds support for draft locations (and draft  location ops), then this can be removed 
             $location = new Location(
                 [
                     'content' => $content,

--- a/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
+++ b/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
@@ -67,7 +67,7 @@ class PreviewLocationProviderTest extends TestCase
 
         $location = $this->provider->loadMainLocation($contentId);
         $this->assertInstanceOf(APILocation::class, $location);
-        $this->assertSame($content, $location->content);
+        $this->assertSame($content, $location->getContent());
         $this->assertNull($location->id);
         $this->assertEquals($parentLocationId, $location->parentLocationId);
     }
@@ -99,8 +99,7 @@ class PreviewLocationProviderTest extends TestCase
 
         $returnedLocation = $this->provider->loadMainLocation($contentId);
         $this->assertSame($location, $returnedLocation);
-        $this->assertSame($content, $location->content);
-        //$this->assertSame($contentInfo, $returnedLocation->contentInfo);
+        $this->assertSame($content, $location->getContent());
     }
 
     public function testGetPreviewLocationNoLocation()

--- a/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
+++ b/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
@@ -13,7 +13,9 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo as APIContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\Core\Helper\PreviewLocationProvider;
+use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as SPILocationHandler;
 use PHPUnit\Framework\TestCase;
 
@@ -45,17 +47,13 @@ class PreviewLocationProviderTest extends TestCase
     {
         $contentId = 123;
         $parentLocationId = 456;
-
-        $contentInfo = $this
-            ->getMockBuilder(APIContentInfo::class)
-            ->setConstructorArgs([['id' => $contentId]])
-            ->getMockForAbstractClass();
+        $content = $this->getContentMock($contentId);
 
         $this->contentService
             ->expects($this->once())
-            ->method('loadContentInfo')
+            ->method('loadContent')
             ->with($contentId)
-            ->will($this->returnValue($contentInfo));
+            ->willReturn($content);
 
         $this->locationService
             ->expects($this->never())
@@ -69,7 +67,7 @@ class PreviewLocationProviderTest extends TestCase
 
         $location = $this->provider->loadMainLocation($contentId);
         $this->assertInstanceOf(APILocation::class, $location);
-        $this->assertSame($contentInfo, $location->contentInfo);
+        $this->assertSame($content, $location->content);
         $this->assertNull($location->id);
         $this->assertEquals($parentLocationId, $location->parentLocationId);
     }
@@ -78,44 +76,44 @@ class PreviewLocationProviderTest extends TestCase
     {
         $contentId = 123;
         $locationId = 456;
-        $contentInfo = $this
-            ->getMockBuilder(APIContentInfo::class)
-            ->setConstructorArgs([['id' => $contentId, 'mainLocationId' => $locationId]])
-            ->getMockForAbstractClass();
+        $content = $this->getContentMock($contentId, $locationId);
+
         $location = $this
             ->getMockBuilder(Location::class)
-            ->setConstructorArgs([['id' => $locationId, 'contentInfo' => $contentInfo]])
+            ->setConstructorArgs([['id' => $locationId, 'content' => $content]])
             ->getMockForAbstractClass();
+
         $this->contentService
             ->expects($this->once())
-            ->method('loadContentInfo')
+            ->method('loadContent')
             ->with($contentId)
-            ->will($this->returnValue($contentInfo));
+            ->willReturn($content);
+
         $this->locationService
             ->expects($this->once())
             ->method('loadLocation')
             ->with($locationId)
             ->will($this->returnValue($location));
+
         $this->locationHandler->expects($this->never())->method('loadParentLocationsForDraftContent');
 
         $returnedLocation = $this->provider->loadMainLocation($contentId);
         $this->assertSame($location, $returnedLocation);
-        $this->assertSame($contentInfo, $returnedLocation->contentInfo);
+        $this->assertSame($content, $location->content);
+        //$this->assertSame($contentInfo, $returnedLocation->contentInfo);
     }
 
     public function testGetPreviewLocationNoLocation()
     {
         $contentId = 123;
+        $content = $this->getContentMock($contentId);
 
-        $contentInfo = $this
-            ->getMockBuilder(APIContentInfo::class)
-            ->setConstructorArgs([['id' => $contentId]])
-            ->getMockForAbstractClass();
         $this->contentService
             ->expects($this->once())
-            ->method('loadContentInfo')
+            ->method('loadContent')
             ->with($contentId)
-            ->will($this->returnValue($contentInfo));
+            ->willReturn($content);
+
         $this->locationHandler
             ->expects($this->once())
             ->method('loadParentLocationsForDraftContent')
@@ -125,5 +123,26 @@ class PreviewLocationProviderTest extends TestCase
         $this->locationHandler->expects($this->never())->method('loadLocationsByContent');
 
         $this->assertNull($this->provider->loadMainLocation($contentId));
+    }
+
+    private function getContentMock(int $contentId, ?int $mainLocationId = null, bool $published = false): Content
+    {
+        $contentInfo = new APIContentInfo([
+            'id' => $contentId,
+            'mainLocationId' => $mainLocationId,
+            'published' => $published,
+        ]);
+
+        $versionInfo = $this->createMock(VersionInfo::class);
+        $versionInfo->expects($this->once())
+            ->method('getContentInfo')
+            ->willReturn($contentInfo);
+
+        $content = $this->createMock(Content::class);
+        $content->expects($this->once())
+            ->method('getVersionInfo')
+            ->willReturn($versionInfo);
+
+        return $content;
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -72,7 +72,7 @@ class PreviewController
 
         try {
             $content = $this->contentService->loadContent($contentId, [$language], $versionNo);
-            $location = $this->locationProvider->loadMainLocation($contentId);
+            $location = $this->locationProvider->loadMainLocationByContent($content);
 
             if (!$location instanceof Location) {
                 throw new NotImplementedException('Preview for content without locations');

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
@@ -107,8 +107,8 @@ class PreviewControllerTest extends TestCase
 
         $this->locationProvider
             ->expects($this->once())
-            ->method('loadMainLocation')
-            ->with($contentId)
+            ->method('loadMainLocationByContent')
+            ->with($content)
             ->will($this->returnValue($this->createMock(Location::class)));
         $this->contentService
             ->expects($this->once())
@@ -138,8 +138,8 @@ class PreviewControllerTest extends TestCase
         // Repository expectations
         $this->locationProvider
             ->expects($this->once())
-            ->method('loadMainLocation')
-            ->with($contentId)
+            ->method('loadMainLocationByContent')
+            ->with($content)
             ->will($this->returnValue($location));
         $this->contentService
             ->expects($this->once())
@@ -229,8 +229,8 @@ class PreviewControllerTest extends TestCase
         // Repository expectations
         $this->locationProvider
             ->expects($this->once())
-            ->method('loadMainLocation')
-            ->with($contentId)
+            ->method('loadMainLocationByContent')
+            ->with($content)
             ->will($this->returnValue($location));
         $this->contentService
             ->expects($this->once())


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30839](https://jira.ez.no/browse/EZP-30839)
| **Bug/Improvement**| yes
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Preview's hardcoded "draft location" was not adapted when introducing `$location->getContent()` causing code that took advantage of this feature to break on un-published 1st drafts.

*REVIEW NOTE:* API is changed (in safe way) to take Content as argument as we need to make sure it's the same content as loaded by the system _(same translation and same version)_. This also saves having to load this info twice, and makes sure the instance is the same in case of for instance content proxy being used.

## Steps to reproduce for QA:

_Note: this is not the direct use case from the issue Reporter, but it shows the issue._

For eZ Platform OSS 2.5 clean, assuming you have set in the `ezplatform.yml`:
```yaml
ez_platform_standard_design:
    override_kernel_templates: true
```

1. Create `app/Resources/views/themes/standard/pagelayout.html.twig` with the following contents:
```twig
{{ location.content.name }}
```
2. Go to AdminUI and start creating Content from "Create" widget on the right sidebar.
3. Do not publish, click "Preview" instead.
4. You should see HTTP 500 error with the message:
```
Impossible to access an attribute ("name") on a null variable.
```

After applying the fix, simply Content name should be displayed.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
