### PR TITLE
EZP-31006: Bumped hautelook/templated-uri-bundle to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony-cmf/routing": "^2.1",
         "kriswallsmith/buzz": "^1.0",
         "nelmio/cors-bundle": "^1.5.0",
-        "hautelook/templated-uri-bundle": "^2.1",
+        "hautelook/templated-uri-bundle": "^3.0",
         "pagerfanta/pagerfanta": "^2.0",
         "ocramius/proxy-manager": "^2.1",
         "doctrine/doctrine-bundle": "^1.11",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31006](https://jira.ez.no/browse/EZP-31006)
| **Bug/Improvement**| no
| **New feature**    | no
| **Target version** | `master` for eZ Platform v3.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Just to keep deps uptodate, no relevant breaking changes as far as I can see.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
