### PR TITLE
EZP-30823: [6.x] Isolated cache during transactions to avoid race condition

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/Adapter/Item/TransactionItem.php
+++ b/eZ/Publish/Core/Persistence/Cache/Adapter/Item/TransactionItem.php
@@ -4,7 +4,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\Persistence\Cache\Adapter;
+namespace eZ\Publish\Core\Persistence\Cache\Adapter\Item;
 
 use Tedivm\StashBundle\Service\CacheItem;
 
@@ -17,7 +17,10 @@ use Tedivm\StashBundle\Service\CacheItem;
  */
 class TransactionItem extends CacheItem
 {
+    /** @var callable */
     private $clearFn;
+
+    /** @var callable */
     private $isItemDeferedClearedFn;
 
     public function setClearCallback(callable $clear)

--- a/eZ/Publish/Core/Persistence/Cache/Adapter/TransactionAwareAdapterInterface.php
+++ b/eZ/Publish/Core/Persistence/Cache/Adapter/TransactionAwareAdapterInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Persistence\Cache\Adapter;
+
+/**
+ * Interface for cache adapter which is aware of persistence transactions.
+ *
+ * It is used for deferring cache invalidation until transaction is committed to avoid race conditions due to
+ * shared cache pool vs isolated transactions.
+ *
+ * @internal
+ */
+interface TransactionAwareAdapterInterface
+{
+    /**
+     * Called when transaction starts.
+     */
+    public function beginTransaction();
+
+    /**
+     * Called when transaction is committed.
+     *
+     * WARNING: Must be called just AFTER database commit, to avoid theoretical cache pool race issues if done before.
+     */
+    public function commitTransaction();
+
+    /**
+     * Called when transaction is rolled back.
+     */
+    public function rollbackTransaction();
+}

--- a/eZ/Publish/Core/Persistence/Cache/Adapter/TransactionItem.php
+++ b/eZ/Publish/Core/Persistence/Cache/Adapter/TransactionItem.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Persistence\Cache\Adapter;
+
+use Tedivm\StashBundle\Service\CacheItem;
+
+/**
+ * Class TransactionItem.
+ *
+ * Custom Item class for use during transactions, routes calls to save() and clear() to clear callback.
+ *
+ * @internal
+ */
+class TransactionItem extends CacheItem
+{
+    private $clearFn;
+    private $isItemDeferedClearedFn;
+
+    public function setClearCallback(callable $clear)
+    {
+        $this->clearFn = $clear;
+    }
+
+    public function setIsClearedCallback(callable $isItemDeferedCleared)
+    {
+        $this->isItemDeferedClearedFn = $isItemDeferedCleared;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isMiss()
+    {
+        // Mark any cache item which has been scheduled to be cleared as a miss.
+        // We do this using callback since isHit property is private, & it will be reset on get()
+        $fn = $this->isItemDeferedClearedFn;
+        if ($fn($this->keyString)) {
+            return true;
+        }
+
+        return parent::isMiss();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save()
+    {
+        // We don't save cache during transaction (as cache is shared), & given the use of cache items within eZ
+        // Platform kernel is not used across transaction boundaries items (these) given by pool can safely be assumed
+        // to still be within transaction when save() is called.
+        // ...
+        // We do need to tell Pool that it should delete the item tough (which is done on commit if in transaction)
+        // so this save will be done on-demand when needed.
+        $clear = $this->clearFn;
+        $clear($this->keyString);
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        $clear = $this->clearFn;
+        $clear($this->keyString);
+
+        return true;
+    }
+}

--- a/eZ/Publish/Core/Persistence/Cache/Tests/TransactionHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/TransactionHandlerTest.php
@@ -23,8 +23,8 @@ class TransactionHandlerTest extends HandlerTest
             ->method('logCall');
 
         $this->cacheMock
-            ->expects($this->never())
-            ->method($this->anything());
+            ->expects($this->once())
+            ->method('beginTransaction');
 
         $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\TransactionHandler');
         $this->persistenceHandlerMock
@@ -50,8 +50,8 @@ class TransactionHandlerTest extends HandlerTest
             ->method('logCall');
 
         $this->cacheMock
-            ->expects($this->never())
-            ->method($this->anything());
+            ->expects($this->once())
+            ->method('commitTransaction');
 
         $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\TransactionHandler');
         $this->persistenceHandlerMock
@@ -77,8 +77,12 @@ class TransactionHandlerTest extends HandlerTest
             ->method('logCall');
 
         $this->cacheMock
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('clear');
+
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('rollbackTransaction');
 
         $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\TransactionHandler');
         $this->persistenceHandlerMock

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -114,7 +114,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup
      */
-    public function createContentTypeGroup(ContentTypeGroupCreateStruct  $contentTypeGroupCreateStruct)
+    public function createContentTypeGroup(ContentTypeGroupCreateStruct $contentTypeGroupCreateStruct)
     {
         if (!$this->repository->canUser('class', 'create', $contentTypeGroupCreateStruct)) {
             throw new UnauthorizedException('ContentType', 'create');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30823](https://jira.ez.no/browse/EZP-30823)
| **Bug/Improvement**| yes
| **Target version** | `6.7`+ _(see #2749 for 7.x PR)_
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Similar to what was done for 2.5.3 (#2703) and followup in #2749, but adapted for Stash:
- As Stash has "fat Items" need to catch calls to store/clear on the object itself, this part is not relevant for 7.x
- Route calls to store items to just deferred delete the key instead
- Make it so that Items with keys that are marked as invalidated gets returned as a "miss" by the system
- And with that be able to get rid of the need to clear all cache on rollback, we instead just need to wipe out local changes



**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
