### PR TITLE
Fixed reference to undefined property "settingsSchema" in Generic\Type::validateFieldSettings

### DIFF
--- a/eZ/Publish/SPI/FieldType/Generic/Type.php
+++ b/eZ/Publish/SPI/FieldType/Generic/Type.php
@@ -151,7 +151,7 @@ abstract class Type extends FieldType
 
     public function validateFieldSettings($fieldSettings): array
     {
-        if (empty($this->settingsSchema) && !empty($fieldSettings)) {
+        if (empty($this->getSettingsSchema()) && !empty($fieldSettings)) {
             return [
                 new NonConfigurableValidationError($this->getFieldTypeIdentifier(), 'fieldType'),
             ];


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | -
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Follow up for https://github.com/ezsystems/ezpublish-kernel/pull/2632. Fixed reference to undefined property "settingsSchema" (replaced by `getSettingsSchema` method) in `eZ\Publish\SPI\FieldType\Generic\Type::validateFieldSettings`.

**TODO**:
- [X] Implement feature / fix a bug.
- [ ] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
