### PR TITLE
Fixed missing % in parameters names passed to {UnknownValidator,NonConfigurable}ValidationError

### DIFF
--- a/eZ/Publish/SPI/FieldType/ValidationError/NonConfigurableValidationError.php
+++ b/eZ/Publish/SPI/FieldType/ValidationError/NonConfigurableValidationError.php
@@ -15,7 +15,7 @@ final class NonConfigurableValidationError extends AbstractValidationError
         parent::__construct(
             "FieldType '%fieldType%' does not accept settings",
             [
-                'fieldType' => $fieldTypeValidatorIdentifier,
+                '%fieldType%' => $fieldTypeValidatorIdentifier,
             ],
             $target
         );

--- a/eZ/Publish/SPI/FieldType/ValidationError/UnknownValidatorValidationError.php
+++ b/eZ/Publish/SPI/FieldType/ValidationError/UnknownValidatorValidationError.php
@@ -15,7 +15,7 @@ final class UnknownValidatorValidationError extends AbstractValidationError
         parent::__construct(
             "Validator '%validator%' is unknown",
             [
-                'validator' => $validatorIdentifier,
+                '%validator%' => $validatorIdentifier,
             ],
             $target
         );


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | -
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Follow up for #2632. Added missing `%` in the parameters names passed to message template in `eZ\Publish\SPI\FieldType\ValidationError\{UnknownValidatorValidationError,NonConfigurableValidationError}`

**TODO**:
- [X] Implement feature / fix a bug.
- [ ] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
