### PR TITLE
EZP-31000: Added support to fragment identifier for URL alias generator

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -73,11 +73,11 @@ class UrlAliasGenerator extends Generator
      */
     public function doGenerate($location, array $parameters)
     {
-        $siteaccess = $parameters['siteaccess'] ?? null;
+        $siteAccess = $parameters['siteaccess'] ?? null;
 
         unset($parameters['language'], $parameters['contentId'], $parameters['siteaccess']);
 
-        $pathString = $this->createPathString($location, $siteaccess);
+        $pathString = $this->createPathString($location, $siteAccess);
         $queryString = $this->createQueryString($parameters);
         $url = $pathString . $queryString;
 
@@ -175,20 +175,20 @@ class UrlAliasGenerator extends Generator
 
     /**
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
-     * @param string|null $siteaccess
+     * @param string|null $siteAccess
      *
      * @return string
      */
-    private function createPathString(Location $location, ?string $siteaccess = null): string
+    private function createPathString(Location $location, ?string $siteAccess = null): string
     {
         $urlAliasService = $this->repository->getURLAliasService();
 
-        if ($siteaccess) {
+        if ($siteAccess) {
             // We generate for a different SiteAccess, so potentially in a different language.
-            $languages = $this->configResolver->getParameter('languages', null, $siteaccess);
+            $languages = $this->configResolver->getParameter('languages', null, $siteAccess);
             $urlAliases = $urlAliasService->listLocationAliases($location, false, null, null, $languages);
             // Use the target SiteAccess root location
-            $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id', null, $siteaccess);
+            $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id', null, $siteAccess);
         } else {
             $languages = null;
             $urlAliases = $urlAliasService->listLocationAliases($location, false);
@@ -199,7 +199,7 @@ class UrlAliasGenerator extends Generator
             $path = $urlAliases[0]->path;
             // Remove rootLocation's prefix if needed.
             if ($rootLocationId !== null) {
-                $pathPrefix = $this->getPathPrefixByRootLocationId($rootLocationId, $languages, $siteaccess);
+                $pathPrefix = $this->getPathPrefixByRootLocationId($rootLocationId, $languages, $siteAccess);
                 // "/" cannot be considered as a path prefix since it's root, so we ignore it.
                 if ($pathPrefix !== '/' && ($path === $pathPrefix || mb_stripos($path, $pathPrefix . '/') === 0)) {
                     $path = mb_substr($path, mb_strlen($pathPrefix));
@@ -241,6 +241,7 @@ class UrlAliasGenerator extends Generator
         }
 
         if ($fragment) {
+            // logic aligned with Symfony 3.4: \Symfony\Component\Routing\Generator\UrlGenerator::doGenerate
             $queryString .= '#' . strtr(rawurlencode($fragment), ['%2F' => '/', '%3F' => '?']);
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -210,8 +210,10 @@ class UrlAliasGeneratorTest extends TestCase
 
     /**
      * @dataProvider providerTestDoGenerateWithSiteaccess
+     *
+     * @param array $parameters
      */
-    public function testDoGenerateWithSiteAccessParam(URLAlias $urlAlias, array $parameters, $expected)
+    public function testDoGenerateWithSiteAccessParam(URLAlias $urlAlias, array $parameters, string $expected)
     {
         $siteaccessName = 'foo';
         $parameters += ['siteaccess' => $siteaccessName];
@@ -296,82 +298,6 @@ class UrlAliasGeneratorTest extends TestCase
                 [],
                 '/special-chars-%22%3C%3E%27',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider providerTestDoGenerateWithFragment
-     */
-    public function testDoGenerateWithFragmentParameter(URLAlias $urlAlias, array $parameters, string $expected)
-    {
-        $siteaccessName = 'foo';
-        $parameters += ['siteaccess' => $siteaccessName];
-        $languages = ['esl-ES', 'fre-FR', 'eng-GB'];
-
-        $saRootLocations = [
-            'foo' => 2,
-            'bar' => 100,
-        ];
-        $treeRootUrlAlias = [
-            2 => new URLAlias(['path' => '/']),
-            100 => new URLAlias(['path' => '/foo/bar']),
-        ];
-
-        $this->configResolver
-            ->expects($this->any())
-            ->method('getParameter')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        ['languages', null, 'foo', $languages],
-                        ['languages', null, 'bar', $languages],
-                        ['content.tree_root.location_id', null, 'foo', $saRootLocations['foo']],
-                        ['content.tree_root.location_id', null, 'bar', $saRootLocations['bar']],
-                    ]
-                )
-            );
-
-        $location = new Location(['id' => 123]);
-        $this->urlAliasService
-            ->expects($this->exactly(1))
-            ->method('listLocationAliases')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        [$location, false, null, null, $languages, [$urlAlias]],
-                    ]
-                )
-            );
-
-        $this->locationService
-            ->expects($this->once())
-            ->method('loadLocation')
-            ->will(
-                $this->returnCallback(
-                    function ($locationId) {
-                        return new Location(['id' => $locationId]);
-                    }
-                )
-            );
-        $this->urlAliasService
-            ->expects($this->exactly(1))
-            ->method('reverseLookup')
-            ->will(
-                $this->returnCallback(
-                    function ($location) use ($treeRootUrlAlias) {
-                        return $treeRootUrlAlias[$location->id];
-                    }
-                )
-            );
-
-        $this->urlAliasGenerator->setSiteAccess(new SiteAccess('test', 'fake', $this->createMock(SiteAccess\URILexer::class)));
-
-        $this->assertSame($expected, $this->urlAliasGenerator->doGenerate($location, $parameters));
-    }
-
-    public function providerTestDoGenerateWithFragment()
-    {
-        return [
             'fragment' => [
                 new URLAlias(['path' => '/foo/bar']),
                 ['_fragment' => 'qux'],

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -302,7 +302,7 @@ class UrlAliasGeneratorTest extends TestCase
     /**
      * @dataProvider providerTestDoGenerateWithFragment
      */
-    public function testDoGenerateWithFragmentParameter(URLAlias $urlAlias, array $parameters, $expected)
+    public function testDoGenerateWithFragmentParameter(URLAlias $urlAlias, array $parameters, string $expected)
     {
         $siteaccessName = 'foo';
         $parameters += ['siteaccess' => $siteaccessName];


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31000](https://jira.ez.no/browse/EZP-31000)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Since Symfony 3.2 it allows defining the fragment when generating a URL with reserved routing property `_fragment`. URLAliasGenerator has no support for this parameter. This resulted in an error when the URL for pagination embedded in the tab was generated.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
