### PR TITLE
EZP-30968: Added method to count the number of content's reverse relations

### DIFF
--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -374,6 +374,15 @@ interface ContentService
     public function loadRelations(VersionInfo $versionInfo);
 
     /**
+     * Counts all incoming relations for the given content object.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     *
+     * @return int The number of reverse relations ({@link Relation})
+     */
+    public function countReverseRelations(ContentInfo $contentInfo): int;
+
+    /**
      * Loads all incoming relations for a content object.
      *
      * The relations come only from published versions of the source content objects

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -3491,6 +3491,59 @@ XML
     }
 
     /**
+     * Test for the countReverseRelations() method.
+     *
+     * @covers \eZ\Publish\API\Repository\ContentService::countReverseRelations
+     */
+    public function testCountReverseRelations(): void
+    {
+        $contentWithReverseRelations = $this->createContentWithReverseRelations([
+            $this->contentService->createContentDraft(
+                $this->createFolder([self::ENG_GB => 'Foo'], 2)->contentInfo
+            ),
+            $this->contentService->createContentDraft(
+                $this->createFolder([self::ENG_GB => 'Bar'], 2)->contentInfo
+            ),
+        ]);
+
+        $contentInfo = $contentWithReverseRelations->content->getVersionInfo()->getContentInfo();
+
+        $this->assertEquals(2, $this->contentService->countReverseRelations($contentInfo));
+    }
+
+    /**
+     * Test for the countReverseRelations() method.
+     *
+     * @covers \eZ\Publish\API\Repository\ContentService::countReverseRelations
+     */
+    public function testCountReverseRelationsReturnsZeroByDefault(): void
+    {
+        $draft = $this->createContentDraftVersion1();
+
+        $this->assertSame(0, $this->contentService->countReverseRelations($draft->getVersionInfo()->getContentInfo()));
+    }
+
+    /**
+     * Test for the countReverseRelations() method.
+     *
+     * @covers \eZ\Publish\API\Repository\ContentService::countReverseRelations
+     */
+    public function testCountReverseRelationsForUnauthorizedUser(): void
+    {
+        $contentWithReverseRelations = $this->createContentWithReverseRelations([
+            $this->contentService->createContentDraft(
+                $this->createFolder([self::ENG_GB => 'Foo'], 2)->contentInfo
+            ),
+        ]);
+        $mediaUser = $this->createMediaUserVersion1();
+        $this->permissionResolver->setCurrentUserReference($mediaUser);
+
+        $contentInfo = $contentWithReverseRelations->content->contentInfo;
+
+        $this->assertSame(0, $this->contentService->countReverseRelations($contentInfo));
+    }
+
+    /**
      * Test for the loadReverseRelations() method.
      *
      * @see \eZ\Publish\API\Repository\ContentService::loadReverseRelations()
@@ -6163,5 +6216,40 @@ XML
                 ['module' => 'content', 'function' => 'edit'],
             ]
         );
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content[] $drafts
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     *
+     * @return object
+     */
+    private function createContentWithReverseRelations(array $drafts)
+    {
+        $contentWithReverseRelations = new class() {
+            /** @var \eZ\Publish\API\Repository\Values\Content\Content */
+            public $content;
+
+            /** @var \eZ\Publish\API\Repository\Values\Content\Content[] */
+            public $reverseRelations;
+        };
+        $content = $this->createContentVersion1();
+        $versionInfo = $content->getVersionInfo();
+        $contentInfo = $versionInfo->getContentInfo();
+        $contentWithReverseRelations->content = $content;
+
+        /** @var \eZ\Publish\API\Repository\Values\Content\Content $draft */
+        foreach ($drafts as $draft) {
+            $this->contentService->addRelation(
+                $draft->getVersionInfo(),
+                $contentInfo
+            );
+
+            $contentWithReverseRelations->reverseRelations[] = $this->contentService->publishVersion($draft->getVersionInfo());
+        }
+
+        return $contentWithReverseRelations;
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -402,6 +402,16 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
     /**
      * {@inheritdoc}
      */
+    public function countReverseRelations(int $destinationContentId, ?int $type = null): int
+    {
+        $this->logger->logCall(__METHOD__, ['content' => $destinationContentId, 'type' => $type]);
+
+        return $this->persistenceHandler->contentHandler()->countReverseRelations($destinationContentId, $type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function loadReverseRelations($destinationContentId, $type = null)
     {
         $this->logger->logCall(__METHOD__, ['content' => $destinationContentId, 'type' => $type]);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -401,6 +401,16 @@ abstract class Gateway
     abstract public function loadRelations($contentId, $contentVersionNo = null, $relationType = null);
 
     /**
+     * Counts number of related to/from $contentId.
+     *
+     * @param int $contentId
+     * @param int|null $relationType
+     *
+     * @return int
+     */
+    abstract public function countReverseRelations(int $contentId, ?int $relationType = null): int;
+
+    /**
      * Loads data of related to/from $contentId.
      *
      * @param int $contentId

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -694,6 +694,18 @@ class ExceptionConversion extends Gateway
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function countReverseRelations(int $contentId, ?int $relationType = null): int
+    {
+        try {
+            return $this->innerGateway->countReverseRelations($contentId, $relationType);
+        } catch (DBALException | PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
+
+    /**
      * Loads data of related to/from $contentId.
      *
      * @param int $contentId

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -820,6 +820,14 @@ class Handler implements BaseContentHandler
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function countReverseRelations(int $destinationContentId, ?int $type = null): int
+    {
+        return $this->contentGateway->countReverseRelations($destinationContentId, $type);
+    }
+
+    /**
      * Loads relations from $contentId. Optionally, loads only those with $type.
      *
      * Only loads relations against published versions.

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -618,6 +618,14 @@ class ContentService implements APIContentService, Sessionable
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function countReverseRelations(ContentInfo $contentInfo): int
+    {
+        throw new \Exception('@todo: Implement.');
+    }
+
+    /**
      * Loads all incoming relations for a content object.
      *
      * The relations come only

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1944,6 +1944,20 @@ class ContentService implements ContentServiceInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function countReverseRelations(ContentInfo $contentInfo): int
+    {
+        if (!$this->repository->canUser('content', 'reverserelatedlist', $contentInfo)) {
+            return 0;
+        }
+
+        return $this->persistenceHandler->contentHandler()->countReverseRelations(
+            $contentInfo->id
+        );
+    }
+
+    /**
      * Loads all incoming relations for a content object.
      *
      * The relations come only from published versions of the source content objects

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -178,6 +178,14 @@ class ContentService implements ContentServiceInterface
         return $this->service->loadRelations($versionInfo);
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function countReverseRelations(ContentInfo $contentInfo): int
+    {
+        return $this->service->countReverseRelations($contentInfo);
+    }
+
     public function loadReverseRelations(ContentInfo $contentInfo)
     {
         return $this->service->loadReverseRelations($contentInfo);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
@@ -85,6 +85,8 @@ class ContentServiceTest extends AbstractServiceTest
 
             ['loadRelations', [$versionInfo]],
 
+            ['countReverseRelations', [$contentInfo]],
+
             ['loadReverseRelations', [$contentInfo]],
 
             ['addRelation', [$versionInfo, $contentInfo]],

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -521,6 +521,14 @@ class ContentService implements ContentServiceInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function countReverseRelations(ContentInfo $contentInfo): int
+    {
+        return $this->service->countReverseRelations($contentInfo);
+    }
+
+    /**
      * Loads all incoming relations for a content object.
      *
      * The relations come only from published versions of the source content objects

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
@@ -253,6 +253,12 @@ class ContentServiceTest extends ServiceTest
                 0,
             ],
             [
+                'countReverseRelations',
+                [$contentInfo],
+                0,
+                0,
+            ],
+            [
                 'loadReverseRelations',
                 [$contentInfo],
                 $relations,

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -290,6 +290,16 @@ interface Handler
     public function loadRelations($sourceContentId, $sourceContentVersionNo = null, $type = null);
 
     /**
+     * Counts relations from $destinationContentId only against published versions. Optionally, count only those with $type.
+     *
+     * @param int $destinationContentId Destination Content ID
+     * @param int|null $type The relation type bitmask {@see \eZ\Publish\API\Repository\Values\Content\Relation}
+     *
+     * @return int
+     */
+    public function countReverseRelations(int $destinationContentId, ?int $type = null): int;
+
+    /**
      * Loads relations from $contentId. Optionally, loads only those with $type.
      *
      * Only loads relations against published versions.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30968](https://jira.ez.no/browse/EZP-30968)
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.5`
| **BC breaks**      |no
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

This method is needed to add pagination to content's reverse relation list


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
