### PR TITLE
[Behat] EZP-30884: Added support for class name as service id

### DIFF
--- a/eZ/Bundle/PlatformBehatBundle/Context/Argument/AnnotationArgumentResolver.php
+++ b/eZ/Bundle/PlatformBehatBundle/Context/Argument/AnnotationArgumentResolver.php
@@ -66,7 +66,7 @@ class AnnotationArgumentResolver implements ArgumentResolver
         // parse array from (numeric key => 'annotation <value>') to (annotation => value)
         $methodServices = [];
         foreach ($annotations as $annotation) {
-            if (!preg_match('/^(\w+)\s+\$(\w+)\s+([\w\.\@\%]+)/', $annotation, $matches)) {
+            if (!preg_match('/^(\w+)\s+\$(\w+)\s+([\w\.\\\@\%]+)/', $annotation, $matches)) {
                 continue;
             }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30884](https://jira.ez.no/browse/EZP-30884)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 7.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This regex, as part of EzSystemsBehatExtension, is responsible for splitting a string like:
`injectService $argumentParser @EzSystems\BehatBundle\Helper\ArgumentParser`
into three parts:
- `injectService`
- `$argumentParser`
- `@EzSystems\BehatBundle\Helper\ArgumentParser`

Unfortunely currently it works as:
- `injectService`
- `$argumentParser`
- `@EzSystems`

which makes it impossible to inject services using class name.

Usage: https://github.com/ezsystems/ezplatform-admin-ui/pull/1068/files#diff-1cc2fa436666ba5b8522af19a0efe93fR29

Merging upstream: this file has been removed in master, needs to be ported to BehatBundle for 3.0: https://github.com/ezsystems/BehatBundle/blob/master/src/lib/Core/Behat/AnnotationArgumentResolver.php#L73

