### PR TITLE
EZP-30823: Cleared in-memory cache pools during rollback

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/Adapter/TransactionalInMemoryCacheAdapter.php
+++ b/eZ/Publish/Core/Persistence/Cache/Adapter/TransactionalInMemoryCacheAdapter.php
@@ -141,9 +141,7 @@ class TransactionalInMemoryCacheAdapter implements TransactionAwareAdapterInterf
     public function invalidateTags(array $tags)
     {
         // No tracking of tags in in-memory, as it's anyway meant to only optimize for reads (GETs) and not writes.
-        foreach ($this->inMemoryPools as $inMemory) {
-            $inMemory->clear();
-        }
+        $this->clearInMemoryPools();
 
         if ($this->transactionDepth > 0) {
             $this->deferredTagsInvalidation += \array_fill_keys($tags, true);
@@ -159,9 +157,7 @@ class TransactionalInMemoryCacheAdapter implements TransactionAwareAdapterInterf
      */
     public function clear()
     {
-        foreach ($this->inMemoryPools as $inMemory) {
-            $inMemory->clear();
-        }
+        $this->clearInMemoryPools();
 
         // @todo Should we trow RunTime error or add support deferring full cache clearing?
         $this->transactionDepth = 0;
@@ -298,5 +294,12 @@ class TransactionalInMemoryCacheAdapter implements TransactionAwareAdapterInterf
         }
 
         return false;
+    }
+
+    private function clearInMemoryPools(): void
+    {
+        foreach ($this->inMemoryPools as $inMemory) {
+            $inMemory->clear();
+        }
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/Adapter/TransactionalInMemoryCacheAdapter.php
+++ b/eZ/Publish/Core/Persistence/Cache/Adapter/TransactionalInMemoryCacheAdapter.php
@@ -223,6 +223,8 @@ class TransactionalInMemoryCacheAdapter implements TransactionAwareAdapterInterf
         $this->transactionDepth = 0;
         $this->deferredItemsDeletion = [];
         $this->deferredTagsInvalidation = [];
+
+        $this->clearInMemoryPools();
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Follow-up [EZP-30823](https://jira.ez.no/browse/EZP-30823)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | <ul><li>`7.5` for eZ Platform `v2.5.x`</li><li>`master (8.0@dev)` for eZ Platform `v3.0`</li></ul>
| **BC breaks**      | no
| **Tests pass**     | yes ([`master`](https://travis-ci.org/ezsystems/ezpublish-kernel/builds/593071347), [`7.5`](https://travis-ci.org/ezsystems/ezpublish-kernel/builds/593178560))
| **Doc needed**     | no

This PR is an attempt to fix failing CI without reverting #2749 (as done in #2794).

~First approach is to restore explicit cache clearing in `\eZ\Publish\Core\Persistence\Cache\TransactionHandler::rollback`. Since this should be handled by just clearing deferred lists (staged changes), I'm not sure it's a good approach (not the root cause), but at least let's see if CI passes.~

The culprit was in-memory cache which wasn't cleared on rollback.

**TODO**:
- [x] **Target to 7.5 once CI passes on `master`**.
- [x] Find root cause.
- [x] Extract clearing of in-memory cache pools to a private method in `TransactionalInMemoryCacheAdapter`.
- [x] Clear in-memory cache pools on rollback in `TransactionalInMemoryCacheAdapter::rollbackTransaction` 
- [x] ~Try resolving issue by restoring explicit cache clearing in `\eZ\Publish\Core\Persistence\Cache\TransactionHandler::rollback.`~
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.