### PR TITLE
EZP-30899: Propagated ContentInfo::isHidden status when publishing

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -234,7 +234,7 @@ class ContentViewBuilder implements ViewBuilder
 
         $request = $this->requestStack->getCurrentRequest();
         if (!$request || !$request->attributes->get(PreviewController::PREVIEW_PARAMETER_NAME, false)) {
-            if ($location->invisible) {
+            if ($location->invisible || $location->hidden) {
                 throw new HiddenLocationException($location, 'Location cannot be displayed as it is flagged as invisible.');
             }
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -83,6 +83,7 @@ class Mapper
         $contentInfo->currentVersionNo = $currentVersionNo;
         $contentInfo->status = ContentInfo::STATUS_DRAFT;
         $contentInfo->isPublished = false;
+        $contentInfo->isHidden = $struct->isHidden;
 
         return $contentInfo;
     }
@@ -507,6 +508,7 @@ class Mapper
         $struct->initialLanguageId = $this->languageHandler->loadByLanguageCode($content->versionInfo->initialLanguageCode)->id;
         $struct->mainLanguageId = $this->languageHandler->loadByLanguageCode($content->versionInfo->contentInfo->mainLanguageCode)->id;
         $struct->modified = time();
+        $struct->isHidden = $content->versionInfo->contentInfo->isHidden;
 
         foreach ($content->fields as $field) {
             $newField = clone $field;

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1636,12 +1636,13 @@ class ContentService implements ContentServiceInterface
             $publicationDate = $currentTime;
         }
 
+        $contentInfo = $versionInfo->getContentInfo();
         $metadataUpdateStruct = new SPIMetadataUpdateStruct();
         $metadataUpdateStruct->publicationDate = $publicationDate;
         $metadataUpdateStruct->modificationDate = $currentTime;
-        $metadataUpdateStruct->isHidden = $versionInfo->contentInfo->isHidden;
+        $metadataUpdateStruct->isHidden = $contentInfo->isHidden;
 
-        $contentId = $versionInfo->getContentInfo()->id;
+        $contentId = $contentInfo->id;
         $spiContent = $this->persistenceHandler->contentHandler()->publish(
             $contentId,
             $versionInfo->versionNo,

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1639,6 +1639,7 @@ class ContentService implements ContentServiceInterface
         $metadataUpdateStruct = new SPIMetadataUpdateStruct();
         $metadataUpdateStruct->publicationDate = $publicationDate;
         $metadataUpdateStruct->modificationDate = $currentTime;
+        $metadataUpdateStruct->isHidden = $versionInfo->contentInfo->isHidden;
 
         $contentId = $versionInfo->getContentInfo()->id;
         $spiContent = $this->persistenceHandler->contentHandler()->publish(

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5483,8 +5483,14 @@ class ContentTest extends BaseServiceMockTest
 
         $contentInfoMock->expects($this->any())
             ->method('__get')
-            ->with('id')
-            ->will($this->returnValue(42));
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['isHidden', true],
+                        ['id', 42],
+                    ]
+                )
+            );
         $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock->expects($this->any())
@@ -5542,7 +5548,7 @@ class ContentTest extends BaseServiceMockTest
             ->will($this->returnValue($versionInfoMock));
 
         /* @var \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfoMock */
-        $content = $this->mockPublishVersion(123456, 126666);
+        $content = $this->mockPublishVersion(123456, 126666, true);
         $locationServiceMock->expects($this->once())
             ->method('createLocation')
             ->with(
@@ -5608,8 +5614,13 @@ class ContentTest extends BaseServiceMockTest
 
         $contentInfoMock->expects($this->any())
             ->method('__get')
-            ->with('id')
-            ->will($this->returnValue(42));
+            ->will(
+                $this->returnValueMap([
+                    ['isHidden', true],
+                    ['id', 42],
+                ])
+            );
+
         $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock->expects($this->any())
@@ -5665,7 +5676,7 @@ class ContentTest extends BaseServiceMockTest
             ->will($this->returnValue($versionInfoMock));
 
         /* @var \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfoMock */
-        $content = $this->mockPublishVersion(123456, 126666);
+        $content = $this->mockPublishVersion(123456, 126666, true);
         $locationServiceMock->expects($this->once())
             ->method('createLocation')
             ->with(
@@ -5862,10 +5873,11 @@ class ContentTest extends BaseServiceMockTest
     /**
      * @param int|null $publicationDate
      * @param int|null $modificationDate
+     * @param bool $isHidden
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
-    protected function mockPublishVersion($publicationDate = null, $modificationDate = null)
+    protected function mockPublishVersion($publicationDate = null, $modificationDate = null, $isHidden = false)
     {
         $versionInfoMock = $this->createMock(APIVersionInfo::class);
         $contentInfoMock = $this->createMock(APIContentInfo::class);
@@ -5925,6 +5937,7 @@ class ContentTest extends BaseServiceMockTest
         // Account for 1 second of test execution time
         $metadataUpdateStruct->publicationDate = $publicationDate;
         $metadataUpdateStruct->modificationDate = $modificationDate ?? $currentTime;
+        $metadataUpdateStruct->isHidden = $isHidden;
 
         $contentHandlerMock->expects($this->once())
             ->method('publish')

--- a/eZ/Publish/SPI/Persistence/Content/CreateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/CreateStruct.php
@@ -72,4 +72,11 @@ class CreateStruct extends ValueObject
      * @var int
      */
     public $modified;
+
+    /**
+     * Is hidden flag.
+     *
+     * @var bool
+     */
+    public $isHidden;
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30889](https://jira.ez.no/browse/EZP-30889)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

https://jira.ez.no/browse/EZP-30889

Excerpt from JIRA:
>Content marked as "hidden" does not preserve this state after copying it to another Location.


**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
