### PR TITLE
EZP-30988: Implemented Section filtering URL Query Criterion

### DIFF
--- a/eZ/Publish/API/Repository/Tests/URLServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLServiceTest.php
@@ -32,91 +32,109 @@ class URLServiceTest extends BaseURLServiceTest
                 'name' => 'Twitter',
                 'url' => 'http://twitter.com/',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'Facebook',
                 'url' => 'http://www.facebook.com/',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'Google',
                 'url' => 'http://www.google.com/',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'Vimeo',
                 'url' => 'http://vimeo.com/',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'Facebook Sharer',
                 'url' => 'http://www.facebook.com/sharer.php',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'Youtube',
                 'url' => 'http://www.youtube.com/',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'Googel support',
                 'url' => 'http://support.google.com/chrome/answer/95647?hl=es',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'Instagram',
                 'url' => 'http://instagram.com/',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'Discuz',
                 'url' => 'http://www.discuz.net/forum.php',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'Google calendar',
                 'url' => 'http://calendar.google.com/calendar/render',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'Wikipedia',
                 'url' => 'http://www.wikipedia.org/',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'Google Analytics',
                 'url' => 'http://www.google.com/analytics/',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'nazwa.pl',
                 'url' => 'http://www.nazwa.pl/',
                 'published' => true,
+                'sectionId' => 1,
             ],
             [
                 'name' => 'Apache',
                 'url' => 'http://www.apache.org/',
                 'published' => true,
+                'sectionId' => 2,
             ],
             [
                 'name' => 'Nginx',
                 'url' => 'http://www.nginx.com/',
                 'published' => true,
+                'sectionId' => 2,
             ],
             [
                 'name' => 'Microsoft.com',
                 'url' => 'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
                 'published' => true,
+                'sectionId' => 3,
             ],
             [
                 'name' => 'Dropbox',
                 'url' => 'http://www.dropbox.com/',
                 'published' => false,
+                'sectionId' => 3,
             ],
             [
                 'name' => 'Google [DE]',
                 'url' => 'http://www.google.de/',
                 'published' => true,
+                'sectionId' => 3,
             ],
         ];
 
@@ -132,6 +150,7 @@ class URLServiceTest extends BaseURLServiceTest
             $struct = $contentService->newContentCreateStruct($contentType, 'eng-GB');
             $struct->setField('name', $data['name']);
             $struct->setField('url', $data['url']);
+            $struct->sectionId = $data['sectionId'];
 
             $location = $locationService->newLocationCreateStruct($parentLocationId);
 
@@ -246,6 +265,119 @@ class URLServiceTest extends BaseURLServiceTest
 
         $query = new URLQuery();
         $query->filter = new Criterion\Validity(true);
+
+        $this->doTestFindUrls($query, $expectedUrls);
+    }
+
+    /**
+     * Test for URLService::findUrls() method.
+     *
+     * @covers \eZ\Publish\Core\Repository\URLService::findUrls
+     * @depends eZ\Publish\API\Repository\Tests\URLServiceTest::testFindUrls
+     */
+    public function testFindUrlsUsingSectionIdCriterion(): void
+    {
+        $expectedUrls = [
+            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'http://www.dropbox.com/',
+            'http://www.google.de/',
+        ];
+
+        $query = new URLQuery();
+        $query->filter = new Criterion\SectionId([3]);
+
+        $this->doTestFindUrls($query, $expectedUrls);
+    }
+
+    /**
+     * Test for URLService::findUrls() method.
+     *
+     * @covers \eZ\Publish\Core\Repository\URLService::findUrls()
+     * @depends eZ\Publish\API\Repository\Tests\URLServiceTest::testFindUrls
+     */
+    public function testFindUrlsUsingSectionIdAndValidityCriterionValid(): void
+    {
+        $expectedUrls = [
+            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'http://www.dropbox.com/',
+            'http://www.google.de/',
+        ];
+
+        $query = new URLQuery();
+        $query->filter = new Criterion\LogicalAnd([
+            new Criterion\SectionId([3]),
+            new Criterion\Validity(true),
+        ]);
+
+        $this->doTestFindUrls($query, $expectedUrls);
+    }
+
+    /**
+     * Test for URLService::findUrls() method.
+     *
+     * @covers \eZ\Publish\Core\Repository\URLService::findUrls
+     * @depends eZ\Publish\API\Repository\Tests\URLServiceTest::testFindUrls
+     */
+    public function testFindUrlsUsingSectionIdentifierCriterion(): void
+    {
+        $expectedUrls = [
+            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'http://www.dropbox.com/',
+            'http://www.google.de/',
+        ];
+
+        $query = new URLQuery();
+        $query->filter = new Criterion\SectionIdentifier(['media']);
+
+        $this->doTestFindUrls($query, $expectedUrls);
+    }
+
+    /**
+     * Test for URLService::findUrls() method.
+     *
+     * @covers \eZ\Publish\Core\Repository\URLService::findUrls()
+     * @depends eZ\Publish\API\Repository\Tests\URLServiceTest::testFindUrls
+     */
+    public function testFindUrlsUsingSectionIdentifierAndValidityCriterionValid(): void
+    {
+        $expectedUrls = [
+            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'http://www.dropbox.com/',
+            'http://www.google.de/',
+            'http://www.apache.org/',
+            'http://www.nginx.com/',
+        ];
+
+        $query = new URLQuery();
+        $query->filter = new Criterion\LogicalAnd([
+            new Criterion\SectionIdentifier(['media', 'users']),
+            new Criterion\Validity(true),
+        ]);
+
+        $this->doTestFindUrls($query, $expectedUrls);
+    }
+
+    /**
+     * Test for URLService::findUrls() method.
+     *
+     * @covers \eZ\Publish\Core\Repository\URLService::findUrls()
+     * @depends eZ\Publish\API\Repository\Tests\URLServiceTest::testFindUrls
+     */
+    public function testFindUrlsUsingSectionIdentifierOrSectionIdCriterion(): void
+    {
+        $expectedUrls = [
+            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'http://www.dropbox.com/',
+            'http://www.google.de/',
+            'http://www.apache.org/',
+            'http://www.nginx.com/',
+        ];
+
+        $query = new URLQuery();
+        $query->filter = new Criterion\LogicalOr([
+            new Criterion\SectionIdentifier(['media']),
+            new Criterion\SectionId([2]),
+        ]);
 
         $this->doTestFindUrls($query, $expectedUrls);
     }

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/SectionId.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/SectionId.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\URL\Query\Criterion;
+
+/**
+ * Matches URLs which used by content placed in specified section ids.
+ */
+class SectionId extends Matcher
+{
+    /**
+     * IDs of related content section.
+     *
+     * @var int[]
+     */
+    public $sectionIds;
+
+    /**
+     * @param int[] $sectionIds
+     */
+    public function __construct(array $sectionIds)
+    {
+        $this->sectionIds = $sectionIds;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/SectionIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/SectionIdentifier.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\URL\Query\Criterion;
+
+/**
+ * Matches URLs which used by content placed in specified section identifiers.
+ */
+class SectionIdentifier extends Matcher
+{
+    /**
+     * Identifiers of related content section.
+     *
+     * @var string[]
+     */
+    public $sectionIdentifiers;
+
+    /**
+     * @param string[] $sectionIdentifiers
+     */
+    public function __construct(array $sectionIdentifiers)
+    {
+        $this->sectionIdentifiers = $sectionIdentifiers;
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Gateway/DoctrineDatabase.php
@@ -243,21 +243,19 @@ class DoctrineDatabase extends Gateway
      *
      * @return \eZ\Publish\Core\Persistence\Database\SelectQuery
      */
-    protected function createSelectQuery()
+    protected function createSelectQuery(): SelectQuery
     {
-        $query = $this->handler->createSelectQuery();
-        $query->select(
-            $this->handler->quoteColumn(self::COLUMN_ID),
-            $this->handler->quoteColumn(self::COLUMN_URL),
-            $this->handler->quoteColumn(self::COLUMN_ORIGINAL_URL_MD5),
-            $this->handler->quoteColumn(self::COLUMN_IS_VALID),
-            $this->handler->quoteColumn(self::COLUMN_LAST_CHECKED),
-            $this->handler->quoteColumn(self::COLUMN_CREATED),
-            $this->handler->quoteColumn(self::COLUMN_MODIFIED)
-        )->from(
-            $this->handler->quoteTable(self::URL_TABLE)
-        );
-
-        return $query;
+        return $this->handler->createSelectQuery()
+            ->select(
+                $this->handler->quoteColumn(self::COLUMN_ID, self::URL_TABLE),
+                $this->handler->quoteColumn(self::COLUMN_URL, self::URL_TABLE),
+                $this->handler->quoteColumn(self::COLUMN_ORIGINAL_URL_MD5, self::URL_TABLE),
+                $this->handler->quoteColumn(self::COLUMN_IS_VALID, self::URL_TABLE),
+                $this->handler->quoteColumn(self::COLUMN_LAST_CHECKED, self::URL_TABLE),
+                $this->handler->quoteColumn(self::COLUMN_CREATED, self::URL_TABLE),
+                $this->handler->quoteColumn(self::COLUMN_MODIFIED, self::URL_TABLE)
+            )->from(
+                $this->handler->quoteTable(self::URL_TABLE)
+            );
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Base.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Base.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
+
+abstract class Base implements CriterionHandler
+{
+    /**
+     * Inner join `ezurl_object_link` table if not joined yet.
+     *
+     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     */
+    protected function joinContentObjectLink(SelectQuery $query): void
+    {
+        if (strpos($query->getQuery(), 'INNER JOIN ezurl_object_link ') === false) {
+            $query->innerJoin(
+                'ezurl_object_link',
+                $query->expr->eq('ezurl.id', 'ezurl_object_link.url_id')
+            );
+        }
+    }
+
+    /**
+     * Inner join `ezcontentobject` table if not joined yet.
+     *
+     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     */
+    protected function joinContentObject(SelectQuery $query): void
+    {
+        if (strpos($query->getQuery(), 'INNER JOIN ezcontentobject ') === false) {
+            $query->innerJoin(
+                'ezcontentobject',
+                $query->expr->eq('ezcontentobject.id', 'ezcontentobject_attribute.contentobject_id')
+            );
+        }
+    }
+
+    /**
+     * Inner join `ezcontentobject_attribute` table if not joined yet.
+     *
+     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     */
+    protected function joinContentObjectAttribute(SelectQuery $query): void
+    {
+        if (strpos($query->getQuery(), 'INNER JOIN ezcontentobject_attribute ') === false) {
+            $query->innerJoin('ezcontentobject_attribute', $query->expr->lAnd(
+                $query->expr->eq(
+                    'ezurl_object_link.contentobject_attribute_id',
+                    'ezcontentobject_attribute.id'
+                ),
+                $query->expr->eq(
+                    'ezurl_object_link.contentobject_attribute_version',
+                    'ezcontentobject_attribute.version'
+                )
+            ));
+        }
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/SectionId.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/SectionId.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
+
+use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
+
+class SectionId extends Base
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof Criterion\SectionId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion): string
+    {
+        $this->joinContentObjectLink($query);
+        $this->joinContentObjectAttribute($query);
+        $this->joinContentObject($query);
+
+        return $query->expr->in('ezcontentobject.section_id', $criterion->sectionIds);
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/SectionIdentifier.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/SectionIdentifier.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
+
+use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
+
+class SectionIdentifier extends Base
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof Criterion\SectionIdentifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion): string
+    {
+        $this->joinContentObjectLink($query);
+        $this->joinContentObjectAttribute($query);
+        $this->joinContentObject($query);
+
+        if (strpos($query->getQuery(), 'INNER JOIN ezsection ') === false) {
+            $query->innerJoin(
+                'ezsection',
+                $query->expr->eq('ezcontentobject.section_id', 'ezsection.id')
+            );
+        }
+
+        return $query->expr->in('ezsection.identifier', $criterion->sectionIdentifiers);
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/VisibleOnly.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/VisibleOnly.php
@@ -6,13 +6,12 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\ParameterType;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
-use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
-use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
-use PDO;
+use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 
-class VisibleOnly implements CriterionHandler
+class VisibleOnly extends Base
 {
     /**
      * {@inheritdoc}
@@ -27,43 +26,26 @@ class VisibleOnly implements CriterionHandler
      */
     public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion)
     {
-        return $query->expr->in('ezurl.id', $this->getVisibleOnlySubQuery($query));
-    }
+        $this->joinContentObjectLink($query);
+        $this->joinContentObjectAttribute($query);
 
-    /**
-     * Generate query that selects ids of visible URLs.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @return \eZ\Publish\Core\Persistence\Database\SelectQuery
-     */
-    protected function getVisibleOnlySubQuery(SelectQuery $query)
-    {
-        // TODO: The following query requires optimization
-        $subSelect = $query->subSelect();
-        $subSelect
-            ->selectDistinct('ezurl_object_link.url_id')
-            ->from('ezurl_object_link')
-            ->innerJoin(
-                'ezcontentobject_attribute',
-                $query->expr->lAnd(
-                    $query->expr->eq('ezurl_object_link.contentobject_attribute_id', 'ezcontentobject_attribute.id'),
-                    $query->expr->eq('ezurl_object_link.contentobject_attribute_version', 'ezcontentobject_attribute.version')
-                )
-            )
-            ->innerJoin(
-                'ezcontentobject_tree',
-                $query->expr->lAnd(
-                    $query->expr->eq('ezcontentobject_tree.contentobject_id', 'ezcontentobject_attribute.contentobject_id'),
-                    $query->expr->eq('ezcontentobject_tree.contentobject_version', 'ezcontentobject_attribute.version')
-                )
-            )
-            ->where(
+        $currentQuery = $query->getQuery();
+        if (strpos($currentQuery, 'INNER JOIN ezcontentobject_tree') === false) {
+            $query->innerJoin('ezcontentobject_tree', $query->expr->lAnd(
                 $query->expr->eq(
-                    'ezcontentobject_tree.is_invisible',
-                    $query->bindValue(0, null, PDO::PARAM_INT)
+                    'ezcontentobject_tree.contentobject_id',
+                    'ezcontentobject_attribute.contentobject_id'
+                ),
+                $query->expr->eq(
+                    'ezcontentobject_tree.contentobject_version',
+                    'ezcontentobject_attribute.version'
                 )
-            );
+            ));
+        }
 
-        return $subSelect;
+        return $query->expr->eq(
+            'ezcontentobject_tree.is_invisible',
+            $query->bindValue(0, null, ParameterType::INTEGER)
+        );
     }
 }

--- a/eZ/Publish/Core/settings/storage_engines/legacy/url_criterion_handlers.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/url_criterion_handlers.yml
@@ -7,6 +7,8 @@ parameters:
     ezpublish.persistence.legacy.url.criterion_handler.validity.class: eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler\Validity
     ezpublish.persistence.legacy.url.criterion_handler.pattern.class: eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler\Pattern
     ezpublish.persistence.legacy.url.criterion_handler.visible_only.class: eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler\VisibleOnly
+    ezpublish.persistence.legacy.url.criterion_handler.section_id.class: eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler\SectionId
+    ezpublish.persistence.legacy.url.criterion_handler.section_identifier.class: eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler\SectionIdentifier
 
 services:
    ezpublish.persistence.legacy.url.criterion_handler.base:
@@ -58,5 +60,17 @@ services:
    ezpublish.persistence.legacy.url.criterion_handler.visible_only:
        parent: ezpublish.persistence.legacy.url.criterion_handler.base
        class: '%ezpublish.persistence.legacy.url.criterion_handler.visible_only.class%'
+       tags:
+           - { name: ezpublish.persistence.legacy.url.criterion_handler }
+
+   ezpublish.persistence.legacy.url.criterion_handler.section_id:
+       parent: ezpublish.persistence.legacy.url.criterion_handler.base
+       class: '%ezpublish.persistence.legacy.url.criterion_handler.section_id.class%'
+       tags:
+           - { name: ezpublish.persistence.legacy.url.criterion_handler }
+
+   ezpublish.persistence.legacy.url.criterion_handler.section_identifier:
+       parent: ezpublish.persistence.legacy.url.criterion_handler.base
+       class: '%ezpublish.persistence.legacy.url.criterion_handler.section_identifier.class%'
        tags:
            - { name: ezpublish.persistence.legacy.url.criterion_handler }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30988](https://jira.ez.no/browse/EZP-30988)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5.x` for eZ Platform `v2.5.x` LTS
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

- Implement Section criteria for URL lookup
- Fix slow query when filter by VisibleOnly criteria

// Edited by @alongosz:
### QA
- You can play with the test command to find URLs filtered by Content Section:
https://github.com/ezsystems/ezplatform/compare/2.5...alongosz:for-qa-ezp-30988-find-urls-cmd.
Usage: `php ./bin/console test:find-urls [<url1> <url2> ...]`. No arguments returns all registered URLs. An URL is registered when e.g. added to Content RichText field or set via URL Field. By manipulating Content item Section you can test the feature.
- Sanity checks for LinkManager (might be an overkill, because new code is not used there).

### Doc

I can't find doc about API to find URLs. Either it's too late and I'm not seeing something obvious or indeed we need to document the whole thing (more than the scope of this feature).

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
