### PR TITLE
[RFC] Location references

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/LocationReferenceConfigParser.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/LocationReferenceConfigParser.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+/**
+ * Configuration parser for Location References.
+ *
+ * Example configuration:
+ *
+ * ```yaml
+ * ezpublish:
+ *   system:
+ *      default: # configuration per siteaccess or siteaccess group
+ *          location_references:
+ *              media: remote_id("babe4a915b1dd5d369e79adb9d6c0c6a")
+ *              # ...
+ * ```
+ */
+final class LocationReferenceConfigParser extends AbstractParser
+{
+    private const ROOT_NODE_KEY = 'location_references';
+
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
+    {
+        $nodeBuilder
+            ->arrayNode(self::ROOT_NODE_KEY)
+                ->useAttributeAsKey('name')
+                ->scalarPrototype()
+            ->end();
+    }
+
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
+    {
+        $contextualizer->setContextualParameter(
+            'location_references',
+            $currentScope,
+            $scopeSettings['location_references'] ?? []
+        );
+    }
+
+    public function postMap(array $config, ContextualizerInterface $contextualizer): void
+    {
+        $contextualizer->mapConfigArray('location_references', $config);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -313,6 +313,7 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
         $coreLoader->load('notification.yml');
         $coreLoader->load('user_preference.yml');
         $coreLoader->load('events.yml');
+        $coreLoader->load('location_references.yml');
 
         // Public API services
         $loader->load('papi.yml');

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -117,6 +117,7 @@ class EzPublishCoreBundle extends Bundle
                 new ConfigParser\FieldDefinitionEditTemplates(),
                 new ConfigParser\Image(),
                 new ConfigParser\Languages(),
+                new ConfigParser\LocationReferenceConfigParser(),
                 new ConfigParser\IO(new ComplexSettingParser()),
                 new ConfigParser\UrlChecker(),
             ]);

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -141,6 +141,9 @@ parameters:
     ezsettings.default.security.login_template: "@@EzPublishCore/Security/login.html.twig"
     ezsettings.default.security.base_layout: "%ezsettings.default.page_layout%"
 
+    # Location references
+    ezsettings.default.location_references: []
+
     # Image settings
     ezsettings.default.image.temporary_dir: imagetmp
     ezsettings.default.image.published_images_dir: images

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -106,4 +106,5 @@ services:
             $contentService: '@ezpublish.api.service.content'
             $locationService: '@ezpublish.api.service.location'
             $contentTypeService: '@ezpublish.api.service.content_type'
+            $locationReferenceResolver: '@eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface'
             $mappings: '$fieldtypes.ezimageasset.mappings$'

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/location_references.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/location_references.yml
@@ -1,0 +1,24 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    eZ\Publish\Core\LocationReference\ExpressionLanguage\ExpressionLanguage: ~
+
+    eZ\Publish\Core\LocationReference\LimitedLocationService: ~
+
+    eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProvider: ~
+
+    eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProviderInterface:
+        alias: eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProvider
+
+    eZ\Publish\Core\LocationReference\LocationReferenceResolver: ~
+
+    eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface:
+        alias: eZ\Publish\Core\LocationReference\LocationReferenceResolver
+
+    eZ\Publish\Core\LocationReference\ConfigResolver\LocationConfigResolver: ~
+
+    eZ\Publish\Core\LocationReference\ConfigResolver\LocationConfigResolverInterface:
+        alias: eZ\Publish\Core\LocationReference\ConfigResolver\LocationConfigResolver

--- a/eZ/Publish/Core/LocationReference/ConfigResolver/LocationConfigResolver.php
+++ b/eZ/Publish/Core/LocationReference/ConfigResolver/LocationConfigResolver.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\ConfigResolver;
+
+use eZ\Publish\Core\LocationReference\LocationReference;
+use eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+
+final class LocationConfigResolver implements LocationConfigResolverInterface
+{
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    /** @var \eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface */
+    private $referenceResolver;
+
+    public function __construct(
+        ConfigResolverInterface $configResolver,
+        LocationReferenceResolverInterface $referenceResolver
+    ) {
+        $this->configResolver = $configResolver;
+        $this->referenceResolver = $referenceResolver;
+    }
+
+    public function getLocation(string $name, ?string $namespace = null, ?string $scope = null): Location
+    {
+        return $this->referenceResolver->resolve($this->getReference($name, $namespace, $scope));
+    }
+
+    public function getLocationReference(
+        string $name,
+        ?string $namespace = null,
+        ?string $scope = null
+    ): LocationReference {
+        return new LocationReference(
+            $this->referenceResolver,
+            $this->getReference($name, $namespace, $scope)
+        );
+    }
+
+    private function getReference(string $name, ?string $namespace, ?string $scope)
+    {
+        $reference = $this->configResolver->getParameter($name, $namespace, $scope);
+        if (is_int($reference)) {
+            $reference = (string)$reference;
+        }
+
+        return $reference;
+    }
+}

--- a/eZ/Publish/Core/LocationReference/ConfigResolver/LocationConfigResolverInterface.php
+++ b/eZ/Publish/Core/LocationReference/ConfigResolver/LocationConfigResolverInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace eZ\Publish\Core\LocationReference\ConfigResolver;
+
+use eZ\Publish\Core\LocationReference\LocationReference;
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+interface LocationConfigResolverInterface
+{
+    public function getLocation(string $name, ?string $namespace = null, ?string $scope = null): Location;
+
+    public function getLocationReference(string $name, ?string $namespace = null, ?string $scope = null): LocationReference;
+}

--- a/eZ/Publish/Core/LocationReference/ExpressionLanguage/ExpressionLanguage.php
+++ b/eZ/Publish/Core/LocationReference/ExpressionLanguage/ExpressionLanguage.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\ExpressionLanguage;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
+
+final class ExpressionLanguage extends BaseExpressionLanguage
+{
+    public function __construct(CacheItemPoolInterface $parser = null, array $providers = [])
+    {
+        // prepends the default provider to let users override it
+        array_unshift($providers, new ExpressionLanguageProvider());
+
+        parent::__construct($parser, $providers);
+    }
+}

--- a/eZ/Publish/Core/LocationReference/ExpressionLanguage/ExpressionLanguageProvider.php
+++ b/eZ/Publish/Core/LocationReference/ExpressionLanguage/ExpressionLanguageProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\ExpressionLanguage;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+final class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    public function getFunctions(): array
+    {
+        return [
+            new ExpressionFunction(
+                'remote_id',
+                function (string $args): string {
+                    return sprintf('$__location_service->loadLocationByRemoteId(%s)', $args);
+                },
+                function (array $variables, string $remoteId): Location {
+                    return $variables['__location_service']->loadLocationByRemoteId($remoteId);
+                }
+            ),
+            new ExpressionFunction(
+                'local_id',
+                function (string $args): string {
+                    return sprintf('$__location_service->loadLocation(%s)', $args);
+                },
+                function (array $variables, int $id): Location {
+                    return $variables['__location_service']->loadLocation($id);
+                }
+            ),
+            new ExpressionFunction(
+                'path',
+                function (string $args): string {
+                    return sprintf('$__location_service->loadLocationByPathString(%s)', $args);
+                },
+                function (array $variables, string $path): Location {
+                    return $variables['__location_service']->loadLocationByPathString($path);
+                }
+            ),
+            new ExpressionFunction(
+                'parent',
+                function (string $args): string {
+                    return sprintf('$__location_service->loadParentLocation(%s)', $args);
+                },
+                function (array $variables, Location $location): Location {
+                    return $variables['__location_service']->loadParentLocation($location);
+                }
+            ),
+            new ExpressionFunction(
+                'root',
+                function (string $args): string {
+                    return '$__self->resolve($___named_references->getReference("__root"))';
+                },
+                function (array $variables): Location {
+                    return $variables['__self']->resolve($variables['__named_references']->getReference('__root'));
+                }
+            ),
+            new ExpressionFunction(
+                'named',
+                function (string $args): string {
+                    return sprintf('$__self->resolve($___named_references->getReference(%s))', $args);
+                },
+                function (array $variables, string $name): Location {
+                    return $variables['__self']->resolve($variables['__named_references']->getReference($name));
+                }
+            ),
+        ];
+    }
+}

--- a/eZ/Publish/Core/LocationReference/LimitedLocationService.php
+++ b/eZ/Publish/Core/LocationReference/LimitedLocationService.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+/**
+ * Limited (readonly) location service.
+ *
+ * @internal
+ */
+final class LimitedLocationService
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
+    public function loadLocation(int $locationId): Location
+    {
+        return $this->locationService->loadLocation($locationId);
+    }
+
+    public function loadLocationByRemoteId(string $remoteId): Location
+    {
+        return $this->locationService->loadLocationByRemoteId($remoteId);
+    }
+
+    public function loadLocationByPathString(string $path): Location
+    {
+        return $this->locationService->loadLocation(
+            $this->extractIdFromPath($path)
+        );
+    }
+
+    public function loadParentLocation(Location $location): Location
+    {
+        return $this->locationService->loadLocation($location->parentLocationId);
+    }
+
+    /**
+     * Extracts location ID from path.
+     *
+     * @param string $path
+     *
+     * @return int
+     */
+    private function extractIdFromPath(string $path): int
+    {
+        $ids = explode('/', trim($path, '/'));
+
+        return (int)end($ids);
+    }
+}

--- a/eZ/Publish/Core/LocationReference/LocationReference.php
+++ b/eZ/Publish/Core/LocationReference/LocationReference.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+final class LocationReference
+{
+    /** @var \eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface */
+    private $resolver;
+
+    /** @var string */
+    private $reference;
+
+    public function __construct(LocationReferenceResolverInterface $resolver, string $reference)
+    {
+        $this->reference = $reference;
+        $this->resolver = $resolver;
+    }
+
+    public function getLocation(): Location
+    {
+        return $this->resolver->resolve($this->reference);
+    }
+
+    public function getLocationOrNull(): ?Location
+    {
+        try {
+            return $this->resolver->resolve($this->reference);
+        } catch (NotFoundException | UnauthorizedException $e) {
+            return null;
+        }
+    }
+
+    public function getLocationOrDefault(Location $default): Location
+    {
+        try {
+            return $this->resolver->resolve($this->reference);
+        } catch (NotFoundException | UnauthorizedException $e) {
+            return $default;
+        }
+    }
+
+    public function __invoke(): Location
+    {
+        return $this->getLocation();
+    }
+
+    public function __toString()
+    {
+        return $this->reference;
+    }
+}

--- a/eZ/Publish/Core/LocationReference/LocationReferenceResolver.php
+++ b/eZ/Publish/Core/LocationReference/LocationReferenceResolver.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference;
+
+use eZ\Publish\Core\LocationReference\ExpressionLanguage\ExpressionLanguage;
+use eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProviderInterface;
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+final class LocationReferenceResolver implements LocationReferenceResolverInterface
+{
+    /** @var \eZ\Publish\Core\LocationReference\LimitedLocationService */
+    private $limitedLocationService;
+
+    /** @var \eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProviderInterface */
+    private $namedReferencesProvider;
+
+    /** @var \Symfony\Component\ExpressionLanguage\ExpressionLanguage */
+    private $expressionLanguage;
+
+    public function __construct(
+        LimitedLocationService $limitedLocationService,
+        NamedReferencesProviderInterface $namedReferencesProvider,
+        ExpressionLanguage $expressionLanguage)
+    {
+        $this->limitedLocationService = $limitedLocationService;
+        $this->namedReferencesProvider = $namedReferencesProvider;
+        $this->expressionLanguage = $expressionLanguage;
+    }
+
+    public function resolve(string $reference): Location
+    {
+        if ($this->isLocationId($reference)) {
+            return $this->limitedLocationService->loadLocation((int)$reference);
+        }
+
+        return $this->expressionLanguage->evaluate($reference, [
+            '__location_service' => $this->limitedLocationService,
+            '__named_references' => $this->namedReferencesProvider->getNamedReferences(),
+            '__self' => $this,
+        ]);
+    }
+
+    private function isLocationId(string $reference): bool
+    {
+        return ctype_digit($reference);
+    }
+}

--- a/eZ/Publish/Core/LocationReference/LocationReferenceResolverInterface.php
+++ b/eZ/Publish/Core/LocationReference/LocationReferenceResolverInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+interface LocationReferenceResolverInterface
+{
+    public function resolve(string $reference): Location;
+}

--- a/eZ/Publish/Core/LocationReference/NamedReferences/InMemoryNamedReferenceProvider.php
+++ b/eZ/Publish/Core/LocationReference/NamedReferences/InMemoryNamedReferenceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\NamedReferences;
+
+final class InMemoryNamedReferenceProvider implements NamedReferencesProviderInterface
+{
+    /** @var string[] */
+    private $namedReferences = [];
+
+    public function __construct(array $references = [])
+    {
+        $this->namedReferences = $references;
+    }
+
+    public function getNamedReferences(): NamedReferencesCollection
+    {
+        return new NamedReferencesCollection($this->namedReferences);
+    }
+}

--- a/eZ/Publish/Core/LocationReference/NamedReferences/NamedReferencesCollection.php
+++ b/eZ/Publish/Core/LocationReference/NamedReferences/NamedReferencesCollection.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\NamedReferences;
+
+use ArrayIterator;
+use Countable;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use IteratorAggregate;
+use Traversable;
+
+final class NamedReferencesCollection implements IteratorAggregate, Countable
+{
+    /** @var string[] */
+    private $references;
+
+    public function __construct(array $references)
+    {
+        $this->references = $references;
+    }
+
+    public function getReference(string $name): string
+    {
+        if (!$this->hasReference($name)) {
+            throw new NotFoundException('named reference', $name);
+        }
+
+        return $this->references[$name];
+    }
+
+    public function hasReference(string $name): bool
+    {
+        return isset($this->references[$name]);
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->references);
+    }
+
+    public function count(): int
+    {
+        return count($this->references);
+    }
+}

--- a/eZ/Publish/Core/LocationReference/NamedReferences/NamedReferencesProvider.php
+++ b/eZ/Publish/Core/LocationReference/NamedReferences/NamedReferencesProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\NamedReferences;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+
+final class NamedReferencesProvider implements NamedReferencesProviderInterface
+{
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    public function __construct(ConfigResolverInterface $configResolver)
+    {
+        $this->configResolver = $configResolver;
+    }
+
+    public function getNamedReferences(): NamedReferencesCollection
+    {
+        $references = $this->configResolver->getParameter('location_references');
+        $references['__root'] = $this->configResolver->getParameter('content.tree_root.location_id');
+
+        return new NamedReferencesCollection($references);
+    }
+}

--- a/eZ/Publish/Core/LocationReference/NamedReferences/NamedReferencesProviderInterface.php
+++ b/eZ/Publish/Core/LocationReference/NamedReferences/NamedReferencesProviderInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace eZ\Publish\Core\LocationReference\NamedReferences;
+
+interface NamedReferencesProviderInterface
+{
+    public function getNamedReferences(): NamedReferencesCollection;
+}

--- a/eZ/Publish/Core/LocationReference/Tests/ConfigResolver/LocationConfigResolverTest.php
+++ b/eZ/Publish/Core/LocationReference/Tests/ConfigResolver/LocationConfigResolverTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\Tests\ConfigResolver;
+
+use eZ\Publish\Core\LocationReference\ConfigResolver\LocationConfigResolver;
+use eZ\Publish\Core\LocationReference\LocationReference;
+use eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use PHPUnit\Framework\TestCase;
+
+final class LocationConfigResolverTest extends TestCase
+{
+    private const EXAMPLE_REFERENCE = 'remote_id("babe4a915b1dd5d369e79adb9d6c0c6a")';
+    private const EXAMPLE_LOCATION_ID = 2;
+    private const EXAMPLE_PARAMETER = ['tree_root', 'content', 'default'];
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $configResolver;
+
+    /** @var \eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $referenceResolver;
+
+    /** @var \eZ\Publish\Core\LocationReference\ConfigResolver\LocationConfigResolver */
+    private $locationConfigResolver;
+
+    protected function setUp(): void
+    {
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->referenceResolver = $this->createMock(LocationReferenceResolverInterface::class);
+
+        $this->locationConfigResolver = new LocationConfigResolver(
+            $this->configResolver,
+            $this->referenceResolver
+        );
+    }
+
+    public function testGetLocation(): void
+    {
+        $location = $this->createMock(Location::class);
+
+        $this->configResolver
+            ->method('getParameter')
+            ->with(...self::EXAMPLE_PARAMETER)
+            ->willReturn(self::EXAMPLE_REFERENCE);
+
+        $this->referenceResolver
+            ->method('resolve')
+            ->with(self::EXAMPLE_REFERENCE)
+            ->willReturn($location);
+
+        $this->assertEquals($location, $this->locationConfigResolver->getLocation(
+            ...self::EXAMPLE_PARAMETER
+        ));
+    }
+
+    public function testGetLocationAcceptLocationId(): void
+    {
+        $location = $this->createMock(Location::class);
+
+        $this->configResolver
+            ->method('getParameter')
+            ->with(...self::EXAMPLE_PARAMETER)
+            ->willReturn(self::EXAMPLE_LOCATION_ID);
+
+        $this->referenceResolver
+            ->method('resolve')
+            ->with((string) self::EXAMPLE_LOCATION_ID)
+            ->willReturn($location);
+
+        $this->assertEquals($location, $this->locationConfigResolver->getLocation(
+            ...self::EXAMPLE_PARAMETER
+        ));
+    }
+
+    public function testGetLocationReference(): void
+    {
+        $this->configResolver
+            ->method('getParameter')
+            ->with(...self::EXAMPLE_PARAMETER)
+            ->willReturn(self::EXAMPLE_REFERENCE);
+
+        $reference = $this->locationConfigResolver->getLocationReference(
+            ...self::EXAMPLE_PARAMETER
+        );
+
+        $this->assertInstanceOf(LocationReference::class, $reference);
+        $this->assertEquals(self::EXAMPLE_REFERENCE, (string)$reference);
+    }
+
+    public function testGetLocationReferenceAcceptLocationId(): void
+    {
+        $this->configResolver
+            ->method('getParameter')
+            ->with(...self::EXAMPLE_PARAMETER)
+            ->willReturn(self::EXAMPLE_LOCATION_ID);
+
+        $reference = $this->locationConfigResolver->getLocationReference(
+            ...self::EXAMPLE_PARAMETER
+        );
+
+        $this->assertInstanceOf(LocationReference::class, $reference);
+        $this->assertEquals((string)self::EXAMPLE_LOCATION_ID, (string)$reference);
+    }
+}

--- a/eZ/Publish/Core/LocationReference/Tests/LimitedLocationServiceTest.php
+++ b/eZ/Publish/Core/LocationReference/Tests/LimitedLocationServiceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\Tests;
+
+use eZ\Publish\Core\LocationReference\LimitedLocationService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use PHPUnit\Framework\TestCase;
+
+final class LimitedLocationServiceTest extends TestCase
+{
+    private const LOCATION_ID = 54;
+    private const LOCATION_REMOTE_ID = 'babe4a915b1dd5d369e79adb9d6c0c6a';
+    private const LOCATION_PATH = '/1/2/54/';
+
+    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit\Framework\MockObject\MockObject */
+    private $locationService;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Location */
+    private $expectedLocation;
+
+    /** @var \eZ\Publish\Core\LocationReference\LimitedLocationService */
+    private $limitedLocationService;
+
+    protected function setUp(): void
+    {
+        $this->locationService = $this->createMock(LocationService::class);
+        $this->expectedLocation = $this->createMock(Location::class);
+        $this->limitedLocationService = new LimitedLocationService($this->locationService);
+    }
+
+    public function testLoadLocation(): void
+    {
+        $this->locationService
+            ->method('loadLocation')
+            ->with(self::LOCATION_ID)
+            ->willReturn($this->expectedLocation);
+
+        $this->assertEquals(
+            $this->expectedLocation,
+            $this->limitedLocationService->loadLocation(self::LOCATION_ID)
+        );
+    }
+
+    public function testLocationByRemoteId(): void
+    {
+        $this->locationService
+            ->method('loadLocationByRemoteId')
+            ->with(self::LOCATION_REMOTE_ID)
+            ->willReturn($this->expectedLocation);
+
+        $this->assertEquals(
+            $this->expectedLocation,
+            $this->limitedLocationService->loadLocationByRemoteId(self::LOCATION_REMOTE_ID)
+        );
+    }
+
+    public function testLocationByPathString(): void
+    {
+        $this->locationService
+            ->method('loadLocation')
+            ->with(self::LOCATION_ID)
+            ->willReturn($this->expectedLocation);
+
+        $this->assertEquals(
+            $this->expectedLocation,
+            $this->limitedLocationService->loadLocationByPathString(self::LOCATION_PATH)
+        );
+    }
+
+    public function testParentLocation(): void
+    {
+        $location = $this->createMock(Location::class);
+        $location
+            ->method('__get')
+            ->with('parentLocationId')
+            ->willReturn(self::LOCATION_ID);
+
+        $this->locationService
+            ->method('loadLocation')
+            ->with(self::LOCATION_ID)
+            ->willReturn($this->expectedLocation);
+
+        $this->assertEquals(
+            $this->expectedLocation,
+            $this->limitedLocationService->loadParentLocation($location)
+        );
+    }
+}

--- a/eZ/Publish/Core/LocationReference/Tests/LocationReferenceResolverTest.php
+++ b/eZ/Publish/Core/LocationReference/Tests/LocationReferenceResolverTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\Tests;
+
+use eZ\Publish\Core\LocationReference\ExpressionLanguage\ExpressionLanguage;
+use eZ\Publish\Core\LocationReference\LimitedLocationService;
+use eZ\Publish\Core\LocationReference\LocationReferenceResolver;
+use eZ\Publish\Core\LocationReference\Tests\Stubs\NamedReferencesProviderStub;
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+final class LocationReferenceResolverTest extends BaseTest
+{
+    private const ROOT_LOCATION_ID = 2;
+    private const EXAMPLE_REMOTE_ID = 'example';
+
+    /** @var \eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface */
+    private $locationReferenceResolver;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Location */
+    private $exampleLocation;
+
+    protected function setUp(): void
+    {
+        $this->exampleLocation = $this->createExampleLocation();
+
+        $this->locationReferenceResolver = new LocationReferenceResolver(
+            new LimitedLocationService($this->getRepository()->getLocationService()),
+            new NamedReferencesProviderStub([
+                '__root' => 'local_id(2)',
+                'example' => sprintf('remote_id("%s")', self::EXAMPLE_REMOTE_ID),
+            ]),
+            new ExpressionLanguage()
+        );
+    }
+
+    public function testResolveLocalId(): void
+    {
+        $this->assertLocationReference(
+            sprintf('local_id(%d)', $this->exampleLocation->id),
+            $this->exampleLocation->id
+        );
+    }
+
+    public function testResolveRemoteId(): void
+    {
+        $this->assertLocationReference(
+            sprintf('remote_id("%s")', $this->exampleLocation->remoteId),
+            $this->exampleLocation->id
+        );
+    }
+
+    public function testResolvePath(): void
+    {
+        $this->assertLocationReference(
+            sprintf('path("%s")', $this->exampleLocation->pathString),
+            $this->exampleLocation->id
+        );
+    }
+
+    public function testResolveRoot(): void
+    {
+        $this->assertLocationReference('root()', self::ROOT_LOCATION_ID);
+    }
+
+    public function testResolveParent(): void
+    {
+        $this->assertLocationReference(
+            sprintf('parent(local_id(%d))', $this->exampleLocation->id),
+            $this->exampleLocation->parentLocationId
+        );
+    }
+
+    public function testResolveNamed(): void
+    {
+        $this->assertLocationReference('named("example")', $this->exampleLocation->id);
+    }
+
+    private function assertLocationReference(string $reference, ?int $expectedLocationId): void
+    {
+        $expectedLocation = $this->getRepository()->getLocationService()->loadLocation(
+            $expectedLocationId
+        );
+
+        $actualLocation = $this->locationReferenceResolver->resolve($reference);
+
+        $this->assertEquals($expectedLocation, $actualLocation);
+    }
+
+    private function createExampleLocation(): Location
+    {
+        $locationService = $this->getRepository()->getLocationService();
+        $contentService = $this->getRepository()->getContentService();
+
+        $contentType = $this->getRepository()
+            ->getContentTypeService()
+            ->loadContentTypeByIdentifier('folder');
+
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, 'eng-GB');
+        $contentCreateStruct->setField('name', 'Example folder');
+
+        $locationCreateStruct = $locationService->newLocationCreateStruct(self::ROOT_LOCATION_ID);
+        $locationCreateStruct->remoteId = self::EXAMPLE_REMOTE_ID;
+
+        $content = $contentService->publishVersion(
+            $contentService->createContent($contentCreateStruct, [$locationCreateStruct]
+        )->getVersionInfo());
+
+        return $locationService->loadLocation(
+            $content->contentInfo->mainLocationId
+        );
+    }
+}

--- a/eZ/Publish/Core/LocationReference/Tests/LocationReferenceTest.php
+++ b/eZ/Publish/Core/LocationReference/Tests/LocationReferenceTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\Tests;
+
+use eZ\Publish\Core\LocationReference\LocationReference;
+use eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+final class LocationReferenceTest extends TestCase
+{
+    private const EXAMPLE_REFERENCE = 'remote_id("babe4a915b1dd5d369e79adb9d6c0c6a")';
+
+    public function testGetLocation(): void
+    {
+        $location = $this->createMock(Location::class);
+
+        $reference = new LocationReference(
+            $this->createResolverMockForValidReference(self::EXAMPLE_REFERENCE, $location),
+            self::EXAMPLE_REFERENCE
+        );
+
+        $this->assertEquals($location, $reference->getLocation());
+    }
+
+    public function testGetLocationOrNullReturnsLocation(): void
+    {
+        $location = $this->createMock(Location::class);
+
+        $reference = new LocationReference(
+            $this->createResolverMockForValidReference(self::EXAMPLE_REFERENCE, $location),
+            self::EXAMPLE_REFERENCE
+        );
+
+        $this->assertEquals($location, $reference->getLocationOrNull());
+    }
+
+    /**
+     * @dataProvider dataProviderForExceptionsThrownByLoadLocation
+     */
+    public function testGetLocationOrNullReturnsNull(Throwable $exception): void
+    {
+        $reference = new LocationReference(
+            $this->createResolverMockForInvalidReference(self::EXAMPLE_REFERENCE, $exception),
+            self::EXAMPLE_REFERENCE
+        );
+
+        $this->assertNull($reference->getLocationOrNull());
+    }
+
+    public function testGetLocationOrDefaultReturnsLocation(): void
+    {
+        $location = $this->createMock(Location::class);
+        $fallback = $this->createMock(Location::class);
+
+        $reference = new LocationReference(
+            $this->createResolverMockForValidReference(self::EXAMPLE_REFERENCE, $location),
+            self::EXAMPLE_REFERENCE
+        );
+
+        $this->assertEquals($location, $reference->getLocationOrDefault($fallback));
+    }
+
+    /**
+     * @dataProvider dataProviderForExceptionsThrownByLoadLocation
+     */
+    public function testGetLocationOrDefaultReturnsDefault(Throwable $exception): void
+    {
+        $fallback = $this->createMock(Location::class);
+
+        $reference = new LocationReference(
+            $this->createResolverMockForInvalidReference(self::EXAMPLE_REFERENCE, $exception),
+            self::EXAMPLE_REFERENCE
+        );
+
+        $this->assertEquals($fallback, $reference->getLocationOrDefault($fallback));
+    }
+
+    public function dataProviderForExceptionsThrownByLoadLocation(): array
+    {
+        return [
+            [$this->createMock(NotFoundException::class)],
+            [$this->createMock(UnauthorizedException::class)],
+        ];
+    }
+
+    private function createResolverMockForValidReference(string $reference, Location $location): LocationReferenceResolverInterface
+    {
+        $locationReferenceResolver = $this->createMock(LocationReferenceResolverInterface::class);
+        $locationReferenceResolver
+            ->method('resolve')
+            ->with($reference)
+            ->willReturn($location);
+
+        return $locationReferenceResolver;
+    }
+
+    private function createResolverMockForInvalidReference(string $reference, Throwable $exception): LocationReferenceResolverInterface
+    {
+        $locationReferenceResolver = $this->createMock(LocationReferenceResolverInterface::class);
+        $locationReferenceResolver
+            ->method('resolve')
+            ->with($reference)
+            ->willThrowException($exception);
+
+        return $locationReferenceResolver;
+    }
+}

--- a/eZ/Publish/Core/LocationReference/Tests/NamedReferences/NamedReferencesCollectionTest.php
+++ b/eZ/Publish/Core/LocationReference/Tests/NamedReferences/NamedReferencesCollectionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\Tests\NamedReferences;
+
+use eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesCollection;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class NamedReferencesCollectionTest extends TestCase
+{
+    private const EXAMPLE_REFERENCES = [
+        'images' => 'remote_id("IMAGES")',
+        'videos' => 'remote_id("VIDEOS")',
+        'other' => 'remote_id("OTHER")',
+    ];
+
+    public function testGetReference(): void
+    {
+        $collection = new NamedReferencesCollection(self::EXAMPLE_REFERENCES);
+
+        $this->assertEquals(
+            self::EXAMPLE_REFERENCES['images'],
+            $collection->getReference('images')
+        );
+    }
+
+    public function testGetReferenceThrowsNotFoundException(): void
+    {
+        $this->expectException(NotFoundException::class);
+
+        $collection = new NamedReferencesCollection(self::EXAMPLE_REFERENCES);
+        $collection->getReference('root');
+    }
+
+    public function testHasReference(): void
+    {
+        $collection = new NamedReferencesCollection(self::EXAMPLE_REFERENCES);
+
+        $this->assertTrue($collection->hasReference('images'));
+        $this->assertFalse($collection->hasReference('root'));
+    }
+
+    public function testCount(): void
+    {
+        $this->assertEquals(
+            count(self::EXAMPLE_REFERENCES),
+            count(new NamedReferencesCollection(self::EXAMPLE_REFERENCES))
+        );
+    }
+
+    public function testCountEmptyCollection(): void
+    {
+        $this->assertEquals(0, count(new NamedReferencesCollection([])));
+    }
+}

--- a/eZ/Publish/Core/LocationReference/Tests/NamedReferences/NamedReferencesCollectionTest.php
+++ b/eZ/Publish/Core/LocationReference/Tests/NamedReferences/NamedReferencesCollectionTest.php
@@ -52,6 +52,6 @@ final class NamedReferencesCollectionTest extends TestCase
 
     public function testCountEmptyCollection(): void
     {
-        $this->assertEquals(0, count(new NamedReferencesCollection([])));
+        $this->assertCount(0, new NamedReferencesCollection([]));
     }
 }

--- a/eZ/Publish/Core/LocationReference/Tests/NamedReferences/NamedReferencesProviderTest.php
+++ b/eZ/Publish/Core/LocationReference/Tests/NamedReferences/NamedReferencesProviderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\Tests\NamedReferences;
+
+use eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProvider;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use PHPUnit\Framework\TestCase;
+
+final class NamedReferencesProviderTest extends TestCase
+{
+    private const TREE_ROOT_REFERENCE = 2;
+
+    private const CONFIGURED_REFERENCES = [
+        'images' => 'remote_id("IMAGES")',
+        'videos' => 'remote_id("VIDEOS")',
+        'other' => 'remote_id("OTHER")',
+    ];
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $configResolver;
+
+    /** @var \eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProvider */
+    private $namedReferenceProvider;
+
+    protected function setUp(): void
+    {
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->namedReferenceProvider = new NamedReferencesProvider($this->configResolver);
+    }
+
+    public function testGetNamedReferences(): void
+    {
+        $this->configResolver
+            ->method('getParameter')
+            ->willReturnMap([
+                ['location_references', null, null, self::CONFIGURED_REFERENCES],
+                ['content.tree_root.location_id', null, null, self::TREE_ROOT_REFERENCE],
+            ]);
+
+        $references = $this->namedReferenceProvider->getNamedReferences();
+
+        $this->assertCount(count(self::CONFIGURED_REFERENCES) + 1, $references);
+        foreach ($references as $name => $reference) {
+            $this->assertTrue($name === '__root' || isset(self::CONFIGURED_REFERENCES[$name]));
+        }
+    }
+}

--- a/eZ/Publish/Core/LocationReference/Tests/Stubs/NamedReferencesProviderStub.php
+++ b/eZ/Publish/Core/LocationReference/Tests/Stubs/NamedReferencesProviderStub.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\LocationReference\Tests\Stubs;
+
+use eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesCollection;
+use eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProviderInterface;
+
+final class NamedReferencesProviderStub implements NamedReferencesProviderInterface
+{
+    private $namedReferences = [];
+
+    public function __construct(array $references = [])
+    {
+        $this->namedReferences = $references;
+    }
+
+    public function getNamedReferences(): NamedReferencesCollection
+    {
+        return new NamedReferencesCollection($this->namedReferences);
+    }
+}

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -111,7 +111,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup
      */
-    public function createContentTypeGroup(ContentTypeGroupCreateStruct  $contentTypeGroupCreateStruct)
+    public function createContentTypeGroup(ContentTypeGroupCreateStruct $contentTypeGroupCreateStruct)
     {
         if (!$this->repository->canUser('class', 'create', $contentTypeGroupCreateStruct)) {
             throw new UnauthorizedException('ContentType', 'create');

--- a/eZ/Publish/Core/settings/containerBuilder.php
+++ b/eZ/Publish/Core/settings/containerBuilder.php
@@ -50,6 +50,7 @@ $loader->load('utils.yml');
 $loader->load('tests/common.yml');
 $loader->load('policies.yml');
 $loader->load('events.yml');
+$loader->load('location_references.yml');
 
 // Cache settings (takes same env variables as ezplatform does, only supports "singleredis" setup)
 if (getenv('CUSTOM_CACHE_POOL') === 'singleredis') {

--- a/eZ/Publish/Core/settings/fieldtype_services.yml
+++ b/eZ/Publish/Core/settings/fieldtype_services.yml
@@ -53,6 +53,7 @@ services:
             $contentService: '@ezpublish.api.service.content'
             $locationService: '@ezpublish.api.service.location'
             $contentTypeService: '@ezpublish.api.service.content_type'
+            $locationReferenceResolver: '@eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface'
             $mappings: '$fieldtypes.ezimageasset.mappings$'
 
     eZ\Publish\Core\FieldType\FieldTypeRegistry: ~

--- a/eZ/Publish/Core/settings/location_references.yml
+++ b/eZ/Publish/Core/settings/location_references.yml
@@ -8,17 +8,12 @@ services:
 
     eZ\Publish\Core\LocationReference\LimitedLocationService: ~
 
-    eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProvider: ~
+    eZ\Publish\Core\LocationReference\NamedReferences\InMemoryNamedReferenceProvider: ~
 
     eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProviderInterface:
-        alias: eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProvider
+        alias: eZ\Publish\Core\LocationReference\NamedReferences\InMemoryNamedReferenceProvider
 
     eZ\Publish\Core\LocationReference\LocationReferenceResolver: ~
 
     eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface:
         alias: eZ\Publish\Core\LocationReference\LocationReferenceResolver
-
-    eZ\Publish\Core\LocationReference\ConfigResolver\LocationConfigResolver: ~
-
-    eZ\Publish\Core\LocationReference\ConfigResolver\LocationConfigResolverInterface:
-        alias: eZ\Publish\Core\LocationReference\ConfigResolver\LocationConfigResolver

--- a/eZ/Publish/Core/settings/location_references.yml
+++ b/eZ/Publish/Core/settings/location_references.yml
@@ -1,0 +1,24 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    eZ\Publish\Core\LocationReference\ExpressionLanguage\ExpressionLanguage: ~
+
+    eZ\Publish\Core\LocationReference\LimitedLocationService: ~
+
+    eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProvider: ~
+
+    eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProviderInterface:
+        alias: eZ\Publish\Core\LocationReference\NamedReferences\NamedReferencesProvider
+
+    eZ\Publish\Core\LocationReference\LocationReferenceResolver: ~
+
+    eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface:
+        alias: eZ\Publish\Core\LocationReference\LocationReferenceResolver
+
+    eZ\Publish\Core\LocationReference\ConfigResolver\LocationConfigResolver: ~
+
+    eZ\Publish\Core\LocationReference\ConfigResolver\LocationConfigResolverInterface:
+        alias: eZ\Publish\Core\LocationReference\ConfigResolver\LocationConfigResolver

--- a/eZ/Publish/Core/settings/tests/integration_legacy.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy.yml
@@ -18,6 +18,7 @@ services:
             $contentService: '@ezpublish.api.service.content'
             $locationService: '@ezpublish.api.service.location'
             $contentTypeService: '@ezpublish.api.service.content_type'
+            $locationReferenceResolver: '@eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface'
             # Siteaccess aware configuration is not available in the integration tests
             $mappings: '%ezsettings.default.fieldtypes.ezimageasset.mappings%'
 

--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -586,6 +586,7 @@ abstract class BaseIntegrationTest extends TestCase
         $loader->load('tests/common.yml');
         $loader->load('policies.yml');
         $loader->load('events.yml');
+        $loader->load('location_references.yml');
 
         $containerBuilder->setParameter('ezpublish.kernel.root_dir', $installDir);
 

--- a/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
@@ -152,6 +152,7 @@ abstract class FileBaseIntegrationTest extends BaseIntegrationTest
         $loader->load('tests/common.yml');
         $loader->load('policies.yml');
         $loader->load('events.yml');
+        $loader->load('location_references.yml');
 
         $containerBuilder->setParameter('ezpublish.kernel.root_dir', $installDir);
 

--- a/eZ/Publish/SPI/Tests/FieldType/ImageAssetIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageAssetIntegrationTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\FieldType;
+use eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageAssetConverter;
 use eZ\Publish\SPI\Persistence\Content;
 
@@ -33,6 +34,7 @@ class ImageAssetIntegrationTest extends BaseIntegrationTest
         $contentService = $this->createMock(ContentService::class);
         $locationService = $this->createMock(LocationService::class);
         $contentTypeService = $this->createMock(ContentTypeService::class);
+        $locationReferenceResolver = $this->createMock(LocationReferenceResolverInterface::class);
         $contentHandler = $this->createMock(Content\Handler::class);
 
         $config = [];
@@ -41,6 +43,7 @@ class ImageAssetIntegrationTest extends BaseIntegrationTest
             $contentService,
             $locationService,
             $contentTypeService,
+            $locationReferenceResolver,
             $config
         );
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -68,6 +68,9 @@
     <testsuite name="eZ\Publish\API\Repository\Values\Content">
       <directory>eZ/Publish/API/Repository/Tests/Values/Content</directory>
     </testsuite>
+    <testsuite name="eZ\Publish\Core\LocationReference">
+      <directory>eZ/Publish/Core/LocationReference/Tests</directory>
+    </testsuite>
   </testsuites>
   <filter>
     <whitelist>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://jira.ez.no/browse/EZP-30950
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

Features like content view configuration, workflow etc. reference to location ids in configuration files. This doesn't work well with deployment, where the production and development database differ.

PR introduces DSL based on Symfony Expression Language component, allowing developer refer locations using meaningful and descriptive expressions. 

| Function    | Description                  | Example                                         |
|-------------|------------------------------|-------------------------------------------------|
| `root`      | Load root location           | `root()`                                        |
| `parent`    | Load parent location         | `parent(local_id(54))`                          |
| `local_id`  | Load location by ID          | `local_id(54)`                                  |
| `remote_id` | Load location by remote ID   | `remote_id("babe4a915b1dd5d369e79adb9d6c0c6a")` |
| `path`      | Load location by path string | `path("/1/2/54")`                               |
| `named`     | Load named reference         | `named("MEDIA")`                                |

Original repository: https://github.com/adamwojs/ezplatform-location-reference

### Configuration example

```yaml
ezpublush:
    system:
        default:
            fieldtypes:
                ezimageasset:
                    # ... 
                    # Use location with remote id = 1b26c0454b09bb49dfb1b9190ffd67cb to store image assets
                    parent_location_id: remote_id("1b26c0454b09bb49dfb1b9190ffd67cb")
```
###  PHP API examples 

#### Resolve location references

Location reference expressions could be resolved using `LocationReferenceResolver` e.g.

```php
<?php

namespace App\Service; 

class FooService 
{
    /**
     * @var \eZ\Publish\Core\LocationReference\LocationReferenceResolverInterface  
     */
    private $locationReferenceResolver;

    public function __construct(LocationReferenceResolverInterface $locationReferenceResolver)
    {
        $this->locationReferenceResolver = $locationReferenceResolver;
    }

    public function foo(): void
    {
        $location = $this->locationReferenceResolver->resolve(
            'remote_id("babe4a915b1dd5d369e79adb9d6c0c6a")'
        );

        // ...
    }
}
```

#### Retrieving location reference from SiteAccess aware configuration

Location references could be retrieved from the SiteAccess aware configuration 
using `LocationConfigResolver`:  

```php
<?php 

interface LocationConfigResolverInterface
{
    public function getLocation(string $name, ?string $namespace = null, ?string $scope = null): Location;

    public function getLocationReference(string $name, ?string $namespace = null, ?string $scope = null): LocationReference;
}
```


Arguments for both `getLocation` and `getLocationReference` methods are exactly the same as for 
`\eZ\Publish\Core\MVC\ConfigResolverInterface::getParameter`. 


Example:

```php
<?php 

class BarService 
{
    /**
     * @var \eZ\Publish\Core\LocationReference\ConfigResolver\LocationConfigResolverInterface  
     */
    private $locationConfigResolver;

    public function __construct(LocationConfigResolverInterface $locationConfigResolver)
    {
        $this->locationConfigResolver = $locationConfigResolver;
    }

    // ...

    public function foo(): void
    {
        // Get reference to location 
        $reference = $this->locationConfigResolver->getLocationReference('content.tree_root.location_id');
        
        // Resolve location reference 
        $location = $reference->getLocation();
        // Return null if location is not available (not found or unauthorized)  
        $location = $reference->getLocationOrNull();
        // Return $defaultLocation if location is not available (not found or unauthorized)
        $location = $reference->getLocationOrDefault($defaultLocation);
        
        // Get reference and immediately resolve
        $location = $this->locationConfigResolver->getLocation('fieldtypes.ezimageasset.parent_location');
    }
}
```

## Backward Compatibility 

To keep backward compatibility integers are valid references and interpreted as location id.
Ref. https://github.com/ezsystems/ezpublish-kernel/pull/2766/files#diff-7feea87ea33adcaeec5a8069b6810c7bR47-R49


**TODO**:
- [x] Create JIRA issue
- [x] Add PR description 
- [x] Ask for feedback
- [ ] Implement feature 
- [ ] Implement cache layer
- [ ] Accept references in all location related settings
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
