### PR TITLE
EZP-30866: Section is updated after location is moved

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -397,10 +397,6 @@ class Handler implements BaseLocationHandler
             $destinationParentId,
             Gateway::NODE_ASSIGNMENT_OP_CODE_MOVE
         );
-
-        $sourceLocation = $this->load($sourceId);
-        $destinationParentSectionId = $this->getSectionId($destinationParentId);
-        $this->updateSubtreeSectionIfNecessary($sourceLocation, $destinationParentSectionId);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
@@ -236,40 +236,8 @@ class LocationHandlerTest extends TestCase
             ->with(67, 2, 77, 5);
 
         $this->treeHandler
-            ->expects($this->at(0))
-            ->method('loadLocation')
-            ->with($sourceData['node_id'])
-            ->will($this->returnValue(
-                new Location(
-                    [
-                        'id' => $sourceData['node_id'],
-                        'contentId' => $sourceData['contentobject_id'],
-                    ]
-                )
-            ));
-
-        $this->treeHandler
-            ->expects($this->at(1))
-            ->method('loadLocation')
-            ->with($destinationData['node_id'])
-            ->will($this->returnValue(new Location(['contentId' => $destinationData['contentobject_id']])));
-
-        $this->contentHandler
-            ->expects($this->at(0))
-            ->method('loadContentInfo')
-            ->with($destinationData['contentobject_id'])
-            ->will($this->returnValue(new ContentInfo(['sectionId' => 12345])));
-
-        $this->contentHandler
-            ->expects($this->at(1))
-            ->method('loadContentInfo')
-            ->with($sourceData['contentobject_id'])
-            ->will($this->returnValue(new ContentInfo(['mainLocationId' => 69])));
-
-        $this->treeHandler
-            ->expects($this->once())
-            ->method('setSectionForSubtree')
-            ->with(69, 12345);
+            ->expects($this->never())
+            ->method('setSectionForSubtree');
 
         $handler->move(69, 77);
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30866](https://jira.ez.no/browse/EZP-30866)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**Steps to reproduce**
1. Create new sections: "New" and "Old"
2. Create "New" folder, under root location. Set its section to "New".
3. Create "Move me" folder, under the root location. Set its section to "Old".
4. Move "Move me" folder under "New" location.

**Expected result**: "Move me" folder has the same section as before, which is "Old".

**Actual result**: The section for "Move me" folder is updated to the same value as the parent location ("New") section.

Please note, the section was not updated after location move in legacy.

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
