### PR TITLE
EZP-30912: Provided forward compatibility for CoreInstaller

### DIFF
--- a/doc/bc/changes-7.5.md
+++ b/doc/bc/changes-7.5.md
@@ -25,3 +25,13 @@ Changes affecting version compatibility with former or future versions.
   Creating draft from existing Versions is no longer disallowed, even if a source Version does not
   contain any of the translations that are within the scope of the Language Limitations.
   This is due to the fact that when creating a Draft, an intent of translating is not known yet.
+
+## Deprecations
+
+* The `\EzSystems\PlatformInstallerBundle\Installer\CleanInstaller` class and its Service Container
+  definition (`ezplatform.installer.clean_installer`) have been deprecated in favor of
+  `EzSystems\PlatformInstallerBundle\Installer\CoreInstaller` which requires the
+  [Doctrine Schema Bundle](https://github.com/ezsystems/doctrine-dbal-schema) to be enabled.
+
+* The `ezplatform.installer.db_based_installer` Service Container definition has been deprecated in
+  favor of its FQCN-named equivalent `EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller`.

--- a/eZ/Bundle/PlatformInstallerBundle/src/DependencyInjection/Compiler/SchemaBuilderInstallerPass.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/DependencyInjection/Compiler/SchemaBuilderInstallerPass.php
@@ -10,8 +10,11 @@ namespace EzSystems\PlatformInstallerBundle\DependencyInjection\Compiler;
 
 use EzSystems\DoctrineSchema\API\Builder\SchemaBuilder;
 use EzSystems\PlatformInstallerBundle\Installer\CoreInstaller;
+use EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * Enable installer which uses SchemaBuilder.
@@ -24,6 +27,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class SchemaBuilderInstallerPass implements CompilerPassInterface
 {
     const CLEAN_INSTALLER_DEF_ID = 'ezplatform.installer.clean_installer';
+    const DB_BASED_INSTALLER_DEF_ID = 'ezplatform.installer.db_based_installer';
 
     /**
      * Replace Clean installer with CoreInstaller if required SchemaBuilder from DoctrineSchemaBundle is available.
@@ -48,6 +52,52 @@ class SchemaBuilderInstallerPass implements CompilerPassInterface
             // remove the actual definition first for alias to work properly
             $container->removeDefinition(self::CLEAN_INSTALLER_DEF_ID);
             $container->setAlias(self::CLEAN_INSTALLER_DEF_ID, CoreInstaller::class);
+        }
+
+        $this->warnAboutRelyingOnDeprecatedService(
+            $container,
+            [
+                self::DB_BASED_INSTALLER_DEF_ID => DbBasedInstaller::class,
+                self::CLEAN_INSTALLER_DEF_ID => CoreInstaller::class,
+            ]
+        );
+    }
+
+    /**
+     * Find usages of deprecated service definitions in custom services.
+     *
+     * Note: natural choice would be to use `deprecated` attribute in DIC instead, however
+     * in Symfony 3.4 neither deprecating service alias nor deprecating abstract service gives
+     * proper warning in the application logs.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @param string[] a map of old to new names (associative array)
+     */
+    private function warnAboutRelyingOnDeprecatedService(
+        ContainerBuilder $container,
+        array $oldNewNameMap
+    ): void {
+        // find usages of deprecated definitions as parents
+        /** @var \Symfony\Component\DependencyInjection\ChildDefinition[] $deprecatedParentDefinitions */
+        $deprecatedParentDefinitions = array_filter(
+            $container->getDefinitions(),
+            function (Definition $definition) use ($oldNewNameMap) {
+                return $definition instanceof ChildDefinition
+                    && array_key_exists($definition->getParent(), $oldNewNameMap);
+            }
+        );
+        // trigger deprecation warnings to be logged
+        foreach ($deprecatedParentDefinitions as $id => $definition) {
+            $parent = $definition->getParent();
+            @trigger_error(
+                sprintf(
+                    'The service definition "%s" relies on the deprecated "%s" service. Use "%s" instead',
+                    $id,
+                    $parent,
+                    $oldNewNameMap[$parent]
+                ),
+                E_USER_DEPRECATED
+            );
         }
     }
 }

--- a/eZ/Bundle/PlatformInstallerBundle/src/EzSystemsPlatformInstallerBundle.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/EzSystemsPlatformInstallerBundle.php
@@ -18,7 +18,7 @@ class EzSystemsPlatformInstallerBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
-        $container->addCompilerPass(new InstallerTagPass());
         $container->addCompilerPass(new SchemaBuilderInstallerPass());
+        $container->addCompilerPass(new InstallerTagPass());
     }
 }

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -10,13 +10,22 @@ services:
         arguments:
             - '@=service("kernel").locateResource("@EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml")'
 
-    ezplatform.installer.db_based_installer:
+    EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller:
         abstract: true
-        class:  "%ezplatform.installer.db_based_installer.class%"
         arguments: ["@ezpublish.persistence.connection"]
         lazy: true
 
+    ezplatform.installer.db_based_installer:
+        alias: EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller
+
+    EzSystems\PlatformInstallerBundle\Installer\CoreInstaller:
+        autowire: true
+        parent: EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller
+        tags:
+            - {name: ezplatform.installer, type: clean}
+
     ezplatform.installer.clean_installer:
+        deprecated: '%service_id% is deprecated since eZ Platform v2.5 LTS. Enable DoctrineSchemaBundle and use CoreInstaller instead'
         class: "%ezplatform.installer.clean_installer.class%"
         parent: ezplatform.installer.db_based_installer
         tags:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30912](https://jira.ez.no/browse/EZP-30912)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5` (see #2751 `master` changes)
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | ezsystems/developer-documentation#758

When working on [EZP-30624](https://jira.ez.no/browse/EZP-30624) and [EZP-30898](https://jira.ez.no/browse/EZP-30898) I realized that there was no way to use `CoreInstaller` as a `parent` in Dependency Injection Container because only BC was provided w/o actual forward compatibility. It wasn't the intention so I've qualified this as a bug.

This PR introduces the following changes:
- [x] Having not enabled Doctrine Schema Bundle results in the deprecated
  warning and removal of the dependent `CoreInstaller`.
- [x] Enabling Doctrine Schema Bundle results in `CleanInstaller`
  definition being aliased to `CoreInstaller` (instead of being replaced).
- [x] The `ezplatform.installer.clean_installer` service definition became deprecated in favor of `CoreInstaller`
- [x] The `ezplatform.installer.db_based_installer` service definition became deprecated in favor of its FQCN equivalent.

### Open question

- [x] There's no way to deprecate service alias in Symfony 3.4 (available since Symfony 4.3) and if a service is abstract it gets removed from the container, so out-of-the-box reporting of those deprecated names doesn't seem to be working. I've created `warnAboutRelyingOnDeprecatedService` method inside a Compiler Pass to detect using them in custom code. It looks like overkill, so the question is - should we care about this much detail in the log or is it enough to mention it in the doc only? Separated as 3120016 for optional removal.


### QA

- [x] Sanities for installation process of v2.5 OSS clean and ideally EE Demo, using MySQL and PostgreSQL.
- [x] BC sanities for installation process on the EE Demo test branch https://github.com/alongosz/ezplatform-ee-demo/tree/ezp-30912-forward-compat-for-qa which contains previous version of the installer relying on deprecated CleanInstaller. New bundle is disabled there, so it should work with MySQL only.

**TODO**:
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
