### PR TITLE
Fixed "Out of range value for 'password_update_at'" error during the 7.5.4 to 7.5.5 update script execution on Maria DB

### DIFF
--- a/data/update/mysql/dbupdate-7.5.4-to-7.5.5.sql
+++ b/data/update/mysql/dbupdate-7.5.4-to-7.5.5.sql
@@ -4,7 +4,7 @@
 
 ALTER TABLE ezuser ADD COLUMN password_updated_at INT(11) NULL;
 
-UPDATE ezuser SET password_updated_at = CURRENT_TIMESTAMP;
+UPDATE ezuser SET password_updated_at = UNIX_TIMESTAMP();
 
 --
 -- EZP-30797: end.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | -
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Follow up for https://github.com/ezsystems/ezpublish-kernel/pull/2803. Fixed the following error during the update eZ Platform from 2.5.5 to 2.5.6 on 10.4.6-MariaDB

![image](https://user-images.githubusercontent.com/211967/66207907-41907a00-e6b4-11e9-8509-f9e31b4009b6.png)


**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
