### PR TITLE
EZP-30689: Registered Query Types for automatic configuration

### DIFF
--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -208,6 +208,11 @@ Changes affecting version compatibility with former or future versions.
 
   Use `DoctrineStorage` Gateways from the same namespace instead.
 
+* Query Types: Traversing bundles to automatically register a Query Type by the naming
+  convention `<Bundle>\QueryType\*QueryType` has been dropped.
+  Register your Query Type as a service and explicitly tag that service with `ezpublish.query`
+  or enable its automatic configuration (`autoconfigure: true`).
+
 ## Deprecated features
 
 * Using SiteAccess-aware `pagelayout` setting is derecated, use `page_layout` instead.

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
@@ -13,6 +13,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class QueryTypePass implements CompilerPassInterface
 {
+    public const QUERY_TYPE_SERVICE_TAG = 'ezpublish.query_type';
+
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('ezpublish.query_type.registry')) {
@@ -23,7 +25,7 @@ class QueryTypePass implements CompilerPassInterface
         $queryTypesClasses = [];
 
         // tagged query types
-        $taggedServiceIds = $container->findTaggedServiceIds('ezpublish.query_type');
+        $taggedServiceIds = $container->findTaggedServiceIds(self::QUERY_TYPE_SERVICE_TAG);
         foreach ($taggedServiceIds as $taggedServiceId => $tags) {
             $queryTypeDefinition = $container->getDefinition($taggedServiceId);
             $queryTypeClass = $container->getParameterBag()->resolveValue($queryTypeDefinition->getClass());

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
@@ -4,11 +4,8 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
 
-use Exception;
-use ReflectionClass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -37,49 +34,6 @@ class QueryTypePass implements CompilerPassInterface
                 $name = isset($tags[$i]['alias']) ? $tags[$i]['alias'] : $queryTypeClass::getName();
                 $queryTypes[$name] = new Reference($taggedServiceId);
                 $queryTypesClasses[$queryTypeClass][$name] = true;
-            }
-        }
-
-        // named by convention query types
-        if ($container->hasParameter('kernel.bundles')) {
-            foreach ($container->getParameter('kernel.bundles') as $bundleName => $bundleClass) {
-                $bundleReflectionClass = new ReflectionClass($bundleClass);
-                $bundleDir = dirname($bundleReflectionClass->getFileName());
-
-                $bundleQueryTypesDir = $bundleDir . DIRECTORY_SEPARATOR . 'QueryType';
-
-                if (!is_dir($bundleQueryTypesDir)) {
-                    continue;
-                }
-
-                $queryTypeServices = [];
-                $bundleQueryTypeNamespace = substr($bundleClass, 0, strrpos($bundleClass, '\\') + 1) . 'QueryType';
-                foreach (glob($bundleQueryTypesDir . DIRECTORY_SEPARATOR . '*QueryType.php') as $queryTypeFilePath) {
-                    $queryTypeFileName = basename($queryTypeFilePath, '.php');
-                    $queryTypeClassName = $bundleQueryTypeNamespace . '\\' . $queryTypeFileName;
-                    if (!class_exists($queryTypeClassName)) {
-                        throw new Exception("Expected $queryTypeClassName to be defined in $queryTypeFilePath");
-                    }
-
-                    $queryTypeName = $queryTypeClassName::getName();
-
-                    // skip if the class was already registered as a tagged service with the same name
-                    if (isset($queryTypesClasses[$queryTypeClassName][$queryTypeName])) {
-                        continue;
-                    }
-
-                    $queryTypeReflectionClass = new ReflectionClass($queryTypeClassName);
-                    if (!$queryTypeReflectionClass->implementsInterface('eZ\Publish\Core\QueryType\QueryType')) {
-                        throw new Exception("$queryTypeClassName needs to implement eZ\\Publish\\Core\\QueryType\\QueryType");
-                    }
-
-                    $serviceId = 'ezpublish.query_type.convention.' . strtolower($bundleName) . '_' . strtolower($queryTypeFileName);
-                    $queryTypeServices[$serviceId] = new Definition($queryTypeClassName);
-
-                    $queryTypes[$queryTypeName] = new Reference($serviceId);
-                }
-
-                $container->addDefinitions($queryTypeServices);
             }
         }
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection;
 
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\QueryTypePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigParser;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ConfigurationProcessor;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\Collector\SuggestionCollector;
@@ -135,7 +136,7 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
         $this->buildPolicyMap($container);
 
         $container->registerForAutoconfiguration(QueryType::class)
-            ->addTag('ezpublish.query_type');
+            ->addTag(QueryTypePass::QUERY_TYPE_SERVICE_TAG);
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -16,6 +16,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\F
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\PoliciesConfigBuilder;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\PolicyProviderInterface;
 use eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessConfigurationFilter;
+use eZ\Publish\Core\QueryType\QueryType;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -132,6 +133,9 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
 
         $this->handleSiteAccessesRelation($container);
         $this->buildPolicyMap($container);
+
+        $container->registerForAutoconfiguration(QueryType::class)
+            ->addTag('ezpublish.query_type');
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryControllerContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryControllerContext.php
@@ -54,7 +54,7 @@ class QueryControllerContext extends RawMinkContext implements Context
         $configurationBlock = array_merge(
             Yaml::parse($string),
             [
-                'template' => 'eZBehatBundle:tests:dump.html.twig',
+                'template' => '@eZBehat/tests/dump.html.twig',
                 'match' => [
                     'Id\Content' => $this->matchedContent->id,
                 ],

--- a/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/query_controller.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/query_controller.feature
@@ -3,7 +3,6 @@ Feature: Query controller
     As a developer
     I want to run repository queries from content views
 
-@broken
 Scenario: A content view can be configured to run and render a query
     Given a content item that matches the view configuration block below
       And the following content view configuration block:
@@ -16,10 +15,10 @@ Scenario: A content view can be configured to run and render a query
                   parentLocationId: 2
               assign_results_to: 'children'
       """
-      And a LocationChildren QueryType defined in "src/AppBundle/QueryType/LocationChildrenQueryType.php":
+      And a LocationChildren QueryType defined in "src/QueryType/LocationChildrenQueryType.php":
       """
       <?php
-      namespace AppBundle\QueryType;
+      namespace App\QueryType;
 
       use eZ\Publish\API\Repository\Values\Content\LocationQuery;
       use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
@@ -34,7 +34,7 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
     public function testRegisterTaggedQueryType()
     {
         $def = new Definition();
-        $def->addTag('ezpublish.query_type');
+        $def->addTag(QueryTypePass::QUERY_TYPE_SERVICE_TAG);
         $def->setClass(self::$queryTypeClass);
         $serviceId = 'test.query_type';
         $this->setDefinition($serviceId, $def);
@@ -51,7 +51,7 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
     {
         $this->setParameter('query_type_class', self::$queryTypeClass);
         $def = new Definition();
-        $def->addTag('ezpublish.query_type');
+        $def->addTag(QueryTypePass::QUERY_TYPE_SERVICE_TAG);
         $def->setClass('%query_type_class%');
         $serviceId = 'test.query_type';
         $this->setDefinition($serviceId, $def);
@@ -75,12 +75,12 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
         $this->setParameter('kernel.bundles', ['QueryTypeBundle' => QueryTypeBundle::class]);
 
         $def = new Definition();
-        $def->addTag('ezpublish.query_type', ['alias' => 'overridden_type']);
+        $def->addTag(QueryTypePass::QUERY_TYPE_SERVICE_TAG, ['alias' => 'overridden_type']);
         $def->setClass(self::$queryTypeClass);
         $this->setDefinition('test.query_type_override', $def);
 
         $def = new Definition();
-        $def->addTag('ezpublish.query_type', ['alias' => 'other_overridden_type']);
+        $def->addTag(QueryTypePass::QUERY_TYPE_SERVICE_TAG, ['alias' => 'other_overridden_type']);
         $def->setClass(self::$queryTypeClass);
         $this->setDefinition('test.query_type_other_override', $def);
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
@@ -64,38 +64,6 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
         );
     }
 
-    public function testConventionQueryType()
-    {
-        $this->setParameter('kernel.bundles', ['QueryTypeBundle' => QueryTypeBundle::class]);
-
-        $this->compile();
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'ezpublish.query_type.registry',
-            'addQueryTypes',
-            [['Test:Test' => new Reference('ezpublish.query_type.convention.querytypebundle_testquerytype')]]
-        );
-    }
-
-    public function testConventionSkippedIfTagged()
-    {
-        $this->setParameter('kernel.bundles', ['QueryTypeBundle' => QueryTypeBundle::class]);
-
-        $def = new Definition();
-        $def->addTag('ezpublish.query_type');
-        $def->setClass(self::$queryTypeClass);
-        $serviceId = 'test.query_type';
-        $this->setDefinition($serviceId, $def);
-
-        $this->compile();
-
-        $this->assertContainerBuilderNotHasService('ezpublish.query_type.convention.querytypebundle_testquerytype');
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'ezpublish.query_type.registry',
-            'addQueryTypes',
-            [['Test:Test' => new Reference($serviceId)]]
-        );
-    }
-
     /**
      * Tests query type name override using the 'alias' tag attribute.
      *
@@ -118,7 +86,7 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
 
         $this->compile();
 
-        $this->assertContainerBuilderHasService('ezpublish.query_type.convention.querytypebundle_testquerytype');
+        $this->assertContainerBuilderHasService('test.query_type_override');
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'ezpublish.query_type.registry',
             'addQueryTypes',
@@ -126,7 +94,6 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
                 [
                     'overridden_type' => new Reference('test.query_type_override'),
                     'other_overridden_type' => new Reference('test.query_type_other_override'),
-                    'Test:Test' => new Reference('ezpublish.query_type.convention.querytypebundle_testquerytype'),
                 ],
             ]
         );

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection;
 
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\QueryTypePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Common;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Content;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
@@ -879,7 +880,7 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasServiceDefinitionWithTag(
             TestQueryType::class,
-            'ezpublish.query_type'
+            QueryTypePass::QUERY_TYPE_SERVICE_TAG
         );
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -11,6 +11,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Common;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Content;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
+use eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryType\TestQueryType;
 use eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\StubPolicyProvider;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Component\DependencyInjection\Definition;
@@ -859,5 +860,37 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
             $configuration,
             $parsedConfig
         );
+    }
+
+    /**
+     * Test automatic configuration of services implementing QueryType interface.
+     *
+     * @see \eZ\Publish\Core\QueryType\QueryType
+     */
+    public function testQueryTypeAutomaticConfiguration(): void
+    {
+        $definition = new Definition(TestQueryType::class);
+        $definition->setAutoconfigured(true);
+        $this->container->setDefinition(TestQueryType::class, $definition);
+
+        $this->load();
+
+        $this->compileCoreContainer();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            TestQueryType::class,
+            'ezpublish.query_type'
+        );
+    }
+
+    /**
+     * Prepare Core Container for compilation by mocking required parameters and compile it.
+     */
+    private function compileCoreContainer(): void
+    {
+        $this->container->setParameter('webroot_dir', __DIR__);
+        $this->container->setParameter('kernel.root_dir', __DIR__);
+        $this->container->setParameter('kernel.debug', false);
+        $this->compile();
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30689](https://jira.ez.no/browse/EZP-30689)
| **Required by** | #2651 
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform v3.0
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR both provides an improvement and fixes broken behat test for Query Types by providing automatic configuration for them (`autoconfigure: true` causing auto-tagging of the services which implement `\eZ\Publish\Core\QueryType\QueryType` with `ezpublish.query_type`).

The reason for doing it now is unblocking Travis for #2651 to proceed with QA.

### Breaking changes

Traversing through bundles to automatically register Query Types by the naming convention `<Bundle>\QueryType\*QueryType` has been dropped. 

This convention imposed on a Developer specific directory structure, which is Symfony 2 mindset. Instead we provided automatic configuration for all services which implement `QueryType` interface.
It might seem like an additional setup step, but in fact, when we look at the [`services.yaml` shipped with Symfony 4](https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/4.2/config/services.yaml#L11-L17), we can see that the entire `src` directory has been mapped to `App\*` services with auto-configuration. It means that just placing that class in developer-chosen "autoconfigured" namespace is enough. It yields the same DX as it used to, without 50 lines of our code.

### Doc

If the changes are accepted, the section ["By convention"](https://doc.ezplatform.com/en/master/guide/controllers/#by-convention) needs to be dropped or rephrased. The replacement convention now is auto-configuring service. The following section "Using a service tag" needs to be adjusted.
DIC config examples:

Recommended:
``` yaml
    App\Query\LatestContent:
        autoconfigure: true
```

By Service Tag:
``` yaml
    App\Query\LatestContent:
        tags:
            - {name: ezpublish.query_type}
```

By explicit alias instead of name (might be required in the future, if your QueryType needs to be `lazy`):
``` yaml
    App\Query\LatestContent:
        tags:
            - { name: ezpublish.query_type, alias: LatestContent }
```

**TODO**:
- [x] Register instances of `\eZ\Publish\Core\QueryType\QueryType` for auto-configuration.
- [x] Drop traversing through bundles to find Query Types (in favor of ^ auto-conf).
- [x] Implement DI tests.
- [x] Extract `ezpublish.query_type`" to a constant.
- [x] Fix Behat Query Types Feature scenario.
- [x] See if Behat test passes.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
