### PR TITLE
Fixed PermissionCriterionResolver::getPermissionsCriterion calls without parameters

### DIFF
--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -128,7 +128,7 @@ class LocationService implements LocationServiceInterface
         /** Check read access to whole source subtree
          * @var bool|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
          */
-        $contentReadCriterion = $this->permissionCriterionResolver->getPermissionsCriterion();
+        $contentReadCriterion = $this->permissionCriterionResolver->getPermissionsCriterion('content', 'read');
         if ($contentReadCriterion === false) {
             throw new UnauthorizedException('content', 'read');
         } elseif ($contentReadCriterion !== true) {
@@ -675,7 +675,7 @@ class LocationService implements LocationServiceInterface
         /** Check read access to whole source subtree
          * @var bool|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
          */
-        $contentReadCriterion = $this->permissionCriterionResolver->getPermissionsCriterion();
+        $contentReadCriterion = $this->permissionCriterionResolver->getPermissionsCriterion('content', 'read');
         if ($contentReadCriterion === false) {
             throw new UnauthorizedException('content', 'read');
         } elseif ($contentReadCriterion !== true) {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | -
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** |`7.x` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Fixed `\eZ\Publish\API\Repository\PermissionCriterionResolver::getPermissionsCriterion` calls without required `module` and `function` parameters:

https://github.com/ezsystems/ezpublish-kernel/blob/b40ee9a5a7297e6161cfc4855e6cb9b3d65c83d5/eZ/Publish/API/Repository/PermissionCriterionResolver.php#L28

in `\eZ\Publish\Core\Repository\LocationService`. It depends on `\eZ\Publish\API\Repository\PermissionCriterionResolver` and shouldn't rely on default values from concrete implementation: https://github.com/ezsystems/ezpublish-kernel/blob/368f3cfbdebf61a887be87a3cd0b0e7bf1f9f676/eZ/Publish/Core/Repository/Permission/PermissionCriterionResolver.php#L57

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
