### PR TITLE
EZP-30845: Fixed importing XSLT stylesheet file with spaces in path

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Converter/Xslt.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Xslt.php
@@ -77,8 +77,8 @@ class Xslt extends XmlBase implements Converter
             $hrefAttr = $xslDoc->createAttribute('href');
 
             // Prevents showing XSLTProcessor::importStylesheet() warning on Windows file system
-            $hrefAttr->value = str_replace('\\', '/', $stylesheet);
-
+            // & allows loading stylesheets if project's directory name contains space(s)
+            $hrefAttr->value = str_replace(['\\', ' '], ['/', '%20'], $stylesheet);
             $newEl->appendChild($hrefAttr);
             $xslDoc->documentElement->insertBefore($newEl, $insertBeforeEl);
         }

--- a/eZ/Publish/Core/FieldType/RichText/Converter/Xslt.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Xslt.php
@@ -78,7 +78,8 @@ class Xslt extends XmlBase implements Converter
 
             // Prevents showing XSLTProcessor::importStylesheet() warning on Windows file system
             // & allows loading stylesheets if project's directory name contains space(s)
-            $hrefAttr->value = str_replace(['\\', ' '], ['/', '%20'], $stylesheet);
+            $hrefAttr->value = rawurlencode($stylesheet);
+
             $newEl->appendChild($hrefAttr);
             $xslDoc->documentElement->insertBefore($newEl, $insertBeforeEl);
         }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30845](https://jira.ez.no/browse/EZP-30845)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`/`6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR fixes bug described in the JIRA ticket. Please refer to the ticket for more information. 

There is work on progress on the second PR for `ezplatform-richtext` package for v2.x.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
