### PR TITLE
EZP-31044: Implemented SiteAccess providers

### DIFF
--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -242,6 +242,15 @@ Changes affecting version compatibility with former or future versions.
   ```php
   public function supports(int $capabilityFlag): bool;
   ```
+* The signature of the `\eZ\Publish\API\Repository\Values\ValueObject\SiteAccess::__construct` method was changed to make `name` property required:
+  ```php
+  public function __construct(
+      string $name,
+      string $matchingType = self::DEFAULT_MATCHING_TYPE,
+      $matcher = null,
+      ?string $provider = null
+  );
+  ```  
 
 ## Removed services
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -76,6 +76,21 @@ services:
         arguments:
             - '@eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessMatcherRegistry'
 
+    ezpublish.siteaccess.provider.static:
+        class: eZ\Publish\Core\MVC\Symfony\SiteAccess\Provider\StaticSiteAccessProvider
+        arguments:
+            - "%ezpublish.siteaccess.list%"
+        tags:
+            - { name: ezplatform.siteaccess.provider, priority: 10 }
+
+    ezpublish.siteaccess.provider.chain:
+        class: eZ\Publish\Core\MVC\Symfony\SiteAccess\Provider\ChainSiteAccessProvider
+        arguments:
+            $providers: !tagged ezplatform.siteaccess.provider
+
+    ezpublish.siteaccess.provider:
+        alias: ezpublish.siteaccess.provider.chain
+
     ezpublish.siteaccess_router:
         class: "%ezpublish.siteaccess_router.class%"
         arguments:
@@ -83,7 +98,7 @@ services:
             - "@logger"
             - "%ezpublish.siteaccess.default%"
             - "%ezpublish.siteaccess.match_config%"
-            - "%ezpublish.siteaccess.list%"
+            - "@ezpublish.siteaccess.provider"
             - "%ezpublish.siteaccess.class%"
             - "%kernel.debug%"
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -67,7 +67,7 @@ services:
         class: "%ezpublish.console_event_listener.class%"
         arguments:
             - "%ezpublish.siteaccess.default%"
-            - "%ezpublish.siteaccess.list%"
+            - '@ezpublish.siteaccess.provider'
             - "@event_dispatcher"
             - "%kernel.debug%"
         calls:

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RequestEventListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RequestEventListenerTest.php
@@ -132,7 +132,7 @@ class RequestEventListenerTest extends TestCase
         $semanticPathinfo = '/foo/something';
         $request->attributes->set('semanticPathinfo', $semanticPathinfo);
         $request->attributes->set('needsRedirect', true);
-        $request->attributes->set('siteaccess', new SiteAccess());
+        $request->attributes->set('siteaccess', new SiteAccess('test'));
 
         $event = new RequestEvent($this->httpKernel, $request, HttpKernelInterface::MASTER_REQUEST);
         $this->requestEventListener->onKernelRequestRedirect($event);
@@ -154,7 +154,7 @@ class RequestEventListenerTest extends TestCase
         $request->attributes->set('semanticPathinfo', $semanticPathinfo);
         $request->attributes->set('needsRedirect', true);
         $request->attributes->set('locationId', 123);
-        $request->attributes->set('siteaccess', new SiteAccess());
+        $request->attributes->set('siteaccess', new SiteAccess('test'));
 
         $event = new RequestEvent($this->httpKernel, $request, HttpKernelInterface::MASTER_REQUEST);
         $this->requestEventListener->onKernelRequestRedirect($event);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RoutingListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RoutingListenerTest.php
@@ -80,7 +80,7 @@ class RoutingListenerTest extends TestCase
             ->method('setExcludedUriPrefixes')
             ->with($excludedUriPrefixes);
 
-        $event = new PostSiteAccessMatchEvent(new SiteAccess(), new Request(), HttpKernelInterface::MASTER_REQUEST);
+        $event = new PostSiteAccessMatchEvent(new SiteAccess('test'), new Request(), HttpKernelInterface::MASTER_REQUEST);
         $listener = new RoutingListener($this->configResolver, $this->urlAliasRouter, $this->urlAliasGenerator);
         $listener->onSiteAccessMatch($event);
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionInitByPostListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionInitByPostListenerTest.php
@@ -44,14 +44,14 @@ class SessionInitByPostListenerTest extends TestCase
 
     public function testOnSiteAccessMatchNoSessionService()
     {
-        $event = new PostSiteAccessMatchEvent(new SiteAccess(), new Request(), HttpKernelInterface::MASTER_REQUEST);
+        $event = new PostSiteAccessMatchEvent(new SiteAccess('test'), new Request(), HttpKernelInterface::MASTER_REQUEST);
         $listener = new SessionInitByPostListener(null);
         $this->assertNull($listener->onSiteAccessMatch($event));
     }
 
     public function testOnSiteAccessMatchSubRequest()
     {
-        $event = new PostSiteAccessMatchEvent(new SiteAccess(), new Request(), HttpKernelInterface::SUB_REQUEST);
+        $event = new PostSiteAccessMatchEvent(new SiteAccess('test'), new Request(), HttpKernelInterface::SUB_REQUEST);
         $this->session
             ->expects($this->never())
             ->method('getName');
@@ -61,7 +61,7 @@ class SessionInitByPostListenerTest extends TestCase
     public function testOnSiteAccessMatchRequestNoSessionName()
     {
         $sessionName = 'eZSESSID';
-        $event = new PostSiteAccessMatchEvent(new SiteAccess(), new Request(), HttpKernelInterface::MASTER_REQUEST);
+        $event = new PostSiteAccessMatchEvent(new SiteAccess('test'), new Request(), HttpKernelInterface::MASTER_REQUEST);
 
         $this->session
             ->expects($this->once())
@@ -87,7 +87,7 @@ class SessionInitByPostListenerTest extends TestCase
         $sessionId = 'foobar123';
         $request = new Request();
         $request->request->set($sessionName, $sessionId);
-        $event = new PostSiteAccessMatchEvent(new SiteAccess(), $request, HttpKernelInterface::MASTER_REQUEST);
+        $event = new PostSiteAccessMatchEvent(new SiteAccess('test'), $request, HttpKernelInterface::MASTER_REQUEST);
 
         $this->session
             ->expects($this->once())

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionSetDynamicNameListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionSetDynamicNameListenerTest.php
@@ -62,7 +62,7 @@ class SessionSetDynamicNameListenerTest extends TestCase
             ->expects($this->never())
             ->method('setOptions');
         $listener = new SessionSetDynamicNameListener($this->configResolver, null, $this->sessionStorage);
-        $listener->onSiteAccessMatch(new PostSiteAccessMatchEvent(new SiteAccess(), new Request(), HttpKernelInterface::MASTER_REQUEST));
+        $listener->onSiteAccessMatch(new PostSiteAccessMatchEvent(new SiteAccess('test'), new Request(), HttpKernelInterface::MASTER_REQUEST));
     }
 
     public function testOnSiteAccessMatchSubRequest()
@@ -71,7 +71,7 @@ class SessionSetDynamicNameListenerTest extends TestCase
             ->expects($this->never())
             ->method('setOptions');
         $listener = new SessionSetDynamicNameListener($this->configResolver, $this->session, $this->sessionStorage);
-        $listener->onSiteAccessMatch(new PostSiteAccessMatchEvent(new SiteAccess(), new Request(), HttpKernelInterface::SUB_REQUEST));
+        $listener->onSiteAccessMatch(new PostSiteAccessMatchEvent(new SiteAccess('test'), new Request(), HttpKernelInterface::SUB_REQUEST));
     }
 
     public function testOnSiteAccessMatchNonNativeSessionStorage()
@@ -84,7 +84,7 @@ class SessionSetDynamicNameListenerTest extends TestCase
             $this->session,
             $this->createMock(SessionStorageInterface::class)
         );
-        $listener->onSiteAccessMatch(new PostSiteAccessMatchEvent(new SiteAccess(), new Request(), HttpKernelInterface::SUB_REQUEST));
+        $listener->onSiteAccessMatch(new PostSiteAccessMatchEvent(new SiteAccess('test'), new Request(), HttpKernelInterface::SUB_REQUEST));
     }
 
     /**
@@ -165,6 +165,6 @@ class SessionSetDynamicNameListenerTest extends TestCase
             ->will($this->returnValue($configuredSessionStorageOptions));
 
         $listener = new SessionSetDynamicNameListener($this->configResolver, $this->session, $this->sessionStorage);
-        $listener->onSiteAccessMatch(new PostSiteAccessMatchEvent(new SiteAccess(), new Request(), HttpKernelInterface::MASTER_REQUEST));
+        $listener->onSiteAccessMatch(new PostSiteAccessMatchEvent(new SiteAccess('test'), new Request(), HttpKernelInterface::MASTER_REQUEST));
     }
 }

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP22840RoleLimitations.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP22840RoleLimitations.php
@@ -84,7 +84,7 @@ class EZP22840RoleLimitations extends BaseTest
 
         // try to login
         $this->assertTrue(
-            $permissionResolver->canUser('user', 'login', new SiteAccess()),
+            $permissionResolver->canUser('user', 'login', new SiteAccess('test')),
             'Could not verify that user can login with section limitation'
         );
     }

--- a/eZ/Publish/Core/Limitation/Tests/SiteAccessLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SiteAccessLimitationTypeTest.php
@@ -231,7 +231,7 @@ class SiteAccessLimitationTypeTest extends Base
             // invalid limitation
             [
                 'limitation' => new ObjectStateLimitation(),
-                'object' => new SiteAccess(),
+                'object' => new SiteAccess('test'),
             ],
             // invalid object
             [

--- a/eZ/Publish/Core/MVC/Exception/InvalidSiteAccessException.php
+++ b/eZ/Publish/Core/MVC/Exception/InvalidSiteAccessException.php
@@ -8,24 +8,30 @@
  */
 namespace eZ\Publish\Core\MVC\Exception;
 
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface;
 use RuntimeException;
 
 /**
- * This exception is thrown if an invalid siteaccess was matched.
+ * This exception is thrown if an invalid SiteAccess was matched.
  */
 class InvalidSiteAccessException extends RuntimeException
 {
     /**
-     * @param string $siteAccess The invalid siteaccess
-     * @param array $siteAccessList All valid siteaccesses, as a regular array
+     * @param string $siteAccess The invalid SiteAccess
+     * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface $siteAccessProvider
      * @param string $matchType How $siteAccess was matched
      * @param bool $debug If true, Symfony environment is a debug one (like 'dev')
      */
-    public function __construct($siteAccess, array $siteAccessList, $matchType, $debug = false)
-    {
-        $message = "Invalid siteaccess '$siteAccess', matched by $matchType.";
+    public function __construct(
+        string $siteAccess,
+        SiteAccessProviderInterface $siteAccessProvider,
+        string $matchType,
+        bool $debug = false
+    ) {
+        $message = "Invalid SiteAccess '$siteAccess', matched by $matchType.";
         if ($debug) {
-            $message .= ' Valid siteaccesses are ' . implode(', ', $siteAccessList);
+            $siteAccessList = array_column(iterator_to_array($siteAccessProvider->getSiteAccesses()), 'name');
+            $message .= ' Valid SiteAccesses are ' . implode(', ', $siteAccessList);
         }
 
         parent::__construct($message);

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
@@ -50,7 +50,7 @@ class SiteAccessMatchListenerTest extends TestCase
 
     public function testOnKernelRequestSerializedSA()
     {
-        $siteAccess = new SiteAccess();
+        $siteAccess = new SiteAccess('test');
         $request = new Request();
         $request->attributes->set('serialized_siteaccess', serialize($siteAccess));
         $event = new RequestEvent(
@@ -76,7 +76,7 @@ class SiteAccessMatchListenerTest extends TestCase
 
     public function testOnKernelRequestSiteAccessPresent()
     {
-        $siteAccess = new SiteAccess();
+        $siteAccess = new SiteAccess('test');
         $request = new Request();
         $request->attributes->set('siteaccess', $siteAccess);
         $event = new RequestEvent(
@@ -101,7 +101,7 @@ class SiteAccessMatchListenerTest extends TestCase
 
     public function testOnKernelRequest()
     {
-        $siteAccess = new SiteAccess();
+        $siteAccess = new SiteAccess('test');
         $scheme = 'https';
         $host = 'phoenix-rises.fm';
         $port = 1234;
@@ -143,7 +143,7 @@ class SiteAccessMatchListenerTest extends TestCase
 
     public function testOnKernelRequestUserHashWithOriginalRequest()
     {
-        $siteAccess = new SiteAccess();
+        $siteAccess = new SiteAccess('test');
         $scheme = 'https';
         $host = 'phoenix-rises.fm';
         $port = 1234;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/EventListener/SecurityListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/EventListener/SecurityListenerTest.php
@@ -184,7 +184,7 @@ class SecurityListenerTest extends TestCase
             ->will($this->returnValue($user));
 
         $request = new Request();
-        $siteAccess = new SiteAccess();
+        $siteAccess = new SiteAccess('test');
         $request->attributes->set('siteaccess', $siteAccess);
 
         $this->authChecker
@@ -206,7 +206,7 @@ class SecurityListenerTest extends TestCase
             ->will($this->returnValue($user));
 
         $request = new Request();
-        $siteAccess = new SiteAccess();
+        $siteAccess = new SiteAccess('test');
         $request->attributes->set('siteaccess', $siteAccess);
 
         $this->authChecker
@@ -229,7 +229,7 @@ class SecurityListenerTest extends TestCase
             ->will($this->returnValue($user));
 
         $request = new Request();
-        $siteAccess = new SiteAccess();
+        $siteAccess = new SiteAccess('test');
         $request->attributes->set('siteaccess', $siteAccess);
 
         $this->authChecker
@@ -315,7 +315,7 @@ class SecurityListenerTest extends TestCase
     public function testOnKernelRequestNullToken()
     {
         $request = new Request();
-        $request->attributes->set('siteaccess', new SiteAccess());
+        $request->attributes->set('siteaccess', new SiteAccess('test'));
         $event = new RequestEvent(
             $this->createMock(HttpKernelInterface::class),
             $request,
@@ -336,7 +336,7 @@ class SecurityListenerTest extends TestCase
     public function testOnKernelRequestLoginRoute()
     {
         $request = new Request();
-        $request->attributes->set('siteaccess', new SiteAccess());
+        $request->attributes->set('siteaccess', new SiteAccess('test'));
         $request->attributes->set('_route', 'login');
         $event = new RequestEvent(
             $this->createMock(HttpKernelInterface::class),
@@ -360,7 +360,7 @@ class SecurityListenerTest extends TestCase
         $this->expectException(UnauthorizedSiteAccessException::class);
 
         $request = new Request();
-        $request->attributes->set('siteaccess', new SiteAccess());
+        $request->attributes->set('siteaccess', new SiteAccess('test'));
         $event = new RequestEvent(
             $this->createMock(HttpKernelInterface::class),
             $request,
@@ -388,7 +388,7 @@ class SecurityListenerTest extends TestCase
     public function testOnKernelRequestAccessGranted()
     {
         $request = new Request();
-        $request->attributes->set('siteaccess', new SiteAccess());
+        $request->attributes->set('siteaccess', new SiteAccess('test'));
         $event = new RequestEvent(
             $this->createMock(HttpKernelInterface::class),
             $request,

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/HttpUtilsTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/HttpUtilsTest.php
@@ -23,7 +23,7 @@ class HttpUtilsTest extends TestCase
     {
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $httpUtils = new HttpUtils($urlGenerator);
-        $httpUtils->setSiteAccess(new SiteAccess());
+        $httpUtils->setSiteAccess(new SiteAccess('test'));
         $request = Request::create('http://ezpublish.dev/');
         $request->attributes->set('siteaccess', new SiteAccess('test'));
         $requestAttributes = ['foo' => 'bar', 'some' => 'thing'];
@@ -101,7 +101,7 @@ class HttpUtilsTest extends TestCase
     public function testCheckRequestPathStandard()
     {
         $httpUtils = new HttpUtils();
-        $httpUtils->setSiteAccess(new SiteAccess());
+        $httpUtils->setSiteAccess(new SiteAccess('test'));
         $request = Request::create('http://ezpublish.dev/foo/bar');
         $this->assertTrue($httpUtils->checkRequestPath($request, '/foo/bar'));
     }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the SiteAccess class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -15,6 +13,8 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  */
 class SiteAccess extends ValueObject
 {
+    public const DEFAULT_MATCHING_TYPE = 'default';
+
     /**
      * Name of the siteaccess.
      *
@@ -37,11 +37,23 @@ class SiteAccess extends ValueObject
      */
     public $matcher;
 
-    public function __construct($name = null, $matchingType = null, $matcher = null)
-    {
+    /**
+     * The name of the provider from which Site Access comes.
+     *
+     * @var string
+     */
+    public $provider;
+
+    public function __construct(
+        string $name,
+        string $matchingType = self::DEFAULT_MATCHING_TYPE,
+        $matcher = null,
+        ?string $provider = null
+    ) {
         $this->name = $name;
         $this->matchingType = $matchingType;
         $this->matcher = $matcher;
+        $this->provider = $provider;
     }
 
     public function __toString()

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Provider/ChainSiteAccessProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Provider/ChainSiteAccessProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Provider;
+
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface;
+use Traversable;
+
+final class ChainSiteAccessProvider implements SiteAccessProviderInterface
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface[] */
+    private $providers;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface[] $providers
+     */
+    public function __construct(iterable $providers = [])
+    {
+        $this->providers = $providers;
+    }
+
+    public function getSiteAccesses(): Traversable
+    {
+        foreach ($this->providers as $provider) {
+            foreach ($provider->getSiteAccesses() as $siteAccess) {
+                yield $siteAccess;
+            }
+        }
+
+        yield from [];
+    }
+
+    public function isDefined(string $name): bool
+    {
+        foreach ($this->providers as $provider) {
+            if ($provider->isDefined($name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException
+     */
+    public function getSiteAccess(string $name): SiteAccess
+    {
+        foreach ($this->providers as $provider) {
+            if ($provider->isDefined($name)) {
+                return $provider->getSiteAccess($name);
+            }
+        }
+
+        throw new NotFoundException('Site Access', $name);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Provider/StaticSiteAccessProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Provider/StaticSiteAccessProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Provider;
+
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface;
+use Traversable;
+
+/**
+ * @internal For internal use only, do not rely on this class.
+ *           Be aware this should be regarded as experimental feature.
+ *           As in, method signatures and behavior might change in the future.
+ */
+final class StaticSiteAccessProvider implements SiteAccessProviderInterface
+{
+    /** @var string[] */
+    private $siteAccessList;
+
+    /**
+     * @param string[] $siteAccessList
+     */
+    public function __construct(
+        array $siteAccessList
+    ) {
+        $this->siteAccessList = $siteAccessList;
+    }
+
+    public function getSiteAccesses(): Traversable
+    {
+        foreach ($this->siteAccessList as $name) {
+            yield new SiteAccess($name, SiteAccess::DEFAULT_MATCHING_TYPE, null, self::class);
+        }
+
+        yield from [];
+    }
+
+    public function isDefined(string $name): bool
+    {
+        return \in_array($name, $this->siteAccessList, true);
+    }
+
+    public function getSiteAccess(string $name): SiteAccess
+    {
+        if ($this->isDefined($name)) {
+            return new SiteAccess($name, SiteAccess::DEFAULT_MATCHING_TYPE, null, self::class);
+        }
+
+        throw new NotFoundException('Site Access', $name);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Router.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Router.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\MVC\Symfony\SiteAccess\Router class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -17,6 +15,9 @@ use InvalidArgumentException;
 
 class Router implements SiteAccessRouterInterface, SiteAccessAware
 {
+    public const HEADER_SA_MATCHING_TYPE = 'header';
+    public const ENV_SA_MATCHING_TYPE = 'env';
+
     /**
      * Name of the default siteaccess.
      *
@@ -54,17 +55,13 @@ class Router implements SiteAccessRouterInterface, SiteAccessAware
      */
     protected $siteAccessesConfiguration;
 
-    /**
-     * List of configured siteaccesses.
-     * Siteaccess name is the key, "true" is the value.
-     *
-     * @var array
-     */
-    protected $siteAccessList;
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface */
+    protected $siteAccessProvider;
 
     /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess */
     protected $siteAccess;
 
+    /** @var string */
     protected $siteAccessClass;
 
     /** @var \Psr\Log\LoggerInterface */
@@ -80,23 +77,28 @@ class Router implements SiteAccessRouterInterface, SiteAccessAware
     protected $debug;
 
     /**
-     * Constructor.
-     *
      * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilderInterface $matcherBuilder
      * @param \Psr\Log\LoggerInterface $logger
      * @param string $defaultSiteAccess
      * @param array $siteAccessesConfiguration
-     * @param array $siteAccessList
+     * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface $siteAccessProvider
      * @param string|null $siteAccessClass
      * @param bool $debug
      */
-    public function __construct(MatcherBuilderInterface $matcherBuilder, LoggerInterface $logger, $defaultSiteAccess, array $siteAccessesConfiguration, array $siteAccessList, $siteAccessClass = null, $debug = false)
-    {
+    public function __construct(
+        MatcherBuilderInterface $matcherBuilder,
+        LoggerInterface $logger,
+        $defaultSiteAccess,
+        array $siteAccessesConfiguration,
+        SiteAccessProviderInterface $siteAccessProvider,
+        $siteAccessClass = null,
+        $debug = false
+    ) {
         $this->matcherBuilder = $matcherBuilder;
         $this->logger = $logger;
         $this->defaultSiteAccess = $defaultSiteAccess;
         $this->siteAccessesConfiguration = $siteAccessesConfiguration;
-        $this->siteAccessList = array_fill_keys($siteAccessList, true);
+        $this->siteAccessProvider = $siteAccessProvider;
         $this->siteAccessClass = $siteAccessClass ?: 'eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess';
         $this->request = new SimplifiedRequest();
         $this->debug = $debug;
@@ -127,20 +129,21 @@ class Router implements SiteAccessRouterInterface, SiteAccessAware
             return $this->siteAccess;
         }
 
-        $siteAccessClass = $this->siteAccessClass;
-        $this->siteAccess = new $siteAccessClass();
-
         // Request header always have precedence
         // Note: request headers are always in lower cased.
         if (!empty($request->headers['x-siteaccess'])) {
             $siteaccessName = $request->headers['x-siteaccess'][0];
-            if (!isset($this->siteAccessList[$siteaccessName])) {
-                unset($this->siteAccess);
-                throw new InvalidSiteAccessException($siteaccessName, array_keys($this->siteAccessList), 'X-Siteaccess request header', $this->debug);
+            if (!$this->siteAccessProvider->isDefined($siteaccessName)) {
+                throw new InvalidSiteAccessException(
+                    $siteaccessName,
+                    $this->siteAccessProvider,
+                    'X-Siteaccess request header',
+                    $this->debug
+                );
             }
 
-            $this->siteAccess->name = $siteaccessName;
-            $this->siteAccess->matchingType = 'header';
+            $this->siteAccess = $this->siteAccessProvider->getSiteAccess($siteaccessName);
+            $this->siteAccess->matchingType = self::HEADER_SA_MATCHING_TYPE;
 
             return $this->siteAccess;
         }
@@ -148,13 +151,17 @@ class Router implements SiteAccessRouterInterface, SiteAccessAware
         // Then check environment variable
         $siteaccessEnvName = getenv('EZPUBLISH_SITEACCESS');
         if ($siteaccessEnvName !== false) {
-            if (!isset($this->siteAccessList[$siteaccessEnvName])) {
-                unset($this->siteAccess);
-                throw new InvalidSiteAccessException($siteaccessEnvName, array_keys($this->siteAccessList), 'EZPUBLISH_SITEACCESS Environment variable', $this->debug);
+            if (!$this->siteAccessProvider->isDefined($siteaccessEnvName)) {
+                throw new InvalidSiteAccessException(
+                    $siteaccessEnvName,
+                    $this->siteAccessProvider,
+                    'EZPUBLISH_SITEACCESS environment variable',
+                    $this->debug
+                );
             }
 
-            $this->siteAccess->name = $siteaccessEnvName;
-            $this->siteAccess->matchingType = 'env';
+            $this->siteAccess = $this->siteAccessProvider->getSiteAccess($siteaccessEnvName);
+            $this->siteAccess->matchingType = self::ENV_SA_MATCHING_TYPE;
 
             return $this->siteAccess;
         }
@@ -178,20 +185,19 @@ class Router implements SiteAccessRouterInterface, SiteAccessAware
                 $matcher->setMatcherBuilder($this->matcherBuilder);
             }
 
-            if (($siteaccessName = $matcher->match()) !== false) {
-                if (isset($this->siteAccessList[$siteaccessName])) {
-                    $this->siteAccess->name = $siteaccessName;
-                    $this->siteAccess->matchingType = $matcher->getName();
-                    $this->siteAccess->matcher = $matcher;
+            $siteAccessName = $matcher->match();
+            if ($siteAccessName !== false && $this->siteAccessProvider->isDefined($siteAccessName)) {
+                $this->siteAccess = $this->siteAccessProvider->getSiteAccess($siteAccessName);
+                $this->siteAccess->matchingType = $matcher->getName();
+                $this->siteAccess->matcher = $matcher;
 
-                    return $this->siteAccess;
-                }
+                return $this->siteAccess;
             }
         }
 
         $this->logger->notice('Siteaccess not matched against configuration, returning default siteaccess.');
-        $this->siteAccess->name = $this->defaultSiteAccess;
-        $this->siteAccess->matchingType = 'default';
+        $this->siteAccess = new $this->siteAccessClass($this->defaultSiteAccess);
+        $this->siteAccess->matchingType = SiteAccess::DEFAULT_MATCHING_TYPE;
 
         return $this->siteAccess;
     }
@@ -209,7 +215,7 @@ class Router implements SiteAccessRouterInterface, SiteAccessAware
      */
     public function matchByName($siteAccessName)
     {
-        if (!isset($this->siteAccessList[$siteAccessName])) {
+        if (!$this->siteAccessProvider->isDefined($siteAccessName)) {
             throw new InvalidArgumentException("Invalid SiteAccess name provided for reverse matching: $siteAccessName");
         }
 
@@ -236,8 +242,7 @@ class Router implements SiteAccessRouterInterface, SiteAccessAware
             }
 
             /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteAccess */
-            $siteAccess = new $siteAccessClass();
-            $siteAccess->name = $siteAccessName;
+            $siteAccess = new $siteAccessClass($siteAccessName);
             $siteAccess->matcher = $reverseMatcher;
             $siteAccess->matchingType = $reverseMatcher->getName();
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessProviderInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessProviderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\SiteAccess;
+
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use Traversable;
+
+/**
+ * @internal
+ */
+interface SiteAccessProviderInterface
+{
+    public function isDefined(string $name): bool;
+
+    public function getSiteAccess(string $name): SiteAccess;
+
+    public function getSiteAccesses(): Traversable;
+}

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Provider/ChainSiteAccessProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Provider/ChainSiteAccessProviderTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Test\Provider;
+
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use PHPUnit\Framework\TestCase;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Provider\ChainSiteAccessProvider;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Provider\StaticSiteAccessProvider;
+
+final class ChainSiteAccessProviderTest extends TestCase
+{
+    private const EXISTING_SA_NAME = 'existing_sa';
+    private const UNDEFINED_SA_NAME = 'undefined_sa';
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface[] */
+    private $providers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->providers = [
+            new StaticSiteAccessProvider([self::EXISTING_SA_NAME, 'first_sa']),
+            new StaticSiteAccessProvider(['second_sa']),
+        ];
+    }
+
+    public function testIsDefinedForExistingSiteAccess(): void
+    {
+        $chainSiteAccessProvider = $this->getChainSiteAccessProvider();
+
+        $this->assertTrue($chainSiteAccessProvider->isDefined(self::EXISTING_SA_NAME));
+    }
+
+    public function testIsDefinedForUndefinedSiteAccess(): void
+    {
+        $chainSiteAccessProvider = $this->getChainSiteAccessProvider();
+
+        $this->assertFalse($chainSiteAccessProvider->isDefined(self::UNDEFINED_SA_NAME));
+    }
+
+    public function testGetSiteAccesses(): void
+    {
+        $chainSiteAccessProvider = $this->getChainSiteAccessProvider();
+        $siteAccesses = iterator_to_array($chainSiteAccessProvider->getSiteAccesses());
+
+        $this->assertCount(3, $siteAccesses);
+
+        $expectedSiteAccessNames = [self::EXISTING_SA_NAME, 'first_sa', 'second_sa'];
+
+        foreach ($expectedSiteAccessNames as $key => $expectedSiteAccessName) {
+            $expectedSiteAccess = new SiteAccess(
+                $expectedSiteAccessName,
+                SiteAccess::DEFAULT_MATCHING_TYPE,
+                null,
+                StaticSiteAccessProvider::class
+            );
+            $this->assertEquals($expectedSiteAccess, $siteAccesses[$key]);
+        }
+
+        $this->assertNotContains(
+            new SiteAccess(
+                self::UNDEFINED_SA_NAME,
+                SiteAccess::DEFAULT_MATCHING_TYPE,
+                null,
+                StaticSiteAccessProvider::class
+            ),
+            $siteAccesses
+        );
+    }
+
+    public function testGetExistingSiteAccess(): void
+    {
+        $chainSiteAccessProvider = $this->getChainSiteAccessProvider();
+        $this->assertEquals(
+            new SiteAccess(
+                self::EXISTING_SA_NAME,
+                SiteAccess::DEFAULT_MATCHING_TYPE,
+                null,
+                StaticSiteAccessProvider::class
+            ),
+            $chainSiteAccessProvider->getSiteAccess(self::EXISTING_SA_NAME)
+        );
+    }
+
+    public function testGetUndefinedSiteAccess(): void
+    {
+        $chainSiteAccessProvider = $this->getChainSiteAccessProvider();
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage("Could not find 'Site Access' with identifier 'undefined_sa'");
+
+        $chainSiteAccessProvider->getSiteAccess(self::UNDEFINED_SA_NAME);
+    }
+
+    private function getChainSiteAccessProvider(): ChainSiteAccessProvider
+    {
+        return new ChainSiteAccessProvider($this->providers);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterBaseTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterBaseTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
+
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use PHPUnit\Framework\TestCase;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
+use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
+
+abstract class RouterBaseTest extends TestCase
+{
+    protected const UNDEFINED_SA_NAME = 'undefined_sa';
+    protected const ENV_SA_NAME = 'env_sa';
+    protected const HEADERBASED_SA_NAME = 'headerbased_sa';
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder */
+    protected $matcherBuilder;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface */
+    protected $siteAccessProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->matcherBuilder = new MatcherBuilder();
+        $this->siteAccessProvider = $this->createSiteAccessProviderMock();
+    }
+
+    public function testConstruct(): Router
+    {
+        return $this->createRouter();
+    }
+
+    /**
+     * @dataProvider matchProvider
+     */
+    public function testMatch(SimplifiedRequest $request, string $siteAccess)
+    {
+        $router = $this->createRouter();
+        $sa = $router->match($request);
+        $this->assertInstanceOf(SiteAccess::class, $sa);
+        $this->assertSame($siteAccess, $sa->name);
+        // SiteAccess must be serializable as a whole. See https://jira.ez.no/browse/EZP-21613
+        $this->assertIsString(serialize($sa));
+        $router->setSiteAccess();
+    }
+
+    abstract public function matchProvider(): array;
+
+    abstract protected function createRouter(): Router;
+
+    private function createSiteAccessProviderMock(): SiteAccess\SiteAccessProviderInterface
+    {
+        $isDefinedMap = [];
+        $getSiteAccessMap = [];
+        foreach ($this->getSiteAccessProviderSettings() as $sa) {
+            $isDefinedMap[] = [$sa->name, $sa->isDefined];
+            $getSiteAccessMap[] = [
+                $sa->name,
+                new SiteAccess(
+                    $sa->name,
+                    $sa->matchingType
+                ),
+            ];
+        }
+        $siteAccessProviderMock = $this->createMock(SiteAccess\SiteAccessProviderInterface::class);
+        $siteAccessProviderMock
+            ->method('isDefined')
+            ->willReturnMap($isDefinedMap);
+        $siteAccessProviderMock
+            ->method('getSiteAccess')
+            ->willReturnMap($getSiteAccessMap);
+
+        return $siteAccessProviderMock;
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\SiteAccessSetting[]
+     */
+    abstract public function getSiteAccessProviderSettings(): array;
+}

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostElementTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostElementTest.php
@@ -10,61 +10,14 @@ namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\HostElement;
-use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map\Host as HostMapMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use Psr\Log\LoggerInterface;
 
-class RouterHostElementTest extends TestCase
+class RouterHostElementTest extends RouterBaseTest
 {
-    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder */
-    private $matcherBuilder;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->matcherBuilder = new MatcherBuilder();
-    }
-
-    public function testConstruct()
-    {
-        return new Router(
-            $this->matcherBuilder,
-            $this->createMock(LoggerInterface::class),
-            'default_sa',
-            [
-                'HostElement' => [
-                    'value' => 2,
-                ],
-                'Map\\URI' => [
-                    'first_sa' => 'first_sa',
-                    'second_sa' => 'second_sa',
-                ],
-                'Map\\Host' => [
-                    'first_sa' => 'first_sa',
-                    'first_siteaccess' => 'first_sa',
-                    'second_sa' => 'second_sa',
-                ],
-            ],
-            ['first_sa', 'second_sa', 'third_sa', 'fourth_sa', 'fifth_sa', 'example']
-        );
-    }
-
-    /**
-     * @depends testConstruct
-     * @dataProvider matchProvider
-     */
-    public function testMatch(SimplifiedRequest $request, $siteAccess, Router $router)
-    {
-        $sa = $router->match($request);
-        $this->assertInstanceOf(SiteAccess::class, $sa);
-        $this->assertSame($siteAccess, $sa->name);
-        $router->setSiteAccess();
-    }
-
-    public function matchProvider()
+    public function matchProvider(): array
     {
         return [
             [SimplifiedRequest::fromUrl('http://www.example.com'), 'example'],
@@ -170,5 +123,44 @@ class RouterHostElementTest extends TestCase
         $serializedSA2 = serialize($sa);
 
         $this->assertSame($serializedSA1, $serializedSA2);
+    }
+
+    protected function createRouter(): Router
+    {
+        return new Router(
+            $this->matcherBuilder,
+            $this->createMock(LoggerInterface::class),
+            'default_sa',
+            [
+                'HostElement' => [
+                    'value' => 2,
+                ],
+                'Map\\URI' => [
+                    'first_sa' => 'first_sa',
+                    'second_sa' => 'second_sa',
+                ],
+                'Map\\Host' => [
+                    'first_sa' => 'first_sa',
+                    'first_siteaccess' => 'first_sa',
+                    'second_sa' => 'second_sa',
+                ],
+            ],
+            $this->siteAccessProvider
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\SiteAccessSetting[]
+     */
+    public function getSiteAccessProviderSettings(): array
+    {
+        return [
+            new SiteAccessSetting('first_sa', true),
+            new SiteAccessSetting('second_sa', true),
+            new SiteAccessSetting('third_sa', true),
+            new SiteAccessSetting('fourth_sa', true),
+            new SiteAccessSetting('fifth_sa', true),
+            new SiteAccessSetting('example', true),
+        ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostPortURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostPortURITest.php
@@ -10,66 +10,13 @@ namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map\Host;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map\Port;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use Psr\Log\LoggerInterface;
 
-class RouterHostPortURITest extends TestCase
+class RouterHostPortURITest extends RouterBaseTest
 {
-    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder */
-    private $matcherBuilder;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->matcherBuilder = new MatcherBuilder();
-    }
-
-    public function testConstruct()
-    {
-        return new Router(
-            $this->matcherBuilder,
-            $this->createMock(LoggerInterface::class),
-            'default_sa',
-            [
-                'Map\\Host' => [
-                    'first_sa' => 'first_sa',
-                    'first_siteaccess' => 'first_sa',
-                    'third_siteaccess' => 'third_sa',
-                ],
-                'Map\\Port' => [
-                    80 => 'fifth_sa',
-                    81 => 'third_sa',
-                    82 => 'fourth_sa',
-                    83 => 'first_sa',
-                    85 => 'first_sa',
-                    443 => 'fourth_sa',
-                ],
-                'Map\\URI' => [
-                    'first_sa' => 'first_sa',
-                    'second_sa' => 'second_sa',
-                ],
-            ],
-            ['first_sa', 'second_sa', 'third_sa', 'fourth_sa', 'fifth_sa']
-        );
-    }
-
-    /**
-     * @depends testConstruct
-     * @dataProvider matchProvider
-     */
-    public function testMatch(SimplifiedRequest $request, $siteAccess, Router $router)
-    {
-        $sa = $router->match($request);
-        $this->assertInstanceOf(SiteAccess::class, $sa);
-        $this->assertSame($siteAccess, $sa->name);
-        $router->setSiteAccess();
-    }
-
-    public function matchProvider()
+    public function matchProvider(): array
     {
         return [
             [SimplifiedRequest::fromUrl('http://example.com'), 'fifth_sa'],
@@ -208,5 +155,48 @@ class RouterHostPortURITest extends TestCase
         $this->assertSame(8000, $result->getMapKey());
         $this->assertSame(8000, $result->getRequest()->port);
         $this->assertSame('http', $result->getRequest()->scheme);
+    }
+
+    protected function createRouter(): Router
+    {
+        return new Router(
+            $this->matcherBuilder,
+            $this->createMock(LoggerInterface::class),
+            'default_sa',
+            [
+                'Map\\Host' => [
+                    'first_sa' => 'first_sa',
+                    'first_siteaccess' => 'first_sa',
+                    'third_siteaccess' => 'third_sa',
+                ],
+                'Map\\Port' => [
+                    80 => 'fifth_sa',
+                    81 => 'third_sa',
+                    82 => 'fourth_sa',
+                    83 => 'first_sa',
+                    85 => 'first_sa',
+                    443 => 'fourth_sa',
+                ],
+                'Map\\URI' => [
+                    'first_sa' => 'first_sa',
+                    'second_sa' => 'second_sa',
+                ],
+            ],
+            $this->siteAccessProvider
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\SiteAccessSetting[]
+     */
+    public function getSiteAccessProviderSettings(): array
+    {
+        return [
+            new SiteAccessSetting('first_sa', true),
+            new SiteAccessSetting('second_sa', true),
+            new SiteAccessSetting('third_sa', true),
+            new SiteAccessSetting('fourth_sa', true),
+            new SiteAccessSetting('fifth_sa', true),
+        ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostRegexTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostRegexTest.php
@@ -1,68 +1,19 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\RouterHostRegexTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
-use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Regex\Host as HostRegexMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use Psr\Log\LoggerInterface;
 
-class RouterHostRegexTest extends TestCase
+class RouterHostRegexTest extends RouterBaseTest
 {
-    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder */
-    private $matcherBuilder;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->matcherBuilder = new MatcherBuilder();
-    }
-
-    public function testConstruct()
-    {
-        return new Router(
-            $this->matcherBuilder,
-            $this->createMock(LoggerInterface::class),
-            'default_sa',
-            [
-                'Regex\\Host' => [
-                    'regex' => '^(\\w+_sa)$',
-                ],
-                'Map\\URI' => [
-                    'first_sa' => 'first_sa',
-                    'second_sa' => 'second_sa',
-                ],
-                'Map\\Host' => [
-                    'first_sa' => 'first_sa',
-                    'first_siteaccess' => 'first_sa',
-                ],
-            ],
-            ['first_sa', 'second_sa', 'third_sa', 'fourth_sa', 'fifth_sa']
-        );
-    }
-
-    /**
-     * @depends testConstruct
-     * @dataProvider matchProvider
-     */
-    public function testMatch($request, $siteAccess, $router)
-    {
-        $sa = $router->match($request);
-        $this->assertInstanceOf(SiteAccess::class, $sa);
-        $this->assertSame($siteAccess, $sa->name);
-        $router->setSiteAccess();
-    }
-
-    public function matchProvider()
+    public function matchProvider(): array
     {
         return [
             [SimplifiedRequest::fromUrl('http://example.com'), 'default_sa'],
@@ -124,5 +75,46 @@ class RouterHostRegexTest extends TestCase
     {
         $matcher = new HostRegexMatcher(['host' => 'foo'], []);
         $this->assertSame('host:regexp', $matcher->getName());
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Router
+     */
+    protected function createRouter(): Router
+    {
+        return new Router(
+            $this->matcherBuilder,
+            $this->createMock(LoggerInterface::class),
+            'default_sa',
+            [
+                'Regex\\Host' => [
+                    'regex' => '^(\\w+_sa)$',
+                ],
+                'Map\\URI' => [
+                    'first_sa' => 'first_sa',
+                    'second_sa' => 'second_sa',
+                ],
+                'Map\\Host' => [
+                    'first_sa' => 'first_sa',
+                    'first_siteaccess' => 'first_sa',
+                ],
+            ],
+            $this->siteAccessProvider
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\SiteAccessSetting[]
+     */
+    public function getSiteAccessProviderSettings(): array
+    {
+        return [
+            new SiteAccessSetting('first_sa', true),
+            new SiteAccessSetting('second_sa', true),
+            new SiteAccessSetting('third_sa', true),
+            new SiteAccessSetting('fourth_sa', true),
+            new SiteAccessSetting('fifth_sa', true),
+            new SiteAccessSetting('example', true),
+        ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostTextTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostTextTest.php
@@ -1,69 +1,19 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\RouterHostTextTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
-use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\HostText as HostTextMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use Psr\Log\LoggerInterface;
 
-class RouterHostTextTest extends TestCase
+class RouterHostTextTest extends RouterBaseTest
 {
-    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder */
-    private $matcherBuilder;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->matcherBuilder = new MatcherBuilder();
-    }
-
-    public function testConstruct()
-    {
-        return new Router(
-            $this->matcherBuilder,
-            $this->createMock(LoggerInterface::class),
-            'default_sa',
-            [
-                'HostText' => [
-                    'prefix' => 'www.',
-                    'suffix' => '.com',
-                ],
-                'Map\\URI' => [
-                    'first_sa' => 'first_sa',
-                    'second_sa' => 'second_sa',
-                ],
-                'Map\\Host' => [
-                    'first_sa' => 'first_sa',
-                    'first_siteaccess' => 'first_sa',
-                ],
-            ],
-            ['first_sa', 'second_sa', 'third_sa', 'fourth_sa', 'fifth_sa', 'example']
-        );
-    }
-
-    /**
-     * @depends testConstruct
-     * @dataProvider matchProvider
-     */
-    public function testMatch(SimplifiedRequest $request, $siteAccess, Router $router)
-    {
-        $sa = $router->match($request);
-        $this->assertInstanceOf(SiteAccess::class, $sa);
-        $this->assertSame($siteAccess, $sa->name);
-        $router->setSiteAccess();
-    }
-
-    public function matchProvider()
+    public function matchProvider(): array
     {
         return [
             [SimplifiedRequest::fromUrl('http://example.com'), 'default_sa'],
@@ -142,5 +92,44 @@ class RouterHostTextTest extends TestCase
         $request = $result->getRequest();
         $this->assertInstanceOf(SimplifiedRequest::class, $request);
         $this->assertSame('www.foobar.com', $request->host);
+    }
+
+    protected function createRouter(): Router
+    {
+        return new Router(
+            $this->matcherBuilder,
+            $this->createMock(LoggerInterface::class),
+            'default_sa',
+            [
+                'HostText' => [
+                    'prefix' => 'www.',
+                    'suffix' => '.com',
+                ],
+                'Map\\URI' => [
+                    'first_sa' => 'first_sa',
+                    'second_sa' => 'second_sa',
+                ],
+                'Map\\Host' => [
+                    'first_sa' => 'first_sa',
+                    'first_siteaccess' => 'first_sa',
+                ],
+            ],
+            $this->siteAccessProvider
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\SiteAccessSetting[]
+     */
+    public function getSiteAccessProviderSettings(): array
+    {
+        return [
+            new SiteAccessSetting('first_sa', true),
+            new SiteAccessSetting('second_sa', true),
+            new SiteAccessSetting('third_sa', true),
+            new SiteAccessSetting('fourth_sa', true),
+            new SiteAccessSetting('fifth_sa', true),
+            new SiteAccessSetting('example', true),
+        ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterPortHostURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterPortHostURITest.php
@@ -1,73 +1,18 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\RouterPortHostURITest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
-use PHPUnit\Framework\TestCase;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use Psr\Log\LoggerInterface;
 
-class RouterPortHostURITest extends TestCase
+class RouterPortHostURITest extends RouterBaseTest
 {
-    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder */
-    private $matcherBuilder;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->matcherBuilder = new MatcherBuilder();
-    }
-
-    public function testConstruct()
-    {
-        return new Router(
-            $this->matcherBuilder,
-            $this->createMock(LoggerInterface::class),
-            'default_sa',
-            [
-                'Map\\Port' => [
-                    80 => 'fifth_sa',
-                    81 => 'third_sa',
-                    82 => 'fourth_sa',
-                    83 => 'first_sa',
-                    85 => 'first_sa',
-                    443 => 'fourth_sa',
-                ],
-                'Map\\Host' => [
-                    'first_sa' => 'first_sa',
-                    'first_siteaccess' => 'first_sa',
-                    'third_siteaccess' => 'third_sa',
-                ],
-                'Map\\URI' => [
-                    'first_sa' => 'first_sa',
-                    'second_sa' => 'second_sa',
-                ],
-            ],
-            ['first_sa', 'second_sa', 'third_sa', 'fourth_sa', 'fifth_sa']
-        );
-    }
-
-    /**
-     * @depends testConstruct
-     * @dataProvider matchProvider
-     */
-    public function testMatch($request, $siteAccess, $router)
-    {
-        $sa = $router->match($request);
-        $this->assertInstanceOf(SiteAccess::class, $sa);
-        $this->assertSame($siteAccess, $sa->name);
-        $router->setSiteAccess();
-    }
-
-    public function matchProvider()
+    public function matchProvider(): array
     {
         return [
             [SimplifiedRequest::fromUrl('http://example.com'), 'fifth_sa'],
@@ -132,6 +77,49 @@ class RouterPortHostURITest extends TestCase
             [SimplifiedRequest::fromUrl('http://example.com:82/'), 'fourth_sa'],
             [SimplifiedRequest::fromUrl('https://example.com:82/'), 'fourth_sa'],
             [SimplifiedRequest::fromUrl('https://example.com:82/foo'), 'fourth_sa'],
+        ];
+    }
+
+    protected function createRouter(): Router
+    {
+        return new Router(
+            $this->matcherBuilder,
+            $this->createMock(LoggerInterface::class),
+            'default_sa',
+            [
+                'Map\\Port' => [
+                    80 => 'fifth_sa',
+                    81 => 'third_sa',
+                    82 => 'fourth_sa',
+                    83 => 'first_sa',
+                    85 => 'first_sa',
+                    443 => 'fourth_sa',
+                ],
+                'Map\\Host' => [
+                    'first_sa' => 'first_sa',
+                    'first_siteaccess' => 'first_sa',
+                    'third_siteaccess' => 'third_sa',
+                ],
+                'Map\\URI' => [
+                    'first_sa' => 'first_sa',
+                    'second_sa' => 'second_sa',
+                ],
+            ],
+            $this->siteAccessProvider
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\SiteAccessSetting[]
+     */
+    public function getSiteAccessProviderSettings(): array
+    {
+        return [
+            new SiteAccessSetting('first_sa', true),
+            new SiteAccessSetting('second_sa', true),
+            new SiteAccessSetting('third_sa', true),
+            new SiteAccessSetting('fourth_sa', true),
+            new SiteAccessSetting('fifth_sa', true),
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterSpecialPortsTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterSpecialPortsTest.php
@@ -1,74 +1,19 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\RouterSpecialPortsTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
-use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map\Port as PortMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use Psr\Log\LoggerInterface;
 
-class RouterSpecialPortsTest extends TestCase
+class RouterSpecialPortsTest extends RouterBaseTest
 {
-    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder */
-    private $matcherBuilder;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->matcherBuilder = new MatcherBuilder();
-    }
-
-    public function testConstruct()
-    {
-        return new Router(
-            $this->matcherBuilder,
-            $this->createMock(LoggerInterface::class),
-            'default_sa',
-            [
-                'Map\\URI' => [
-                    'first_sa' => 'first_sa',
-                    'second_sa' => 'second_sa',
-                ],
-                'Map\\Host' => [
-                    'first_sa' => 'first_sa',
-                    'first_siteaccess' => 'first_sa',
-                    'third_siteaccess' => 'third_sa',
-                ],
-                'Map\\Port' => [
-                    80 => 'fifth_sa',
-                    81 => 'third_sa',
-                    82 => 'fourth_sa',
-                    83 => 'first_sa',
-                    85 => 'first_sa',
-                    443 => 'fourth_sa',
-                ],
-            ],
-            ['first_sa', 'second_sa', 'third_sa', 'fourth_sa', 'fifth_sa']
-        );
-    }
-
-    /**
-     * @depends testConstruct
-     * @dataProvider matchProvider
-     */
-    public function testMatch($request, $siteAccess, $router)
-    {
-        $sa = $router->match($request);
-        $this->assertInstanceOf(SiteAccess::class, $sa);
-        $this->assertSame($siteAccess, $sa->name);
-        $router->setSiteAccess();
-    }
-
-    public function matchProvider()
+    public function matchProvider(): array
     {
         return [
             [SimplifiedRequest::fromUrl('http://example.com'), 'fifth_sa'],
@@ -133,5 +78,48 @@ class RouterSpecialPortsTest extends TestCase
     {
         $matcher = new PortMatcher(['port' => '8080', 'scheme' => 'http'], []);
         $this->assertSame('port', $matcher->getName());
+    }
+
+    protected function createRouter(): Router
+    {
+        return new Router(
+            $this->matcherBuilder,
+            $this->createMock(LoggerInterface::class),
+            'default_sa',
+            [
+                'Map\\URI' => [
+                    'first_sa' => 'first_sa',
+                    'second_sa' => 'second_sa',
+                ],
+                'Map\\Host' => [
+                    'first_sa' => 'first_sa',
+                    'first_siteaccess' => 'first_sa',
+                    'third_siteaccess' => 'third_sa',
+                ],
+                'Map\\Port' => [
+                    80 => 'fifth_sa',
+                    81 => 'third_sa',
+                    82 => 'fourth_sa',
+                    83 => 'first_sa',
+                    85 => 'first_sa',
+                    443 => 'fourth_sa',
+                ],
+            ],
+            $this->siteAccessProvider
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\SiteAccessSetting[]
+     */
+    public function getSiteAccessProviderSettings(): array
+    {
+        return [
+            new SiteAccessSetting('first_sa', true),
+            new SiteAccessSetting('second_sa', true),
+            new SiteAccessSetting('third_sa', true),
+            new SiteAccessSetting('fourth_sa', true),
+            new SiteAccessSetting('fifth_sa', true),
+        ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\RouterURIElement2Test class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -10,60 +8,14 @@ namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement;
-use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement as URIElementMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use Psr\Log\LoggerInterface;
 
-class RouterURIElement2Test extends TestCase
+class RouterURIElement2Test extends RouterBaseTest
 {
-    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder */
-    private $matcherBuilder;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->matcherBuilder = new MatcherBuilder();
-    }
-
-    public function testConstruct()
-    {
-        return new Router(
-            $this->matcherBuilder,
-            $this->createMock(LoggerInterface::class),
-            'default_sa',
-            [
-                'URIElement' => [
-                    'value' => 2,
-                ],
-                'Map\\URI' => [
-                    'first_sa' => 'first_sa',
-                    'second_sa' => 'second_sa',
-                ],
-                'Map\\Host' => [
-                    'first_sa' => 'first_sa',
-                    'first_siteaccess' => 'first_sa',
-                ],
-            ],
-            ['first_sa', 'second_sa', 'third_sa', 'fourth_sa', 'fifth_sa', 'foo_baz', 'test_foo', 'first_sa_foo', 'second_sa_foo']
-        );
-    }
-
-    /**
-     * @depends testConstruct
-     * @dataProvider matchProvider
-     */
-    public function testMatch(SimplifiedRequest $request, $siteAccess, Router $router)
-    {
-        $sa = $router->match($request);
-        $this->assertInstanceOf(SiteAccess::class, $sa);
-        $this->assertSame($siteAccess, $sa->name);
-        $router->setSiteAccess();
-    }
-
-    public function matchProvider()
+    public function matchProvider(): array
     {
         return [
             [SimplifiedRequest::fromUrl('http://example.com'), 'default_sa'],
@@ -222,5 +174,46 @@ class RouterURIElement2Test extends TestCase
         $serializedSA2 = serialize($sa);
 
         $this->assertSame($serializedSA1, $serializedSA2);
+    }
+
+    protected function createRouter(): Router
+    {
+        return new Router(
+            $this->matcherBuilder,
+            $this->createMock(LoggerInterface::class),
+            'default_sa',
+            [
+                'URIElement' => [
+                    'value' => 2,
+                ],
+                'Map\\URI' => [
+                    'first_sa' => 'first_sa',
+                    'second_sa' => 'second_sa',
+                ],
+                'Map\\Host' => [
+                    'first_sa' => 'first_sa',
+                    'first_siteaccess' => 'first_sa',
+                ],
+            ],
+            $this->siteAccessProvider
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\SiteAccessSetting[]
+     */
+    public function getSiteAccessProviderSettings(): array
+    {
+        return [
+            new SiteAccessSetting('first_sa', true),
+            new SiteAccessSetting('second_sa', true),
+            new SiteAccessSetting('third_sa', true),
+            new SiteAccessSetting('fourth_sa', true),
+            new SiteAccessSetting('fifth_sa', true),
+            new SiteAccessSetting('test_foo', true),
+            new SiteAccessSetting('first_sa_foo', true),
+            new SiteAccessSetting('second_sa_foo', true),
+            new SiteAccessSetting('foo_baz', true),
+        ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElementTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElementTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\RouterURIElementTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -10,60 +8,14 @@ namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement;
-use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement as URIElementMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use Psr\Log\LoggerInterface;
 
-class RouterURIElementTest extends TestCase
+class RouterURIElementTest extends RouterBaseTest
 {
-    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder */
-    private $matcherBuilder;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->matcherBuilder = new MatcherBuilder();
-    }
-
-    public function testConstruct()
-    {
-        return new Router(
-            $this->matcherBuilder,
-            $this->createMock(LoggerInterface::class),
-            'default_sa',
-            [
-                'URIElement' => [
-                    'value' => 1,
-                ],
-                'Map\\URI' => [
-                    'first_sa' => 'first_sa',
-                    'second_sa' => 'second_sa',
-                ],
-                'Map\\Host' => [
-                    'first_sa' => 'first_sa',
-                    'first_siteaccess' => 'first_sa',
-                ],
-            ],
-            ['first_sa', 'second_sa', 'first_siteaccess', 'first_salt', 'first_sa.foo', 'test', 'foo']
-        );
-    }
-
-    /**
-     * @depends testConstruct
-     * @dataProvider matchProvider
-     */
-    public function testMatch(SimplifiedRequest $request, $siteAccess, Router $router)
-    {
-        $sa = $router->match($request);
-        $this->assertInstanceOf(SiteAccess::class, $sa);
-        $this->assertSame($siteAccess, $sa->name);
-        $router->setSiteAccess();
-    }
-
-    public function matchProvider()
+    public function matchProvider(): array
     {
         return [
             [SimplifiedRequest::fromUrl('http://example.com'), 'default_sa'],
@@ -194,5 +146,45 @@ class RouterURIElementTest extends TestCase
         $serializedSA2 = serialize($sa);
 
         $this->assertSame($serializedSA1, $serializedSA2);
+    }
+
+    protected function createRouter(): Router
+    {
+        return new Router(
+            $this->matcherBuilder,
+            $this->createMock(LoggerInterface::class),
+            'default_sa',
+            [
+                'URIElement' => [
+                    'value' => 1,
+                ],
+                'Map\\URI' => [
+                    'first_sa' => 'first_sa',
+                    'second_sa' => 'second_sa',
+                ],
+                'Map\\Host' => [
+                    'first_sa' => 'first_sa',
+                    'first_siteaccess' => 'first_sa',
+                ],
+            ],
+            $this->siteAccessProvider
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\SiteAccessSetting[]
+     */
+    public function getSiteAccessProviderSettings(): array
+    {
+        return [
+            new SiteAccessSetting('first_sa', true),
+            new SiteAccessSetting('second_sa', true),
+            new SiteAccessSetting('first_siteaccess', true),
+            new SiteAccessSetting('first_salt', true),
+            new SiteAccessSetting('first_sa.foo', true),
+            new SiteAccessSetting('test', true),
+            new SiteAccessSetting('foo', true),
+            new SiteAccessSetting('default_sa', true),
+        ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIRegexTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIRegexTest.php
@@ -9,60 +9,14 @@
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Regex\URI as RegexMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use Psr\Log\LoggerInterface;
 
-class RouterURIRegexTest extends TestCase
+class RouterURIRegexTest extends RouterBaseTest
 {
-    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder */
-    private $matcherBuilder;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->matcherBuilder = new MatcherBuilder();
-    }
-
-    public function testConstruct()
-    {
-        return new Router(
-            $this->matcherBuilder,
-            $this->createMock(LoggerInterface::class),
-            'default_sa',
-            [
-                'Regex\\URI' => [
-                    'regex' => '^/foo(\\w+)bar',
-                ],
-                'Map\\URI' => [
-                    'first_sa' => 'first_sa',
-                    'second_sa' => 'second_sa',
-                ],
-                'Map\\Host' => [
-                    'first_sa' => 'first_sa',
-                    'first_siteaccess' => 'first_sa',
-                ],
-            ],
-            ['first_sa', 'second_sa', 'foowoobar', 'test']
-        );
-    }
-
-    /**
-     * @depends testConstruct
-     * @dataProvider matchProvider
-     */
-    public function testMatch($request, $siteAccess, $router)
-    {
-        $sa = $router->match($request);
-        $this->assertInstanceOf(SiteAccess::class, $sa);
-        $this->assertSame($siteAccess, $sa->name);
-        $router->setSiteAccess();
-    }
-
-    public function matchProvider()
+    public function matchProvider(): array
     {
         return [
             [SimplifiedRequest::fromUrl('http://example.com'), 'default_sa'],
@@ -142,5 +96,43 @@ class RouterURIRegexTest extends TestCase
         $serializedSA2 = serialize($sa);
 
         $this->assertSame($serializedSA1, $serializedSA2);
+    }
+
+    protected function createRouter(): Router
+    {
+        return new Router(
+            $this->matcherBuilder,
+            $this->createMock(LoggerInterface::class),
+            'default_sa',
+            [
+                'Regex\\URI' => [
+                    'regex' => '^/foo(\\w+)bar',
+                ],
+                'Map\\URI' => [
+                    'first_sa' => 'first_sa',
+                    'second_sa' => 'second_sa',
+                ],
+                'Map\\Host' => [
+                    'first_sa' => 'first_sa',
+                    'first_siteaccess' => 'first_sa',
+                ],
+            ],
+            $this->siteAccessProvider
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\SiteAccessSetting[]
+     */
+    public function getSiteAccessProviderSettings(): array
+    {
+        return [
+            new SiteAccessSetting('first_sa', true),
+            new SiteAccessSetting('second_sa', true),
+            new SiteAccessSetting('third_sa', true),
+            new SiteAccessSetting('fourth_sa', true),
+            new SiteAccessSetting('fifth_sa', true),
+            new SiteAccessSetting('test', true),
+        ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURITextTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURITextTest.php
@@ -1,70 +1,20 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\RouterURITextTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
-use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIText;
-use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIText as URITextMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use Psr\Log\LoggerInterface;
 
-class RouterURITextTest extends TestCase
+class RouterURITextTest extends RouterBaseTest
 {
-    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder */
-    private $matcherBuilder;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->matcherBuilder = new MatcherBuilder();
-    }
-
-    public function testConstruct()
-    {
-        return new Router(
-            $this->matcherBuilder,
-            $this->createMock(LoggerInterface::class),
-            'default_sa',
-            [
-                'URIText' => [
-                    'prefix' => 'foo',
-                    'suffix' => 'bar',
-                ],
-                'Map\\URI' => [
-                    'first_sa' => 'first_sa',
-                    'second_sa' => 'second_sa',
-                ],
-                'Map\\Host' => [
-                    'first_sa' => 'first_sa',
-                    'first_siteaccess' => 'first_sa',
-                ],
-            ],
-            ['first_sa', 'second_sa', 'third_sa', 'fourth_sa', 'fifth_sa', 'test']
-        );
-    }
-
-    /**
-     * @depends testConstruct
-     * @dataProvider matchProvider
-     */
-    public function testMatch(SimplifiedRequest $request, $siteAccess, Router $router)
-    {
-        $sa = $router->match($request);
-        $this->assertInstanceOf(SiteAccess::class, $sa);
-        $this->assertSame($siteAccess, $sa->name);
-        $router->setSiteAccess();
-    }
-
-    public function matchProvider()
+    public function matchProvider(): array
     {
         return [
             [SimplifiedRequest::fromUrl('http://example.com'), 'default_sa'],
@@ -174,5 +124,44 @@ class RouterURITextTest extends TestCase
         $request = $result->getRequest();
         $this->assertInstanceOf(SimplifiedRequest::class, $request);
         $this->assertSame("/foosomethingbar{$semanticURI}", $request->pathinfo);
+    }
+
+    protected function createRouter(): Router
+    {
+        return new Router(
+            $this->matcherBuilder,
+            $this->createMock(LoggerInterface::class),
+            'default_sa',
+            [
+                'URIText' => [
+                    'prefix' => 'foo',
+                    'suffix' => 'bar',
+                ],
+                'Map\\URI' => [
+                    'first_sa' => 'first_sa',
+                    'second_sa' => 'second_sa',
+                ],
+                'Map\\Host' => [
+                    'first_sa' => 'first_sa',
+                    'first_siteaccess' => 'first_sa',
+                ],
+            ],
+            $this->siteAccessProvider
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\SiteAccessSetting[]
+     */
+    public function getSiteAccessProviderSettings(): array
+    {
+        return [
+            new SiteAccessSetting('first_sa', true),
+            new SiteAccessSetting('second_sa', true),
+            new SiteAccessSetting('third_sa', true),
+            new SiteAccessSetting('fourth_sa', true),
+            new SiteAccessSetting('fifth_sa', true),
+            new SiteAccessSetting('test', true),
+        ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/SiteAccessSetting.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/SiteAccessSetting.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
+
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+
+/**
+ * This class represents settings which will be used to construct SiteAccessProvider mock.
+ */
+final class SiteAccessSetting
+{
+    /** @var string */
+    public $name;
+
+    /** @var bool */
+    public $isDefined;
+
+    /** @var string */
+    public $matchingType;
+
+    public function __construct(
+        string $name,
+        bool $isDefined,
+        string $matchingType = SiteAccess::DEFAULT_MATCHING_TYPE
+    ) {
+        $this->name = $name;
+        $this->isDefined = $isDefined;
+        $this->matchingType = $matchingType;
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31044](https://jira.ez.no/browse/EZP-31044)
| **Improvement**| yes
| **New feature**    |no
| **Target version** | `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR adds the possibility of having more than one source of available SiteAccesses. 

By default, we have `StaticSiteAccessProvider` which contains SiteAccesses fetched from configuration files. Provides are gathered by `ChainSiteAccessProvider` which implements `SiteAccessProviderInterface`. The chain is used instead of Strategy because the order of loaded SiteAccesses is important. Those coming from configuration files should be matched first. 

This will allows us to add another provider that will fetch another SiteAccesses from the database. This is required to introduce Site Factory. 


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
