### PR TITLE
EZP-30481: Character "İ" causes publishing to fail with legacy search

### DIFF
--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
@@ -297,14 +297,14 @@ class DoctrineDatabase extends Gateway
         $wordIDArray = [];
         $wordArray = [];
 
-        // store the words in the index and remember the ID
+        // Store the words in the index and remember the ID
         $this->dbHandler->beginTransaction();
         for ($arrayCount = 0; $arrayCount < $wordCount; $arrayCount += 500) {
             // Fetch already indexed words from database
-            $wordArrayChuck = array_slice($indexArrayOnlyWords, $arrayCount, 500);
-            $wordRes = $this->searchIndex->getWords($wordArrayChuck);
+            $wordArrayChunk = array_slice($indexArrayOnlyWords, $arrayCount, 500);
+            $wordRes = $this->searchIndex->getWords($wordArrayChunk);
 
-            // Build a has of the existing words
+            // Build a hash of the existing words
             $wordResCount = count($wordRes);
             $existingWordArray = [];
             for ($i = 0; $i < $wordResCount; ++$i) {
@@ -318,8 +318,8 @@ class DoctrineDatabase extends Gateway
                 $this->searchIndex->incrementWordObjectCount($wordIDArray);
             }
 
-            // Insert if there is any news words
-            $newWordArray = array_diff($wordArrayChuck, $existingWordArray);
+            // Insert if there are any new words
+            $newWordArray = array_diff($wordArrayChunk, $existingWordArray);
             if (count($newWordArray) > 0) {
                 $this->searchIndex->addWords($newWordArray);
                 $newWordRes = $this->searchIndex->getWords($newWordArray);

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
@@ -253,6 +253,11 @@ class DoctrineDatabase extends Gateway
             } else {
                 $nextWordId = 0;
             }
+
+            if ($wordId === null || $nextWordId === null) {
+                continue;
+            }
+
             $frequency = 0;
             $this->searchIndex->addObjectWordLink(
                 $wordId,

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
@@ -329,6 +329,17 @@ class DoctrineDatabase extends Gateway
                     $wordArray[$wordLowercase] = $newWordRes[$i]['id'];
                 }
             }
+
+            // Check if any of the words in $wordArrayChunk are missing in $wordArray, which can happen due to
+            // collation/transformation issues. If so, we must deal with them one by one.
+            $missingWordArray = array_diff($wordArrayChunk, array_keys($wordArray));
+            foreach ($missingWordArray as $missingWord) {
+                $foundWordRes = $this->searchIndex->getWords([$missingWord]);
+                // We may get more than one match. It's hard to deal intelligently with that. Just use the first one.
+                if (count($foundWordRes) > 0) {
+                    $wordArray[$missingWord] = $foundWordRes[0]['id'];
+                }
+            }
         }
         $this->dbHandler->commit();
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30481](https://jira.ez.no/browse/EZP-30481)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 7.5 (should be 6.7 for final fix)
| **BC breaks**      | TBD
| **Tests pass**     | TBD
| **Doc needed**     | no

**Problem**
- Publishing Turkish text can lead to SQL errors in the legacy search, because of collation and transformation issues with Turkish dotted and dotless `i`'s. Turkish has dotted and dotless i's in both upper and lower case: `İ i - I ı`. Case changes in PHP, and non-Turkish collation in the database, leads to errors in conversion between them. This in itself is a minor issue here.
- We cannot expect Turkish to behave 100% correctly in eZ Platform without adding Turkish transformation rules. This is not a bug - we do not guarantee correct transformations of every language in the world (it's an enormous task). Adding this is a feature request.
- Changing letter case is locale dependent. PHP mbstring functions cannot be trusted to do this correctly in every language.
- However, eZ Platform should not produce invalid SQL queries, even if a language isn't fully supported in eZ Platform or in PHP.
- Legacy codebase is probably also affected by this, since the code is ported from there.
- The original code is performance optimised by working in batches. This means there is no way to determine the relation between the word we try to index, and the word that ends up being stored in the DB. I suspect a complete fix will require us to work on one word at a time, which will hurt performance.

**Fix**
- I believe a proper, by-the-book, correct-in-all-cases fix would require eZ Platform to be fully aware of the collation rules in the DB, the locale rules in PHP, and to have correct transformation rules for Turkish. This is out of scope. Avoiding SQL errors is the main goal, and making the transformed words searchable.
- https://github.com/ezsystems/ezpublish-kernel/pull/2754/commits/be9c5993e1318bd8a2e6da201594d7c46a2519fe fixes the symptom, not the cause, by inserting nothing rather than a faulty `ezsearch_object_word_link` entry. This means the corresponding word is not found in searches, and it leaves inconsistencies in the `ezsearch_word` table, but those faults also existed before the fix.
- https://github.com/ezsystems/ezpublish-kernel/pull/2754/commits/91abe52ea3fa016fb607a197b980a36a0b172d40 ensures words with transformed chars are searchable. It keeps the efficient batch processing of most words. Only when words end up not being stored as is, because of transformation, will it process those words one by one. It creates references from the original word to the transformed word in the DB, which means `indexWords()` doesn't crash, and the words are searchable. (This makes the previous commit redundant, but I like it as a failsafe anyway, though it ought to have error logging.)

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
