### PR TITLE
EZP-30885: Introduced strict types for LanguageService

### DIFF
--- a/eZ/Publish/API/Repository/LanguageService.php
+++ b/eZ/Publish/API/Repository/LanguageService.php
@@ -19,77 +19,77 @@ interface LanguageService
     /**
      * Creates the a new Language in the content repository.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the languageCode already exists
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\LanguageCreateStruct $languageCreateStruct
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the languageCode already exists
      */
-    public function createLanguage(LanguageCreateStruct $languageCreateStruct);
+    public function createLanguage(LanguageCreateStruct $languageCreateStruct): Language;
 
     /**
      * Changes the name of the language in the content repository.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Language $language
      * @param string $newName
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
      */
-    public function updateLanguageName(Language $language, $newName);
+    public function updateLanguageName(Language $language, string $newName): Language;
 
     /**
      * Enables a language.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Language $language
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
      */
-    public function enableLanguage(Language $language);
+    public function enableLanguage(Language $language): Language;
 
     /**
      * Disables a language.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Language $language
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
      */
-    public function disableLanguage(Language $language);
+    public function disableLanguage(Language $language): Language;
 
     /**
      * Loads a Language from its language code ($languageCode).
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if language could not be found
-     *
      * @param string $languageCode
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if language could not be found
      */
-    public function loadLanguage($languageCode);
+    public function loadLanguage(string $languageCode): Language;
 
     /**
      * Loads all Languages.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language[]
      */
-    public function loadLanguages();
+    public function loadLanguages(): iterable;
 
     /**
      * Loads a Language by its id ($languageId).
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if language could not be found
-     *
-     * @param mixed $languageId
+     * @param int $languageId
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if language could not be found
      */
-    public function loadLanguageById($languageId);
+    public function loadLanguageById(int $languageId): Language;
 
     /**
      * Bulk-load Languages by language codes.
@@ -116,26 +116,26 @@ interface LanguageService
     /**
      * Deletes  a language from content repository.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     *         if language can not be deleted
+     * @param \eZ\Publish\API\Repository\Values\Content\Language $language
+     *
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if language can not be deleted
      *         because it is still assigned to some content / type / (...).
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user is not allowed to delete a language
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\Language $language
      */
-    public function deleteLanguage(Language $language);
+    public function deleteLanguage(Language $language): void;
 
     /**
      * Returns a configured default language code.
      *
      * @return string
      */
-    public function getDefaultLanguageCode();
+    public function getDefaultLanguageCode(): string;
 
     /**
      * Instantiates an object to be used for creating languages.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LanguageCreateStruct
      */
-    public function newLanguageCreateStruct();
+    public function newLanguageCreateStruct(): LanguageCreateStruct;
 }

--- a/eZ/Publish/API/Repository/Tests/LanguageServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LanguageServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use Exception;
 use eZ\Publish\API\Repository\Values\Content\Language;
@@ -128,7 +129,7 @@ class LanguageServiceTest extends BaseTest
      */
     public function testCreateLanguageThrowsInvalidArgumentException()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Argument \'languageCreateStruct\' is invalid: language with specified language code already exists');
 
         $repository = $this->getRepository();
@@ -263,7 +264,7 @@ class LanguageServiceTest extends BaseTest
      */
     public function testUpdateLanguageNameThrowsInvalidArgumentException()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Argument \'newName\' is invalid: \'\' is wrong value');
 
         $repository = $this->getRepository();
@@ -412,12 +413,12 @@ class LanguageServiceTest extends BaseTest
      */
     public function testLoadLanguageThrowsInvalidArgumentException()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Argument \'languageCode\' is invalid: language code has an invalid value');
 
         $repository = $this->getRepository();
 
-        $repository->getContentLanguageService()->loadLanguage(PHP_INT_MAX);
+        $repository->getContentLanguageService()->loadLanguage('');
     }
 
     /**
@@ -531,7 +532,7 @@ class LanguageServiceTest extends BaseTest
      */
     public function testDeleteLanguageThrowsInvalidArgumentException()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Argument \'language\' is invalid: Deleting language logic error, some content still references that language and therefore it can\'t be deleted');
 
         $repository = $this->getRepository();

--- a/eZ/Publish/Core/Event/LanguageService.php
+++ b/eZ/Publish/Core/Event/LanguageService.php
@@ -62,7 +62,7 @@ class LanguageService extends LanguageServiceDecorator
 
     public function updateLanguageName(
         Language $language,
-        $newName
+        string $newName
     ): Language {
         $eventData = [
             $language,

--- a/eZ/Publish/Core/Repository/LanguageService.php
+++ b/eZ/Publish/Core/Repository/LanguageService.php
@@ -65,14 +65,14 @@ class LanguageService implements LanguageServiceInterface
     /**
      * Creates the a new Language in the content repository.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the languageCode already exists
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\LanguageCreateStruct $languageCreateStruct
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the languageCode already exists
      */
-    public function createLanguage(LanguageCreateStruct $languageCreateStruct)
+    public function createLanguage(LanguageCreateStruct $languageCreateStruct): Language
     {
         if (!is_string($languageCreateStruct->name) || empty($languageCreateStruct->name)) {
             throw new InvalidArgumentValue('name', $languageCreateStruct->name, 'LanguageCreateStruct');
@@ -121,18 +121,17 @@ class LanguageService implements LanguageServiceInterface
     /**
      * Changes the name of the language in the content repository.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
-     *         is not string
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Language $language
      * @param string $newName
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
+     *         is not string
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
      */
-    public function updateLanguageName(Language $language, $newName)
+    public function updateLanguageName(Language $language, string $newName): Language
     {
-        if (!is_string($newName) || empty($newName)) {
+        if (empty($newName)) {
             throw new InvalidArgumentValue('newName', $newName);
         }
 
@@ -166,13 +165,12 @@ class LanguageService implements LanguageServiceInterface
     /**
      * Enables a language.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Language $language
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
      */
-    public function enableLanguage(Language $language)
+    public function enableLanguage(Language $language): Language
     {
         if (!$this->permissionResolver->canUser('content', 'translations', $language)) {
             throw new UnauthorizedException('content', 'translations');
@@ -204,13 +202,12 @@ class LanguageService implements LanguageServiceInterface
     /**
      * Disables a language.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Language $language
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
      */
-    public function disableLanguage(Language $language)
+    public function disableLanguage(Language $language): Language
     {
         if (!$this->permissionResolver->canUser('content', 'translations', $language)) {
             throw new UnauthorizedException('content', 'translations');
@@ -242,17 +239,16 @@ class LanguageService implements LanguageServiceInterface
     /**
      * Loads a Language from its language code ($languageCode).
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
-     *         is not string
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if language could not be found
-     *
      * @param string $languageCode
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
+     *         is not string
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if language could not be found
      */
-    public function loadLanguage($languageCode)
+    public function loadLanguage(string $languageCode): Language
     {
-        if (!is_string($languageCode) || empty($languageCode)) {
+        if (empty($languageCode)) {
             throw new InvalidArgumentException('languageCode', 'language code has an invalid value');
         }
 
@@ -266,7 +262,7 @@ class LanguageService implements LanguageServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language[]
      */
-    public function loadLanguages()
+    public function loadLanguages(): iterable
     {
         $languages = $this->languageHandler->loadAll();
 
@@ -281,13 +277,12 @@ class LanguageService implements LanguageServiceInterface
     /**
      * Loads a Language by its id ($languageId).
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if language could not be found
-     *
      * @param mixed $languageId
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Language
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if language could not be found
      */
-    public function loadLanguageById($languageId)
+    public function loadLanguageById(int $languageId): Language
     {
         $language = $this->languageHandler->load($languageId);
 
@@ -327,14 +322,13 @@ class LanguageService implements LanguageServiceInterface
     /**
      * Deletes  a language from content repository.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     *         if language can not be deleted
+     * @param \eZ\Publish\API\Repository\Values\Content\Language $language
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if language can not be deleted
      *         because it is still assigned to some content / type / (...).
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If user does not have access to content translations
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\Language $language
      */
-    public function deleteLanguage(Language $language)
+    public function deleteLanguage(Language $language): void
     {
         if (!$this->permissionResolver->canUser('content', 'translations', $language)) {
             throw new UnauthorizedException('content', 'translations');
@@ -360,7 +354,7 @@ class LanguageService implements LanguageServiceInterface
      *
      * @return string
      */
-    public function getDefaultLanguageCode()
+    public function getDefaultLanguageCode(): string
     {
         return $this->settings['languages'][0];
     }
@@ -381,7 +375,7 @@ class LanguageService implements LanguageServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LanguageCreateStruct
      */
-    public function newLanguageCreateStruct()
+    public function newLanguageCreateStruct(): LanguageCreateStruct
     {
         return new LanguageCreateStruct();
     }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/LanguageService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/LanguageService.php
@@ -33,37 +33,37 @@ class LanguageService implements LanguageServiceInterface
         $this->service = $service;
     }
 
-    public function createLanguage(LanguageCreateStruct $languageCreateStruct)
+    public function createLanguage(LanguageCreateStruct $languageCreateStruct): Language
     {
         return $this->service->createLanguage($languageCreateStruct);
     }
 
-    public function updateLanguageName(Language $language, $newName)
+    public function updateLanguageName(Language $language, string $newName): Language
     {
         return $this->service->updateLanguageName($language, $newName);
     }
 
-    public function enableLanguage(Language $language)
+    public function enableLanguage(Language $language): Language
     {
         return $this->service->enableLanguage($language);
     }
 
-    public function disableLanguage(Language $language)
+    public function disableLanguage(Language $language): Language
     {
         return $this->service->disableLanguage($language);
     }
 
-    public function loadLanguage($languageCode)
+    public function loadLanguage(string $languageCode): Language
     {
         return $this->service->loadLanguage($languageCode);
     }
 
-    public function loadLanguages()
+    public function loadLanguages(): iterable
     {
         return $this->service->loadLanguages();
     }
 
-    public function loadLanguageById($languageId)
+    public function loadLanguageById(int $languageId): Language
     {
         return $this->service->loadLanguageById($languageId);
     }
@@ -78,17 +78,17 @@ class LanguageService implements LanguageServiceInterface
         return $this->service->loadLanguageListById($languageIds);
     }
 
-    public function deleteLanguage(Language $language)
+    public function deleteLanguage(Language $language): void
     {
-        return $this->service->deleteLanguage($language);
+        $this->service->deleteLanguage($language);
     }
 
-    public function getDefaultLanguageCode()
+    public function getDefaultLanguageCode(): string
     {
         return $this->service->getDefaultLanguageCode();
     }
 
-    public function newLanguageCreateStruct()
+    public function newLanguageCreateStruct(): LanguageCreateStruct
     {
         return $this->service->newLanguageCreateStruct();
     }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LanguageServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LanguageServiceTest.php
@@ -26,27 +26,27 @@ class LanguageServiceTest extends AbstractServiceTest
 
         // string $method, array $arguments, bool $return = true
         return [
-            ['createLanguage', [$languageCreateStruct]],
+            ['createLanguage', [$languageCreateStruct], $language],
 
-            ['updateLanguageName', [$language, 'Afrikaans']],
+            ['updateLanguageName', [$language, 'Afrikaans'], $language],
 
-            ['enableLanguage', [$language]],
+            ['enableLanguage', [$language], $language],
 
-            ['disableLanguage', [$language]],
+            ['disableLanguage', [$language], $language],
 
-            ['loadLanguage', ['eng-GB']],
+            ['loadLanguage', ['eng-GB'], $language],
             ['loadLanguageListByCode', [['eng-GB']], []],
 
-            ['loadLanguages', []],
+            ['loadLanguages', [], []],
 
-            ['loadLanguageById', [4]],
+            ['loadLanguageById', [4], $language],
             ['loadLanguageListById', [[4]], []],
 
-            ['deleteLanguage', [$language]],
+            ['deleteLanguage', [$language], null],
 
-            ['getDefaultLanguageCode', []],
+            ['getDefaultLanguageCode', [], ''],
 
-            ['newLanguageCreateStruct', []],
+            ['newLanguageCreateStruct', [], $languageCreateStruct],
         ];
     }
 

--- a/eZ/Publish/SPI/Repository/Decorator/LanguageServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/LanguageServiceDecorator.php
@@ -22,39 +22,39 @@ abstract class LanguageServiceDecorator implements LanguageService
         $this->innerService = $innerService;
     }
 
-    public function createLanguage(LanguageCreateStruct $languageCreateStruct)
+    public function createLanguage(LanguageCreateStruct $languageCreateStruct): Language
     {
         return $this->innerService->createLanguage($languageCreateStruct);
     }
 
     public function updateLanguageName(
         Language $language,
-        $newName
-    ) {
+        string $newName
+    ): Language {
         return $this->innerService->updateLanguageName($language, $newName);
     }
 
-    public function enableLanguage(Language $language)
+    public function enableLanguage(Language $language): Language
     {
         return $this->innerService->enableLanguage($language);
     }
 
-    public function disableLanguage(Language $language)
+    public function disableLanguage(Language $language): Language
     {
         return $this->innerService->disableLanguage($language);
     }
 
-    public function loadLanguage($languageCode)
+    public function loadLanguage(string $languageCode): Language
     {
         return $this->innerService->loadLanguage($languageCode);
     }
 
-    public function loadLanguages()
+    public function loadLanguages(): iterable
     {
         return $this->innerService->loadLanguages();
     }
 
-    public function loadLanguageById($languageId)
+    public function loadLanguageById(int $languageId): Language
     {
         return $this->innerService->loadLanguageById($languageId);
     }
@@ -69,17 +69,17 @@ abstract class LanguageServiceDecorator implements LanguageService
         return $this->innerService->loadLanguageListById($languageIds);
     }
 
-    public function deleteLanguage(Language $language)
+    public function deleteLanguage(Language $language): void
     {
-        return $this->innerService->deleteLanguage($language);
+        $this->innerService->deleteLanguage($language);
     }
 
-    public function getDefaultLanguageCode()
+    public function getDefaultLanguageCode(): string
     {
         return $this->innerService->getDefaultLanguageCode();
     }
 
-    public function newLanguageCreateStruct()
+    public function newLanguageCreateStruct(): LanguageCreateStruct
     {
         return $this->innerService->newLanguageCreateStruct();
     }

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/LanguageServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/LanguageServiceDecoratorTest.php
@@ -108,7 +108,7 @@ class LanguageServiceDecoratorTest extends TestCase
         $serviceMock = $this->createServiceMock();
         $decoratedService = $this->createDecorator($serviceMock);
 
-        $parameters = ['random_value_5ced05ce0e4f86.21411523'];
+        $parameters = [100];
 
         $serviceMock->expects($this->once())->method('loadLanguageById')->with(...$parameters);
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30885](https://jira.ez.no/browse/EZP-30885)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | yes!
| **Tests pass**     | yes
| **Doc needed**     | no

This PR introduces strict types for the `\eZ\Publish\API\Repository\LanguageService`

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.

**QA**
- [x] Sanities for language management
- [x] Sanities for COTF
- [x] Sanities for creating content
- [x] Sanities for creating content translation
- [x] Sanities for UDW
- [x] Sanities for language lists
