### PR TITLE
EZP-30481: Character "İ" causes publishing to fail with legacy search

### DIFF
--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Tests\Content;
+
+use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper as ContentTypeMapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as ContentTypeUpdateHandler;
+
+/**
+ * Abstract test suite for legacy search.
+ */
+class AbstractTestCase extends LanguageAwareTestCase
+{
+    private static $setup;
+
+    /**
+     * Field registry mock.
+     *
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry
+     */
+    private $converterRegistry;
+
+    /** @var \eZ\Publish\SPI\Persistence\Content\Type\Handler */
+    private $contentTypeHandler;
+
+    /**
+     * Only set up once for these read only tests on a large fixture.
+     *
+     * Skipping the reset-up, since setting up for these tests takes quite some
+     * time, which is not required to spent, since we are only reading from the
+     * database anyways.
+     */
+    public function setUp()
+    {
+        if (!self::$setup) {
+            parent::setUp();
+            $this->insertDatabaseFixture(__DIR__ . '/../_fixtures/full_dump.php');
+            self::$setup = $this->handler;
+        } else {
+            $this->handler = self::$setup;
+            $this->connection = $this->handler->getConnection();
+        }
+    }
+
+    /**
+     * Assert that the elements are.
+     */
+    protected function assertSearchResults($expectedIds, $searchResult)
+    {
+        $ids = $this->getIds($searchResult);
+        $this->assertEquals($expectedIds, $ids);
+    }
+
+    protected function getIds($searchResult)
+    {
+        $ids = array_map(
+            function ($hit) {
+                return $hit->valueObject->id;
+            },
+            $searchResult->searchHits
+        );
+
+        sort($ids);
+
+        return $ids;
+    }
+
+    protected function getContentTypeHandler()
+    {
+        if (!isset($this->contentTypeHandler)) {
+            $this->contentTypeHandler = new ContentTypeHandler(
+                new ContentTypeGateway(
+                    $this->getDatabaseHandler(),
+                    $this->getDatabaseConnection(),
+                    $this->getLanguageMaskGenerator()
+                ),
+                new ContentTypeMapper($this->getConverterRegistry(), $this->getLanguageMaskGenerator()),
+                $this->createMock(ContentTypeUpdateHandler::class)
+            );
+        }
+
+        return $this->contentTypeHandler;
+    }
+
+    protected function getConverterRegistry()
+    {
+        if (!isset($this->converterRegistry)) {
+            $this->converterRegistry = new ConverterRegistry(
+                [
+                    'ezdatetime' => new Converter\DateAndTimeConverter(),
+                    'ezinteger' => new Converter\IntegerConverter(),
+                    'ezstring' => new Converter\TextLineConverter(),
+                    'ezprice' => new Converter\IntegerConverter(),
+                    'ezurl' => new Converter\UrlConverter(),
+                    'ezrichtext' => new Converter\RichTextConverter(),
+                    'ezboolean' => new Converter\CheckboxConverter(),
+                    'ezkeyword' => new Converter\KeywordConverter(),
+                    'ezauthor' => new Converter\AuthorConverter(),
+                    'ezimage' => new Converter\NullConverter(),
+                    'ezsrrating' => new Converter\NullConverter(),
+                    'ezmultioption' => new Converter\NullConverter(),
+                ]
+            );
+        }
+
+        return $this->converterRegistry;
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
@@ -81,7 +81,6 @@ class AbstractTestCase extends LanguageAwareTestCase
             $this->contentTypeHandler = new ContentTypeHandler(
                 new ContentTypeGateway(
                     $this->getDatabaseHandler(),
-                    $this->getDatabaseConnection(),
                     $this->getLanguageMaskGenerator()
                 ),
                 new ContentTypeMapper($this->getConverterRegistry(), $this->getLanguageMaskGenerator()),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/WordIndexer/GateWay/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/WordIndexer/GateWay/DoctrineDatabaseTest.php
@@ -36,11 +36,14 @@ class DoctrineDatabaseTest extends AbstractTestCase
      */
     protected function getContentHandler()
     {
+        $dbHandler = $this->getDatabaseHandler();
         if (!isset($this->contentHandler)) {
             $this->contentHandler = new ContentHandler(
                 new ContentGateway(
-                    $this->getDatabaseHandler(),
+                    $dbHandler,
                     $this->getDatabaseConnection(),
+                    new ContentGateway\QueryBuilder($dbHandler),
+                    $this->getLanguageHandler(),
                     $this->getLanguageMaskGenerator()
                 )
             );

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/WordIndexer/GateWay/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/WordIndexer/GateWay/DoctrineDatabaseTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * File contains: eZ\Publish\Core\Search\Legacy\Tests\Content\WordIndexer\Gateway\DoctrineDatabaseTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Tests\Content\WordIndexer\Gateway;
+
+use eZ\Publish\Core\Persistence\Legacy\Content\Gateway\DoctrineDatabase as ContentGateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Handler as ContentHandler;
+use eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase;
+use eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex;
+use eZ\Publish\Core\Search\Legacy\Tests\Content\AbstractTestCase;
+
+/**
+ * Test case for eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase.
+ */
+class DoctrineDatabaseTest extends AbstractTestCase
+{
+    /**
+     * Database gateway to test.
+     *
+     * @var \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase
+     */
+    protected $databaseGateway;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Handler
+     */
+    private $contentHandler;
+
+    /**
+     * @return \eZ\Publish\SPI\Persistence\Content\Handler
+     */
+    protected function getContentHandler()
+    {
+        if (!isset($this->contentHandler)) {
+            $this->contentHandler = new ContentHandler(
+                new ContentGateway(
+                    $this->getDatabaseHandler(),
+                    $this->getDatabaseConnection(),
+                    $this->getLanguageMaskGenerator()
+                )
+            );
+        }
+
+        return $this->contentHandler;
+    }
+
+    /**
+     * @return \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex
+     */
+    protected function getSearchIndex()
+    {
+        return new SearchIndex($this->getDatabaseHandler());
+    }
+
+    /**
+     * Returns a ready to test DoctrineDatabase gateway.
+     *
+     * @return \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase
+     */
+    protected function getDatabaseGateway()
+    {
+        if (!isset($this->databaseGateway)) {
+            $this->databaseGateway = new DoctrineDatabase(
+                $this->getDatabaseHandler(),
+                $this->getContentTypeHandler(),
+                $this->getDefinitionBasedTransformationProcessor(),
+                $this->getSearchIndex(),
+                [] // Means the default config should be used
+            );
+        }
+
+        return $this->databaseGateway;
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase::__construct
+     */
+    public function testCtor()
+    {
+        $handler = $this->getDatabaseHandler();
+        $gateway = $this->getDatabaseGateway();
+
+        $this->assertAttributeSame(
+            $handler,
+            'dbHandler',
+            $gateway
+        );
+    }
+
+    /**
+     * Test indexing of Turkish characters.
+     * The fixture must contain the words "eei eeİ eeı eeI".
+     *
+     * @see https://jira.ez.no/browse/EZP-30481
+     * @covers \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase::buildWordIDArray
+     */
+    public function testBuildWordIDArrayWithTurkishChars()
+    {
+        $gateway = $this->getDatabaseGateway();
+
+        $content = $this->getContentHandler()->load(100);
+        $fullTextMapper = $this->getFullTextMapper($this->getContentTypeHandler());
+        $fullTextData = $fullTextMapper->mapContent($content);
+
+        $gateway->index($fullTextData);
+
+        // Assert words where saved in the index
+        self::assertQueryResult(
+            [
+                [
+                    'word' => 'eei',
+                    'object_count' => '1',
+                ],
+                [
+                    'word' => 'eeI',
+                    'object_count' => '1',
+                ],
+            ],
+            $this->getDatabaseHandler()->createSelectQuery()
+                ->select('word', 'object_count')
+                ->from('ezsearch_word')
+                ->where('word in (\'eei\', \'eeI\')')
+        );
+
+        // Assert the object-word-link entries where created - this does not happen correctly pre-EZP-30481
+        self::assertQueryResult(
+            [
+                [
+                    'word' => 'eei',
+                    'count' => '1',
+                ],
+                [
+                    'word' => 'eeI',
+                    'count' => '3',
+                ],
+            ],
+            $this->getDatabaseHandler()->createSelectQuery()
+                ->select('ezsearch_word.word', 'COUNT(ezsearch_word.id) as count')
+                ->from('ezsearch_word, ezsearch_object_word_link')
+                ->where('ezsearch_word.id = ezsearch_object_word_link.word_id AND ezsearch_word.word in (\'eei\', \'eeI\') GROUP BY ezsearch_word.id')
+        );
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30481](https://jira.ez.no/browse/EZP-30481)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 6.7, 6.13, 7.5
| **BC breaks**      | TBD
| **Tests pass**     | TBD
| **Doc needed**     | no

**Problem**
- Publishing Turkish text can lead to SQL errors in the legacy search, because of collation and transformation issues with Turkish dotted and dotless `i`'s. Turkish has dotted and dotless i's in both upper and lower case: `İ i - I ı`. Case changes in PHP, and non-Turkish collation in the database, leads to errors in conversion between them. This in itself is a minor issue here.
- We cannot expect Turkish to behave 100% correctly in eZ Platform without adding Turkish transformation rules. This is not a bug - we do not guarantee correct transformations of every language in the world (it's an enormous task). Adding this is a feature request.
- Changing letter case is locale dependent. PHP mbstring functions cannot be trusted to do this correctly in every language.
- However, eZ Platform should not produce invalid SQL queries, even if a language isn't fully supported in eZ Platform or in PHP.
- Legacy codebase is probably also affected by this, since the code is ported from there.
- The original code is performance optimised by working in batches. This means there is no way to determine the relation between the word we try to index, and the word that ends up being stored in the DB. I suspect a complete fix will require us to work on one word at a time, which will hurt performance.

**Fix**
- I believe a proper, by-the-book, correct-in-all-cases fix would require eZ Platform to be fully aware of the collation rules in the DB, the locale rules in PHP, and to have correct transformation rules for Turkish. This is out of scope. Avoiding SQL errors is the main goal, and making the transformed words searchable.
- https://github.com/ezsystems/ezpublish-kernel/pull/2754/commits/be9c5993e1318bd8a2e6da201594d7c46a2519fe (not in this PR yet) fixes the symptom, not the cause, by inserting nothing rather than a faulty `ezsearch_object_word_link` entry. This means the corresponding word is not found in searches, and it leaves inconsistencies in the `ezsearch_word` table, but those faults also existed before the fix.
- https://github.com/ezsystems/ezpublish-kernel/pull/2754/commits/91abe52ea3fa016fb607a197b980a36a0b172d40 (not in this PR yet) ensures words with transformed chars are searchable. It keeps the efficient batch processing of most words. Only when words end up not being stored as is, because of transformation, will it process those words one by one. It creates references from the original word to the transformed word in the DB, which means `indexWords()` doesn't crash, and the words are searchable. (This makes the previous commit redundant, but I like it as a failsafe anyway, though it ought to have error logging.)

**TODO**:
- [ ] Implement feature / fix a bug.
- [x] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
