### PR TITLE
Added password_updated_at column initialization to the 7.5.3 to 7.5.4 update scripts

### DIFF
--- a/data/update/mysql/dbupdate-7.5.4-to-7.5.5.sql
+++ b/data/update/mysql/dbupdate-7.5.4-to-7.5.5.sql
@@ -4,6 +4,8 @@
 
 ALTER TABLE ezuser ADD COLUMN password_updated_at INT(11) NULL;
 
+UPDATE ezuser SET password_updated_at = CURRENT_TIMESTAMP;
+
 --
 -- EZP-30797: end.
 --

--- a/data/update/postgres/dbupdate-7.5.4-to-7.5.5.sql
+++ b/data/update/postgres/dbupdate-7.5.4-to-7.5.5.sql
@@ -4,6 +4,8 @@
 
 ALTER TABLE ezuser ADD COLUMN password_updated_at integer;
 
+UPDATE ezuser SET password_updated_at = cast(extract(epoch from CURRENT_TIMESTAMP) as integer);
+
 --
 -- EZP-30797: end.
 --


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | -
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Added `password_updated_at` column initialization to the `data/update/{mysql,postgres}/dbupdate-7.5.4-to-7.5.5.sql`

**TODO**:
- [X] Implement feature / fix a bug.
- [ ] ~Implement tests.~
- [ ] ~Fix new code according to Coding Standards (`$ composer fix-cs`).~
- [x] Ask for Code Review.
