### PR TITLE
EZP-31026: Fixed resolving of lang params in SA loadContentListByContentInfo

### DIFF
--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -222,9 +222,13 @@ class ContentService implements ContentServiceInterface
         return $this->service->deleteTranslationFromDraft($versionInfo, $languageCode);
     }
 
-    public function loadContentListByContentInfo(array $contentInfoList, array $languages = [], $useAlwaysAvailable = true)
+    public function loadContentListByContentInfo(array $contentInfoList, array $languages = null, $useAlwaysAvailable = null)
     {
-        return $this->service->loadContentListByContentInfo($contentInfoList, $languages, $useAlwaysAvailable);
+        return $this->service->loadContentListByContentInfo(
+            $contentInfoList,
+            $this->languageResolver->getPrioritizedLanguages($languages),
+            $this->languageResolver->getUseAlwaysAvailable($useAlwaysAvailable)
+        );
     }
 
     public function hideContent(ContentInfo $contentInfo): void

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
@@ -123,6 +123,9 @@ class ContentServiceTest extends AbstractServiceTest
 
             ['loadContentByRemoteId', ['f348tj4gorgji4'], true, 1],
             ['loadContentByRemoteId', ['f348tj4gorgji4', self::LANG_ARG, 4, false], true, 1],
+
+            ['loadContentListByContentInfo', [[$contentInfo]], [], 1],
+            ['loadContentListByContentInfo', [[$contentInfo], self::LANG_ARG, false], [], 1],
         ];
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31026](https://jira.ez.no/browse/EZP-31026)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     |  no

_Issue discovered while working on https://github.com/ezsystems/ezpublish-kernel/pull/2786_

Method `\eZ\Publish\API\Repository\ContentService::loadContentListByContentInfo` called from the site access aware layer doens't respect current siteaccess languages settings.

**TODO**:
- [X] Implement feature / fix a bug.
- [x] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
