### PR TITLE
EZP-30382: Add content hide/reveal to REST API

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -1224,6 +1224,26 @@ In this example
       <status>PUBLISHED</status>
     </Content>
 
+Hide Content
+``````````````
+:Resource: /content/objects/<ID>/hide
+:Method: POST
+:Description: The content is hidden.
+:Response: 204
+:Error Codes:
+    :404: content object was not found
+    :401: If the user is not authorized to hide this object
+
+Reveal Content
+``````````````
+:Resource: /content/objects/<ID>/reveal
+:Method: POST
+:Description: The content is revealed.
+:Response: 204
+:Error Codes:
+    :404: content object was not found
+    :401: If the user is not authorized to reveal this object
+
 Delete Content
 ``````````````
 :Resource: /content/objects/<ID>

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
@@ -225,6 +225,22 @@ ezpublish_rest_createDraftFromCurrentVersion:
     requirements:
         contentId: \d+
 
+ezpublish_rest_hideContent:
+    path: /content/objects/{contentId}/hide
+    defaults:
+        _controller: ezpublish_rest.controller.content:hideContent
+    methods: [POST]
+    requirements:
+        contentId: \d+
+
+ezpublish_rest_revealContent:
+    path: /content/objects/{contentId}/reveal
+    defaults:
+        _controller: ezpublish_rest.controller.content:revealContent
+    methods: [POST]
+    requirements:
+        contentId: \d+
+
 # Binary content
 
 ezpublish_rest_binaryContent_getImageVariation:

--- a/eZ/Publish/Core/REST/Server/Controller/Content.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Content.php
@@ -732,6 +732,40 @@ class Content extends RestController
     }
 
     /**
+     * @param int $contentId
+     *
+     * @return \eZ\Publish\Core\REST\Server\Values\NoContent
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function hideContent(int $contentId): Values\NoContent
+    {
+        $contentInfo = $this->repository->getContentService()->loadContentInfo($contentId);
+
+        $this->repository->getContentService()->hideContent($contentInfo);
+
+        return new Values\NoContent();
+    }
+
+    /**
+     * @param int $contentId
+     *
+     * @return \eZ\Publish\Core\REST\Server\Values\NoContent
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function revealContent(int $contentId): Values\NoContent
+    {
+        $contentInfo = $this->repository->getContentService()->loadContentInfo($contentId);
+
+        $this->repository->getContentService()->revealContent($contentInfo);
+
+        return new Values\NoContent();
+    }
+
+    /**
      * Creates and executes a content view.
      *
      * @deprecated Since platform 1.0. Forwards the request to the new /views location, but returns a 301.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30382](https://jira.ez.no/browse/EZP-30382)
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `7.5` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

This adds missing functionality on hide/reveal content via REST API.

When merging up this must be moved to new REST repository and only REST DOC file need to be merged up!

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
