### PR TITLE
EZP-30598: Removed Container::get calls from SiteAccess MatcherBuilder

### DIFF
--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -93,4 +93,4 @@ site:
                     '@App\Matcher\MyMatcher': ~
 ```
 
-* Service based SiteAccess Matchers now require to be tagged with `ezpublish.matcher.siteaccess`.
+* Service based SiteAccess Matchers now require to be tagged with `ezplatform.matcher.siteaccess`.

--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -93,4 +93,4 @@ site:
                     '@App\Matcher\MyMatcher': ~
 ```
 
-* Service based SiteAccess Matchers now require to be tagged with `ezplatform.matcher.siteaccess`.
+* Service based SiteAccess Matchers now require to be tagged with `ezplatform.siteaccess.matcher`.

--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -90,5 +90,7 @@ site:
             home:
                 template: "content.html.twig"
                 match:
-                    '@App\Matcher\MyMatcher': 2
+                    '@App\Matcher\MyMatcher': ~
 ```
+
+* Service based SiteAccess Matchers now require to be tagged with `ezpublish.matcher.siteaccess`.

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SiteAccessMatcherRegistryPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SiteAccessMatcherRegistryPass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * The SiteAccessMatcherRegistryPass will register all services tagged as "ezpublish.matcher.siteaccess" to the registry.
  */
-class SiteAccessMatcherRegistryPass implements CompilerPassInterface
+final class SiteAccessMatcherRegistryPass implements CompilerPassInterface
 {
     public const MATCHER_TAG = 'ezpublish.matcher.siteaccess';
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SiteAccessMatcherRegistryPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SiteAccessMatcherRegistryPass.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * File containing the ChainConfigResolverPass class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
+
+use eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessMatcherRegistry;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * The SiteAccessMatcherRegistryPass will register all services tagged as "ezpublish.matcher.siteaccess" to the registry.
+ */
+class SiteAccessMatcherRegistryPass implements CompilerPassInterface
+{
+    public const MATCHER_TAG = 'ezpublish.matcher.siteaccess';
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(SiteAccessMatcherRegistry::class)) {
+            return;
+        }
+
+        $matcherServiceRegistry = $container->getDefinition(SiteAccessMatcherRegistry::class);
+
+        foreach ($container->findTaggedServiceIds(self::MATCHER_TAG) as $id => $attributes) {
+            $matcherServiceRegistry->addMethodCall(
+                'setMatcher',
+                [
+                    $id,
+                    new Reference($id),
+                ]
+            );
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SiteAccessMatcherRegistryPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SiteAccessMatcherRegistryPass.php
@@ -16,11 +16,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * The SiteAccessMatcherRegistryPass will register all services tagged as "ezpublish.matcher.siteaccess" to the registry.
+ * The SiteAccessMatcherRegistryPass will register all services tagged as "ezplatform.matcher.siteaccess" to the registry.
  */
 final class SiteAccessMatcherRegistryPass implements CompilerPassInterface
 {
-    public const MATCHER_TAG = 'ezpublish.matcher.siteaccess';
+    public const MATCHER_TAG = 'ezplatform.matcher.siteaccess';
 
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SiteAccessMatcherRegistryPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SiteAccessMatcherRegistryPass.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the ChainConfigResolverPass class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -16,16 +14,16 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * The SiteAccessMatcherRegistryPass will register all services tagged as "ezplatform.matcher.siteaccess" to the registry.
+ * The SiteAccessMatcherRegistryPass will register all services tagged as "ezplatform.siteaccess.matcher" to the registry.
  */
 final class SiteAccessMatcherRegistryPass implements CompilerPassInterface
 {
-    public const MATCHER_TAG = 'ezplatform.matcher.siteaccess';
+    public const MATCHER_TAG = 'ezplatform.siteaccess.matcher';
 
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(SiteAccessMatcherRegistry::class)) {
             return;

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -29,6 +29,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ContentViewPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\LocationViewPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RouterPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\SecurityPass;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\SiteAccessMatcherRegistryPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\SlugConverterConfigurationPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\TranslationCollectorPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ViewProvidersPass;
@@ -82,6 +83,7 @@ class EzPublishCoreBundle extends Bundle
         $container->addCompilerPass(new NotificationRendererPass());
         $container->addCompilerPass(new ConsoleCacheWarmupPass());
         $container->addCompilerPass(new ViewMatcherRegistryPass());
+        $container->addCompilerPass(new SiteAccessMatcherRegistryPass());
 
         // Storage passes
         $container->addCompilerPass(new ExternalStorageRegistryPass());

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -69,9 +69,12 @@ services:
             - "%ezpublish.urlalias_generator.charmap%"
         parent: ezpublish.url_generator.base
 
+    eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessMatcherRegistry: ~
+
     ezpublish.siteaccess.matcher_builder:
         class: "%ezpublish.siteaccess.matcher_builder.class%"
-        arguments: ["@service_container"]
+        arguments:
+            - '@eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessMatcherRegistry'
 
     ezpublish.siteaccess_router:
         class: "%ezpublish.siteaccess_router.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/MatcherBuilder.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/MatcherBuilder.php
@@ -14,7 +14,7 @@ use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 /**
  * Siteaccess matcher builder based on services.
  */
-class MatcherBuilder extends BaseMatcherBuilder
+final class MatcherBuilder extends BaseMatcherBuilder
 {
     /** @var \eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessMatcherRegistry */
     protected $siteAccessMatcherRegistry;

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/MatcherBuilder.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/MatcherBuilder.php
@@ -9,26 +9,24 @@
 namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder as BaseMatcherBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
-use RuntimeException;
 
 /**
  * Siteaccess matcher builder based on services.
  */
 class MatcherBuilder extends BaseMatcherBuilder
 {
-    /** @var \Symfony\Component\DependencyInjection\ContainerInterface */
-    protected $container;
+    /** @var \eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessMatcherRegistry */
+    protected $siteAccessMatcherRegistry;
 
-    public function __construct(ContainerInterface $container)
+    public function __construct(SiteAccessMatcherRegistry $siteAccessMatcherRegistry)
     {
-        $this->container = $container;
+        $this->siteAccessMatcherRegistry = $siteAccessMatcherRegistry;
     }
 
     /**
      * Builds siteaccess matcher.
-     * If $matchingClass begins with "@", it will be considered as a service identifier and loaded with the service container.
+     * If $matchingClass begins with "@", it will be considered as a service identifier.
      *
      * @param $matchingClass
      * @param $matchingConfiguration
@@ -36,16 +34,12 @@ class MatcherBuilder extends BaseMatcherBuilder
      *
      * @return \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Matcher
      *
-     * @throws \RuntimeException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function buildMatcher($matchingClass, $matchingConfiguration, SimplifiedRequest $request)
     {
-        if ($matchingClass[0] === '@') {
-            /** @var $matcher \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Matcher */
-            $matcher = $this->container->get(substr($matchingClass, 1));
-            if (!$matcher instanceof Matcher) {
-                throw new RuntimeException('A service based siteaccess matcher MUST implement ' . __NAMESPACE__ . '\\Matcher interface.');
-            }
+        if (strpos($matchingClass, '@') === 0) {
+            $matcher = $this->siteAccessMatcherRegistry->getMatcher(substr($matchingClass, 1));
 
             $matcher->setMatchingConfiguration($matchingConfiguration);
             $matcher->setRequest($request);

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistry.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistry.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;
+
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+
+class SiteAccessMatcherRegistry
+{
+    /** @var \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Matcher[] */
+    protected $matchers;
+
+    /**
+     * @param \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Matcher[] $matchers
+     */
+    public function __construct(array $matchers = [])
+    {
+        $this->matchers = $matchers;
+    }
+
+    /**
+     * @return \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Matcher[]
+     */
+    public function getMatchers(): array
+    {
+        return $this->matchers;
+    }
+
+    /**
+     * @param \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Matcher[] $matchers
+     */
+    public function setMatchers(array $matchers): void
+    {
+        $this->matchers = $matchers;
+    }
+
+    public function setMatcher(string $identifier, Matcher $matcher): void
+    {
+        $this->matchers[$identifier] = $matcher;
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function getMatcher(string $identifier): Matcher
+    {
+        if (!$this->hasMatcher($identifier)) {
+            throw new NotFoundException('SiteAccess Matcher', $identifier);
+        }
+
+        return $this->matchers[$identifier];
+    }
+
+    public function hasMatcher(string $identifier): bool
+    {
+        return isset($this->matchers[$identifier]);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistry.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistry.php
@@ -12,7 +12,7 @@ use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 final class SiteAccessMatcherRegistry
 {
     /** @var \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Matcher[] */
-    protected $matchers;
+    private $matchers;
 
     /**
      * @param \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Matcher[] $matchers

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistry.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistry.php
@@ -22,22 +22,6 @@ final class SiteAccessMatcherRegistry
         $this->matchers = $matchers;
     }
 
-    /**
-     * @return \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Matcher[]
-     */
-    public function getMatchers(): array
-    {
-        return $this->matchers;
-    }
-
-    /**
-     * @param \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Matcher[] $matchers
-     */
-    public function setMatchers(array $matchers): void
-    {
-        $this->matchers = $matchers;
-    }
-
     public function setMatcher(string $identifier, Matcher $matcher): void
     {
         $this->matchers[$identifier] = $matcher;

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistry.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistry.php
@@ -5,6 +5,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);
+
 namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;
 
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistry.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistry.php
@@ -9,7 +9,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;
 
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 
-class SiteAccessMatcherRegistry
+final class SiteAccessMatcherRegistry
 {
     /** @var \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Matcher[] */
     protected $matchers;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SiteAccessMatcherRegistryPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SiteAccessMatcherRegistryPassTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\SiteAccessMatcherRegistryPass;
+use eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessMatcherRegistry;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class SiteAccessMatcherRegistryPassTest extends AbstractCompilerPassTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setDefinition(SiteAccessMatcherRegistry::class, new Definition());
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new SiteAccessMatcherRegistryPass());
+    }
+
+    public function testSetMatcher(): void
+    {
+        $def = new Definition();
+        $def->addTag(SiteAccessMatcherRegistryPass::MATCHER_TAG);
+        $serviceId = 'service_id';
+        $this->setDefinition($serviceId, $def);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            SiteAccessMatcherRegistry::class,
+            'setMatcher',
+            [
+                $serviceId,
+                new Reference($serviceId),
+            ]
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/SiteAccessMatcherRegistryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/SiteAccessMatcherRegistryTest.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/SiteAccessMatcherRegistryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/SiteAccessMatcherRegistryTest.php
@@ -1,8 +1,11 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/SiteAccessMatcherRegistryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/SiteAccessMatcherRegistryTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use PHPUnit\Framework\TestCase;
+
+class SiteAccessMatcherRegistryTest extends TestCase
+{
+    private const MATCHER_NAME = 'test_matcher';
+
+    public function testGetMatcher(): void
+    {
+        $matcher = $this->getMatcherMock();
+        $registry = new SiteAccessMatcherRegistry([self::MATCHER_NAME => $matcher]);
+
+        $this->assertSame($matcher, $registry->getMatcher(self::MATCHER_NAME));
+    }
+
+    public function testSetMatcher(): void
+    {
+        $matcher = $this->getMatcherMock();
+        $registry = new SiteAccessMatcherRegistry();
+
+        $registry->setMatcher(self::MATCHER_NAME, $matcher);
+
+        $this->assertSame($matcher, $registry->getMatcher(self::MATCHER_NAME));
+    }
+
+    public function testSetMatcherOverride(): void
+    {
+        $matcher = $this->getMatcherMock();
+        $newMatcher = $this->getMatcherMock();
+        $registry = new SiteAccessMatcherRegistry([self::MATCHER_NAME, $matcher]);
+
+        $registry->setMatcher(self::MATCHER_NAME, $newMatcher);
+
+        $this->assertSame($newMatcher, $registry->getMatcher(self::MATCHER_NAME));
+    }
+
+    public function testGetMatcherNotFound(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $registry = new SiteAccessMatcherRegistry();
+
+        $registry->getMatcher(self::MATCHER_NAME);
+    }
+
+    protected function getMatcherMock(): Matcher
+    {
+        return $this->createMock(Matcher::class);
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30598](https://jira.ez.no/browse/EZP-30598)
| **Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

# Description
This PR removes `Container::get` calls from `MatcherBuilder`. You can still use old syntax for using siteaccess matchers based on services:
```yaml
    siteaccess:
        list: [site]
        groups:
            site_group: [site]
        default_siteaccess: site
        match:
            '@App\Matcher\MySiteaccessMatcher': 1
``` 
But it now requires to tag the service using `ezpublish.siteaccess.matcher` tag.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
