### PR TITLE
EZP-30956: Added raw URL encoding of download file name

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ContentDownloadRouteReferenceListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ContentDownloadRouteReferenceListener.php
@@ -67,7 +67,7 @@ class ContentDownloadRouteReferenceListener implements EventSubscriberInterface
         }
 
         $routeReference->set(self::OPT_CONTENT_ID, $options[self::OPT_CONTENT_ID]);
-        $routeReference->set(self::OPT_DOWNLOAD_NAME, $options[self::OPT_DOWNLOAD_NAME]);
+        $routeReference->set(self::OPT_DOWNLOAD_NAME, rawurlencode($options[self::OPT_DOWNLOAD_NAME]));
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30956](https://jira.ez.no/browse/EZP-30956)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.x`/`7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | maybe

If you have uploaded a file with a name beginning with a left parenthesis `(` character, trying to download it with the route ez_content_download:
`/content/download/{contentId}/{fieldIdentifier}/{filename}`

...means the filename gets interpreted as a view parameter. So the router thinks there are only 4 parameters, and it will actually match the route ez_content_download_field_id:
`/content/download/{contentId}/{fieldId}`

...which fails since the field identifier isn't a valid field id. This happens regardless of whether the filename is url encoded or not in the request.

Fixing it by `rawurlencode()` of the filename in the `ContentDownloadRouteReferenceListener`. Download using the redirect route (ez_content_download_field_id) works with this patch. This redirects to ez_content_download. However, calling ez_content_download directly still does not work with such filenames, and leads to the same error as before the patch. So the fix is incomplete, if we intend for direct use to be possible.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
