### PR TITLE
EZP-30852: Section handler has been used in methods create and updateSection

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
@@ -8,13 +8,13 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 
 /**
  * Test case for operations in the SectionService using in memory storage.
  *
  * @see eZ\Publish\API\Repository\SectionService
- * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testLoadAnonymousUser
  * @group integration
  * @group authorization
  */
@@ -24,8 +24,6 @@ class SectionServiceAuthorizationTest extends BaseTest
      * Test for the createSection() method.
      *
      * @see \eZ\Publish\API\Repository\SectionService::createSection()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testCreateSection
      */
     public function testCreateSectionThrowsUnauthorizedException()
     {
@@ -43,9 +41,11 @@ class SectionServiceAuthorizationTest extends BaseTest
         $sectionCreate->identifier = 'uniqueKey';
 
         // Set anonymous user
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
-        // This call will fail with a "UnauthorizedException"
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage("User does not have access to 'edit' 'section");
+
         $sectionService->createSection($sectionCreate);
         /* END: Use Case */
     }
@@ -54,8 +54,6 @@ class SectionServiceAuthorizationTest extends BaseTest
      * Test for the loadSection() method.
      *
      * @see \eZ\Publish\API\Repository\SectionService::loadSection()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSection
      */
     public function testLoadSectionThrowsUnauthorizedException()
     {
@@ -75,9 +73,11 @@ class SectionServiceAuthorizationTest extends BaseTest
         $sectionId = $sectionService->createSection($sectionCreate)->id;
 
         // Set anonymous user
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
-        // This call will fail with a "UnauthorizedException"
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage("User does not have access to 'view' 'section");
+
         $sectionService->loadSection($sectionId);
         /* END: Use Case */
     }
@@ -86,8 +86,6 @@ class SectionServiceAuthorizationTest extends BaseTest
      * Test for the updateSection() method.
      *
      * @see \eZ\Publish\API\Repository\SectionService::updateSection()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testUpdateSection
      */
     public function testUpdateSectionThrowsUnauthorizedException()
     {
@@ -111,9 +109,11 @@ class SectionServiceAuthorizationTest extends BaseTest
         $sectionUpdate->identifier = 'newUniqueKey';
 
         // Set anonymous user
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
-        // This call will fail with a "UnauthorizedException"
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage("User does not have access to 'edit' 'section");
+
         $sectionService->updateSection($section, $sectionUpdate);
         /* END: Use Case */
     }
@@ -122,7 +122,6 @@ class SectionServiceAuthorizationTest extends BaseTest
      * Test for the loadSections() method.
      *
      * @see \eZ\Publish\API\Repository\SectionService::loadSections()
-     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
      */
     public function testLoadSectionsLoadsEmptyListForAnonymousUser()
     {
@@ -148,7 +147,7 @@ class SectionServiceAuthorizationTest extends BaseTest
         $sectionService->createSection($sectionCreateTwo);
 
         // Set anonymous user
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
         $sections = $sectionService->loadSections();
         /* END: Use Case */
@@ -160,7 +159,6 @@ class SectionServiceAuthorizationTest extends BaseTest
      * Test for the loadSections() method.
      *
      * @see \eZ\Publish\API\Repository\SectionService::loadSections()
-     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSections
      */
     public function testLoadSectionFiltersSections()
     {
@@ -206,7 +204,6 @@ class SectionServiceAuthorizationTest extends BaseTest
      * Test for the loadSectionByIdentifier() method.
      *
      * @see \eZ\Publish\API\Repository\SectionService::loadSectionByIdentifier()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
     public function testLoadSectionByIdentifierThrowsUnauthorizedException()
     {
@@ -226,9 +223,11 @@ class SectionServiceAuthorizationTest extends BaseTest
         $sectionService->createSection($sectionCreate);
 
         // Set anonymous user
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
-        // This call will fail with a "UnauthorizedException"
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage("User does not have access to 'view' 'section");
+
         $sectionService->loadSectionByIdentifier('uniqueKey');
         /* END: Use Case */
     }
@@ -267,7 +266,7 @@ class SectionServiceAuthorizationTest extends BaseTest
         $section = $sectionService->loadSection($standardSectionId);
 
         // Set anonymous user
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
         // This call will fail with a "UnauthorizedException"
         $sectionService->assignSection($contentInfo, $section);
@@ -298,7 +297,7 @@ class SectionServiceAuthorizationTest extends BaseTest
         $section = $sectionService->createSection($sectionCreate);
 
         // Set anonymous user
-        $repository->setCurrentUser($userService->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($userService->loadUser($anonymousUserId));
 
         // This call will fail with a "UnauthorizedException"
         $sectionService->deleteSection($section);

--- a/eZ/Publish/API/Repository/Tests/SectionServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceTest.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\API\Repository\Tests;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\Section;
 use Exception;
+use eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation;
+use eZ\Publish\API\Repository\Values\Content\SectionCreateStruct;
+use eZ\Publish\API\Repository\Values\Content\SectionUpdateStruct;
 
 /**
  * Test case for operations in the SectionService using in memory storage.
@@ -21,12 +24,17 @@ use Exception;
  */
 class SectionServiceTest extends BaseTest
 {
+    private const SECTION_UNIQUE_KEY = 'uniqueKey';
+
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    protected $permissionResolver;
+
     /**
      * Tests that the required <b>ContentService::loadContentInfoByRemoteId()</b>
      * at least returns an object, because this method is utilized in several
      * tests,.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -57,6 +65,9 @@ class SectionServiceTest extends BaseTest
                 $e
             );
         }
+
+        $repository = $this->getRepository(false);
+        $this->permissionResolver = $repository->getPermissionResolver();
     }
 
     /**
@@ -74,7 +85,7 @@ class SectionServiceTest extends BaseTest
         $sectionCreate = $sectionService->newSectionCreateStruct();
         /* END: Use Case */
 
-        $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\Content\\SectionCreateStruct', $sectionCreate);
+        $this->assertInstanceOf(SectionCreateStruct::class, $sectionCreate);
     }
 
     /**
@@ -92,12 +103,50 @@ class SectionServiceTest extends BaseTest
 
         $sectionCreate = $sectionService->newSectionCreateStruct();
         $sectionCreate->name = 'Test Section';
-        $sectionCreate->identifier = 'uniqueKey';
+        $sectionCreate->identifier = self::SECTION_UNIQUE_KEY;
 
         $section = $sectionService->createSection($sectionCreate);
         /* END: Use Case */
 
-        $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\Content\\Section', $section);
+        $this->assertInstanceOf(Section::class, $section);
+    }
+
+    /**
+     * Test for the createSection() method.
+     *
+     * @see \eZ\Publish\API\Repository\SectionService::createSection()
+     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testNewSectionCreateStruct
+     */
+    public function testCreateSectionForUserWithSectionLimitation()
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $sectionService = $repository->getSectionService();
+
+        $sectionCreate = $sectionService->newSectionCreateStruct();
+        $sectionCreate->name = 'Test Section';
+        $sectionCreate->identifier = self::SECTION_UNIQUE_KEY;
+
+        $this->createRoleWithPolicies('sectionCreator', [
+            ['module' => 'section', 'function' => 'edit'],
+        ]);
+
+        $user = $this->createCustomUserWithLogin(
+            'user',
+            'user@example.com',
+            'sectionCreators',
+            'sectionCreator',
+            new SectionLimitation(['limitationValues' => [1]])
+        );
+
+        $repository->getPermissionResolver()->setCurrentUserReference($user);
+
+        $section = $sectionService->createSection($sectionCreate);
+        /* END: Use Case */
+
+        $this->assertInstanceOf(Section::class, $section);
+        $this->assertSame(self::SECTION_UNIQUE_KEY, $section->identifier);
     }
 
     /**
@@ -116,13 +165,13 @@ class SectionServiceTest extends BaseTest
 
         $sectionCreateOne = $sectionService->newSectionCreateStruct();
         $sectionCreateOne->name = 'Test section one';
-        $sectionCreateOne->identifier = 'uniqueKey';
+        $sectionCreateOne->identifier = self::SECTION_UNIQUE_KEY;
 
         $sectionService->createSection($sectionCreateOne);
 
         $sectionCreateTwo = $sectionService->newSectionCreateStruct();
         $sectionCreateTwo->name = 'Test section two';
-        $sectionCreateTwo->identifier = 'uniqueKey';
+        $sectionCreateTwo->identifier = self::SECTION_UNIQUE_KEY;
 
         // This will fail, because identifier uniqueKey already exists.
         $sectionService->createSection($sectionCreateTwo);
@@ -186,7 +235,7 @@ class SectionServiceTest extends BaseTest
         $sectionUpdate = $sectionService->newSectionUpdateStruct();
         /* END: Use Case */
 
-        $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\Content\\SectionUpdateStruct', $sectionUpdate);
+        $this->assertInstanceOf(SectionUpdateStruct::class, $sectionUpdate);
     }
 
     /**
@@ -218,12 +267,69 @@ class SectionServiceTest extends BaseTest
         /* END: Use Case */
 
         // Verify that service returns an instance of Section
-        $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\Content\\Section', $updatedSection);
+        $this->assertInstanceOf(Section::class, $updatedSection);
 
         // Verify that the service also persists the changes
         $updatedSection = $sectionService->loadSection($standardSectionId);
 
         $this->assertEquals('New section name', $updatedSection->name);
+    }
+
+    /**
+     * Test for the updateSection() method.
+     *
+     * @see \eZ\Publish\API\Repository\SectionService::updateSection()
+     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testCreateSection
+     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testLoadSection
+     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testNewSectionUpdateStruct
+     */
+    public function testUpdateSectionForUserWithSectionLimitation()
+    {
+        $repository = $this->getRepository();
+        $administratorUserId = $this->generateId('user', 14);
+        /* BEGIN: Use Case */
+        // $standardSectionId contains the ID of the "Standard" section in a eZ
+        // Publish demo installation.
+
+        $sectionService = $repository->getSectionService();
+        $userService = $repository->getUserService();
+
+        $sectionCreate = $sectionService->newSectionCreateStruct();
+        $sectionCreate->name = 'Test Section';
+        $sectionCreate->identifier = self::SECTION_UNIQUE_KEY;
+        $section = $sectionService->createSection($sectionCreate);
+
+        $sectionUpdate = $sectionService->newSectionUpdateStruct();
+        $sectionUpdate->name = 'New section name';
+        $sectionUpdate->identifier = 'newUniqueKey';
+
+        $this->createRoleWithPolicies('sectionCreator', [
+            ['module' => 'section', 'function' => 'edit'],
+        ]);
+        $user = $this->createCustomUserWithLogin(
+            'user',
+            'user@example.com',
+            'sectionCreators',
+            'sectionCreator',
+            new SectionLimitation(['limitationValues' => [$section->id]])
+        );
+        $this->permissionResolver->setCurrentUserReference($user);
+
+        $updatedSection = $sectionService->updateSection($section, $sectionUpdate);
+        /* END: Use Case */
+
+        // Verify that service returns an instance of Section
+        $this->assertInstanceOf(Section::class, $updatedSection);
+
+        // Load section as an administrator
+        $administratorUser = $userService->loadUser($administratorUserId);
+        $this->permissionResolver->setCurrentUserReference($administratorUser);
+
+        // Verify that the service also persists the changes
+        $updatedSection = $sectionService->loadSection($section->id);
+
+        $this->assertEquals('New section name', $updatedSection->name);
+        $this->assertEquals('newUniqueKey', $updatedSection->identifier);
     }
 
     /**
@@ -445,11 +551,11 @@ class SectionServiceTest extends BaseTest
 
         $sectionCreate = $sectionService->newSectionCreateStruct();
         $sectionCreate->name = 'Test Section';
-        $sectionCreate->identifier = 'uniqueKey';
+        $sectionCreate->identifier = self::SECTION_UNIQUE_KEY;
 
         $sectionId = $sectionService->createSection($sectionCreate)->id;
 
-        $section = $sectionService->loadSectionByIdentifier('uniqueKey');
+        $section = $sectionService->loadSectionByIdentifier(self::SECTION_UNIQUE_KEY);
         /* END: Use Case */
 
         $this->assertEquals($sectionId, $section->id);
@@ -655,7 +761,7 @@ class SectionServiceTest extends BaseTest
 
         $sectionCreate = $sectionService->newSectionCreateStruct();
         $sectionCreate->name = 'Test Section';
-        $sectionCreate->identifier = 'uniqueKey';
+        $sectionCreate->identifier = self::SECTION_UNIQUE_KEY;
 
         $section = $sectionService->createSection($sectionCreate);
 
@@ -681,7 +787,7 @@ class SectionServiceTest extends BaseTest
 
         $sectionCreate = $sectionService->newSectionCreateStruct();
         $sectionCreate->name = 'Test Section';
-        $sectionCreate->identifier = 'uniqueKey';
+        $sectionCreate->identifier = self::SECTION_UNIQUE_KEY;
 
         $section = $sectionService->createSection($sectionCreate);
 
@@ -707,7 +813,7 @@ class SectionServiceTest extends BaseTest
 
         $sectionCreate = $sectionService->newSectionCreateStruct();
         $sectionCreate->name = 'Test Section';
-        $sectionCreate->identifier = 'uniqueKey';
+        $sectionCreate->identifier = self::SECTION_UNIQUE_KEY;
 
         $section = $sectionService->createSection($sectionCreate);
 
@@ -734,7 +840,7 @@ class SectionServiceTest extends BaseTest
 
         $sectionCreate = $sectionService->newSectionCreateStruct();
         $sectionCreate->name = 'Test Section';
-        $sectionCreate->identifier = 'uniqueKey';
+        $sectionCreate->identifier = self::SECTION_UNIQUE_KEY;
 
         $section = $sectionService->createSection($sectionCreate);
 
@@ -803,7 +909,7 @@ class SectionServiceTest extends BaseTest
             // Get a create struct and set some properties
             $sectionCreate = $sectionService->newSectionCreateStruct();
             $sectionCreate->name = 'Test Section';
-            $sectionCreate->identifier = 'uniqueKey';
+            $sectionCreate->identifier = self::SECTION_UNIQUE_KEY;
 
             // Create a new section
             $sectionService->createSection($sectionCreate);
@@ -818,7 +924,7 @@ class SectionServiceTest extends BaseTest
 
         try {
             // This call will fail with a not found exception
-            $sectionService->loadSectionByIdentifier('uniqueKey');
+            $sectionService->loadSectionByIdentifier(self::SECTION_UNIQUE_KEY);
         } catch (NotFoundException $e) {
             // Expected execution path
         }
@@ -848,7 +954,7 @@ class SectionServiceTest extends BaseTest
             // Get a create struct and set some properties
             $sectionCreate = $sectionService->newSectionCreateStruct();
             $sectionCreate->name = 'Test Section';
-            $sectionCreate->identifier = 'uniqueKey';
+            $sectionCreate->identifier = self::SECTION_UNIQUE_KEY;
 
             // Create a new section
             $sectionService->createSection($sectionCreate);
@@ -862,10 +968,10 @@ class SectionServiceTest extends BaseTest
         }
 
         // Load new section
-        $section = $sectionService->loadSectionByIdentifier('uniqueKey');
+        $section = $sectionService->loadSectionByIdentifier(self::SECTION_UNIQUE_KEY);
         /* END: Use Case */
 
-        $this->assertEquals('uniqueKey', $section->identifier);
+        $this->assertEquals(self::SECTION_UNIQUE_KEY, $section->identifier);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/SectionService.php
+++ b/eZ/Publish/Core/Repository/SectionService.php
@@ -101,7 +101,7 @@ class SectionService implements SectionServiceInterface
         }
 
         try {
-            $existingSection = $this->loadSectionByIdentifier($sectionCreateStruct->identifier);
+            $existingSection = $this->sectionHandler->loadByIdentifier($sectionCreateStruct->identifier);
             if ($existingSection !== null) {
                 throw new InvalidArgumentException('sectionCreateStruct', 'section with specified identifier already exists');
             }
@@ -151,7 +151,7 @@ class SectionService implements SectionServiceInterface
 
         if ($sectionUpdateStruct->identifier !== null) {
             try {
-                $existingSection = $this->loadSectionByIdentifier($sectionUpdateStruct->identifier);
+                $existingSection = $this->sectionHandler->loadByIdentifier($sectionUpdateStruct->identifier);
 
                 // Allowing identifier update only for the same section
                 if ($existingSection->id != $section->id) {
@@ -162,7 +162,7 @@ class SectionService implements SectionServiceInterface
             }
         }
 
-        $loadedSection = $this->loadSection($section->id);
+        $loadedSection = $this->sectionHandler->load($section->id);
 
         $this->repository->beginTransaction();
         try {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30852](https://jira.ez.no/browse/EZP-30852)
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.5` 
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     |no

User should add and edit section without having view permission. Section/View policy was required because we use API methods `loadSectionByIdentifier` and `loadSection` instead of those from Handler. 

Also, I improved tests to check if `UnauthorizedException` message is correct.

Depends on: https://github.com/ezsystems/ezplatform-admin-ui/pull/1057

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
