### PR TITLE
[Travis] Bumped solr version in tests to 3.0

### DIFF
--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -41,8 +41,8 @@ composer config -g github-oauth.github.com "d0285ed5c8644f30547572ead2ed897431c1
 if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then
     # Install openJDK8 as default v11 is too new for SOLR
     sudo apt-get install openjdk-8-jdk
-    echo "> Require ezsystems/ezplatform-solr-search-engine:^2.0.0@dev"
-    composer require --no-update ezsystems/ezplatform-solr-search-engine:^2.0.0@dev
+    echo "> Require ezsystems/ezplatform-solr-search-engine:^3.0.0@dev"
+    composer require --no-update ezsystems/ezplatform-solr-search-engine:^3.0.0@dev
 fi
 
 # Switch to another Symfony version if asked for


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a, see: https://github.com/ezsystems/ezplatform-solr-search-engine/pull/152
| **Bug/Improvement**| no
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

To quote from https://github.com/ezsystems/ezplatform-solr-search-engine/pull/152:
> Due to the major changes in Solr, support for 7.X will be part of the ezplatform-solr-search-engine 2.0 release which will be compatible with eZ Platform 2.5 release. Solr 6.X will be dropped in this release.
> Solr 7.X and Solr 8.X will be officialy supported in ezplatform-solr-search-engine 3.0 release which will be compatible with eZ Platform 3.X.