### PR TITLE
EZP-31050: Fixed resolving of lang params in SA ContentTypeService::loadContentTypeList

### DIFF
--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
@@ -114,7 +114,7 @@ class ContentTypeService implements ContentTypeServiceInterface
         return $this->service->loadContentTypeDraft($contentTypeId, $ignoreOwnership);
     }
 
-    public function loadContentTypeList(array $contentTypeIds, array $prioritizedLanguages = []): iterable
+    public function loadContentTypeList(array $contentTypeIds, array $prioritizedLanguages = null): iterable
     {
         $prioritizedLanguages = $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages);
 

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentTypeServiceTest.php
@@ -57,8 +57,6 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
             ['loadContentTypeDraft', [22]],
 
-            ['loadContentTypeList', [[22]], [$contentType]],
-
             ['createContentTypeDraft', [$contentType]],
 
             ['updateContentTypeDraft', [$contentTypeDraft, $contentTypeUpdateStruct]],
@@ -102,6 +100,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
     public function providerForLanguagesLookupMethods()
     {
+        $contentType = new ContentType();
         $contentTypeGroup = new ContentTypeGroup();
 
         // string $method, array $arguments, bool $return, int $languageArgumentIndex
@@ -113,6 +112,8 @@ class ContentTypeServiceTest extends AbstractServiceTest
             ['loadContentTypeGroups', [self::LANG_ARG], true, 0],
 
             ['loadContentType', [22, self::LANG_ARG], true, 1],
+
+            ['loadContentTypeList', [[22, self::LANG_ARG]], [$contentType], 1],
 
             ['loadContentTypeByIdentifier', ['article', self::LANG_ARG], true, 1],
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31050](https://jira.ez.no/browse/EZP-31050)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     |  no

_Issue discovered while working on https://github.com/ezsystems/ezpublish-kernel/pull/2786_

Method `\eZ\Publish\Core\Repository\SiteAccessAware\ContentTypeService::loadContentTypeList` called from the site access aware layer doesn't respect current siteaccess languages settings.

**TODO**:
- [X] Implement feature / fix a bug.
- [x] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.