### PR TITLE
[WIP] EZP-30857: Referenced image file is not deleted from storage when removing draft, archived or published version.

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -975,9 +975,11 @@ CREATE TABLE `ezimagefile` (
   `contentobject_attribute_id` int(11) NOT NULL DEFAULT '0',
   `filepath` longtext NOT NULL,
   `id` int(11) NOT NULL AUTO_INCREMENT,
+  `version` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezimagefile_coid` (`contentobject_attribute_id`),
-  KEY `ezimagefile_file` (`filepath` (191))
+  KEY `ezimagefile_file` (`filepath` (191)),
+  KEY `ezimagefile_version` (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -979,7 +979,7 @@ CREATE TABLE `ezimagefile` (
   PRIMARY KEY (`id`),
   KEY `ezimagefile_coid` (`contentobject_attribute_id`),
   KEY `ezimagefile_file` (`filepath` (191)),
-  KEY `ezimagefile_version` (`version`)
+  KEY `ezimagefile_version` (`version`, `contentobject_attribute_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/data/update/mysql/dbupdate-7.5.10-to-7.5.11.sql
+++ b/data/update/mysql/dbupdate-7.5.10-to-7.5.11.sql
@@ -1,0 +1,13 @@
+UPDATE ezsite_data SET value='7.5.11' WHERE name='ezpublish-version';
+
+--
+-- EZP-30857: Files are not deleted from storage when removing archived versions
+--
+
+ALTER TABLE ezimagefile ADD COLUMN version INT(11) NOT NULL DEFAULT '0';
+
+ALTER TABLE ezimagefile ADD KEY ezimage_version ('version');
+
+--
+-- EZP-30857: end.
+--

--- a/data/update/mysql/dbupdate-7.5.10-to-7.5.11.sql
+++ b/data/update/mysql/dbupdate-7.5.10-to-7.5.11.sql
@@ -6,7 +6,7 @@ UPDATE ezsite_data SET value='7.5.11' WHERE name='ezpublish-version';
 
 ALTER TABLE ezimagefile ADD COLUMN version INT(11) NOT NULL DEFAULT '0';
 
-ALTER TABLE ezimagefile ADD KEY ezimage_version ('version');
+ALTER TABLE ezimagefile ADD KEY ezimage_version ('version', 'contentobject_attribute_id');
 
 --
 -- EZP-30857: end.

--- a/data/update/postgres/dbupdate-7.5.10-to-7.5.11.sql
+++ b/data/update/postgres/dbupdate-7.5.10-to-7.5.11.sql
@@ -6,7 +6,7 @@ UPDATE ezsite_data SET value='7.5.11' WHERE name='ezpublish-version';
 
 ALTER TABLE ezimagefile ADD COLUMN version integer DEFAULT 0 NOT NULL;
 
-CREATE INDEX ezimage_version ON ezimagefile (version);
+CREATE INDEX ezimage_version ON ezimagefile (version, contentobject_attribute_id);
 
 --
 -- EZP-30857: end.

--- a/data/update/postgres/dbupdate-7.5.10-to-7.5.11.sql
+++ b/data/update/postgres/dbupdate-7.5.10-to-7.5.11.sql
@@ -1,0 +1,12 @@
+UPDATE ezsite_data SET value='7.5.11' WHERE name='ezpublish-version';
+
+--
+-- EZP-30857: Files are not deleted from storage when removing archived versions
+--
+
+ALTER TABLE ezimagefile ADD COLUMN version integer DEFAULT 0 NOT NULL;
+
+CREATE INDEX ezimage_version ON ezimagefile (version);
+
+--
+-- EZP-30857: end.

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml
@@ -609,11 +609,13 @@ tables:
         indexes:
             ezimagefile_file: { fields: [filepath], options: { lengths: ['191'] } }
             ezimagefile_coid: { fields: [contentobject_attribute_id] }
+            ezimagefile_version: { fields: [version]}
         id:
             id: { type: integer, nullable: false, options: { autoincrement: true } }
         fields:
             contentobject_attribute_id: { type: integer, nullable: false, options: { default: '0' } }
             filepath: { type: text, nullable: false, length: 0 }
+            version: { type: integer, nullable: false, options: { default: '0' } }
     ezinfocollection:
         indexes:
             ezinfocollection_co_id_created: { fields: [contentobject_id, created] }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml
@@ -609,7 +609,7 @@ tables:
         indexes:
             ezimagefile_file: { fields: [filepath], options: { lengths: ['191'] } }
             ezimagefile_coid: { fields: [contentobject_attribute_id] }
-            ezimagefile_version: { fields: [version]}
+            ezimagefile_version: { fields: [version, contentobject_attribute_id]}
         id:
             id: { type: integer, nullable: false, options: { autoincrement: true } }
         fields:

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -124,7 +124,7 @@ class ImageStorage extends GatewayBasedStorage
             $field->value->externalData = null;
         }
 
-        $this->gateway->storeImageReference($field->value->data['uri'], $field->id);
+        $this->gateway->storeImageReference($field->value->data['uri'], $field->id, $versionInfo);
 
         // Data has been updated and needs to be stored!
         return true;

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
@@ -29,6 +29,8 @@ abstract class Gateway extends StorageGateway
      * @param string $uri File IO uri
      * @param mixed $fieldId
      * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     abstract public function storeImageReference($uri, $fieldId, VersionInfo $versionInfo);
 

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
@@ -28,8 +28,9 @@ abstract class Gateway extends StorageGateway
      *
      * @param string $uri File IO uri
      * @param mixed $fieldId
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
      */
-    abstract public function storeImageReference($uri, $fieldId);
+    abstract public function storeImageReference($uri, $fieldId, VersionInfo $versionInfo);
 
     /**
      * Returns a the XML content stored for the given $fieldIds.

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
@@ -91,7 +91,7 @@ class DoctrineStorage extends Gateway
      * @param int $fieldId
      * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
      *
-     * @throws \eZ\Publish\Core\IO\Exception\InvalidBinaryFileIdException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function storeImageReference($uri, $fieldId, VersionInfo $versionInfo)
     {

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
@@ -98,7 +98,7 @@ class LegacyStorage extends Gateway
      * @param mixed $fieldId
      * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
      *
-     * @throws \eZ\Publish\Core\IO\Exception\InvalidBinaryFileIdException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function storeImageReference($uri, $fieldId, VersionInfo $versionInfo)
     {

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
@@ -106,7 +106,9 @@ class LegacyStorage extends Gateway
         $path = $this->redecorator->redecorateFromSource($uri);
 
         if ($this->imageReferenceExistsForVersion($fieldId, $versionInfo)) {
-            return $this->updateImageReferenceForVersion($path, $fieldId, $versionInfo);
+            $this->updateImageReferenceForVersion($path, $fieldId, $versionInfo);
+
+            return;
         }
 
         $connection = $this->getConnection();

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -18,7 +18,7 @@ CREATE TABLE ezimagefile (
   PRIMARY KEY (id),
   KEY ezimagefile_coid (contentobject_attribute_id),
   KEY ezimagefile_file (filepath(200)),
-  KEY ezimagefile_version (version)
+  KEY ezimagefile_version (version, contentobject_attribute_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezmedia;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -14,9 +14,11 @@ CREATE TABLE ezimagefile (
   contentobject_attribute_id int(11) NOT NULL DEFAULT 0,
   filepath longtext NOT NULL,
   id int(11) NOT NULL AUTO_INCREMENT,
+  version int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (id),
   KEY ezimagefile_coid (contentobject_attribute_id),
-  KEY ezimagefile_file (filepath(200))
+  KEY ezimagefile_file (filepath(200)),
+  KEY ezimagefile_version (version)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezmedia;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
@@ -520,6 +520,8 @@ CREATE INDEX ezimagefile_coid ON ezimagefile USING btree (contentobject_attribut
 
 CREATE INDEX ezimagefile_file ON ezimagefile USING btree (filepath);
 
+CREATE INDEX ezimagefile_version ON ezimagefile USING btree (version, contentobject_attribute_id)
+
 CREATE INDEX ezgmaplocation_file ON ezgmaplocation USING btree (latitude,longitude);
 
 CREATE UNIQUE INDEX ezcobj_state_identifier ON ezcobj_state USING btree (group_id, identifier);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
@@ -30,7 +30,8 @@ DROP TABLE IF EXISTS ezimagefile;
 CREATE TABLE ezimagefile (
     contentobject_attribute_id integer DEFAULT 0 NOT NULL,
     filepath text NOT NULL,
-    id SERIAL
+    id SERIAL,
+    version integer DEFAULT 0 NOT NULL
 );
 
 DROP TABLE IF EXISTS ezgmaplocation;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -14,10 +14,12 @@ CREATE TABLE ezbinaryfile (
 CREATE TABLE ezimagefile (
   contentobject_attribute_id integer NOT NULL DEFAULT 0,
   filepath text NOT NULL,
-  id integer NOT NULL PRIMARY KEY AUTOINCREMENT
+  id integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+  version integer NOT NULL DEFAULT 0
 );
 CREATE INDEX ezimagefile_coid ON ezimagefile (contentobject_attribute_id);
 CREATE INDEX ezimagefile_file ON ezimagefile (filepath);
+CREATE INDEX ezimagefile_version ON ezimagefile (version);
 
 CREATE TABLE ezmedia (
   contentobject_attribute_id integer NOT NULL DEFAULT 0,

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -19,7 +19,7 @@ CREATE TABLE ezimagefile (
 );
 CREATE INDEX ezimagefile_coid ON ezimagefile (contentobject_attribute_id);
 CREATE INDEX ezimagefile_file ON ezimagefile (filepath);
-CREATE INDEX ezimagefile_version ON ezimagefile (version);
+CREATE INDEX ezimagefile_version ON ezimagefile (version, contentobject_attribute_id);
 
 CREATE TABLE ezmedia (
   contentobject_attribute_id integer NOT NULL DEFAULT 0,


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30857](https://jira.ez.no/browse/EZP-30857)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.5` / `master`
| **BC breaks**      | no (*?*)
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR fixes an issue described in the referenced JIRA issue.

The solution introduces a new column `version` in the `ezimagefile` table. As for now, the system is unable to remove images since it's impossible to properly resolve a number of references to the particular image file. As content is versioned it has to be reflected in the entries of image references. 
Currently (without this additional column), the only possible way to do so is to search directly in XML (`data_text`) from `ezcontentobject_attribute` which is not a good idea performance-wise (even though legacy did it in the past). 

https://github.com/ezsystems/ezpublish-kernel/commit/27ae5f18c48d176222753385b496552ffe6328e6 contains changes required on the `Gateway` level. AFAIK there is no BC policy on SPI, am I right @alongosz?

https://github.com/ezsystems/ezpublish-kernel/commit/75ad73800f0b31aa5ab8bf94897156be0cc19403 contains database schema changes.

https://github.com/ezsystems/ezpublish-kernel/commit/84847a0e919ffbe0e1ce8a0143b2c2554dfd5adb adds an integration test for this bug.

As mentioned in the TODO list, I'm about to prepare a command which will cleanup both database (_1_) and storage (_2_), but I would love to get your feedback about the approach first.

_1_ - meaning that it will:
* remove duplicates
* remove entries which should be referenced to versions but these versions no longer exist in the system
* set proper version number for each entry

_2_ - meaning it will remove all files which are not referenced to any existing version

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [ ] Create a command for cleaning-up `ezimagefile` table and removing unnecessary files from the storage.
- [ ] On merge up to 8.0 / master: remember to drop dropped schema files.
