### PR TITLE
EZP-30911: Added option to pass location-id parameter to URL alias regeneration Command

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
@@ -132,8 +132,9 @@ EOT
             );
         }
 
-        if  ($locationsCount === 0) {
+        if ($locationsCount === 0) {
             $output->writeln('<info>No location was found. Exiting.</info>');
+
             return;
         }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
@@ -198,9 +198,8 @@ EOT
                     continue;
                 }
 
-                $content = $contentList[$location->contentId];
                 $this->repository->sudo(
-                    function (Repository $repository) use ($location, $content) {
+                    function (Repository $repository) use ($location) {
                         $repository->getURLAliasService()->refreshSystemUrlAliasesForLocation(
                             $location
                         );

--- a/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
@@ -132,6 +132,11 @@ EOT
             );
         }
 
+        if  ($locationsCount === 0) {
+            $output->writeln('<info>No location was found. Exiting.</info>');
+            return;
+        }
+
         $helper = $this->getHelper('question');
         $question = new ConfirmationQuestion(
             sprintf(


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30911](https://jira.ez.no/browse/EZP-30911)
| **Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR adds an option to pass array option `location-id` so regeneration of URL aliases can be done for only specific locations, like this:
`php bin/console ezplatform:urls:regenerate-aliases --location-id=1 --location-id=2 --location-id=100`

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
