### PR TITLE
EZP-31053: Prioritized languages should be respected by Content::getContentType

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
@@ -384,7 +384,7 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
      * Test for the loadContent() method.
      *
      * @see \eZ\Publish\API\Repository\ContentService::loadContent($contentId, $languages)
-     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadContentWithSecondParameter
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadContentWithPrioritizedLanguages
      */
     public function testLoadContentThrowsUnauthorizedExceptionWithSecondParameter()
     {

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -2687,7 +2687,7 @@ XML
      * @see \eZ\Publish\API\Repository\ContentService::loadContent($contentId, $languages)
      * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testPublishVersionFromContentDraft
      */
-    public function testLoadContentWithSecondParameter()
+    public function testLoadContentWithPrioritizedLanguages()
     {
         $draft = $this->createMultipleLanguageDraftVersion1();
 
@@ -2696,21 +2696,39 @@ XML
 
         $this->assertLocaleFieldsEquals($draftLocalized->getFields(), self::ENG_GB);
 
-        return $draft;
+        return $draftLocalized;
     }
 
     /**
      * Test for the loadContent() method using undefined translation.
      *
-     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadContentWithSecondParameter
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadContentWithPrioritizedLanguages
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Content $contentDraft
      */
-    public function testLoadContentWithSecondParameterThrowsNotFoundException(Content $contentDraft)
+    public function testLoadContentWithPrioritizedLanguagesThrowsNotFoundException(Content $contentDraft)
     {
         $this->expectException(NotFoundException::class);
 
         $this->contentService->loadContent($contentDraft->id, [self::GER_DE], null, false);
+    }
+
+    /**
+     * Test for the loadContent() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentService::loadContent
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadContentWithPrioritizedLanguages
+     */
+    public function testLoadContentPassTroughPrioritizedLanguagesToContentType(Content $content): void
+    {
+        $contentTypeService = $this->getRepository()->getContentTypeService();
+
+        $contentType = $contentTypeService->loadContentType(
+            $content->contentInfo->contentTypeId,
+            [self::ENG_GB]
+        );
+
+        $this->assertEquals($contentType, $content->getContentType());
     }
 
     /**

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -382,12 +382,17 @@ class ContentService implements ContentServiceInterface
             );
         }
 
+        if ($languages === null) {
+            $languages = [];
+        }
+
         return $this->domainMapper->buildContentDomainObject(
             $spiContent,
             $this->repository->getContentTypeService()->loadContentType(
-                $spiContent->versionInfo->contentInfo->contentTypeId
+                $spiContent->versionInfo->contentInfo->contentTypeId,
+                $languages
             ),
-            $languages ?? [],
+            $languages,
             $alwaysAvailableLanguageCode
         );
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31053](https://jira.ez.no/browse/EZP-31053)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

_Issue discovered while working on https://github.com/ezsystems/ezpublish-kernel/pull/2786_

Method `\eZ\Publish\Core\Repository\ContentService::internalLoadContent` ignores language priority while loading content type.  

**TODO**:
- [x] Implement feature / fix a bug.
- [X] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [x] Fix JIRA issue id in commit message before merge