### PR TITLE
EZP-30985: Removed usage of deprecated AdvancedUserInterface

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/security.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/security.yml
@@ -12,6 +12,10 @@ services:
             - '@eZ\Publish\API\Repository\UserService'
             - '@eZ\Publish\API\Repository\PermissionResolver'
 
+    eZ\Publish\Core\MVC\Symfony\Security\UserChecker:
+        arguments:
+            - '@eZ\Publish\API\Repository\UserService'
+
     ezpublish.security.voter.core:
         class: "%ezpublish.security.voter.core.class%"
         arguments: ['@eZ\Publish\API\Repository\PermissionResolver']

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/ProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/ProviderTest.php
@@ -9,7 +9,6 @@
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\User;
 
 use eZ\Publish\API\Repository\PermissionResolver;
-use eZ\Publish\API\Repository\Values\User\PasswordInfo;
 use eZ\Publish\API\Repository\Values\User\User as APIUser;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -73,17 +72,10 @@ class ProviderTest extends TestCase
             ->with($username)
             ->will($this->returnValue($apiUser));
 
-        $this->userService
-            ->expects($this->once())
-            ->method('getPasswordInfo')
-            ->with($apiUser)
-            ->willReturn(new PasswordInfo());
-
         $user = $this->userProvider->loadUserByUsername($username);
         $this->assertInstanceOf(UserInterface::class, $user);
         $this->assertSame($apiUser, $user->getAPIUser());
         $this->assertSame(['ROLE_USER'], $user->getRoles());
-        $this->assertSame(true, $user->isCredentialsNonExpired());
     }
 
     public function testRefreshUserNotSupported()
@@ -185,17 +177,10 @@ class ProviderTest extends TestCase
     {
         $apiUser = $this->createMock(APIUser::class);
 
-        $this->userService
-            ->expects($this->once())
-            ->method('getPasswordInfo')
-            ->with($apiUser)
-            ->willReturn(new PasswordInfo());
-
         $user = $this->userProvider->loadUserByAPIUser($apiUser);
 
         $this->assertInstanceOf(MVCUser::class, $user);
         $this->assertSame($apiUser, $user->getAPIUser());
         $this->assertSame(['ROLE_USER'], $user->getRoles());
-        $this->assertSame(true, $user->isCredentialsNonExpired());
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserCheckerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserCheckerTest.php
@@ -78,6 +78,7 @@ final class UserCheckerTest extends TestCase
         );
 
         $this->expectException(DisabledException::class);
+        $this->expectExceptionMessage('User account is locked.');
 
         $this->userChecker->checkPreAuth(new User($apiUser));
     }
@@ -138,6 +139,7 @@ final class UserCheckerTest extends TestCase
             );
 
         $this->expectException(CredentialsExpiredException::class);
+        $this->expectExceptionMessage('User account has expired.');
 
         $this->userChecker->checkPostAuth(new User($apiUser));
     }

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserCheckerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserCheckerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;
+
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\User\PasswordInfo;
+use eZ\Publish\Core\MVC\Symfony\Security\User;
+use eZ\Publish\Core\MVC\Symfony\Security\UserChecker;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
+use Symfony\Component\Security\Core\Exception\DisabledException;
+use eZ\Publish\Core\Repository\Values\User\User as APIUser;
+use Throwable;
+use DateTimeImmutable;
+
+final class UserCheckerTest extends TestCase
+{
+    /** @var \PHPUnit\Framework\MockObject\MockObject */
+    private $userServiceMock;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\Security\UserChecker */
+    private $userChecker;
+
+    protected function setUp(): void
+    {
+        $this->userServiceMock = $this->createMock(UserService::class);
+        $this->userChecker = new UserChecker($this->userServiceMock);
+    }
+
+    public function testCheckPreAuthWithEnabledUser(): void
+    {
+        $apiUser = new APIUser(
+            [
+                'content' => new Content(
+                    [
+                        'versionInfo' => new VersionInfo(
+                            [
+                                'contentInfo' => new ContentInfo(),
+                            ]
+                        ),
+                    ]
+                ),
+                'enabled' => true,
+            ]
+        );
+
+        $this->userServiceMock
+            ->expects(self::once())
+            ->method('getPasswordInfo')
+            ->with(self::identicalTo($apiUser))
+            ->willReturn(new PasswordInfo());
+
+        try {
+            $this->userChecker->checkPreAuth(new User($apiUser));
+        } catch (Throwable $t) {
+            self::fail('Error was not expected to be raised.');
+        }
+    }
+
+    public function testCheckPreAuthWithDisabledUser(): void
+    {
+        $apiUser = new APIUser(
+            [
+                'content' => new Content(
+                    [
+                        'versionInfo' => new VersionInfo(
+                            [
+                                'contentInfo' => new ContentInfo(),
+                            ]
+                        ),
+                    ]
+                ),
+                'enabled' => false,
+            ]
+        );
+
+        $this->userServiceMock
+            ->expects(self::never())
+            ->method('getPasswordInfo');
+
+        $this->expectException(DisabledException::class);
+
+        $this->userChecker->checkPreAuth(new User($apiUser));
+    }
+
+    public function testCheckPreAuthWithExpiredUser(): void
+    {
+        $apiUser = new APIUser(
+            [
+                'content' => new Content(
+                    [
+                        'versionInfo' => new VersionInfo(
+                            [
+                                'contentInfo' => new ContentInfo(),
+                            ]
+                        ),
+                    ]
+                ),
+                'enabled' => true,
+            ]
+        );
+
+        $this->userServiceMock
+            ->expects(self::once())
+            ->method('getPasswordInfo')
+            ->with(self::identicalTo($apiUser))
+            ->willReturn(
+                new PasswordInfo(
+                    DateTimeImmutable::createFromFormat('Y-m-d', '2019-01-01')
+                )
+            );
+
+        $this->expectException(CredentialsExpiredException::class);
+
+        $this->userChecker->checkPreAuth(new User($apiUser));
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserTest.php
@@ -47,10 +47,6 @@ class UserTest extends TestCase
         $this->assertSame($passwordHash, $user->getPassword());
         $this->assertSame($roles, $user->getRoles());
         $this->assertNull($user->getSalt());
-        $this->assertTrue($user->isAccountNonExpired());
-        $this->assertTrue($user->isAccountNonLocked());
-        $this->assertTrue($user->isCredentialsNonExpired());
-        $this->assertTrue($user->isEnabled());
     }
 
     public function testIsEqualTo()

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
@@ -14,7 +14,6 @@ use eZ\Publish\Core\MVC\Symfony\Security\UserWrapped;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
-use Symfony\Component\Security\Core\User\User;
 
 class UserWrappedTest extends TestCase
 {
@@ -49,48 +48,11 @@ class UserWrappedTest extends TestCase
         $this->assertSame($newWrappedUser, $userWrapped->getWrappedUser());
     }
 
-    /**
-     * @dataProvider advancedUserProvider
-     */
-    public function testAdvancedUser($username, $password, $roles, $enabled, $userNonExpired, $credentialsNonExpired, $userNonLocked)
-    {
-        $originalUser = new User($username, $password, $roles, $enabled, $userNonExpired, $credentialsNonExpired, $userNonLocked);
-        $user = new UserWrapped($originalUser, $this->apiUser);
-        $this->assertSame($username, (string)$user);
-        $this->assertSame($username, $user->getUsername());
-        $this->assertSame($password, $user->getPassword());
-        $this->assertSame($roles, $user->getRoles());
-        $this->assertSame($enabled, $user->isEnabled());
-        $this->assertSame($userNonExpired, $user->isAccountNonExpired());
-        $this->assertSame($credentialsNonExpired, $user->isCredentialsNonExpired());
-        $this->assertSame($userNonLocked, $user->isAccountNonLocked());
-        $this->assertSame($originalUser->getSalt(), $user->getSalt());
-        $this->assertSame($originalUser->getUsername(), $user->getWrappedUser()->getUsername());
-        $this->assertSame($originalUser->isEnabled(), $user->getWrappedUser()->isEnabled());
-        $this->assertSame($originalUser, $user->getWrappedUser());
-    }
-
-    public function advancedUserProvider()
-    {
-        return [
-            ['foo', 'password', ['ROLE_USER'], true, true, true, true],
-            ['foo', 'password', ['ROLE_USER'], true, false, true, false],
-            ['foo', 'password', ['ROLE_USER'], false, true, false, true],
-            ['bar', 'secret', ['ROLE_TEST'], true, true, true, true],
-            ['bar', 'secret', ['ROLE_TEST'], false, false, false, false],
-            ['Jérôme', 'NoThisIsNotMyRealPassword', ['ROLE_ADMIN'], true, true, true, true],
-        ];
-    }
-
     public function testRegularUser()
     {
         $originalUser = $this->createMock(SymfonyUserInterface::class);
         $user = new UserWrapped($originalUser, $this->apiUser);
 
-        $this->assertTrue($user->isEnabled());
-        $this->assertTrue($user->isAccountNonExpired());
-        $this->assertTrue($user->isAccountNonLocked());
-        $this->assertTrue($user->isCredentialsNonExpired());
         $this->assertTrue($user->isEqualTo($this->createMock(SymfonyUserInterface::class)));
 
         $originalUser

--- a/eZ/Publish/Core/MVC/Symfony/Security/User.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User.php
@@ -24,15 +24,11 @@ class User implements ReferenceUserInterface, EquatableInterface
     /** @var array */
     private $roles;
 
-    /** @var bool */
-    private $isCredentialsNonExpired;
-
-    public function __construct(APIUser $user = null, array $roles = [], bool $isCredentialsNonExpired = true)
+    public function __construct(APIUser $user = null, array $roles = [])
     {
         $this->user = $user;
         $this->reference = new UserReference($user ? $user->getUserId() : null);
         $this->roles = $roles;
-        $this->isCredentialsNonExpired = $isCredentialsNonExpired;
     }
 
     /**
@@ -147,66 +143,6 @@ class User implements ReferenceUserInterface, EquatableInterface
     public function __toString()
     {
         return $this->getAPIUser()->contentInfo->name;
-    }
-
-    /**
-     * Checks whether the user's account has expired.
-     *
-     * Internally, if this method returns false, the authentication system
-     * will throw an AccountExpiredException and prevent login.
-     *
-     * @return bool true if the user's account is non expired, false otherwise
-     *
-     * @see AccountExpiredException
-     */
-    public function isAccountNonExpired()
-    {
-        return $this->getAPIUser()->enabled;
-    }
-
-    /**
-     * Checks whether the user is locked.
-     *
-     * Internally, if this method returns false, the authentication system
-     * will throw a LockedException and prevent login.
-     *
-     * @return bool true if the user is not locked, false otherwise
-     *
-     * @see LockedException
-     */
-    public function isAccountNonLocked()
-    {
-        return $this->getAPIUser()->enabled;
-    }
-
-    /**
-     * Checks whether the user's credentials (password) has expired.
-     *
-     * Internally, if this method returns false, the authentication system
-     * will throw a CredentialsExpiredException and prevent login.
-     *
-     * @return bool true if the user's credentials are non expired, false otherwise
-     *
-     * @see CredentialsExpiredException
-     */
-    public function isCredentialsNonExpired()
-    {
-        return $this->isCredentialsNonExpired;
-    }
-
-    /**
-     * Checks whether the user is enabled.
-     *
-     * Internally, if this method returns false, the authentication system
-     * will throw a DisabledException and prevent login.
-     *
-     * @return bool true if the user is enabled, false otherwise
-     *
-     * @see DisabledException
-     */
-    public function isEnabled()
-    {
-        return $this->getAPIUser()->enabled;
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/Security/User/Provider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User/Provider.php
@@ -137,12 +137,6 @@ class Provider implements APIUserProviderInterface
      */
     private function createSecurityUser(APIUser $apiUser): User
     {
-        $isPasswordExpired = $this->userService->getPasswordInfo($apiUser)->isPasswordExpired();
-
-        return new User(
-            $apiUser,
-            ['ROLE_USER'],
-            !$isPasswordExpired
-        );
+        return new User($apiUser, ['ROLE_USER']);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserChecker.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserChecker.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Security;
+
+use eZ\Publish\API\Repository\UserService;
+use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
+use Symfony\Component\Security\Core\Exception\DisabledException;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use eZ\Publish\Core\MVC\Symfony\Security\UserInterface as EzUserInterface;
+
+final class UserChecker implements UserCheckerInterface
+{
+    /** @var \eZ\Publish\API\Repository\UserService */
+    private $userService;
+
+    public function __construct(UserService $userService)
+    {
+        $this->userService = $userService;
+    }
+
+    public function checkPreAuth(UserInterface $user): void
+    {
+        if (!$user instanceof EzUserInterface) {
+            return;
+        }
+
+        $apiUser = $user->getAPIUser();
+
+        if (!$apiUser->enabled) {
+            throw new DisabledException();
+        }
+
+        if ($this->userService->getPasswordInfo($apiUser)->isPasswordExpired()) {
+            throw new CredentialsExpiredException();
+        }
+    }
+
+    public function checkPostAuth(UserInterface $user): void
+    {
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserChecker.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserChecker.php
@@ -32,7 +32,7 @@ final class UserChecker implements UserCheckerInterface
         }
 
         if (!$user->getAPIUser()->enabled) {
-            $exception = new DisabledException();
+            $exception = new DisabledException('User account is locked.');
             $exception->setUser($user);
 
             throw $exception;
@@ -46,7 +46,7 @@ final class UserChecker implements UserCheckerInterface
         }
 
         if ($this->userService->getPasswordInfo($user->getAPIUser())->isPasswordExpired()) {
-            $exception = new CredentialsExpiredException();
+            $exception = new CredentialsExpiredException('User account has expired.');
             $exception->setUser($user);
 
             throw $exception;

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserChecker.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserChecker.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace eZ\Publish\Core\MVC\Symfony\Security;
@@ -27,18 +31,25 @@ final class UserChecker implements UserCheckerInterface
             return;
         }
 
-        $apiUser = $user->getAPIUser();
+        if (!$user->getAPIUser()->enabled) {
+            $exception = new DisabledException();
+            $exception->setUser($user);
 
-        if (!$apiUser->enabled) {
-            throw new DisabledException();
-        }
-
-        if ($this->userService->getPasswordInfo($apiUser)->isPasswordExpired()) {
-            throw new CredentialsExpiredException();
+            throw $exception;
         }
     }
 
     public function checkPostAuth(UserInterface $user): void
     {
+        if (!$user instanceof EzUserInterface) {
+            return;
+        }
+
+        if ($this->userService->getPasswordInfo($user->getAPIUser())->isPasswordExpired()) {
+            $exception = new CredentialsExpiredException();
+            $exception->setUser($user);
+
+            throw $exception;
+        }
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserInterface.php
@@ -9,12 +9,12 @@
 namespace eZ\Publish\Core\MVC\Symfony\Security;
 
 use eZ\Publish\API\Repository\Values\User\User as APIUser;
-use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
 
 /**
  * Interface for Repository based users.
  */
-interface UserInterface extends AdvancedUserInterface
+interface UserInterface extends BaseUserInterface
 {
     /**
      * @return \eZ\Publish\API\Repository\Values\User\User

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
@@ -9,7 +9,6 @@
 namespace eZ\Publish\Core\MVC\Symfony\Security;
 
 use eZ\Publish\API\Repository\Values\User\User as APIUser;
-use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\UserInterface as CoreUserInterface;
 use InvalidArgumentException;
@@ -40,26 +39,6 @@ class UserWrapped implements UserInterface, EquatableInterface
     public function __toString()
     {
         return $this->wrappedUser->getUsername();
-    }
-
-    public function isAccountNonExpired()
-    {
-        return $this->wrappedUser instanceof AdvancedUserInterface ? $this->wrappedUser->isAccountNonExpired() : true;
-    }
-
-    public function isAccountNonLocked()
-    {
-        return $this->wrappedUser instanceof AdvancedUserInterface ? $this->wrappedUser->isAccountNonLocked() : true;
-    }
-
-    public function isCredentialsNonExpired()
-    {
-        return $this->wrappedUser instanceof AdvancedUserInterface ? $this->wrappedUser->isCredentialsNonExpired() : true;
-    }
-
-    public function isEnabled()
-    {
-        return $this->wrappedUser instanceof AdvancedUserInterface ? $this->wrappedUser->isEnabled() : true;
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30985](https://jira.ez.no/browse/EZP-30985)
| **Required by** | ezsystems/ezplatform#469
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

### QA

- [x] Sanity checks for password expiration,
- [x] Sanity checks for user account locking/disabling,
- [x] Sanity checks for REST login endpoint,
- [x] Run Behat suite with this branch and ezsystems/ezplatform#469.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
