### PR TITLE
EZP-30869: Added extension point in login form view

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/SecurityController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/SecurityController.php
@@ -9,7 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Controller;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use Symfony\Component\HttpFoundation\Response;
+use eZ\Publish\Core\MVC\Symfony\View\LoginFormView;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Templating\EngineInterface;
 
@@ -33,15 +33,13 @@ class SecurityController
 
     public function loginAction()
     {
-        return new Response(
-            $this->templateEngine->render(
-                $this->configResolver->getParameter('security.login_template'),
-                [
-                    'last_username' => $this->authenticationUtils->getLastUsername(),
-                    'error' => $this->authenticationUtils->getLastAuthenticationError(),
-                    'layout' => $this->configResolver->getParameter('security.base_layout'),
-                ]
-            )
-        );
+        $view = new LoginFormView($this->configResolver->getParameter('security.login_template'));
+        $view->setLastUsername($this->authenticationUtils->getLastUsername());
+        $view->setLastAuthenticationError($this->authenticationUtils->getLastAuthenticationError());
+        $view->addParameters([
+            'layout' => $this->configResolver->getParameter('security.base_layout'),
+        ]);
+
+        return $view;
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/View/LoginFormView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/LoginFormView.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\View;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+final class LoginFormView extends BaseView
+{
+    /** @var string */
+    private $lastUsername;
+
+    /** @var \Symfony\Component\Security\Core\Exception\AuthenticationException|null */
+    private $lastAuthenticationException;
+
+    public function getLastUsername(): ?string
+    {
+        return $this->lastUsername;
+    }
+
+    public function setLastUsername(?string $username): void
+    {
+        $this->lastUsername = $username;
+    }
+
+    public function getLastAuthenticationException(): ?AuthenticationException
+    {
+        return $this->lastAuthenticationException;
+    }
+
+    public function setLastAuthenticationError(?AuthenticationException $authenticationException): void
+    {
+        $this->lastAuthenticationException = $authenticationException;
+    }
+
+    protected function getInternalParameters(): array
+    {
+        return [
+            'last_username' => $this->getLastUsername(),
+            'error' => $this->getLastAuthenticationException(),
+        ];
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/AbstractViewTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/AbstractViewTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\View\Tests;
+
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractViewTest extends TestCase
+{
+    abstract protected function createViewUnderTest($template = null, array $parameters = [], $viewType = 'full'): View;
+
+    /**
+     * Returns parameters that are always returned by this view.
+     *
+     * @return array
+     */
+    protected function getAlwaysAvailableParams(): array
+    {
+        return [];
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\MVC\Symfony\View\View::setParameters
+     * @covers \eZ\Publish\Core\MVC\Symfony\View\View::getParameters
+     */
+    public function testGetSetParameters(): void
+    {
+        $params = [
+            'bar' => 'baz',
+            'fruit' => 'apple',
+        ];
+
+        $view = $this->createViewUnderTest('foo');
+        $view->setParameters($params);
+
+        self::assertSame($this->getAlwaysAvailableParams() + $params, $view->getParameters());
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\MVC\Symfony\View\View::setParameters
+     * @covers \eZ\Publish\Core\MVC\Symfony\View\View::getParameters
+     */
+    public function testAddParameters(): void
+    {
+        $params = ['bar' => 'baz', 'fruit' => 'apple'];
+        $view = $this->createViewUnderTest('foo', $params);
+
+        $additionalParams = ['truc' => 'muche', 'laurel' => 'hardy'];
+        $view->addParameters($additionalParams);
+
+        $this->assertSame($this->getAlwaysAvailableParams() + $params + $additionalParams, $view->getParameters());
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\MVC\Symfony\View\View::setParameters
+     * @covers \eZ\Publish\Core\MVC\Symfony\View\View::getParameters
+     */
+    public function testHasParameter(): View
+    {
+        $view = $this->createViewUnderTest(__METHOD__, ['foo' => 'bar']);
+
+        $this->assertTrue($view->hasParameter('foo'));
+        $this->assertFalse($view->hasParameter('nonExistent'));
+
+        return $view;
+    }
+
+    /**
+     * @depends testHasParameter
+     * @covers  \eZ\Publish\Core\MVC\Symfony\View\View::setParameters
+     * @covers  \eZ\Publish\Core\MVC\Symfony\View\View::getParameters
+     *
+     * @param \eZ\Publish\Core\MVC\Symfony\View\View $view
+     *
+     * @return \eZ\Publish\Core\MVC\Symfony\View\View
+     */
+    public function testGetParameter(View $view): View
+    {
+        $this->assertSame('bar', $view->getParameter('foo'));
+
+        return $view;
+    }
+
+    /**
+     * @depends testGetParameter
+     *
+     * @covers \eZ\Publish\Core\MVC\Symfony\View\View::setParameters
+     * @covers \eZ\Publish\Core\MVC\Symfony\View\View::getParameters
+     */
+    public function testGetParameterFail(View $view): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $view->getParameter('nonExistent');
+    }
+
+    /**
+     * @dataProvider goodTemplateIdentifierProvider
+     *
+     * @param string|callable $templateIdentifier
+     */
+    public function testSetTemplateIdentifier($templateIdentifier): void
+    {
+        $contentView = $this->createViewUnderTest();
+        $contentView->setTemplateIdentifier($templateIdentifier);
+
+        $this->assertSame($templateIdentifier, $contentView->getTemplateIdentifier());
+    }
+
+    public function goodTemplateIdentifierProvider(): array
+    {
+        return [
+            ['foo:bar:baz.html.twig'],
+            [
+                function () {
+                    return 'foo';
+                },
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider badTemplateIdentifierProvider
+     *
+     * @param mixed $badTemplateIdentifier
+     */
+    public function testSetTemplateIdentifierWrongType($badTemplateIdentifier): void
+    {
+        $this->expectException(InvalidArgumentType::class);
+
+        $contentView = $this->createViewUnderTest();
+        $contentView->setTemplateIdentifier($badTemplateIdentifier);
+    }
+
+    public function badTemplateIdentifierProvider(): array
+    {
+        return [
+            [123],
+            [true],
+            [new \stdClass()],
+            [['foo', 'bar']],
+        ];
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewTest.php
@@ -1,20 +1,20 @@
 <?php
 
 /**
- * File containing the ContentViewTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\MVC\Symfony\View\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
-use PHPUnit\Framework\TestCase;
+use eZ\Publish\Core\MVC\Symfony\View\View;
 
 /**
  * @group mvc
  */
-class ContentViewTest extends TestCase
+class ContentViewTest extends AbstractViewTest
 {
     /**
      * Params that are always returned by this view.
@@ -75,117 +75,13 @@ class ContentViewTest extends TestCase
         ];
     }
 
-    /**
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::__construct
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::setParameters
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::getParameters
-     */
-    public function testGetSetParameters()
+    protected function createViewUnderTest($template = null, array $parameters = [], $viewType = 'full'): View
     {
-        $params = ['bar' => 'baz', 'fruit' => 'apple'];
-        $contentView = new ContentView('foo');
-        $contentView->setParameters($params);
-        self::assertSame($this->valueParams + $params, $contentView->getParameters());
+        return new ContentView($template, $parameters, $viewType);
     }
 
-    /**
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::__construct
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::setParameters
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::getParameters
-     */
-    public function testAddParameters()
+    protected function getAlwaysAvailableParams(): array
     {
-        $params = ['bar' => 'baz', 'fruit' => 'apple'];
-        $contentView = new ContentView('foo', $params);
-
-        $additionalParams = ['truc' => 'muche', 'laurel' => 'hardy'];
-        $contentView->addParameters($additionalParams);
-        self::assertSame($this->valueParams + $params + $additionalParams, $contentView->getParameters());
-    }
-
-    /**
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::__construct
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::setParameters
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::getParameters
-     */
-    public function testHasParameter()
-    {
-        $contentView = new ContentView(__METHOD__, ['foo' => 'bar']);
-        self::assertTrue($contentView->hasParameter('foo'));
-        self::assertFalse($contentView->hasParameter('nonExistent'));
-
-        return $contentView;
-    }
-
-    /**
-     * @depends testHasParameter
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::__construct
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::setParameters
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::getParameters
-     */
-    public function testGetParameter(ContentView $contentView)
-    {
-        self::assertSame('bar', $contentView->getParameter('foo'));
-
-        return $contentView;
-    }
-
-    /**
-     * @depends testGetParameter
-     * @expectedException \InvalidArgumentException
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::__construct
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::setParameters
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\ContentView::getParameters
-     */
-    public function testGetParameterFail(ContentView $contentView)
-    {
-        $contentView->getParameter('nonExistent');
-    }
-
-    /**
-     * @dataProvider goodTemplateIdentifierProvider
-     *
-     * @param $templateIdentifier
-     */
-    public function testSetTemplateIdentifier($templateIdentifier)
-    {
-        $contentView = new ContentView();
-        $contentView->setTemplateIdentifier($templateIdentifier);
-        $this->assertSame($templateIdentifier, $contentView->getTemplateIdentifier());
-    }
-
-    public function goodTemplateIdentifierProvider()
-    {
-        return [
-            ['foo:bar:baz.html.twig'],
-            [
-                function () {
-                    return 'foo';
-                },
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider badTemplateIdentifierProvider
-     *
-     * @expectedException \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
-     *
-     * @param $badTemplateIdentifier
-     */
-    public function testSetTemplateIdentifierWrongType($badTemplateIdentifier)
-    {
-        $contentView = new ContentView();
-        $contentView->setTemplateIdentifier($badTemplateIdentifier);
-    }
-
-    public function badTemplateIdentifierProvider()
-    {
-        return [
-            [123],
-            [true],
-            [new \stdClass()],
-            [['foo', 'bar']],
-        ];
+        return $this->valueParams;
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/LoginFormViewTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/LoginFormViewTest.php
@@ -10,12 +10,33 @@ namespace eZ\Publish\Core\MVC\Symfony\View\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\View\LoginFormView;
 use eZ\Publish\Core\MVC\Symfony\View\View;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
  * @group mvc
  */
 final class LoginFormViewTest extends AbstractViewTest
 {
+    public function testSetLastUsername(): void
+    {
+        /** @var \eZ\Publish\Core\MVC\Symfony\View\LoginFormView $view */
+        $view = $this->createViewUnderTest();
+        $view->setLastUsername('johndoe');
+
+        $this->assertEquals('johndoe', $view->getLastUsername());
+    }
+
+    public function testSetLastAuthenticationError(): void
+    {
+        $exception = $this->createMock(AuthenticationException::class);
+
+        /** @var \eZ\Publish\Core\MVC\Symfony\View\LoginFormView $view */
+        $view = $this->createViewUnderTest();
+        $view->setLastAuthenticationError($exception);
+
+        $this->assertEquals($exception, $view->getLastAuthenticationException());
+    }
+
     protected function createViewUnderTest($template = null, array $parameters = [], $viewType = 'full'): View
     {
         return new LoginFormView($template, $parameters, $viewType);

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/LoginFormViewTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/LoginFormViewTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\View\Tests;
+
+use eZ\Publish\Core\MVC\Symfony\View\LoginFormView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+
+/**
+ * @group mvc
+ */
+final class LoginFormViewTest extends AbstractViewTest
+{
+    protected function createViewUnderTest($template = null, array $parameters = [], $viewType = 'full'): View
+    {
+        return new LoginFormView($template, $parameters, $viewType);
+    }
+
+    protected function getAlwaysAvailableParams(): array
+    {
+        return [
+            'last_username' => null,
+            'error' => null,
+        ];
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30869](https://jira.ez.no/browse/EZP-30869)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `7.x`
| **BC breaks**      | yes/no
| **Tests pass**     | yes
| **Doc needed**     | yes

Introduced `\eZ\Publish\Core\MVC\Symfony\View\LoginFormView` to be able to extend login form by subscribing `\eZ\Publish\Core\MVC\Symfony\MVCEvents::PRE_CONTENT_VIEW` event.   
Example use cases:

* Passing additional parameters to view e.g. https://github.com/crevillo/ezplatform-captcha/blob/master/src/bundle/MVC/Symfony/Controller/SecurityController.php#L70

* Completely change render view based on occurred login error as in case of EZP-30797:

![image](https://user-images.githubusercontent.com/211967/63333683-1cc98880-c33a-11e9-8d1e-823213d226f3.png)

Example code: https://gist.github.com/adamwojs/1ed9fac8058fc67bab33a6a6d0965d84

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
