### PR TITLE
EZP-30985: Replaced deprecated ExtensionGuesser with MimeTypes class from symfony/mime

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "symfony/process": "^4.3",
         "symfony/dependency-injection": "^4.3",
         "symfony/event-dispatcher": "^4.3",
+        "symfony/mime": "^4.3",
         "symfony/translation": "^4.3",
         "symfony/yaml": "^4.3",
         "symfony/security": "^4.3",

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ResizeOriginalImagesCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ResizeOriginalImagesCommand.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
+use Symfony\Component\Mime\MimeTypesInterface;
 use Exception;
 
 /**
@@ -62,8 +62,8 @@ class ResizeOriginalImagesCommand extends Command
     /** @var \eZ\Publish\Core\IO\IOServiceInterface */
     private $ioService;
 
-    /** @var \Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface */
-    private $extensionGuesser;
+    /** @var \Symfony\Component\Mime\MimeTypesInterface */
+    private $mimeTypes;
 
     /** @var \Imagine\Image\ImagineInterface */
     private $imagine;
@@ -76,7 +76,7 @@ class ResizeOriginalImagesCommand extends Command
         SearchService $searchService,
         FilterManager $filterManager,
         IOServiceInterface $ioService,
-        ExtensionGuesserInterface $extensionGuesser,
+        MimeTypesInterface $mimeTypes,
         ImagineInterface $imagine
     ) {
         $this->permissionResolver = $permissionResolver;
@@ -86,7 +86,7 @@ class ResizeOriginalImagesCommand extends Command
         $this->searchService = $searchService;
         $this->filterManager = $filterManager;
         $this->ioService = $ioService;
-        $this->extensionGuesser = $extensionGuesser;
+        $this->mimeTypes = $mimeTypes;
         $this->imagine = $imagine;
 
         parent::__construct();
@@ -243,7 +243,7 @@ class ResizeOriginalImagesCommand extends Command
                 $binary = new Binary(
                     $this->ioService->getFileContents($binaryFile),
                     $mimeType,
-                    $this->extensionGuesser->guess($mimeType)
+                    $this->mimeTypes->getExtensions($mimeType)[0] ?? null
                 );
 
                 $resizedImageBinary = $this->filterManager->applyFilter($binary, $filter);

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/BinaryLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/BinaryLoader.php
@@ -15,7 +15,7 @@ use eZ\Publish\Core\IO\Values\MissingBinaryFile;
 use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Model\Binary;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
+use Symfony\Component\Mime\MimeTypesInterface;
 
 /**
  * Binary loader using eZ IOService.
@@ -26,13 +26,13 @@ class BinaryLoader implements LoaderInterface
     /** @var \eZ\Publish\Core\IO\IOServiceInterface */
     private $ioService;
 
-    /** @var \Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface */
-    private $extensionGuesser;
+    /** @var \Symfony\Component\Mime\MimeTypesInterface */
+    private $mimeTypes;
 
-    public function __construct(IOServiceInterface $ioService, ExtensionGuesserInterface $extensionGuesser)
+    public function __construct(IOServiceInterface $ioService, MimeTypesInterface $mimeTypes)
     {
         $this->ioService = $ioService;
-        $this->extensionGuesser = $extensionGuesser;
+        $this->mimeTypes = $mimeTypes;
     }
 
     public function find($path)
@@ -49,7 +49,7 @@ class BinaryLoader implements LoaderInterface
             return new Binary(
                 $this->ioService->getFileContents($binaryFile),
                 $mimeType,
-                $this->extensionGuesser->guess($mimeType)
+                $this->mimeTypes->getExtensions($mimeType)[0] ?? null
             );
         } catch (InvalidBinaryFileIdException $e) {
             $message =

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -70,7 +70,7 @@ services:
     # Filter loaders
     ezpublish.image_alias.imagine.binary_loader:
         class: "%ezpublish.image_alias.imagine.binary_loader.class%"
-        arguments: ["@ezpublish.fieldType.ezimage.io_service", "@liip_imagine.extension_guesser"]
+        arguments: ["@ezpublish.fieldType.ezimage.io_service", "@mime_types"]
         tags:
             - { name: liip_imagine.binary.loader, loader: ezpublish }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -293,7 +293,7 @@ services:
             $filterManager: '@liip_imagine.filter.manager'
             $permissionResolver: "@=service('ezpublish.api.repository').getPermissionResolver()"
             $userService: '@ezpublish.api.service.user'
-            $extensionGuesser: '@liip_imagine.extension_guesser'
+            $mimeTypes: '@mime_types'
         tags:
             - { name: console.command, command: ezplatform:images:resize-original }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
@@ -17,15 +17,12 @@ use eZ\Publish\Core\IO\Values\MissingBinaryFile;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Model\Binary;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
+use Symfony\Component\Mime\MimeTypes;
 
 class BinaryLoaderTest extends TestCase
 {
     /** @var \PHPUnit\Framework\MockObject\MockObject */
     private $ioService;
-
-    /** @var \PHPUnit\Framework\MockObject\MockObject */
-    private $extensionGuesser;
 
     /** @var BinaryLoader */
     private $binaryLoader;
@@ -34,8 +31,7 @@ class BinaryLoaderTest extends TestCase
     {
         parent::setUp();
         $this->ioService = $this->createMock(IOServiceInterface::class);
-        $this->extensionGuesser = $this->createMock(ExtensionGuesserInterface::class);
-        $this->binaryLoader = new BinaryLoader($this->ioService, $this->extensionGuesser);
+        $this->binaryLoader = new BinaryLoader($this->ioService, new MimeTypes());
     }
 
     public function testFindNotFound()
@@ -88,7 +84,7 @@ class BinaryLoaderTest extends TestCase
     public function testFind()
     {
         $path = 'something.jpg';
-        $mimeType = 'foo/mime-type';
+        $mimeType = 'image/jpeg';
         $content = 'some content';
         $binaryFile = new BinaryFile(['id' => $path]);
         $this->ioService
@@ -96,13 +92,6 @@ class BinaryLoaderTest extends TestCase
             ->method('loadBinaryFile')
             ->with($path)
             ->will($this->returnValue($binaryFile));
-
-        $format = 'jpg';
-        $this->extensionGuesser
-            ->expects($this->once())
-            ->method('guess')
-            ->with($mimeType)
-            ->will($this->returnValue($format));
 
         $this->ioService
             ->expects($this->once())
@@ -116,7 +105,7 @@ class BinaryLoaderTest extends TestCase
             ->with($binaryFile->id)
             ->will($this->returnValue($mimeType));
 
-        $expected = new Binary($content, $mimeType, $format);
+        $expected = new Binary($content, $mimeType, 'jpeg');
         $this->assertEquals($expected, $this->binaryLoader->find($path));
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30985](https://jira.ez.no/browse/EZP-30985)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Continuation of #2781 (in order not to block it since it is already approved)

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
