### PR TITLE
EZP-30906: Removed deprecated templating component integration

### DIFF
--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -61,6 +61,8 @@ Changes affecting version compatibility with former or future versions.
     * `eZ\Publish\Core\MVC\Symfony\Matcher\ContentMatcherFactory`
     * `eZ\Publish\Core\MVC\Symfony\Matcher\LocationMatcherFactory`
 
+* Deprecated Symfony framework templating component integration has been dropped.
+
 ## Deprecated features
 
 * Using SiteAccess-aware `pagelayout` setting is derecated, use `page_layout` instead.

--- a/doc/specifications/debug/data_collectors.md
+++ b/doc/specifications/debug/data_collectors.md
@@ -37,16 +37,16 @@ services:
             -
                 name: ezpublish_data_collector
                 id: "ezpublish.debug.persistence"
-                panelTemplate: "EzPublishDebugBundle:Profiler/persistence:panel.html.twig"
-                toolbarTemplate: "EzPublishDebugBundle:Profiler/persistence:toolbar.html.twig"
+                panelTemplate: "@EzPublishDebug/Profiler/siteaccess/panel.html.twig"
+                toolbarTemplate: "@EzPublishDebug/Profiler/siteaccess/toolbar.html.twig"
 
     ezpublish_debug.templates_collector:
         class: %ezpublish_debug.templates_collector.class%
         tags:
             -
                 name: ezpublish_data_collector
-                panelTemplate: "EzPublishDebugBundle:Profiler/templates:panel.html.twig"
-                toolbarTemplate: "EzPublishDebugBundle:Profiler/templates:toolbar.html.twig"
+                panelTemplate: "@EzPublishDebug/Profiler/templates/panel.html.twig"
+                toolbarTemplate: "@EzPublishDebug/Profiler/templates/toolbar.html.twig"
 
 ```
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -13,19 +13,19 @@ parameters:
 
 
     # Default view templates
-    ezplatform.default_view_templates.content.full: 'EzPublishCoreBundle:default:content/full.html.twig'
-    ezplatform.default_view_templates.content.line: 'EzPublishCoreBundle:default:content/line.html.twig'
-    ezplatform.default_view_templates.content.text_linked: 'EzPublishCoreBundle:default:content/text_linked.html.twig'
-    ezplatform.default_view_templates.content.embed: 'EzPublishCoreBundle:default:content/embed.html.twig'
-    ezplatform.default_view_templates.content.embed_inline: 'EzPublishCoreBundle:default:content/embed_inline.html.twig'
-    ezplatform.default_view_templates.content.embed_image: 'EzPublishCoreBundle:default:content/embed_image.html.twig'
-    ezplatform.default_view_templates.content.asset_image: 'EzPublishCoreBundle:default:content/asset_image.html.twig'
-    ezplatform.default_view_templates.block: 'EzPublishCoreBundle:default:block/block.html.twig'
+    ezplatform.default_view_templates.content.full: '@@EzPublishCore/default/content/full.html.twig'
+    ezplatform.default_view_templates.content.line: '@@EzPublishCore/default/content/line.html.twig'
+    ezplatform.default_view_templates.content.text_linked: '@@EzPublishCore/default/content/text_linked.html.twig'
+    ezplatform.default_view_templates.content.embed: '@@EzPublishCore/default/content/embed.html.twig'
+    ezplatform.default_view_templates.content.embed_inline: '@@EzPublishCore/default/content/embed_inline.html.twig'
+    ezplatform.default_view_templates.content.embed_image: '@@EzPublishCore/default/content/embed_image.html.twig'
+    ezplatform.default_view_templates.content.asset_image: '@@EzPublishCore/default/content/asset_image.html.twig'
+    ezplatform.default_view_templates.block: '@@EzPublishCore/default/block/block.html.twig'
 
     # Default templates
-    ezplatform.default_templates.pagelayout: 'EzPublishCoreBundle::pagelayout.html.twig'
-    ezplatform.default_templates.field_templates: 'EzPublishCoreBundle::content_fields.html.twig'
-    ezplatform.default_templates.fielddefinition_settings_templates: 'EzPublishCoreBundle::fielddefinition_settings.html.twig'
+    ezplatform.default_templates.pagelayout: '@@EzPublishCore/pagelayout.html.twig'
+    ezplatform.default_templates.field_templates: '@@EzPublishCore/content_fields.html.twig'
+    ezplatform.default_templates.fielddefinition_settings_templates: '@@EzPublishCore/fielddefinition_settings.html.twig'
 
     # Image Asset mappings
     ezsettings.default.fieldtypes.ezimageasset.mappings:
@@ -138,7 +138,7 @@ parameters:
     ezsettings.default.fielddefinition_edit_templates: []
 
     # Security settings
-    ezsettings.default.security.login_template: "EzPublishCoreBundle:Security:login.html.twig"
+    ezsettings.default.security.login_template: "@@EzPublishCore/Security/login.html.twig"
     ezsettings.default.security.base_layout: "%ezsettings.default.page_layout%"
 
     # Image settings

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/security.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/security.yml
@@ -27,7 +27,7 @@ services:
     ezpublish.security.controller:
         public: true
         class: "%ezpublish.security.controller.class%"
-        arguments: ["@templating", "@ezpublish.config.resolver", "@security.authentication_utils"]
+        arguments: ["@twig", "@ezpublish.config.resolver", "@security.authentication_utils"]
 
     ezpublish.security.login_listener:
         class: "%ezpublish.security.login_listener.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -6,7 +6,7 @@ parameters:
 
     ezpublish.view.matcher_factory.class: eZ\Bundle\EzPublishCoreBundle\Matcher\ServiceAwareMatcherFactory
 
-    ezpublish.content_view.viewbase_layout: "EzPublishCoreBundle::viewbase_layout.html.twig"
+    ezpublish.content_view.viewbase_layout: "@@EzPublishCore/viewbase_layout.html.twig"
     ezpublish.content_view.content_block_name: "content"
     ezpublish.view.custom_location_controller_checker.class: eZ\Publish\Core\MVC\Symfony\View\CustomLocationControllerChecker
 
@@ -54,7 +54,7 @@ services:
     ezpublish.view_manager:
         class: "%ezpublish.view_manager.class%"
         arguments:
-          - "@templating"
+          - "@twig"
           - "@event_dispatcher"
           - "@ezpublish.siteaccessaware.repository"
           - "@ezpublish.config.resolver"
@@ -216,7 +216,7 @@ services:
 
     ezpublish.view.template_renderer:
         class: "%ezpublish.view.template_renderer.class%"
-        arguments: ["@templating", "@event_dispatcher"]
+        arguments: ["@twig", "@event_dispatcher"]
 
     ezpublish.view.renderer_listener:
         class: "%ezpublish.view.renderer_listener.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
@@ -216,7 +216,7 @@ class CommonTest extends AbstractParserTestCase
         );
         $this->assertConfigResolverParameterValue(
             'security.login_template',
-            'EzPublishCoreBundle:Security:login.html.twig',
+            '@EzPublishCore/Security/login.html.twig',
             'ezdemo_site'
         );
     }

--- a/eZ/Bundle/EzPublishDebugBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishDebugBundle/Resources/config/services.yml
@@ -9,7 +9,7 @@ services:
         tags:
             -
                 name: data_collector
-                template: "EzPublishDebugBundle:Profiler:layout"
+                template: '@EzPublishDebug/Profiler/layout.html.twig'
                 id: "ezpublish.debug.toolbar"
 
     ezpublish_debug.siteaccess_collector:
@@ -18,8 +18,8 @@ services:
             -
                 name: ezpublish_data_collector
                 id: "ezpublish.debug.siteaccess"
-                panelTemplate: "EzPublishDebugBundle:Profiler/siteaccess:panel.html.twig"
-                toolbarTemplate: "EzPublishDebugBundle:Profiler/siteaccess:toolbar.html.twig"
+                panelTemplate: '@EzPublishDebug/Profiler/siteaccess/panel.html.twig'
+                toolbarTemplate: '@EzPublishDebug/Profiler/siteaccess/toolbar.html.twig'
 
     ezpublish_debug.persistence_collector:
         class: "%ezpublish_debug.persistence_collector.class%"
@@ -28,5 +28,5 @@ services:
             -
                 name: ezpublish_data_collector
                 id: "ezpublish.debug.persistence"
-                panelTemplate: "EzPublishDebugBundle:Profiler/persistence:panel.html.twig"
-                toolbarTemplate: "EzPublishDebugBundle:Profiler/persistence:toolbar.html.twig"
+                panelTemplate: '@EzPublishDebug/Profiler/persistence/panel.html.twig'
+                toolbarTemplate: '@EzPublishDebug/Profiler/persistence/toolbar.html.twig'

--- a/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/layout.html.twig
+++ b/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/layout.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}

--- a/eZ/Publish/Core/MVC/Symfony/Controller/SecurityController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/SecurityController.php
@@ -11,11 +11,11 @@ namespace eZ\Publish\Core\MVC\Symfony\Controller;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\View\LoginFormView;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 class SecurityController
 {
-    /** @var \Symfony\Component\Templating\EngineInterface */
+    /** @var \Twig\Environment */
     protected $templateEngine;
 
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
@@ -24,7 +24,7 @@ class SecurityController
     /** @var \Symfony\Component\Security\Http\Authentication\AuthenticationUtils */
     protected $authenticationUtils;
 
-    public function __construct(EngineInterface $templateEngine, ConfigResolverInterface $configResolver, AuthenticationUtils $authenticationUtils)
+    public function __construct(Environment $templateEngine, ConfigResolverInterface $configResolver, AuthenticationUtils $authenticationUtils)
     {
         $this->templateEngine = $templateEngine;
         $this->configResolver = $configResolver;

--- a/eZ/Publish/Core/MVC/Symfony/View/Manager.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Manager.php
@@ -14,14 +14,14 @@ use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\Event\PreContentViewEvent;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use Symfony\Component\Templating\EngineInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use RuntimeException;
+use Twig\Environment;
 
 class Manager implements ViewManagerInterface
 {
-    /** @var \Symfony\Component\Templating\EngineInterface */
+    /** @var \Twig\Environment */
     protected $templateEngine;
 
     /** @var \Psr\Log\LoggerInterface */
@@ -68,7 +68,7 @@ class Manager implements ViewManagerInterface
     private $viewConfigurator;
 
     public function __construct(
-        EngineInterface $templateEngine,
+        Environment $templateEngine,
         EventDispatcherInterface $eventDispatcher,
         Repository $repository,
         ConfigResolverInterface $configResolver,

--- a/eZ/Publish/Core/MVC/Symfony/View/Renderer/TemplateRenderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Renderer/TemplateRenderer.php
@@ -11,18 +11,18 @@ use eZ\Publish\Core\MVC\Symfony\View\View;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\Event\PreContentViewEvent;
-use Symfony\Component\Templating\EngineInterface as TemplateEngine;
 use Closure;
+use Twig\Environment;
 
 class TemplateRenderer implements Renderer
 {
-    /** @var \Symfony\Component\Templating\EngineInterface */
+    /** @var \Twig\Environment */
     protected $templateEngine;
 
     /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface */
     protected $eventDispatcher;
 
-    public function __construct(TemplateEngine $templateEngine, EventDispatcherInterface $eventDispatcher)
+    public function __construct(Environment $templateEngine, EventDispatcherInterface $eventDispatcher)
     {
         $this->templateEngine = $templateEngine;
         $this->eventDispatcher = $eventDispatcher;

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Renderer/TemplateRendererTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Renderer/TemplateRendererTest.php
@@ -7,18 +7,18 @@ namespace eZ\Publish\Core\MVC\Symfony\View\Tests\Renderer;
 
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
-use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use eZ\Publish\Core\MVC\Symfony\View\Renderer\TemplateRenderer;
 use eZ\Publish\Core\MVC\Symfony\Event\PreContentViewEvent;
 use PHPUnit\Framework\TestCase;
+use Twig\Environment;
 
 class TemplateRendererTest extends TestCase
 {
     /** @var \eZ\Publish\Core\MVC\Symfony\View\Renderer\TemplateRenderer */
     private $renderer;
 
-    /** @var \Symfony\Component\Templating\EngineInterface|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Twig\Environment|\PHPUnit\Framework\MockObject\MockObject */
     private $templateEngineMock;
 
     /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface|\PHPUnit\Framework\MockObject\MockObject */
@@ -26,7 +26,7 @@ class TemplateRendererTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->templateEngineMock = $this->createMock(EngineInterface::class);
+        $this->templateEngineMock = $this->createMock(Environment::class);
         $this->eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         $this->renderer = new TemplateRenderer(
             $this->templateEngineMock,

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
@@ -21,8 +21,8 @@ use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Twig\Environment;
 
 /**
  * @group mvc
@@ -32,7 +32,7 @@ class ViewManagerTest extends TestCase
     /** @var \eZ\Publish\Core\MVC\Symfony\View\Manager */
     private $viewManager;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\Templating\EngineInterface */
+    /** @var \PHPUnit\Framework\MockObject\MockObject|\Twig\Environment */
     private $templateEngineMock;
 
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\EventDispatcher\EventDispatcherInterface */
@@ -52,7 +52,7 @@ class ViewManagerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->templateEngineMock = $this->createMock(EngineInterface::class);
+        $this->templateEngineMock = $this->createMock(Environment::class);
         $this->eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         $this->repositoryMock = $this->createMock(Repository::class);
         $this->configResolverMock = $this->createMock(ConfigResolverInterface::class);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30906](https://jira.ez.no/browse/EZP-30906)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master` for features
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

main PR:
https://github.com/ezsystems/ezplatform/pull/453

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
