### PR TITLE
EZP-31023: Fixed root location loading with prioritized languages

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -392,10 +392,32 @@ class LocationServiceTest extends BaseTest
         $locationService = $repository->getLocationService();
         $location = $locationService->loadLocation($this->generateId('location', 1));
 
+        $this->assertRootLocationStructValues($location);
+    }
+
+    public function testLoadLocationRootStructValuesWithPrioritizedLanguages(): void
+    {
+        $repository = $this->getRepository();
+
+        $rootLocation = $repository
+            ->getLocationService()
+            ->loadLocation(
+                $this->generateId('location', 1),
+                [
+                    'eng-GB',
+                    'ger-DE',
+                ]
+            );
+
+        $this->assertRootLocationStructValues($rootLocation);
+    }
+
+    private function assertRootLocationStructValues(Location $location): void
+    {
         $legacyDateTime = new \DateTime();
         $legacyDateTime->setTimestamp(1030968000);
 
-        // $location
+        $this->assertInstanceOf(Location::class, $location);
         $this->assertPropertiesCorrect(
             [
                 'id' => $this->generateId('location', 1),
@@ -413,8 +435,7 @@ class LocationServiceTest extends BaseTest
             $location
         );
 
-        // $location->contentInfo
-        $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo', $location->contentInfo);
+        $this->assertInstanceOf(ContentInfo::class, $location->contentInfo);
         $this->assertPropertiesCorrect(
             [
                 'id' => $this->generateId('content', 0),

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -73,7 +73,7 @@ class DoctrineDatabase extends Gateway
     public function getBasicNodeData($nodeId, array $translations = null, bool $useAlwaysAvailable = true)
     {
         $q = $this->createNodeQueryBuilder($translations, $useAlwaysAvailable);
-        $q->where(
+        $q->andWhere(
             $q->expr()->eq('t.node_id', $q->createNamedParameter($nodeId, PDO::PARAM_INT))
         );
 
@@ -90,7 +90,7 @@ class DoctrineDatabase extends Gateway
     public function getNodeDataList(array $locationIds, array $translations = null, bool $useAlwaysAvailable = true): iterable
     {
         $q = $this->createNodeQueryBuilder($translations, $useAlwaysAvailable);
-        $q->where(
+        $q->andWhere(
             $q->expr()->in(
                 't.node_id',
                 $q->createNamedParameter($locationIds, Connection::PARAM_INT_ARRAY)
@@ -106,7 +106,7 @@ class DoctrineDatabase extends Gateway
     public function getBasicNodeDataByRemoteId($remoteId, array $translations = null, bool $useAlwaysAvailable = true)
     {
         $q = $this->createNodeQueryBuilder($translations, $useAlwaysAvailable);
-        $q->where(
+        $q->andWhere(
             $q->expr()->eq('t.remote_id', $q->createNamedParameter($remoteId, PDO::PARAM_STR))
         );
 
@@ -1651,15 +1651,23 @@ class DoctrineDatabase extends Gateway
                 $useAlwaysAvailable
             );
 
-            $queryBuilder->innerJoin(
+            $queryBuilder->leftJoin(
                 't',
                 'ezcontentobject',
                 'c',
-                $expr->andX(
-                    $expr->eq('t.contentobject_id', 'c.id'),
+                $expr->eq('t.contentobject_id', 'c.id')
+            );
+
+            $queryBuilder->andWhere(
+                $expr->orX(
                     $expr->gt(
                         $dbPlatform->getBitAndComparisonExpression('c.language_mask', $mask),
                         0
+                    ),
+                    // Root location doesn't have language mask
+                    $expr->eq(
+                        //'t.contentobject_id', 0
+                        't.node_id', 't.parent_node_id'
                     )
                 )
             );

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1666,7 +1666,6 @@ class DoctrineDatabase extends Gateway
                     ),
                     // Root location doesn't have language mask
                     $expr->eq(
-                        //'t.contentobject_id', 0
                         't.node_id', 't.parent_node_id'
                     )
                 )

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1658,7 +1658,7 @@ class DoctrineDatabase extends Gateway
                 $expr->eq('t.contentobject_id', 'c.id')
             );
 
-            $queryBuilder->andWhere(
+            $queryBuilder->where(
                 $expr->orX(
                     $expr->gt(
                         $dbPlatform->getBitAndComparisonExpression('c.language_mask', $mask),


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31023](https://jira.ez.no/browse/EZP-31023)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`, `master`
| **BC breaks**      | no
| **Tests pass**     | -
| **Doc needed**     | no

_Correct if I'm wrong and this is expected behavior. Issue discovered while working on https://github.com/ezsystems/ezpublish-kernel/pull/2786_

Currently, it's not possible to load the root location (id = 1) with the prioritized language list  

```php
$rootLocation = $repository
    ->getLocationService()
    ->loadLocation(
        $this->generateId('location', 1),
        [
            'eng-GB',
            'ger-DE',
        ]
    );
```

instead of `\eZ\Publish\API\Repository\Exceptions\NotFoundException` is thrown. Ref. https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/596056646

The following SQL query is generated to load root location with prioritized languages:

```sql
SELECT t.* FROM ezcontentobject_tree t INNER JOIN ezcontentobject c ON (t.contentobject_id = c.id AND (c.language_mask & :mask) > 0) WHERE t.node_id = 1
```

but the root location points to the non-existing content object with id = 0 so the query will always return an empty result set.

### FAQ

#### Why not insert a content object with id = 0?

1) MySQL doesn't allow inserting a record with 0 as the value of an auto-incremented column (it's interpreted as `null`)
2) It will become available in search results  (e.g. when `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchAll` is used)

#### Why not remove location with id = 1?

It will require to update the path string of all existing locations. 

#### What is performance impact?

No data available yet. 

**TODO**:
- [x] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
