### PR TITLE
[Travis] Disabled testing 6.7 and 6.13 branches on push / merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: required
 
 language: php
 
+# Disable tests on merge, run them using a cron job in the night
+if: type != push
+
 services:
   - mysql
   - postgresql


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| sort of improvement for Travis
| **New feature**    | no
| **Target version** | 6.7, 6.13, not applicable for 7.5 or master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR tries to reduce the job queue on Travis. When something is merged to 6.7 and then upstrem it triggers 36 jobs on Travis (10 for each 6.7, 6.13, 7.5 and 6 for master), which can take some time to finish.

This PR changes how the jobs are run - after a PR to 6.7 or 6.13 is merged jobs won't be triggered, 
instead they will be triggered during the nightly build (we're running cron build for all supported branches, example: https://travis-ci.org/ezsystems/ezpublish-kernel/builds/595869257). The idea is that development for 6.7 and 6.13 has slowed to the point that we can comfortably wait with running the tests until the night, we do not need the results immediately.

They will still run:
- for PRs
- when triggered manually from Travis
- from cron

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
