### PR TITLE
EZP-30985: Replaced usage of deprecated transchoice Twig function

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/translations/fielddefinition.en.xlf
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/translations/fielddefinition.en.xlf
@@ -267,10 +267,16 @@
         <note>key: fielddefinition.multiple.label</note>
         <jms:reference-file line="386">eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="77c3603526e153eea2b11a851601dabd3bfdbd9a" resname="fielddefinition.multiple.yes_no">
-        <source>{0} No|{1} Yes</source>
-        <target>{0} No|{1} Yes</target>
-        <note>key: fielddefinition.multiple.yes_no</note>
+      <trans-unit id="ec31a6088a9e8cb3266bf0b99e057ca0677fcd82" resname="fielddefinition.multiple.yes">
+        <source>Yes</source>
+        <target>Yes</target>
+        <note>key: fielddefinition.multiple.yes</note>
+        <jms:reference-file line="387">eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="0b8ef090df7e5c7780364c51f060db3f5b8f076a" resname="fielddefinition.multiple.no">
+        <source>No</source>
+        <target>No</target>
+        <note>key: fielddefinition.multiple.no</note>
         <jms:reference-file line="387">eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4d59776118124c81734aacab8a71198ee555479c" resname="fielddefinition.options.label">
@@ -373,10 +379,17 @@
         <jms:reference-file line="122">eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
         <jms:reference-file line="96">eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="f875a84fc9f3c1e0610a90197722f04b9442fa01" resname="fielddefinition.use-seconds.yes_no">
-        <source>{0} No|{1} Yes</source>
-        <target>{0} No|{1} Yes</target>
-        <note>key: fielddefinition.use-seconds.yes_no</note>
+      <trans-unit id="edc26cd0186a48016fc5bc286c4d64e238043658" resname="fielddefinition.use-seconds.yes">
+        <source>Yes</source>
+        <target>Yes</target>
+        <note>key: fielddefinition.use-seconds.yes</note>
+        <jms:reference-file line="123">eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
+        <jms:reference-file line="97">eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="8c785cf266419d05f444b0e88bbf34f07c0b6fde" resname="fielddefinition.use-seconds.no">
+        <source>No</source>
+        <target>No</target>
+        <note>key: fielddefinition.use-seconds.no</note>
         <jms:reference-file line="123">eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
         <jms:reference-file line="97">eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -92,7 +92,7 @@
     {{ block( 'settings_defaultvalue' ) }}
     <li class="ez-fielddefinition-setting use-seconds">
         <div class="ez-fielddefinition-setting-name">{{ 'fielddefinition.use-seconds.label'|trans|desc("Use seconds:")}}</div>
-        <div class="ez-fielddefinition-setting-value">{{ 'fielddefinition.use-seconds.yes_no'|transchoice(settings.useSeconds)|desc("{0} No|{1} Yes") }}</div>
+        <div class="ez-fielddefinition-setting-value">{{ settings.useSeconds ? 'fielddefinition.use-seconds.yes'|trans|desc("Yes") : 'fielddefinition.use-seconds.no'|trans|desc("No") }}</div>
     </li>
 </ul>
 {% endblock %}
@@ -118,7 +118,7 @@
     {{ block( 'settings_defaultvalue' ) }}
     <li class="ez-fielddefinition-setting use-seconds">
         <div class="ez-fielddefinition-setting-name">{{ 'fielddefinition.use-seconds.label'|trans|desc("Use seconds:")}}</div>
-        <div class="ez-fielddefinition-setting-value">{{ 'fielddefinition.use-seconds.yes_no'|transchoice(settings.useSeconds)|desc("{0} No|{1} Yes") }}</div>
+        <div class="ez-fielddefinition-setting-value">{{ settings.useSeconds ? 'fielddefinition.use-seconds.yes'|trans|desc("Yes") : 'fielddefinition.use-seconds.no'|trans|desc("No") }}</div>
     </li>
 </ul>
 {% endblock %}
@@ -387,7 +387,7 @@
 {% block settings_allowmultiple %}
     <li class="ez-fielddefinition-setting multiple">
         <div class="ez-fielddefinition-setting-name">{{ 'fielddefinition.multiple.label'|trans|desc("Allow multiple choices:")}}</div>
-        <div class="ez-fielddefinition-setting-value">{{ 'fielddefinition.multiple.yes_no'|transchoice(isMultiple)|desc("{0} No|{1} Yes") }}</div>
+        <div class="ez-fielddefinition-setting-value">{{ isMultiple ? 'fielddefinition.multiple.yes'|trans|desc("Yes") : 'fielddefinition.multiple.no'|trans|desc("No") }}</div>
     </li>
 {% endblock %}
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30985](https://jira.ez.no/browse/EZP-30985)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | yes? (New translation strings required)
| **Tests pass**     | no
| **Doc needed**     | no

`transchoice` has been deprecated since Symfony 4.2.

Here, I've opted for using separate translation strings, rather than reimplementing `trans` with ICU MessageFormat which requires renaming translation files to have a new prefix for ICU messages to be recognized.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.