### PR TITLE
EZP-30985: Replaced deprecated DI short factory syntax

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -95,7 +95,7 @@ services:
 
     ezpublish.image_alias.imagine.cache_resolver_decorator:
         class: Liip\ImagineBundle\Imagine\Cache\Resolver\ProxyResolver
-        factory: 'ezpublish.image_alias.imagine.cache_resolver_decorator_factory:createCacheResolver'
+        factory: ['@ezpublish.image_alias.imagine.cache_resolver_decorator_factory', 'createCacheResolver']
         decorates: ezpublish.image_alias.imagine.cache_resolver
         lazy: true
 

--- a/eZ/Publish/Core/settings/repository/autowire.yml
+++ b/eZ/Publish/Core/settings/repository/autowire.yml
@@ -20,4 +20,4 @@ services:
     eZ\Publish\API\Repository\TrashService: '@ezpublish.api.service.trash'
 
     eZ\Publish\API\Repository\PermissionResolver:
-        factory: 'eZ\Publish\API\Repository\Repository:getPermissionResolver'
+        factory: ['@eZ\Publish\API\Repository\Repository', 'getPermissionResolver']

--- a/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_common.yml
@@ -85,7 +85,7 @@ services:
     ezpublish.search.legacy.gateway.sort_clause_handler.common.random:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
         class: '%ezpublish.search.legacy.gateway.sort_clause_handler.common.random.class%'
-        factory: 'eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Factory\RandomSortClauseHandlerFactory:getGateway'
+        factory: ['@eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Factory\RandomSortClauseHandlerFactory', 'getGateway']
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}

--- a/eZ/Publish/Core/settings/storage_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy.yml
@@ -51,7 +51,7 @@ services:
     # Compiler pass will alias 'ezpublish.api.storage_engine.legacy.connection' service to the StorageConnectionFactory
     ezpublish.api.storage_engine.legacy.dbhandler:
         class: "%ezpublish.api.storage_engine.legacy.dbhandler.class%"
-        factory: "%ezpublish.api.storage_engine.legacy.dbhandler.class%::createFromConnection"
+        factory: ["%ezpublish.api.storage_engine.legacy.dbhandler.class%", "createFromConnection"]
         arguments:
             - "@ezpublish.api.storage_engine.legacy.connection"
         lazy: true
@@ -59,7 +59,7 @@ services:
 
     ezpublish.api.storage_engine.legacy.connection:
         class: "%ezpublish.persistence.connection.class%"
-        factory: "%ezpublish.api.storage_engine.legacy.dbhandler.class%::createConnectionFromDSN"
+        factory: ["%ezpublish.api.storage_engine.legacy.dbhandler.class%", "createConnectionFromDSN"]
         arguments:
             - "%legacy_dsn%"
 

--- a/eZ/Publish/Core/settings/tests/integration_legacy.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy.yml
@@ -48,6 +48,6 @@ services:
     # build ezpublish.api.storage_engine.legacy.connection for test purposes
     ezpublish.api.storage_engine.legacy.connection:
         class: Doctrine\DBAL\Connection
-        factory: 'eZ\Publish\Core\Persistence\Tests\DatabaseConnectionFactory:createConnection'
+        factory: ['@eZ\Publish\Core\Persistence\Tests\DatabaseConnectionFactory', 'createConnection']
         arguments:
             $databaseURL: '%legacy_dsn%'


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30985](https://jira.ez.no/browse/EZP-30985)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Related upgrade notes: https://github.com/symfony/symfony/blob/4.4/UPGRADE-4.4.md#dependencyinjection (2nd point)

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
