### PR TITLE
EZP-30973: Made siteaccess aware repository to be used as default

### DIFF
--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -265,3 +265,5 @@ site:
 * Service based SiteAccess Matchers now require to be tagged with `ezplatform.siteaccess.matcher`.
 
 * `eZ\Bundle\EzPublishCoreBundle\Controller` extends `Symfony\Bundle\FrameworkBundle\Controller\AbstractController` instead of `Symfony\Bundle\FrameworkBundle\Controller\Controller` which has limited access to the dependency injection container. See https://symfony.com/doc/current/service_container/service_subscribers_locators.html
+
+* SiteAccessAware Repository layer is now used by default. If you need load repository object in all translations, explicitly pass `\eZ\Publish\API\Repository\Values\Content\Language::ALL` as as prioritized languages list.

--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -266,4 +266,4 @@ site:
 
 * `eZ\Bundle\EzPublishCoreBundle\Controller` extends `Symfony\Bundle\FrameworkBundle\Controller\AbstractController` instead of `Symfony\Bundle\FrameworkBundle\Controller\Controller` which has limited access to the dependency injection container. See https://symfony.com/doc/current/service_container/service_subscribers_locators.html
 
-* SiteAccessAware Repository layer is now used by default. If you need load repository object in all translations, explicitly pass `\eZ\Publish\API\Repository\Values\Content\Language::ALL` as as prioritized languages list.
+* SiteAccessAware Repository layer is now used by default. If you need to load repository object in all translations, explicitly pass `\eZ\Publish\API\Repository\Values\Content\Language::ALL` as as prioritized languages list.

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -5739,7 +5739,7 @@ class ContentServiceTest extends BaseContentServiceTest
 
         foreach ($objectStateGroups as $objectStateGroup) {
             $contentState = $objectStateService->getContentState($contentInfo, $objectStateGroup);
-            foreach ($objectStateService->loadObjectStates($objectStateGroup) as $objectState) {
+            foreach ($objectStateService->loadObjectStates($objectStateGroup, []) as $objectState) {
                 // Only check the first object state which is the default one.
                 $this->assertEquals(
                     $objectState,

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -17,6 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\DraftList\Item\UnauthorizedContentDraftListItem;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
@@ -5739,7 +5740,7 @@ class ContentServiceTest extends BaseContentServiceTest
 
         foreach ($objectStateGroups as $objectStateGroup) {
             $contentState = $objectStateService->getContentState($contentInfo, $objectStateGroup);
-            foreach ($objectStateService->loadObjectStates($objectStateGroup, []) as $objectState) {
+            foreach ($objectStateService->loadObjectStates($objectStateGroup, Language::ALL) as $objectState) {
                 // Only check the first object state which is the default one.
                 $this->assertEquals(
                     $objectState,

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1510,12 +1510,12 @@ class LocationServiceTest extends BaseTest
 
         self::assertEquals(
             $folder1,
-            $contentService->loadContent($folder1->id)
+            $contentService->loadContent($folder1->id, [])
         );
 
         self::assertEquals(
             $folder2,
-            $contentService->loadContent($folder2->id)
+            $contentService->loadContent($folder2->id, [])
         );
 
         // only in case of Folder 3, main location id changed due to swap
@@ -1659,12 +1659,12 @@ class LocationServiceTest extends BaseTest
 
         self::assertEquals(
             $folder1,
-            $contentService->loadContent($folder1->id)
+            $contentService->loadContent($folder1->id, [])
         );
 
         self::assertEquals(
             $folder2,
-            $contentService->loadContent($folder2->id)
+            $contentService->loadContent($folder2->id, [])
         );
     }
 
@@ -2198,7 +2198,7 @@ class LocationServiceTest extends BaseTest
 
         foreach ($objectStateGroups as $objectStateGroup) {
             $contentState = $objectStateService->getContentState($contentInfo, $objectStateGroup);
-            foreach ($objectStateService->loadObjectStates($objectStateGroup) as $objectState) {
+            foreach ($objectStateService->loadObjectStates($objectStateGroup, []) as $objectState) {
                 // Only check the first object state which is the default one.
                 $this->assertEquals(
                     $objectState,

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\Exceptions\BadStateException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\LocationList;
@@ -1510,12 +1511,12 @@ class LocationServiceTest extends BaseTest
 
         self::assertEquals(
             $folder1,
-            $contentService->loadContent($folder1->id, [])
+            $contentService->loadContent($folder1->id, Language::ALL)
         );
 
         self::assertEquals(
             $folder2,
-            $contentService->loadContent($folder2->id, [])
+            $contentService->loadContent($folder2->id, Language::ALL)
         );
 
         // only in case of Folder 3, main location id changed due to swap
@@ -1659,12 +1660,12 @@ class LocationServiceTest extends BaseTest
 
         self::assertEquals(
             $folder1,
-            $contentService->loadContent($folder1->id, [])
+            $contentService->loadContent($folder1->id, Language::ALL)
         );
 
         self::assertEquals(
             $folder2,
-            $contentService->loadContent($folder2->id, [])
+            $contentService->loadContent($folder2->id, Language::ALL)
         );
     }
 
@@ -2198,7 +2199,7 @@ class LocationServiceTest extends BaseTest
 
         foreach ($objectStateGroups as $objectStateGroup) {
             $contentState = $objectStateService->getContentState($contentInfo, $objectStateGroup);
-            foreach ($objectStateService->loadObjectStates($objectStateGroup, []) as $objectState) {
+            foreach ($objectStateService->loadObjectStates($objectStateGroup, Language::ALL) as $objectState) {
                 // Only check the first object state which is the default one.
                 $this->assertEquals(
                     $objectState,

--- a/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
@@ -786,7 +786,8 @@ class ObjectStateServiceTest extends BaseTest
         $objectStateService = $repository->getObjectStateService();
 
         $loadedObjectStateGroup = $objectStateService->loadObjectStateGroup(
-            $objectStateGroupId
+            $objectStateGroupId,
+            []
         );
 
         $objectStateCreateStruct = $objectStateService->newObjectStateCreateStruct(
@@ -997,6 +998,11 @@ class ObjectStateServiceTest extends BaseTest
                 'priority' => 1,
                 'mainLanguageCode' => 'eng-US',
                 'languageCodes' => [0 => 'eng-US'],
+                'prioritizedLanguages' => [
+                    0 => 'eng-US',
+                    1 => 'eng-GB',
+                    2 => 'ger-DE',
+                ],
                 'names' => ['eng-US' => 'Locked'],
                 'descriptions' => ['eng-US' => ''],
             ],

--- a/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroupCreateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroupUpdateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
@@ -787,7 +788,7 @@ class ObjectStateServiceTest extends BaseTest
 
         $loadedObjectStateGroup = $objectStateService->loadObjectStateGroup(
             $objectStateGroupId,
-            []
+            Language::ALL
         );
 
         $objectStateCreateStruct = $objectStateService->newObjectStateCreateStruct(

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
@@ -1414,12 +1414,14 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
             ],
             34 => [
                 [
+                    'languages' => [],
                     'useAlwaysAvailable' => true,
                 ],
                 $mainLanguages,
             ],
             35 => [
                 [
+                    'languages' => [],
                     'useAlwaysAvailable' => false,
                 ],
                 $mainLanguages,
@@ -1431,7 +1433,9 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                 $mainLanguages,
             ],
             37 => [
-                [],
+                [
+                    'languages' => [],
+                ],
                 $mainLanguages,
             ],
             38 => [

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the UserServiceTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -29,7 +27,6 @@ use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Values\User\UserGroup;
 use Exception;
-use ReflectionClass;
 
 /**
  * Test case for operations in the UserService using in memory storage.
@@ -905,7 +902,7 @@ class UserServiceTest extends BaseTest
             'ez-user-Domain\username-by-login',
             'username-by-login@ez-user-Domain.com'
         );
-        $loadedUser = $userService->loadUserByLogin('ez-user-Domain\username-by-login');
+        $loadedUser = $userService->loadUserByLogin('ez-user-Domain\username-by-login', []);
 
         $this->assertEquals($createdUser, $loadedUser);
     }
@@ -1221,7 +1218,7 @@ class UserServiceTest extends BaseTest
         $user = $this->createUserVersion1();
 
         // Load the newly created user
-        $userReloaded = $userService->loadUser($user->id);
+        $userReloaded = $userService->loadUser($user->id, []);
         /* END: Use Case */
 
         $this->assertEquals($user, $userReloaded);
@@ -1269,7 +1266,7 @@ class UserServiceTest extends BaseTest
         $user = $this->createUserVersion1();
 
         // Load the newly created user
-        $userReloaded = $userService->loadUserByCredentials('user', 'secret');
+        $userReloaded = $userService->loadUserByCredentials('user', 'secret', []);
         /* END: Use Case */
 
         $this->assertEquals($user, $userReloaded);
@@ -1502,7 +1499,7 @@ class UserServiceTest extends BaseTest
         $user = $this->createUserVersion1();
 
         // Load the newly created user
-        $usersReloaded = $userService->loadUsersByEmail('user@example.com');
+        $usersReloaded = $userService->loadUsersByEmail('user@example.com', []);
         /* END: Use Case */
 
         $this->assertEquals([$user], $usersReloaded);
@@ -1705,32 +1702,10 @@ class UserServiceTest extends BaseTest
     public function testUpdateUserNoPassword()
     {
         $repository = $this->getRepository();
-        $eventUserService = $repository->getUserService();
-
-        $eventUserServiceReflection = new ReflectionClass($eventUserService);
-        $userServiceProperty = $eventUserServiceReflection->getProperty('innerService');
-        $userServiceProperty->setAccessible(true);
-        $userService = $userServiceProperty->getValue($eventUserService);
-
-        $userServiceReflection = new ReflectionClass($userService);
-        $settingsProperty = $userServiceReflection->getProperty('settings');
-        $settingsProperty->setAccessible(true);
-        $settingsProperty->setValue(
-            $userService,
-            [
-                'hashType' => User::PASSWORD_HASH_PHP_DEFAULT,
-            ] + $settingsProperty->getValue($userService)
-        );
+        $userService = $repository->getUserService();
 
         /* BEGIN: Use Case */
         $user = $this->createUserVersion1();
-
-        $settingsProperty->setValue(
-            $userService,
-            [
-                'hashType' => User::PASSWORD_HASH_PHP_DEFAULT,
-            ] + $settingsProperty->getValue($userService)
-        );
 
         // Create a new update struct instance
         $userUpdate = $userService->newUserUpdateStruct();
@@ -2800,7 +2775,7 @@ class UserServiceTest extends BaseTest
 
         $userService->updateUserToken($user, $userTokenUpdateStruct);
 
-        $loadedUser = $userService->loadUserByToken($userTokenUpdateStruct->hashKey);
+        $loadedUser = $userService->loadUserByToken($userTokenUpdateStruct->hashKey, []);
         self::assertEquals($user, $loadedUser);
 
         return $userTokenUpdateStruct->hashKey;

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
 use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
@@ -902,7 +903,7 @@ class UserServiceTest extends BaseTest
             'ez-user-Domain\username-by-login',
             'username-by-login@ez-user-Domain.com'
         );
-        $loadedUser = $userService->loadUserByLogin('ez-user-Domain\username-by-login', []);
+        $loadedUser = $userService->loadUserByLogin('ez-user-Domain\username-by-login', Language::ALL);
 
         $this->assertEquals($createdUser, $loadedUser);
     }
@@ -1218,7 +1219,7 @@ class UserServiceTest extends BaseTest
         $user = $this->createUserVersion1();
 
         // Load the newly created user
-        $userReloaded = $userService->loadUser($user->id, []);
+        $userReloaded = $userService->loadUser($user->id, Language::ALL);
         /* END: Use Case */
 
         $this->assertEquals($user, $userReloaded);
@@ -1266,7 +1267,7 @@ class UserServiceTest extends BaseTest
         $user = $this->createUserVersion1();
 
         // Load the newly created user
-        $userReloaded = $userService->loadUserByCredentials('user', 'secret', []);
+        $userReloaded = $userService->loadUserByCredentials('user', 'secret', Language::ALL);
         /* END: Use Case */
 
         $this->assertEquals($user, $userReloaded);
@@ -1499,7 +1500,7 @@ class UserServiceTest extends BaseTest
         $user = $this->createUserVersion1();
 
         // Load the newly created user
-        $usersReloaded = $userService->loadUsersByEmail('user@example.com', []);
+        $usersReloaded = $userService->loadUsersByEmail('user@example.com', Language::ALL);
         /* END: Use Case */
 
         $this->assertEquals([$user], $usersReloaded);
@@ -2775,7 +2776,7 @@ class UserServiceTest extends BaseTest
 
         $userService->updateUserToken($user, $userTokenUpdateStruct);
 
-        $loadedUser = $userService->loadUserByToken($userTokenUpdateStruct->hashKey, []);
+        $loadedUser = $userService->loadUserByToken($userTokenUpdateStruct->hashKey, Language::ALL);
         self::assertEquals($user, $loadedUser);
 
         return $userTokenUpdateStruct->hashKey;

--- a/eZ/Publish/Core/Repository/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/ObjectStateService.php
@@ -224,7 +224,7 @@ class ObjectStateService implements ObjectStateServiceInterface
             throw $e;
         }
 
-        return $this->buildDomainObjectStateGroupObject($spiObjectStateGroup);
+        return $this->buildDomainObjectStateGroupObject($spiObjectStateGroup, $objectStateGroup->prioritizedLanguages);
     }
 
     /**
@@ -380,7 +380,7 @@ class ObjectStateService implements ObjectStateServiceInterface
             throw $e;
         }
 
-        return $this->buildDomainObjectStateObject($spiObjectState);
+        return $this->buildDomainObjectStateObject($spiObjectState, null, $objectState->prioritizedLanguages);
     }
 
     /**
@@ -572,7 +572,7 @@ class ObjectStateService implements ObjectStateServiceInterface
         APIObjectStateGroup $objectStateGroup = null,
         array $prioritizedLanguages = []
     ): APIObjectState {
-        $objectStateGroup = $objectStateGroup ?: $this->loadObjectStateGroup($spiObjectState->groupId);
+        $objectStateGroup = $objectStateGroup ?: $this->loadObjectStateGroup($spiObjectState->groupId, $prioritizedLanguages);
 
         return new ObjectState(
             [

--- a/eZ/Publish/Core/Repository/Values/ObjectState/ObjectState.php
+++ b/eZ/Publish/Core/Repository/Values/ObjectState/ObjectState.php
@@ -22,6 +22,7 @@ use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
  * @property-read string $mainLanguageCode the default language of the object state names and descriptions used for fallback.
  * @property-read string $defaultLanguageCode deprecated, use $mainLanguageCode
  * @property-read string[] $languageCodes the available languages
+ * @property-read string[] $prioritizedLanguages
  *
  * @internal Meant for internal use by Repository, type hint against API object instead.
  */

--- a/eZ/Publish/Core/Repository/Values/ObjectState/ObjectStateGroup.php
+++ b/eZ/Publish/Core/Repository/Values/ObjectState/ObjectStateGroup.php
@@ -21,6 +21,7 @@ use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
  * @property-read string $mainLanguageCode the default language of the object state group names and description used for fallback.
  * @property-read string $defaultLanguageCode deprecated, use $mainLanguageCode
  * @property-read string[] $languageCodes the available languages
+ * @property-read string[] $prioritizedLanguages
  *
  * @internal Meant for internal use by Repository, type hint against API object instead.
  */

--- a/eZ/Publish/Core/settings/repository.yml
+++ b/eZ/Publish/Core/settings/repository.yml
@@ -1,7 +1,7 @@
 services:
     # API Aliases
     ezpublish.api.repository:
-        alias: eZ\Publish\Core\Event\Repository
+        alias: ezpublish.siteaccessaware.repository
         public: true
 
     ezpublish.api.service.bookmark:
@@ -9,11 +9,11 @@ services:
         public: true
 
     ezpublish.api.service.content:
-        alias: eZ\Publish\Core\Event\ContentService
+        alias: ezpublish.siteaccessaware.service.content
         public: true
 
     ezpublish.api.service.content_type:
-        alias: eZ\Publish\Core\Event\ContentTypeService
+        alias: ezpublish.siteaccessaware.service.content_type
         public: true
 
     ezpublish.api.service.field_type:
@@ -25,7 +25,7 @@ services:
         public: true
 
     ezpublish.api.service.object_state:
-        alias: eZ\Publish\Core\Event\ObjectStateService
+        alias: ezpublish.siteaccessaware.service.object_state
         public: true
 
     ezpublish.api.service.url_wildcard:
@@ -33,31 +33,31 @@ services:
         public: true
 
     ezpublish.api.service.url_alias:
-        alias: eZ\Publish\Core\Event\URLAliasService
+        alias: ezpublish.siteaccessaware.service.url_alias
         public: true
 
     ezpublish.api.service.user:
-        alias: eZ\Publish\Core\Event\UserService
+        alias: ezpublish.siteaccessaware.service.user
         public: true
 
     ezpublish.api.service.search:
-        alias: eZ\Publish\Core\Event\SearchService
+        alias: ezpublish.siteaccessaware.service.search
         public: true
 
     ezpublish.api.service.section:
-        alias: eZ\Publish\Core\Event\SectionService
+        alias: ezpublish.siteaccessaware.service.section
         public: true
 
     ezpublish.api.service.trash:
-        alias: eZ\Publish\Core\Event\TrashService
+        alias: ezpublish.siteaccessaware.service.trash
         public: true
 
     ezpublish.api.service.location:
-        alias: eZ\Publish\Core\Event\LocationService
+        alias: ezpublish.siteaccessaware.service.location
         public: true
 
     ezpublish.api.service.language:
-        alias: eZ\Publish\Core\Event\LanguageService
+        alias: ezpublish.siteaccessaware.service.language
         public: true
 
     ezpublish.api.service.url:
@@ -65,7 +65,7 @@ services:
         public: true
 
     ezpublish.api.service.notification:
-        alias: eZ\Publish\Core\Event\NotificationService
+        alias: ezpublish.siteaccessaware.service.notification
         public: true
 
     ezpublish.api.service.user_preference:

--- a/eZ/Publish/Core/settings/repository.yml
+++ b/eZ/Publish/Core/settings/repository.yml
@@ -1,7 +1,7 @@
 services:
     # API Aliases
     ezpublish.api.repository:
-        alias: ezpublish.siteaccessaware.repository
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\Repository
         public: true
 
     ezpublish.api.service.bookmark:
@@ -9,11 +9,11 @@ services:
         public: true
 
     ezpublish.api.service.content:
-        alias: ezpublish.siteaccessaware.service.content
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\ContentService
         public: true
 
     ezpublish.api.service.content_type:
-        alias: ezpublish.siteaccessaware.service.content_type
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\ContentTypeService
         public: true
 
     ezpublish.api.service.field_type:
@@ -25,7 +25,7 @@ services:
         public: true
 
     ezpublish.api.service.object_state:
-        alias: ezpublish.siteaccessaware.service.object_state
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\ObjectStateService
         public: true
 
     ezpublish.api.service.url_wildcard:
@@ -33,31 +33,31 @@ services:
         public: true
 
     ezpublish.api.service.url_alias:
-        alias: ezpublish.siteaccessaware.service.url_alias
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\URLAliasService
         public: true
 
     ezpublish.api.service.user:
-        alias: ezpublish.siteaccessaware.service.user
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\UserService
         public: true
 
     ezpublish.api.service.search:
-        alias: ezpublish.siteaccessaware.service.search
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\SearchService
         public: true
 
     ezpublish.api.service.section:
-        alias: ezpublish.siteaccessaware.service.section
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\SectionService
         public: true
 
     ezpublish.api.service.trash:
-        alias: ezpublish.siteaccessaware.service.trash
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\TrashService
         public: true
 
     ezpublish.api.service.location:
-        alias: ezpublish.siteaccessaware.service.location
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\LocationService
         public: true
 
     ezpublish.api.service.language:
-        alias: ezpublish.siteaccessaware.service.language
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\LanguageService
         public: true
 
     ezpublish.api.service.url:
@@ -65,7 +65,7 @@ services:
         public: true
 
     ezpublish.api.service.notification:
-        alias: ezpublish.siteaccessaware.service.notification
+        alias: eZ\Publish\Core\Repository\SiteAccessAware\NotificationService
         public: true
 
     ezpublish.api.service.user_preference:

--- a/eZ/Publish/Core/settings/repository/siteaccessaware.yml
+++ b/eZ/Publish/Core/settings/repository/siteaccessaware.yml
@@ -2,85 +2,84 @@ parameters:
     languages: []
 
 services:
-    ezpublish.siteaccessaware.repository:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\Repository
+    eZ\Publish\Core\Repository\SiteAccessAware\Repository:
         arguments:
             - '@eZ\Publish\Core\Event\Repository'
-            - '@ezpublish.siteaccessaware.service.content'
-            - '@ezpublish.siteaccessaware.service.content_type'
-            - '@ezpublish.siteaccessaware.service.object_state'
-            - '@ezpublish.siteaccessaware.service.url_alias'
-            - '@ezpublish.siteaccessaware.service.user'
-            - '@ezpublish.siteaccessaware.service.search'
-            - '@ezpublish.siteaccessaware.service.section'
-            - '@ezpublish.siteaccessaware.service.trash'
-            - '@ezpublish.siteaccessaware.service.location'
-            - '@ezpublish.siteaccessaware.service.language'
-            - '@ezpublish.siteaccessaware.service.notification'
+            - '@eZ\Publish\Core\Repository\SiteAccessAware\ContentService'
+            - '@eZ\Publish\Core\Repository\SiteAccessAware\ContentTypeService'
+            - '@eZ\Publish\Core\Repository\SiteAccessAware\ObjectStateService'
+            - '@eZ\Publish\Core\Repository\SiteAccessAware\URLAliasService'
+            - '@eZ\Publish\Core\Repository\SiteAccessAware\UserService'
+            - '@eZ\Publish\Core\Repository\SiteAccessAware\SearchService'
+            - '@eZ\Publish\Core\Repository\SiteAccessAware\SectionService'
+            - '@eZ\Publish\Core\Repository\SiteAccessAware\TrashService'
+            - '@eZ\Publish\Core\Repository\SiteAccessAware\LocationService'
+            - '@eZ\Publish\Core\Repository\SiteAccessAware\LanguageService'
+            - '@eZ\Publish\Core\Repository\SiteAccessAware\NotificationService'
 
-
-    ezpublish.siteaccessaware.service.content:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\ContentService
+    eZ\Publish\Core\Repository\SiteAccessAware\ContentService:
         arguments:
             - '@eZ\Publish\Core\Event\ContentService'
             - '@ezpublish.helper.language_resolver'
 
-    ezpublish.siteaccessaware.service.content_type:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\ContentTypeService
+    eZ\Publish\Core\Repository\SiteAccessAware\ContentTypeService:
         arguments:
             - '@eZ\Publish\Core\Event\ContentTypeService'
             - '@ezpublish.helper.language_resolver'
 
-    ezpublish.siteaccessaware.service.object_state:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\ObjectStateService
+    eZ\Publish\Core\Repository\SiteAccessAware\ObjectStateService:
         arguments:
             - '@eZ\Publish\Core\Event\ObjectStateService'
             - '@ezpublish.helper.language_resolver'
 
-    ezpublish.siteaccessaware.service.url_alias:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\URLAliasService
+    eZ\Publish\Core\Repository\SiteAccessAware\URLAliasService:
         arguments:
             - '@eZ\Publish\Core\Event\URLAliasService'
             - '@ezpublish.helper.language_resolver'
 
-
-    ezpublish.siteaccessaware.service.user:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\UserService
+    eZ\Publish\Core\Repository\SiteAccessAware\UserService:
         arguments:
             - '@eZ\Publish\Core\Event\UserService'
             - '@ezpublish.helper.language_resolver'
 
-    ezpublish.siteaccessaware.service.search:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\SearchService
+    eZ\Publish\Core\Repository\SiteAccessAware\SearchService:
         arguments:
             - '@eZ\Publish\Core\Event\SearchService'
             - '@ezpublish.helper.language_resolver'
 
-    ezpublish.siteaccessaware.service.section:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\SectionService
+    eZ\Publish\Core\Repository\SiteAccessAware\SectionService:
         arguments:
             - '@eZ\Publish\Core\Event\SectionService'
 
-    ezpublish.siteaccessaware.service.trash:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\TrashService
+    eZ\Publish\Core\Repository\SiteAccessAware\TrashService:
         arguments:
             - '@eZ\Publish\Core\Event\TrashService'
 
-    ezpublish.siteaccessaware.service.location:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\LocationService
+    eZ\Publish\Core\Repository\SiteAccessAware\LocationService:
         arguments:
             - '@eZ\Publish\Core\Event\LocationService'
             - '@ezpublish.helper.language_resolver'
 
-    ezpublish.siteaccessaware.service.language:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\LanguageService
+    eZ\Publish\Core\Repository\SiteAccessAware\LanguageService:
         arguments:
             - '@eZ\Publish\Core\Event\LanguageService'
 
-    ezpublish.siteaccessaware.service.notification:
-        class: eZ\Publish\Core\Repository\SiteAccessAware\NotificationService
+    eZ\Publish\Core\Repository\SiteAccessAware\NotificationService:
         arguments:
             - '@eZ\Publish\Core\Event\NotificationService'
+
+    ezpublish.siteaccessaware.repository: '@eZ\Publish\Core\Repository\SiteAccessAware\Repository'
+    ezpublish.siteaccessaware.service.content: '@eZ\Publish\Core\Repository\SiteAccessAware\ContentService'
+    ezpublish.siteaccessaware.service.content_type: '@eZ\Publish\Core\Repository\SiteAccessAware\ContentTypeService'
+    ezpublish.siteaccessaware.service.object_state: '@eZ\Publish\Core\Repository\SiteAccessAware\ObjectStateService'
+    ezpublish.siteaccessaware.service.url_alias: '@eZ\Publish\Core\Repository\SiteAccessAware\URLAliasService'
+    ezpublish.siteaccessaware.service.user: '@eZ\Publish\Core\Repository\SiteAccessAware\UserService'
+    ezpublish.siteaccessaware.service.search: '@eZ\Publish\Core\Repository\SiteAccessAware\SearchService'
+    ezpublish.siteaccessaware.service.section: '@eZ\Publish\Core\Repository\SiteAccessAware\SectionService'
+    ezpublish.siteaccessaware.service.trash: '@eZ\Publish\Core\Repository\SiteAccessAware\TrashService'
+    ezpublish.siteaccessaware.service.location: '@eZ\Publish\Core\Repository\SiteAccessAware\LocationService'
+    ezpublish.siteaccessaware.service.language: '@eZ\Publish\Core\Repository\SiteAccessAware\LanguageService'
+    ezpublish.siteaccessaware.service.notification: '@eZ\Publish\Core\Repository\SiteAccessAware\NotificationService'
 
     # Helpers
     eZ\Publish\Core\Repository\SiteAccessAware\Language\AbstractLanguageResolver:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30973](https://jira.ez.no/browse/EZP-30973)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | yes/no
| **Tests pass**     | yes
| **Doc needed**     | yes

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x] Rebase after https://github.com/ezsystems/ezpublish-kernel/pull/2815 merge
- [x] Rebase after https://github.com/ezsystems/ezpublish-kernel/pull/2833 merge
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.

**QA**:
- [x] Make sure that site access aware repository layer is used when for instance `ezpublish.api.service.content` service is injected 
- [x] Run all possible sanities
