### PR TITLE
EZP-30985: Replaced deprecated Twig classes

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -37,7 +37,7 @@ parameters:
 services:
     # Enable Twig intl extension
     twig.extension.intl:
-        class: Twig_Extensions_Extension_Intl
+        class: Twig\Extensions\IntlExtension
         tags:
             - {name: twig.extension}
 

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
@@ -20,7 +20,7 @@ use Exception;
 
 /**
  * Class FileSystemTwigIntegrationTestCase
- * This class adds a custom version of the doIntegrationTest from Twig_Test_IntegrationTestCase to
+ * This class adds a custom version of the doIntegrationTest from \Twig\Test\IntegrationTestCase to
  * allow loading (custom) templates located in the FixturesDir.
  */
 abstract class FileSystemTwigIntegrationTestCase extends IntegrationTestCase
@@ -38,7 +38,7 @@ abstract class FileSystemTwigIntegrationTestCase extends IntegrationTestCase
             }
         }
 
-        // changes from the original is here, Twig_Loader_Filesystem has been added
+        // changes from the original is here, \Twig\Loader\FilesystemLoader has been added
         $loader = new ChainLoader(
             [
                 new ArrayLoader($templates),

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/FieldBlockRenderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/FieldBlockRenderer.php
@@ -167,7 +167,7 @@ class FieldBlockRenderer implements FieldBlockRendererInterface
 
         $params += ['field' => $field];
 
-        // Getting instance of Twig_Template that will be used to render blocks
+        // Getting instance of \Twig\Template that will be used to render blocks
         if (is_string($this->baseTemplate)) {
             $this->baseTemplate = $this->twig->loadTemplate($this->baseTemplate);
         }

--- a/eZ/Publish/Core/MVC/Symfony/Translation/TranslatableExceptionsFileVisitor.php
+++ b/eZ/Publish/Core/MVC/Symfony/Translation/TranslatableExceptionsFileVisitor.php
@@ -21,6 +21,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use PhpParser\Node\Scalar\String_;
 use Psr\Log\LoggerInterface;
+use Twig\Node\Node as TwigNode;
 
 /**
  * Visits calls to some known translatable exceptions, into the repository_exceptions domain.
@@ -188,9 +189,9 @@ class TranslatableExceptionsFileVisitor implements LoggerAwareInterface, FileVis
     /**
      * @param \SplFileInfo $file
      * @param MessageCatalogue $catalogue
-     * @param \Twig_Node $ast
+     * @param \Twig\Node\Node $ast
      */
-    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/Translation/ValidationErrorFileVisitor.php
+++ b/eZ/Publish/Core/MVC/Symfony/Translation/ValidationErrorFileVisitor.php
@@ -21,6 +21,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use PhpParser\Node\Scalar\String_;
 use Psr\Log\LoggerInterface;
+use Twig\Node\Node as TwigNode;
 
 /**
  * Visits calls to some known translatable exceptions, into the repository_exceptions domain.
@@ -188,9 +189,9 @@ class ValidationErrorFileVisitor implements LoggerAwareInterface, FileVisitorInt
     /**
      * @param \SplFileInfo $file
      * @param MessageCatalogue $catalogue
-     * @param \Twig_Node $ast
+     * @param \Twig\Node\Node $ast
      */
-    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30985](https://jira.ez.no/browse/EZP-30985)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Part of the patch changes methods which implement `JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface::visitTwigFile` which still uses old Twig class names. However, this is perfectly valid. The following code runs fine:

```php
<?php

require 'vendor/autoload.php';

interface Foo
{
    public function foo(\Twig_Node $node);
}

class Bar implements Foo
{
    public function foo(\Twig\Node\Node $node)
    {
        return 'foo';
    }
}


$b = new Bar();

echo $b->foo(new \Twig\Node\Node());
echo $b->foo(new \Twig_Node());
```

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
