### PR TITLE
EZP-24520: Impl. IteratorAggregate for SearchResult and LocationList

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/LocationList.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationList.php
@@ -8,7 +8,10 @@
  */
 namespace eZ\Publish\API\Repository\Values\Content;
 
+use ArrayIterator;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use IteratorAggregate;
+use Traversable;
 
 /**
  * This class represents a queried location list holding a totalCount and a partial list of locations
@@ -17,7 +20,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read int $totalCount - the total count of found locations (filtered by permissions)
  * @property-read \eZ\Publish\API\Repository\Values\Content\Location[] $locations - the partial list of locations controlled by offset/limit
  **/
-class LocationList extends ValueObject
+class LocationList extends ValueObject implements IteratorAggregate
 {
     /**
      * the total count of found locations (filtered by permissions).
@@ -32,4 +35,9 @@ class LocationList extends ValueObject
      * @var \eZ\Publish\API\Repository\Values\Content\Location[]
      */
     protected $locations;
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->locations);
+    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
@@ -8,12 +8,15 @@
  */
 namespace eZ\Publish\API\Repository\Values\Content\Search;
 
+use ArrayIterator;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use IteratorAggregate;
+use Traversable;
 
 /**
  * This class represents a search result.
  */
-class SearchResult extends ValueObject
+class SearchResult extends ValueObject implements IteratorAggregate
 {
     /**
      * The facets for this search.
@@ -66,4 +69,9 @@ class SearchResult extends ValueObject
      * @var int|null
      */
     public $totalCount;
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->searchHits);
+    }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-24520](https://jira.ez.no/browse/EZP-24520)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes/no

Implemented `\IteratorAggregate` for 

* `eZ\Publish\API\Repository\Values\Content\Search\SearchResult`
* `eZ\Publish\API\Repository\Values\Content\LocationList`

to be able to natively use the `foreach` statement and align them with other List/Result structures in PAPI.

**TODO**:
- [X] Implement feature / fix a bug.
- [ ] ~Implement tests.~
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
