### PR TITLE
EZP-30983: Prevented users from reusing old password

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
@@ -102,6 +102,10 @@ class UserIntegrationTest extends BaseIntegrationTest
                     'type' => 'int',
                     'default' => null,
                 ],
+                'requireNewPassword' => [
+                    'type' => 'int',
+                    'default' => null,
+                ],
                 'minLength' => [
                     'type' => 'int',
                     'default' => 10,
@@ -123,6 +127,7 @@ class UserIntegrationTest extends BaseIntegrationTest
                 'requireAtLeastOneLowerCaseCharacter' => true,
                 'requireAtLeastOneNumericCharacter' => true,
                 'requireAtLeastOneNonAlphanumericCharacter' => false,
+                'requireNewPassword' => false,
                 'minLength' => 10,
             ],
         ];

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -2886,18 +2886,17 @@ class UserServiceTest extends BaseTest
 
         $user = $this->createTestUserWithPassword($password, $contentType);
 
-        /* BEGIN: Use Case */
         $context = new PasswordValidationContext([
             'contentType' => $contentType,
             'user' => $user,
         ]);
 
         $actualErrors = $userService->validatePassword($password, $context);
-        /* END: Use Case */
 
-        $this->assertEquals([
-            new ValidationError('New password cannot be the same as old password', null, [], 'password'),
-        ], $actualErrors);
+        $this->assertEquals(
+            [new ValidationError('New password cannot be the same as old password', null, [], 'password')],
+            $actualErrors
+        );
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -2860,7 +2860,7 @@ class UserServiceTest extends BaseTest
      * @covers \eZ\Publish\API\Repository\UserService::validatePassword()
      * @dataProvider dataProviderForValidatePassword
      */
-    public function testValidatePassword(string $password, array $expectedErrorr)
+    public function testValidatePassword(string $password, array $expectedErrors)
     {
         $userService = $this->getRepository()->getUserService();
         $contentType = $this->createUserContentTypeWithStrongPassword();
@@ -2873,7 +2873,31 @@ class UserServiceTest extends BaseTest
         $actualErrors = $userService->validatePassword($password, $context);
         /* END: Use Case */
 
-        $this->assertEquals($expectedErrorr, $actualErrors);
+        $this->assertEquals($expectedErrors, $actualErrors);
+    }
+
+    public function testValidatePasswordReturnsErrorWhenOldPasswordIsReused(): void
+    {
+        $password = 'P@blish123!';
+
+        $userService = $this->getRepository()->getUserService();
+        // Password expiration needs to be enabled
+        $contentType = $this->createUserContentTypeWithPasswordExpirationDate();
+
+        $user = $this->createTestUserWithPassword($password, $contentType);
+
+        /* BEGIN: Use Case */
+        $context = new PasswordValidationContext([
+            'contentType' => $contentType,
+            'user' => $user,
+        ]);
+
+        $actualErrors = $userService->validatePassword($password, $context);
+        /* END: Use Case */
+
+        $this->assertEquals([
+            new ValidationError('New password cannot be the same as old password', null, [], 'password'),
+        ], $actualErrors);
     }
 
     /**
@@ -3021,6 +3045,7 @@ class UserServiceTest extends BaseTest
                 'requireAtLeastOneLowerCaseCharacter' => 1,
                 'requireAtLeastOneNumericCharacter' => 1,
                 'requireAtLeastOneNonAlphanumericCharacter' => 1,
+                'requireNewPassword' => 1,
                 'minLength' => 8,
             ],
         ]);

--- a/eZ/Publish/Core/FieldType/Tests/UserTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/UserTest.php
@@ -66,6 +66,10 @@ class UserTest extends FieldTypeTest
                     'type' => 'int',
                     'default' => null,
                 ],
+                'requireNewPassword' => [
+                    'type' => 'int',
+                    'default' => null,
+                ],
                 'minLength' => [
                     'type' => 'int',
                     'default' => 10,

--- a/eZ/Publish/Core/FieldType/User/Type.php
+++ b/eZ/Publish/Core/FieldType/User/Type.php
@@ -63,6 +63,10 @@ class Type extends FieldType
                 'type' => 'int',
                 'default' => null,
             ],
+            'requireNewPassword' => [
+                'type' => 'int',
+                'default' => null,
+            ],
             'minLength' => [
                 'type' => 'int',
                 'default' => 10,

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/UserConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/UserConverter.php
@@ -24,6 +24,7 @@ class UserConverter implements Converter
     private const REQUIRE_AT_LEAST_ONE_LOWER_CASE_CHAR = 2;
     private const REQUIRE_AT_LEAST_ONE_NUMERIC_CHAR = 4;
     private const REQUIRE_AT_LEAST_ONE_NON_ALPHANUMERIC_CHAR = 8;
+    private const REQUIRE_NEW_PASSWORD = 16;
 
     /**
      * {@inheritdoc}
@@ -56,6 +57,7 @@ class UserConverter implements Converter
             'requireAtLeastOneLowerCaseCharacter' => self::REQUIRE_AT_LEAST_ONE_LOWER_CASE_CHAR,
             'requireAtLeastOneNumericCharacter' => self::REQUIRE_AT_LEAST_ONE_NUMERIC_CHAR,
             'requireAtLeastOneNonAlphanumericCharacter' => self::REQUIRE_AT_LEAST_ONE_NON_ALPHANUMERIC_CHAR,
+            'requireNewPassword' => self::REQUIRE_NEW_PASSWORD,
         ];
 
         $storageDef->dataInt1 = 0;
@@ -88,6 +90,7 @@ class UserConverter implements Converter
             self::REQUIRE_AT_LEAST_ONE_LOWER_CASE_CHAR => 'requireAtLeastOneLowerCaseCharacter',
             self::REQUIRE_AT_LEAST_ONE_NUMERIC_CHAR => 'requireAtLeastOneNumericCharacter',
             self::REQUIRE_AT_LEAST_ONE_NON_ALPHANUMERIC_CHAR => 'requireAtLeastOneNonAlphanumericCharacter',
+            self::REQUIRE_NEW_PASSWORD => 'requireNewPassword',
         ];
 
         foreach ($rules as $flag => $rule) {

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -1430,7 +1430,7 @@ class UserService implements UserServiceInterface
      * @param string $password User password
      * @param \eZ\Publish\SPI\Persistence\User $spiUser Loaded user handler
      *
-     * @return bool return true if the login and password are sucessfully validate and false, if not.
+     * @return bool return true if the login and password are sucessfully validated and false, if not.
      */
     protected function comparePasswordHashForSPIUser(string $login, string $password, SPIUser $spiUser): bool
     {
@@ -1444,7 +1444,7 @@ class UserService implements UserServiceInterface
      * @param string $password User password
      * @param \eZ\Publish\API\Repository\Values\User\User $apiUser Loaded user
      *
-     * @return bool return true if the login and password are sucessfully validate and false, if not.
+     * @return bool return true if the login and password are sucessfully validated and false, if not.
      */
     protected function comparePasswordHashForAPIUser(string $login, string $password, APIUser $apiUser): bool
     {
@@ -1476,7 +1476,7 @@ class UserService implements UserServiceInterface
      * @param string $passwordHash User password hash
      * @param int $hashAlgorithm Hash type
      *
-     * @return bool return true if the login and password are sucessfully validate and false, if not.
+     * @return bool return true if the login and password are sucessfully validated and false, if not.
      */
     private function comparePasswordHashes(
         string $login,

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -606,7 +606,7 @@ class UserService implements UserServiceInterface
         }
 
         $spiUser = $this->userHandler->loadByLogin($login);
-        if (!$this->verifyPasswordForSPIUser($login, $password, $spiUser)) {
+        if (!$this->comparePasswordHashForSPIUser($login, $password, $spiUser)) {
             throw new NotFoundException('user', $login);
         }
 
@@ -1310,7 +1310,7 @@ class UserService implements UserServiceInterface
             $isNewPasswordRequired = $configuration['PasswordValueValidator']['requireNewPassword'] ?? false;
 
             if (($isPasswordTTLEnabled || $isNewPasswordRequired) &&
-                $this->verifyPasswordForAPIUser($context->user->login, $password, $context->user)
+                $this->comparePasswordHashForAPIUser($context->user->login, $password, $context->user)
             ) {
                 $errors[] = new ValidationError('New password cannot be the same as old password', null, [], 'password');
             }
@@ -1432,9 +1432,9 @@ class UserService implements UserServiceInterface
      *
      * @return bool return true if the login and password are sucessfully validate and false, if not.
      */
-    protected function verifyPasswordForSPIUser(string $login, string $password, SPIUser $spiUser): bool
+    protected function comparePasswordHashForSPIUser(string $login, string $password, SPIUser $spiUser): bool
     {
-        return $this->doVerifyPassword($login, $password, $spiUser->passwordHash, $spiUser->hashAlgorithm);
+        return $this->comparePasswordHashes($login, $password, $spiUser->passwordHash, $spiUser->hashAlgorithm);
     }
 
     /**
@@ -1446,9 +1446,9 @@ class UserService implements UserServiceInterface
      *
      * @return bool return true if the login and password are sucessfully validate and false, if not.
      */
-    protected function verifyPasswordForAPIUser(string $login, string $password, APIUser $apiUser): bool
+    protected function comparePasswordHashForAPIUser(string $login, string $password, APIUser $apiUser): bool
     {
-        return $this->doVerifyPassword($login, $password, $apiUser->passwordHash, $apiUser->hashAlgorithm);
+        return $this->comparePasswordHashes($login, $password, $apiUser->passwordHash, $apiUser->hashAlgorithm);
     }
 
     /**
@@ -1465,7 +1465,7 @@ class UserService implements UserServiceInterface
      */
     protected function verifyPassword($login, $password, $spiUser)
     {
-        return $this->verifyPasswordForSPIUser($login, $password, $spiUser);
+        return $this->comparePasswordHashForSPIUser($login, $password, $spiUser);
     }
 
     /**
@@ -1478,7 +1478,7 @@ class UserService implements UserServiceInterface
      *
      * @return bool return true if the login and password are sucessfully validate and false, if not.
      */
-    private function doVerifyPassword(
+    private function comparePasswordHashes(
         string $login,
         string $plainPassword,
         string $passwordHash,


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30983](https://jira.ez.no/browse/EZP-30983)
| **Bug/Improvement**| yes/no
| **New feature**    | yes/no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Prevent users from reusing old (current) password when password expiration is enabled.

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
