### PR TITLE
EZP-30969: Added method to fetch paginated list of content's reverse relations

### DIFF
--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\API\Repository;
 use eZ\Publish\API\Repository\Values\Content\ContentDraftList;
 use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\API\Repository\Values\Content\RelationList;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
@@ -394,6 +395,21 @@ interface ContentService
      * @return \eZ\Publish\API\Repository\Values\Content\Relation[]
      */
     public function loadReverseRelations(ContentInfo $contentInfo);
+
+    /**
+     * Loads all incoming relations for a content object.
+     *
+     * The relations come only from published versions of the source content objects.
+     * If the user is not allowed to read specific version then UnauthorizedRelationListItem is returned
+     * {@link \eZ\Publish\API\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem}
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     * @param int $limit
+     * @param int $offset
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\RelationList
+     */
+    public function loadReverseRelationList(ContentInfo $contentInfo, int $offset = 0, int $limit = -1): RelationList;
 
     /**
      * Adds a relation of type common.

--- a/eZ/Publish/API/Repository/Lists/UnauthorizedListItem.php
+++ b/eZ/Publish/API/Repository/Lists/UnauthorizedListItem.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 
 namespace eZ\Publish\API\Repository\Lists;
 
+/**
+ * This class represents an element of the list to which the user has no access.
+ */
 abstract class UnauthorizedListItem
 {
     /** @var string */

--- a/eZ/Publish/API/Repository/Lists/UnauthorizedListItem.php
+++ b/eZ/Publish/API/Repository/Lists/UnauthorizedListItem.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Lists;
+
+abstract class UnauthorizedListItem
+{
+    /** @var string */
+    private $module;
+
+    /** @var string */
+    private $function;
+
+    /** @var array */
+    private $payload;
+
+    /**
+     * @param string $module
+     * @param string $function
+     * @param array $payload
+     */
+    public function __construct(string $module, string $function, array $payload)
+    {
+        $this->module = $module;
+        $this->function = $function;
+        $this->payload = $payload;
+    }
+
+    /**
+     * @return string
+     */
+    public function getModule(): string
+    {
+        return $this->module;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFunction(): string
+    {
+        return $this->function;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -3761,6 +3761,160 @@ XML
     }
 
     /**
+     * @covers \eZ\Publish\API\Repository\ContentService::loadReverseRelationList
+     */
+    public function testLoadReverseRelationList(): void
+    {
+        $draft1 = $this->contentService->createContentDraft(
+            $this->createFolder([self::ENG_GB => 'Foo'], 2)->contentInfo
+        );
+        $draft2 = $this->contentService->createContentDraft(
+            $this->createFolder([self::ENG_GB => 'Bar'], 2)->contentInfo
+        );
+        $draft3 = $this->contentService->createContentDraft(
+            $this->createFolder([self::ENG_GB => 'Baz'], 2)->contentInfo
+        );
+
+        $contentWithReverseRelations = $this->createContentWithReverseRelations([
+            $draft1,
+            $draft2,
+            $draft3,
+        ]);
+
+        $contentInfo = $contentWithReverseRelations->content->contentInfo;
+
+        $reverseRelationList = $this->contentService->loadReverseRelationList($contentInfo);
+
+        $this->assertSame(3, $reverseRelationList->totalCount);
+        $this->assertEquals(
+            $contentWithReverseRelations->reverseRelations[2]->contentInfo,
+            $reverseRelationList->items[0]->getRelation()->sourceContentInfo
+        );
+        $this->assertEquals(
+            $contentWithReverseRelations->reverseRelations[1]->contentInfo,
+            $reverseRelationList->items[1]->getRelation()->sourceContentInfo
+        );
+        $this->assertEquals(
+            $contentWithReverseRelations->reverseRelations[0]->contentInfo,
+            $reverseRelationList->items[2]->getRelation()->sourceContentInfo
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\ContentService::loadReverseRelationList
+     */
+    public function testLoadReverseRelationListWithPagination(): void
+    {
+        $draft1 = $this->contentService->createContentDraft(
+            $this->createFolder([self::ENG_GB => 'Foo'], 2)->contentInfo
+        );
+        $draft2 = $this->contentService->createContentDraft(
+            $this->createFolder([self::ENG_GB => 'Bar'], 2)->contentInfo
+        );
+        $draft3 = $this->contentService->createContentDraft(
+            $this->createFolder([self::ENG_GB => 'Baz'], 2)->contentInfo
+        );
+
+        $contentWithReverseRelations = $this->createContentWithReverseRelations([
+            $draft1,
+            $draft2,
+            $draft3,
+        ]);
+
+        $contentInfo = $contentWithReverseRelations->content->contentInfo;
+
+        $reverseRelationPage1 = $this->contentService->loadReverseRelationList($contentInfo, 0, 2);
+        $reverseRelationPage2 = $this->contentService->loadReverseRelationList($contentInfo, 2, 2);
+        $this->assertSame(3, $reverseRelationPage1->totalCount);
+        $this->assertSame(3, $reverseRelationPage2->totalCount);
+        $this->assertEquals(
+            $contentWithReverseRelations->reverseRelations[2]->contentInfo,
+            $reverseRelationPage1->items[0]->getRelation()->sourceContentInfo
+        );
+        $this->assertEquals(
+            $contentWithReverseRelations->reverseRelations[1]->contentInfo,
+            $reverseRelationPage1->items[1]->getRelation()->sourceContentInfo
+        );
+        $this->assertEquals(
+            $contentWithReverseRelations->reverseRelations[0]->contentInfo,
+            $reverseRelationPage2->items[0]->getRelation()->sourceContentInfo
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\ContentService::loadReverseRelationList
+     */
+    public function testLoadReverseRelationListSkipsArchivedContent(): void
+    {
+        $trashService = $this->getRepository()->getTrashService();
+
+        $draft1 = $this->contentService->createContentDraft(
+            $this->createFolder([self::ENG_GB => 'Foo'], 2)->contentInfo
+        );
+        $draft2 = $this->contentService->createContentDraft(
+            $this->createFolder([self::ENG_GB => 'Bar'], 2)->contentInfo
+        );
+        $draft3 = $this->contentService->createContentDraft(
+            $this->createFolder([self::ENG_GB => 'Baz'], 2)->contentInfo
+        );
+
+        $contentWithReverseRelations = $this->createContentWithReverseRelations([
+            $draft1,
+            $draft2,
+            $draft3,
+        ]);
+
+        $locationToTrash = $this->locationService->loadLocation($draft3->contentInfo->mainLocationId);
+
+        // Trashing Content's last Location will change its status to archived, in this case relation from it will not be loaded.
+        $trashService->trash($locationToTrash);
+
+        $contentInfo = $contentWithReverseRelations->content->contentInfo;
+        $reverseRelationList = $this->contentService->loadReverseRelationList($contentInfo);
+
+        $this->assertSame(2, $reverseRelationList->totalCount);
+        $this->assertEquals(
+            $contentWithReverseRelations->reverseRelations[1]->contentInfo,
+            $reverseRelationList->items[0]->getRelation()->sourceContentInfo
+        );
+        $this->assertEquals(
+            $contentWithReverseRelations->reverseRelations[0]->contentInfo,
+            $reverseRelationList->items[1]->getRelation()->sourceContentInfo
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\ContentService::loadReverseRelationList
+     */
+    public function testLoadReverseRelationListSkipsDraftContent()
+    {
+        $draft1 = $this->contentService->createContentDraft(
+            $this->createFolder([self::ENG_GB => 'Foo'], 2)->contentInfo
+        );
+
+        $contentWithReverseRelations = $this->createContentWithReverseRelations([$draft1]);
+
+        $contentInfo = $contentWithReverseRelations->content->contentInfo;
+
+        // create a relation, but without publishing it
+        $draft2 = $this->contentService->createContentDraft(
+            $this->createFolder([self::ENG_GB => 'Bar'], 2)->contentInfo
+        );
+        $this->contentService->addRelation(
+            $draft2->getVersionInfo(),
+            $contentInfo
+        );
+
+        $reverseRelationList = $this->contentService->loadReverseRelationList($contentInfo);
+
+        $this->assertSame(1, $reverseRelationList->totalCount);
+        $this->assertEquals(
+            $contentWithReverseRelations->reverseRelations[0]->contentInfo,
+            $reverseRelationList->items[0]->getRelation()->sourceContentInfo
+        );
+    }
+
+    /**
      * Test for the deleteRelation() method.
      *
      * @see \eZ\Publish\API\Repository\ContentService::deleteRelation()

--- a/eZ/Publish/API/Repository/Values/Content/RelationList.php
+++ b/eZ/Publish/API/Repository/Values/Content/RelationList.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content;
+
+use ArrayIterator;
+use Iterator;
+use IteratorAggregate;
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * List of relations.
+ */
+class RelationList extends ValueObject implements IteratorAggregate
+{
+    /**
+     * @var int
+     */
+    public $totalCount = 0;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\RelationList\RelationListItemInterface[]
+     */
+    public $items = [];
+
+    public function getIterator(): Iterator
+    {
+        return new ArrayIterator($this->items);
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/RelationList/Item/RelationListItem.php
+++ b/eZ/Publish/API/Repository/Values/Content/RelationList/Item/RelationListItem.php
@@ -39,6 +39,6 @@ class RelationListItem implements RelationListItemInterface
      */
     public function hasRelation(): bool
     {
-        return $this->relation instanceof Relation;
+        return true;
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/RelationList/Item/RelationListItem.php
+++ b/eZ/Publish/API/Repository/Values/Content/RelationList/Item/RelationListItem.php
@@ -16,9 +16,7 @@ use eZ\Publish\API\Repository\Values\Content\RelationList\RelationListItemInterf
  */
 class RelationListItem implements RelationListItemInterface
 {
-    /**
-     * @var \eZ\Publish\API\Repository\Values\Content\Relation
-     */
+    /** @var \eZ\Publish\API\Repository\Values\Content\Relation */
     private $relation;
 
     public function __construct(Relation $relation)
@@ -26,17 +24,11 @@ class RelationListItem implements RelationListItemInterface
         $this->relation = $relation;
     }
 
-    /**
-     * @return \eZ\Publish\API\Repository\Values\Content\Relation|null
-     */
     public function getRelation(): ?Relation
     {
         return $this->relation;
     }
 
-    /**
-     * @return bool
-     */
     public function hasRelation(): bool
     {
         return true;

--- a/eZ/Publish/API/Repository/Values/Content/RelationList/Item/RelationListItem.php
+++ b/eZ/Publish/API/Repository/Values/Content/RelationList/Item/RelationListItem.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\RelationList\Item;
+
+use eZ\Publish\API\Repository\Values\Content\Relation;
+use eZ\Publish\API\Repository\Values\Content\RelationList\RelationListItemInterface;
+
+/**
+ * Item of relation list.
+ */
+class RelationListItem implements RelationListItemInterface
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Relation
+     */
+    private $relation;
+
+    public function __construct(Relation $relation)
+    {
+        $this->relation = $relation;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Relation|null
+     */
+    public function getRelation(): ?Relation
+    {
+        return $this->relation;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasRelation(): bool
+    {
+        return $this->relation instanceof Relation;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/RelationList/Item/UnauthorizedRelationListItem.php
+++ b/eZ/Publish/API/Repository/Values/Content/RelationList/Item/UnauthorizedRelationListItem.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\RelationList\Item;
+
+use eZ\Publish\API\Repository\Lists\UnauthorizedListItem;
+use eZ\Publish\API\Repository\Values\Content\RelationList\RelationListItemInterface;
+use eZ\Publish\API\Repository\Values\Content\Relation;
+
+/**
+ * Item of relation list.
+ */
+final class UnauthorizedRelationListItem extends UnauthorizedListItem implements RelationListItemInterface
+{
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Relation|null
+     */
+    public function getRelation(): ?Relation
+    {
+        return null;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasRelation(): bool
+    {
+        return false;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/RelationList/Item/UnauthorizedRelationListItem.php
+++ b/eZ/Publish/API/Repository/Values/Content/RelationList/Item/UnauthorizedRelationListItem.php
@@ -17,17 +17,11 @@ use eZ\Publish\API\Repository\Values\Content\Relation;
  */
 final class UnauthorizedRelationListItem extends UnauthorizedListItem implements RelationListItemInterface
 {
-    /**
-     * @return \eZ\Publish\API\Repository\Values\Content\Relation|null
-     */
     public function getRelation(): ?Relation
     {
         return null;
     }
 
-    /**
-     * @return bool
-     */
     public function hasRelation(): bool
     {
         return false;

--- a/eZ/Publish/API/Repository/Values/Content/RelationList/RelationListItemInterface.php
+++ b/eZ/Publish/API/Repository/Values/Content/RelationList/RelationListItemInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\RelationList;
+
+use eZ\Publish\API\Repository\Values\Content\Relation;
+
+interface RelationListItemInterface
+{
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Relation|null
+     */
+    public function getRelation(): ?Relation;
+
+    /**
+     * @return bool
+     */
+    public function hasRelation(): bool;
+}

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -432,7 +432,7 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
             'content' => $destinationContentId,
             'offset' => $offset,
             'limit' => $limit,
-            'type' => $type
+            'type' => $type,
         ]);
 
         return $this->persistenceHandler->contentHandler()->loadReverseRelationList(

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -428,7 +428,12 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
         int $limit = -1,
         ?int $type = null
     ): array {
-        $this->logger->logCall(__METHOD__, ['content' => $destinationContentId, 'type' => $type]);
+        $this->logger->logCall(__METHOD__, [
+            'content' => $destinationContentId,
+            'offset' => $offset,
+            'limit' => $limit,
+            'type' => $type
+        ]);
 
         return $this->persistenceHandler->contentHandler()->loadReverseRelationList(
             $destinationContentId,

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -422,6 +422,25 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
     /**
      * {@inheritdoc}
      */
+    public function loadReverseRelationList(
+        int $destinationContentId,
+        int $offset = 0,
+        int $limit = -1,
+        ?int $type = null
+    ): array {
+        $this->logger->logCall(__METHOD__, ['content' => $destinationContentId, 'type' => $type]);
+
+        return $this->persistenceHandler->contentHandler()->loadReverseRelationList(
+            $destinationContentId,
+            $offset,
+            $limit,
+            $type
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function publish($contentId, $versionNo, MetadataUpdateStruct $struct)
     {
         $this->logger->logCall(__METHOD__, ['content' => $contentId, 'version' => $versionNo, 'struct' => $struct]);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -432,7 +432,7 @@ abstract class Gateway
      *
      * @return array
      */
-    abstract public function listReverseRelations($contentId, int $offset = 0, int $limit = -1, ?int $relationType = null): array;
+    abstract public function listReverseRelations(int $contentId, int $offset = 0, int $limit = -1, ?int $relationType = null): array;
 
     /**
      * Deletes the relation with the given $relationId.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -428,11 +428,11 @@ abstract class Gateway
      * @param int $contentId
      * @param int $offset
      * @param int $limit
-     * @param int $relationType
+     * @param int|null $relationType
      *
-     * @return string[][]
+     * @return array
      */
-    abstract public function listReverseRelations($contentId, int $offset = 0, int $limit = -1, $relationType = null): array;
+    abstract public function listReverseRelations($contentId, int $offset = 0, int $limit = -1, ?int $relationType = null): array;
 
     /**
      * Deletes the relation with the given $relationId.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -423,6 +423,18 @@ abstract class Gateway
     abstract public function loadReverseRelations($contentId, $relationType = null);
 
     /**
+     * Loads paginated data of related to/from $contentId.
+     *
+     * @param int $contentId
+     * @param int $offset
+     * @param int $limit
+     * @param int $relationType
+     *
+     * @return string[][]
+     */
+    abstract public function listReverseRelations($contentId, int $offset = 0, int $limit = -1, $relationType = null): array;
+
+    /**
      * Deletes the relation with the given $relationId.
      *
      * @param int $relationId

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -2038,6 +2038,48 @@ HEREDOC;
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function listReverseRelations($toContentId, int $offset = 0, int $limit = -1, $relationType = null): array
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $query = $this->createRelationFindQuery();
+        $expr = $query->expr();
+        $query
+            ->where(
+                $expr->eq('l.to_contentobject_id', ':toContentId')
+            )
+            ->innerJoin(
+                'l',
+                'ezcontentobject',
+                'c',
+                $expr->andX(
+                    $expr->eq('l.from_contentobject_id', 'c.id'),
+                    $expr->eq('l.from_contentobject_version', 'c.current_version'),
+                    $expr->eq('c.status', 1)
+                )
+            )
+            ->setParameter(':toContentId', $toContentId, ParameterType::INTEGER);
+
+        // relation type
+        if ($relationType !== null) {
+            $query->andWhere(
+                $expr->gt(
+                    $platform->getBitAndComparisonExpression('l.relation_type', $relationType),
+                    0
+                )
+            );
+        }
+        $query->setFirstResult($offset);
+        if ($limit > 0) {
+            $query->setMaxResults($limit);
+        }
+        $query->orderBy('l.id', 'DESC');
+
+        return $query->execute()->fetchAll(FetchMode::ASSOCIATIVE);
+    }
+
+    /**
      * Inserts a new relation database record.
      *
      * @param \eZ\Publish\SPI\Persistence\Content\Relation\CreateStruct $createStruct
@@ -2497,6 +2539,30 @@ HEREDOC;
                     $expr->eq('t.contentobject_id', 'v.contentobject_id'),
                     $expr->eq('t.main_node_id', 't.node_id')
                 )
+            );
+
+        return $query;
+    }
+
+    /**
+     * Creates a select query for content relations.
+     *
+     * @return \Doctrine\DBAL\Query\QueryBuilder
+     */
+    public function createRelationFindQuery(): DoctrineQueryBuilder
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select(
+                'l.id AS ezcontentobject_link_id',
+                'l.contentclassattribute_id AS ezcontentobject_link_contentclassattribute_id',
+                'l.from_contentobject_id AS ezcontentobject_link_from_contentobject_id',
+                'l.from_contentobject_version AS ezcontentobject_link_from_contentobject_version',
+                'l.relation_type AS ezcontentobject_link_relation_type',
+                'l.to_contentobject_id AS ezcontentobject_link_to_contentobject_id'
+            )
+            ->from(
+                'ezcontentobject_link', 'l'
             );
 
         return $query;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -2040,7 +2040,7 @@ HEREDOC;
     /**
      * {@inheritdoc}
      */
-    public function listReverseRelations($toContentId, int $offset = 0, int $limit = -1, $relationType = null): array
+    public function listReverseRelations($toContentId, int $offset = 0, int $limit = -1, ?int $relationType = null): array
     {
         $platform = $this->connection->getDatabasePlatform();
         $query = $this->createRelationFindQuery();
@@ -2056,7 +2056,7 @@ HEREDOC;
                 $expr->andX(
                     $expr->eq('l.from_contentobject_id', 'c.id'),
                     $expr->eq('l.from_contentobject_version', 'c.current_version'),
-                    $expr->eq('c.status', 1)
+                    $expr->eq('c.status', ContentInfo::STATUS_PUBLISHED)
                 )
             )
             ->setParameter(':toContentId', $toContentId, ParameterType::INTEGER);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -2040,15 +2040,12 @@ HEREDOC;
     /**
      * {@inheritdoc}
      */
-    public function listReverseRelations($toContentId, int $offset = 0, int $limit = -1, ?int $relationType = null): array
+    public function listReverseRelations(int $toContentId, int $offset = 0, int $limit = -1, ?int $relationType = null): array
     {
         $platform = $this->connection->getDatabasePlatform();
         $query = $this->createRelationFindQuery();
         $expr = $query->expr();
         $query
-            ->where(
-                $expr->eq('l.to_contentobject_id', ':toContentId')
-            )
             ->innerJoin(
                 'l',
                 'ezcontentobject',
@@ -2058,6 +2055,9 @@ HEREDOC;
                     $expr->eq('l.from_contentobject_version', 'c.current_version'),
                     $expr->eq('c.status', ContentInfo::STATUS_PUBLISHED)
                 )
+            )
+            ->where(
+                $expr->eq('l.to_contentobject_id', ':toContentId')
             )
             ->setParameter(':toContentId', $toContentId, ParameterType::INTEGER);
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -727,6 +727,18 @@ class ExceptionConversion extends Gateway
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function listReverseRelations($contentId, int $offset = 0, int $limit = -1, $relationType = null): array
+    {
+        try {
+            return $this->innerGateway->listReverseRelations($contentId, $offset, $limit, $relationType);
+        } catch (DBALException | PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
+
+    /**
      * Deletes the relation with the given $relationId.
      *
      * @param int $relationId

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -729,7 +729,7 @@ class ExceptionConversion extends Gateway
     /**
      * {@inheritdoc}
      */
-    public function listReverseRelations($contentId, int $offset = 0, int $limit = -1, ?int $relationType = null): array
+    public function listReverseRelations(int $contentId, int $offset = 0, int $limit = -1, ?int $relationType = null): array
     {
         try {
             return $this->innerGateway->listReverseRelations($contentId, $offset, $limit, $relationType);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -729,7 +729,7 @@ class ExceptionConversion extends Gateway
     /**
      * {@inheritdoc}
      */
-    public function listReverseRelations($contentId, int $offset = 0, int $limit = -1, $relationType = null): array
+    public function listReverseRelations($contentId, int $offset = 0, int $limit = -1, ?int $relationType = null): array
     {
         try {
             return $this->innerGateway->listReverseRelations($contentId, $offset, $limit, $relationType);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -850,6 +850,20 @@ class Handler implements BaseContentHandler
     /**
      * {@inheritdoc}
      */
+    public function loadReverseRelationList(
+        int $destinationContentId,
+        int $offset = 0,
+        int $limit = -1,
+        ?int $type = null
+    ): array {
+        return $this->mapper->extractRelationsFromRows(
+            $this->contentGateway->listReverseRelations($destinationContentId, $offset, $limit, $type)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function removeTranslationFromContent($contentId, $languageCode)
     {
         @trigger_error(

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
+use eZ\Publish\API\Repository\Values\Content\RelationList;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -638,6 +639,14 @@ class ContentService implements APIContentService, Sessionable
      * @return \eZ\Publish\API\Repository\Values\Content\Relation[]
      */
     public function loadReverseRelations(ContentInfo $contentInfo)
+    {
+        throw new \Exception('@todo: Implement.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadReverseRelationList(ContentInfo $contentInfo, int $offset = 0, int $limit = -1): RelationList
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\Values\Content\DraftList\Item\UnauthorizedContentD
 use eZ\Publish\API\Repository\Values\Content\RelationList;
 use eZ\Publish\API\Repository\Values\Content\RelationList\Item\RelationListItem;
 use eZ\Publish\API\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem;
+use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\SPI\Persistence\Handler;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
+use eZ\Publish\API\Repository\Values\Content\RelationList;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
@@ -189,6 +190,11 @@ class ContentService implements ContentServiceInterface
     public function loadReverseRelations(ContentInfo $contentInfo)
     {
         return $this->service->loadReverseRelations($contentInfo);
+    }
+
+    public function loadReverseRelationList(ContentInfo $contentInfo, int $offset = 0, int $limit = -1): RelationList
+    {
+        return $this->service->loadReverseRelationList($contentInfo, $offset, $limit);
     }
 
     public function addRelation(VersionInfo $sourceVersion, ContentInfo $destinationContent)

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\RelationList;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\User\User;
@@ -542,6 +543,14 @@ class ContentService implements ContentServiceInterface
     public function loadReverseRelations(ContentInfo $contentInfo)
     {
         return $this->service->loadReverseRelations($contentInfo);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadReverseRelationList(ContentInfo $contentInfo, int $offset = 0, int $limit = -1): RelationList
+    {
+        return $this->service->loadReverseRelationList($contentInfo, $offset, $limit);
     }
 
     /**

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -315,6 +315,25 @@ interface Handler
     public function loadReverseRelations($destinationContentId, $type = null);
 
     /**
+     * Loads paginated relations from $contentId. Optionally, loads only those with $type.
+     *
+     * Only loads relations against published versions.
+     *
+     * @param int $destinationContentId Destination Content ID
+     * @param int $offset
+     * @param int $limit
+     * @param int|null $type The relation type bitmask {@see \eZ\Publish\API\Repository\Values\Content\Relation}
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\Relation[]
+     */
+    public function loadReverseRelationList(
+        int $destinationContentId,
+        int $offset = 0,
+        int $limit = -1,
+        ?int $type = null
+    ): array;
+
+    /**
      * Performs the publishing operations required to set the version identified by $updateStruct->versionNo and
      * $updateStruct->id as the published one.
      *


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30969](https://jira.ez.no/browse/EZP-30969)
| **Bug/Improvement**| yes
| **Required by** | ezsystems/ezpublish-kernel#2774
| **New feature**    | no
| **Target version** | `7.5` for eZ Platform `v2.5.x` LTS
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This method is needed to add pagination to content's reverse relation list. It is related to [https://jira.ez.no/browse/EZP-30900](https://jira.ez.no/browse/EZP-30900) and [https://jira.ez.no/browse/EZP-30968](https://jira.ez.no/browse/EZP-30968)

A command which can help during QA: https://gist.github.com/mikadamczyk/1d45ef638ffb18357883e7c301fa5c15

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
