### PR TITLE
EZP-30469: Fixed parallel Content publishing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     },
     "require-dev": {
         "brianium/paratest": "^2.2",
+        "jenner/simple_fork": "^1.2",
         "friendsofphp/php-cs-fixer": "~2.15.0",
         "phpunit/phpunit": "^7.0",
         "matthiasnoback/symfony-dependency-injection-test": "~3.0",

--- a/eZ/Publish/API/Repository/Tests/Parallel/BaseParallelTestCase.php
+++ b/eZ/Publish/API/Repository/Tests/Parallel/BaseParallelTestCase.php
@@ -20,8 +20,8 @@ abstract class BaseParallelTestCase extends BaseTest
         $connection = $this->getRawDatabaseConnection();
         $dbms = $connection->getDatabasePlatform()->getName();
 
-        if (!in_array($dbms, ['mysql', 'postgresql'])) {
-            $this->markTestSkipped('Parallel test require mysql or postgresql db');
+        if ($dbms == 'sqlite') {
+            $this->markTestSkipped('Can not run parallel test on sqlite');
         }
     }
 
@@ -41,6 +41,7 @@ abstract class BaseParallelTestCase extends BaseTest
     protected function runParallelProcesses(ParallelProcessList $list): void
     {
         $connection = $this->getRawDatabaseConnection();
+        // @see https://www.php.net/manual/en/function.pcntl-fork.php#70721
         $connection->close();
 
         foreach ($list as $process) {

--- a/eZ/Publish/API/Repository/Tests/Parallel/BaseParallelTestCase.php
+++ b/eZ/Publish/API/Repository/Tests/Parallel/BaseParallelTestCase.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Parallel;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use Jenner\SimpleFork\Process;
+
+abstract class BaseParallelTestCase extends BaseTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connection = $this->getRawDatabaseConnection();
+        $dbms = $connection->getDatabasePlatform()->getName();
+
+        if (!in_array($dbms, ['mysql', 'postgresql'])) {
+            $this->markTestSkipped('Parallel test require mysql or postgresql db');
+        }
+    }
+
+    protected function addParallelProcess(ParallelProcessList $list, callable $callback): void
+    {
+        $connection = $this->getRawDatabaseConnection();
+
+        $process = new Process(function () use ($callback, $connection) {
+            $connection->connect();
+            $callback();
+            $connection->close();
+        });
+
+        $list->addProcess($process);
+    }
+
+    protected function runParallelProcesses(ParallelProcessList $list): void
+    {
+        $connection = $this->getRawDatabaseConnection();
+        $connection->close();
+
+        foreach ($list as $process) {
+            $process->start();
+        }
+
+        foreach ($list as $process) {
+            $process->wait();
+        }
+
+        $connection->connect();
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Parallel/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/Parallel/ContentServiceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Parallel;
+
+use eZ\Publish\Core\Base\Exceptions\BadStateException;
+
+final class ContentServiceTest extends BaseParallelTestCase
+{
+    public function testPublishMultipleVersions(): void
+    {
+        $repository = $this->getRepository();
+
+        $contentService = $repository->getContentService();
+        $content = $this->createFolder(
+            [
+                'eng-US' => 'Content',
+            ],
+            $this->generateId('location', 2)
+        );
+
+        $version1 = $contentService->createContentDraft($content->contentInfo, $content->versionInfo);
+        $version2 = $contentService->createContentDraft($content->contentInfo, $content->versionInfo);
+
+        $processList = new ParallelProcessList();
+        $this->addParallelProcess($processList, function () use ($version1 , $contentService) {
+            try {
+                $contentService->publishVersion($version1->versionInfo);
+            } catch (BadStateException $e) {
+            }
+        });
+
+        $this->addParallelProcess($processList, function () use ($version2 , $contentService) {
+            try {
+                $contentService->publishVersion($version2->versionInfo);
+            } catch (BadStateException $e) {
+            }
+        });
+
+        $this->runParallelProcesses($processList);
+
+        $version1 = $contentService->loadVersionInfo($version1->contentInfo, 2);
+        $version2 = $contentService->loadVersionInfo($version2->contentInfo, 3);
+
+        $this->assertTrue(
+            $version1->isPublished() && $version2->isDraft() || $version1->isDraft() && $version2->isPublished(),
+            'One of the versions should be published and the other should be draft');
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Parallel/ParallelProcessList.php
+++ b/eZ/Publish/API/Repository/Tests/Parallel/ParallelProcessList.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Parallel;
+
+use Jenner\SimpleFork\Process;
+
+class ParallelProcessList implements \IteratorAggregate
+{
+    /** @var \Jenner\SimpleFork\Process[] */
+    private $pool = [];
+
+    public function addProcess(Process $callback): void
+    {
+        $this->pool[] = $callback;
+    }
+
+    public function getIterator(): \Iterator
+    {
+        return new \ArrayIterator($this->pool);
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Parallel/ParallelProcessList.php
+++ b/eZ/Publish/API/Repository/Tests/Parallel/ParallelProcessList.php
@@ -10,14 +10,14 @@ namespace eZ\Publish\API\Repository\Tests\Parallel;
 
 use Jenner\SimpleFork\Process;
 
-class ParallelProcessList implements \IteratorAggregate
+final class ParallelProcessList implements \IteratorAggregate
 {
     /** @var \Jenner\SimpleFork\Process[] */
     private $pool = [];
 
-    public function addProcess(Process $callback): void
+    public function addProcess(Process $process): void
     {
-        $this->pool[] = $callback;
+        $this->pool[] = $process;
     }
 
     public function getIterator(): \Iterator

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -92,6 +92,18 @@ abstract class Gateway
     abstract public function setStatus($contentId, $version, $status);
 
     /**
+     * Dedicated operation which sets Version status as published, similar to setStatus, but checking
+     * state of all versions to avoid race conditions.
+     *
+     * IMPORTANT: This method expects prior published version to have been set to another status then published before called, otherwise you'll get a BadStateException.
+     *
+     * @see setStatus
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if other operation affected publishing process
+     */
+    abstract public function setPublishedStatus(int $contentId, int $status): void;
+
+    /**
      * Inserts a new field.
      *
      * Only used when a new field is created (i.e. a new object or a field in a

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -602,6 +602,66 @@ class DoctrineDatabase extends Gateway
         return (bool)$statement->rowCount();
     }
 
+    public function setPublishedStatus(int $contentId, int $versionNo): void
+    {
+        $query = $this->getSetVersionStatusQuery(
+            $contentId,
+            $versionNo,
+            VersionInfo::STATUS_PUBLISHED
+        );
+
+        /* this part allows set status `published` only if there is no other published version of the content */
+        $notExistPublishedVersion = <<< HEREDOC
+            NOT EXISTS (
+                SELECT 1 FROM (
+                    SELECT 1 FROM ezcontentobject_version  WHERE contentobject_id = :contentId AND status = :status 
+                ) as V
+            )
+HEREDOC;
+
+        $query->andWhere($notExistPublishedVersion);
+        if (0 === $query->execute()) {
+            throw new BadStateException(
+                '$contentId', "Someone just published another Version of the Content item {$contentId}"
+            );
+        }
+        $this->markContentAsPublished($contentId, $versionNo);
+    }
+
+    private function getSetVersionStatusQuery(
+        int $contentId,
+        int $versionNo,
+        int $versionStatus
+    ): DoctrineQueryBuilder {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->update('ezcontentobject_version')
+            ->set('status', ':status')
+            ->set('modified', ':modified')
+            ->where('contentobject_id = :contentId')
+            ->andWhere('version = :versionNo')
+            ->setParameter('status', $versionStatus, ParameterType::INTEGER)
+            ->setParameter('modified', time(), ParameterType::INTEGER)
+            ->setParameter('contentId', $contentId, ParameterType::INTEGER)
+            ->setParameter('versionNo', $versionNo, ParameterType::INTEGER);
+
+        return $query;
+    }
+
+    private function markContentAsPublished(int $contentId, int $versionNo): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->update('ezcontentobject')
+            ->set('status', ':status')
+            ->set('current_version', ':versionNo')
+            ->where('id =:contentId')
+            ->setParameter('status', ContentInfo::STATUS_PUBLISHED, ParameterType::INTEGER)
+            ->setParameter('versionNo', $versionNo, ParameterType::INTEGER)
+            ->setParameter('contentId', $contentId, ParameterType::INTEGER);
+        $query->execute();
+    }
+
     /**
      * Inserts a new field.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -172,6 +172,15 @@ class ExceptionConversion extends Gateway
         }
     }
 
+    public function setPublishedStatus(int $contentId, int $status): void
+    {
+        try {
+            $this->innerGateway->setPublishedStatus($contentId, $status);
+        } catch (DBALException | PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
+
     /**
      * Inserts a new field.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -210,6 +210,9 @@ class Handler implements BaseContentHandler
      * @param \eZ\Publish\SPI\Persistence\Content\MetadataUpdateStruct $metaDataUpdateStruct
      *
      * @return \eZ\Publish\SPI\Persistence\Content The published Content
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function publish($contentId, $versionNo, MetadataUpdateStruct $metaDataUpdateStruct)
     {
@@ -233,7 +236,7 @@ class Handler implements BaseContentHandler
         );
 
         $this->locationGateway->updateLocationsContentVersionNo($contentId, $versionNo);
-        $this->setStatus($contentId, VersionInfo::STATUS_PUBLISHED, $versionNo);
+        $this->contentGateway->setPublishedStatus($contentId, $versionNo);
 
         return $this->load($contentId, $versionNo);
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
@@ -239,7 +239,7 @@ class ContentHandlerTest extends TestCase
      */
     public function testPublishFirstVersion()
     {
-        $handler = $this->getPartlyMockedHandler(['loadVersionInfo', 'setStatus']);
+        $handler = $this->getPartlyMockedHandler(['loadVersionInfo']);
 
         $gatewayMock = $this->getGatewayMock();
         $mapperMock = $this->getMapperMock();
@@ -298,10 +298,10 @@ class ContentHandlerTest extends TestCase
             ->method('updateLocationsContentVersionNo')
             ->with(23, 1);
 
-        $handler
+        $gatewayMock
             ->expects($this->once())
-            ->method('setStatus')
-            ->with(23, VersionInfo::STATUS_PUBLISHED, 1);
+            ->method('setPublishedStatus')
+            ->with(23, 1);
 
         $handler->publish(23, 1, $metadataUpdateStruct);
     }
@@ -311,7 +311,7 @@ class ContentHandlerTest extends TestCase
      */
     public function testPublish()
     {
-        $handler = $this->getPartlyMockedHandler(['loadVersionInfo', 'setStatus']);
+        $handler = $this->getPartlyMockedHandler(['loadVersionInfo']);
 
         $gatewayMock = $this->getGatewayMock();
         $mapperMock = $this->getMapperMock();
@@ -376,10 +376,10 @@ class ContentHandlerTest extends TestCase
             ->method('updateLocationsContentVersionNo')
             ->with(23, 2);
 
-        $handler
+        $gatewayMock
             ->expects($this->at(2))
-            ->method('setStatus')
-            ->with(23, VersionInfo::STATUS_PUBLISHED, 2);
+            ->method('setPublishedStatus')
+            ->with(23, 2);
 
         $handler->publish(23, 2, $metadataUpdateStruct);
     }

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -111,7 +111,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup
      */
-    public function createContentTypeGroup(ContentTypeGroupCreateStruct  $contentTypeGroupCreateStruct)
+    public function createContentTypeGroup(ContentTypeGroupCreateStruct $contentTypeGroupCreateStruct)
     {
         if (!$this->repository->canUser('class', 'create', $contentTypeGroupCreateStruct)) {
             throw new UnauthorizedException('ContentType', 'create');

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -292,6 +292,8 @@ interface Handler
      * @param int $versionNo
      * @param \eZ\Publish\SPI\Persistence\Content\MetadataUpdateStruct $metaDataUpdateStruct
      *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     *
      * @return \eZ\Publish\SPI\Persistence\Content The published Content
      */
     public function publish($contentId, $versionNo, MetadataUpdateStruct $metaDataUpdateStruct);

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -28,6 +28,7 @@
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ContentServiceTest.php</file>
+            <file>eZ/Publish/API/Repository/Tests/Parallel/ContentServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/NonRedundantFieldSetTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LocationServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/UserServiceTest.php</file>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30469](https://jira.ez.no/browse/EZP-30469)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR resolves an edge case where two Editors publish different Versions of the same Content item at the same time.

This PR also creates base for parallel integration testing of Repository services, for now for internal use by the Repository.

## Background

The process of publishing archives recently published content item, therefore at the moment of update there should be no published version. This is the basis for both blocking publishing of another version and assessment if someone else published Content at the same time.

## QA

Testing this manually is quite tricky and requires at least two people working on a shared instance of eZ Platform.
1. Create Content item.
2. Create one draft from the first Version.
3. Create another draft from the first Version.
4. Publish both drafts simultaneously.
5. Observe that there are two Versions with "published" status.

Expected behavior: Observe for one Editor an error stating that someone else just published that Content item. Editor should be able to publish his Version then, keeping in mind that this will override someone else's work.

Alternatively this can be tested by one person by setting breakpoint after the first `setStatus` call in `\eZ\Publish\Core\Persistence\Legacy\Content\Handler::publish`.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
