### PR TITLE
EZP-31078: Enhanced Content Type Value Object

### DIFF
--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -252,6 +252,11 @@ Changes affecting version compatibility with former or future versions.
   );
   ```  
 
+* The signature of the  `\eZ\Publish\API\Repository\Values\ContentType\ContentType::getFieldDefinitions` method was changed to:
+  ```php
+  abstract public function getFieldDefinitions(): FieldDefinitionCollection;
+  ```
+
 ## Removed services
 
 * `ezpublish.field_type_collection.factory` has been removed in favor of `eZ\Publish\Core\FieldType\FieldTypeRegistry`

--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -252,7 +252,7 @@ Changes affecting version compatibility with former or future versions.
   );
   ```  
 
-* The signature of the  `\eZ\Publish\API\Repository\Values\ContentType\ContentType::getFieldDefinitions` method was changed to:
+* The signature of the `\eZ\Publish\API\Repository\Values\ContentType\ContentType::getFieldDefinitions` method was changed to:
   ```php
   abstract public function getFieldDefinitions(): FieldDefinitionCollection;
   ```

--- a/eZ/Publish/API/Repository/Exceptions/OutOfBoundsException.php
+++ b/eZ/Publish/API/Repository/Exceptions/OutOfBoundsException.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 
 namespace eZ\Publish\API\Repository\Exceptions;
 
-use RuntimeException;
-
-class OutOfBoundsException extends RuntimeException
+class OutOfBoundsException extends \OutOfBoundsException
 {
 }

--- a/eZ/Publish/API/Repository/Exceptions/OutOfBoundsException.php
+++ b/eZ/Publish/API/Repository/Exceptions/OutOfBoundsException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Exceptions;
+
+use RuntimeException;
+
+class OutOfBoundsException extends RuntimeException
+{
+}

--- a/eZ/Publish/API/Repository/Exceptions/OutOfBoundsException.php
+++ b/eZ/Publish/API/Repository/Exceptions/OutOfBoundsException.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 
 namespace eZ\Publish\API\Repository\Exceptions;
 
-class OutOfBoundsException extends \OutOfBoundsException
+use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;
+use OutOfBoundsException as BaseOutOfBoundsException;
+
+class OutOfBoundsException extends BaseOutOfBoundsException implements RepositoryException
 {
 }

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -8,13 +8,14 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
-use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection as APIFieldDefinitionCollection;
 use eZ\Publish\API\Repository\Values\Translation\Message;
 use Exception;
 use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
@@ -2745,7 +2746,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
      * @see \eZ\Publish\API\Repository\ContentTypeService::loadContentType()
      * @depends eZ\Publish\API\Repository\Tests\ContentTypeServiceTest::testLoadContentTypeStructValues
      */
-    public function testLoadContentTypeFieldDefinitions(FieldDefinitionCollection $fieldDefinitions)
+    public function testLoadContentTypeFieldDefinitions(APIFieldDefinitionCollection $fieldDefinitions)
     {
         $expectedFieldDefinitions = [
             'name' => [
@@ -3078,7 +3079,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         /* BEGIN: Use Case */
         $contentTypeService = $repository->getContentTypeService();
 
-        $commentType = $contentTypeService->loadContentTypeByIdentifier('comment');
+        $commentType = $contentTypeService->loadContentTypeByIdentifier('comment', Language::ALL);
 
         $commentTypeDraft = $contentTypeService->createContentTypeDraft($commentType);
         /* END: Use Case */

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection;
 use eZ\Publish\API\Repository\Values\Translation\Message;
 use Exception;
 use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
@@ -823,7 +824,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
                 case 'fieldDefinitions':
                     $this->assertFieldDefinitionsCorrect(
                         $typeCreate->fieldDefinitions,
-                        $contentType->fieldDefinitions
+                        $contentType->fieldDefinitions->toArray()
                     );
                     break;
 
@@ -2744,7 +2745,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
      * @see \eZ\Publish\API\Repository\ContentTypeService::loadContentType()
      * @depends eZ\Publish\API\Repository\Tests\ContentTypeServiceTest::testLoadContentTypeStructValues
      */
-    public function testLoadContentTypeFieldDefinitions(array $fieldDefinitions)
+    public function testLoadContentTypeFieldDefinitions(FieldDefinitionCollection $fieldDefinitions)
     {
         $expectedFieldDefinitions = [
             'name' => [
@@ -2779,6 +2780,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
             ],
         ];
 
+        $fieldDefinitions = $fieldDefinitions->toArray();
         foreach ($fieldDefinitions as $index => $fieldDefinition) {
             $this->assertInstanceOf(
                 'eZ\\Publish\\API\\Repository\\Values\\ContentType\\FieldDefinition',

--- a/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
@@ -573,12 +573,12 @@ class UserIntegrationTest extends BaseIntegrationTest
      */
     private function getUserFieldDefinition(ContentType $contentType): FieldDefinition
     {
-        foreach ($contentType->getFieldDefinitions() as $fieldDefinition) {
-            if ($fieldDefinition->fieldTypeIdentifier === 'ezuser') {
-                return $fieldDefinition;
-            }
+        $fieldDefinition = $contentType->getFirstFieldDefinitionOfType('ezuser');
+
+        if ($fieldDefinition === null) {
+            $this->fail("'ezuser' field definition was not found");
         }
 
-        $this->fail("'ezuser' field definition was not found");
+        return $fieldDefinition;
     }
 }

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
@@ -186,7 +186,11 @@ abstract class ContentType extends ValueObject implements MultiLanguageName, Mul
      */
     public function getFieldDefinition($fieldDefinitionIdentifier): ?FieldDefinition
     {
-        return $this->getFieldDefinitions()->get($fieldDefinitionIdentifier);
+        if ($this->hasFieldDefinition($fieldDefinitionIdentifier)) {
+            return $this->getFieldDefinitions()->get($fieldDefinitionIdentifier);
+        }
+
+        return null;
     }
 
     /**
@@ -218,6 +222,11 @@ abstract class ContentType extends ValueObject implements MultiLanguageName, Mul
      */
     public function getFirstFieldDefinitionOfType(string $fieldTypeIdentifier): ?FieldDefinition
     {
-        return $this->getFieldDefinitions()->filterByType($fieldTypeIdentifier)->first();
+        $fieldDefinitionsOfType = $this->getFieldDefinitionsOfType($fieldTypeIdentifier);
+        if (!$fieldDefinitionsOfType->isEmpty()) {
+            return $fieldDefinitionsOfType->first();
+        }
+
+        return null;
     }
 }

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
@@ -16,7 +16,7 @@ use eZ\Publish\SPI\Repository\Values\MultiLanguageDescription;
  * this class represents a content type value.
  *
  * @property-read \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup[] $contentTypeGroups calls getContentTypeGroups
- * @property-read \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[] $fieldDefinitions calls getFieldDefinitions() or on access getFieldDefinition($fieldDefIdentifier)
+ * @property-read \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection $fieldDefinitions calls getFieldDefinitions() or on access getFieldDefinition($fieldDefIdentifier)
  * @property-read mixed $id the id of the content type
  * @property-read int $status the status of the content type. One of ContentType::STATUS_DEFINED|ContentType::STATUS_DRAFT|ContentType::STATUS_MODIFIED
  * @property-read string $identifier the identifier of the content type
@@ -175,16 +175,67 @@ abstract class ContentType extends ValueObject implements MultiLanguageName, Mul
     /**
      * This method returns the content type field definitions from this type.
      *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[]
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection
      */
-    abstract public function getFieldDefinitions();
+    abstract public function getFieldDefinitions(): FieldDefinitionCollection;
 
     /**
      * This method returns the field definition for the given identifier.
      *
      * @param string $fieldDefinitionIdentifier
      *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
+     */
+    public function getFieldDefinition($fieldDefinitionIdentifier): ?FieldDefinition
+    {
+        return $this->getFieldDefinitions()->get($fieldDefinitionIdentifier);
+    }
+
+    /**
+     * This method returns true if the field definition for the given identifier exists.
+     *
+     * @param string $fieldDefinitionIdentifier
+     *
+     * @return bool
+     */
+    public function hasFieldDefinition(string $fieldDefinitionIdentifier): bool
+    {
+        return $this->getFieldDefinitions()->has($fieldDefinitionIdentifier);
+    }
+
+    /**
+     * Returns true if field definition with given field type identifier exists.
+     *
+     * @param string $fieldTypeIdentifier
+     *
+     * @return bool
+     */
+    public function hasFieldDefinitionOfType(string $fieldTypeIdentifier): bool
+    {
+        return $this->getFieldDefinitions()->anyOfType($fieldTypeIdentifier);
+    }
+
+    /**
+     * Returns collection of the field definition for the given field type identifier.
+     *
+     * @param string $fieldTypeIdentifier
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection
+     */
+    public function getFieldDefinitionsOfType(string $fieldTypeIdentifier): FieldDefinitionCollection
+    {
+        return $this->getFieldDefinitions()->filterByType($fieldTypeIdentifier);
+    }
+
+    /**
+     * Returns true if field definition with given field type identifier or null.
+     *
+     * @param string $fieldTypeIdentifier
+     *
      * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition
      */
-    abstract public function getFieldDefinition($fieldDefinitionIdentifier);
+    public function getFirstFieldDefinitionOfType(string $fieldTypeIdentifier): ?FieldDefinition
+    {
+        return $this->getFieldDefinitions()->filterByType($fieldTypeIdentifier)->first();
+    }
 }

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
@@ -174,8 +174,6 @@ abstract class ContentType extends ValueObject implements MultiLanguageName, Mul
 
     /**
      * This method returns the content type field definitions from this type.
-     *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection
      */
     abstract public function getFieldDefinitions(): FieldDefinitionCollection;
 
@@ -193,10 +191,6 @@ abstract class ContentType extends ValueObject implements MultiLanguageName, Mul
 
     /**
      * This method returns true if the field definition for the given identifier exists.
-     *
-     * @param string $fieldDefinitionIdentifier
-     *
-     * @return bool
      */
     public function hasFieldDefinition(string $fieldDefinitionIdentifier): bool
     {
@@ -205,10 +199,6 @@ abstract class ContentType extends ValueObject implements MultiLanguageName, Mul
 
     /**
      * Returns true if field definition with given field type identifier exists.
-     *
-     * @param string $fieldTypeIdentifier
-     *
-     * @return bool
      */
     public function hasFieldDefinitionOfType(string $fieldTypeIdentifier): bool
     {
@@ -217,10 +207,6 @@ abstract class ContentType extends ValueObject implements MultiLanguageName, Mul
 
     /**
      * Returns collection of the field definition for the given field type identifier.
-     *
-     * @param string $fieldTypeIdentifier
-     *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection
      */
     public function getFieldDefinitionsOfType(string $fieldTypeIdentifier): FieldDefinitionCollection
     {
@@ -229,10 +215,6 @@ abstract class ContentType extends ValueObject implements MultiLanguageName, Mul
 
     /**
      * Returns true if field definition with given field type identifier or null.
-     *
-     * @param string $fieldTypeIdentifier
-     *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition
      */
     public function getFirstFieldDefinitionOfType(string $fieldTypeIdentifier): ?FieldDefinition
     {

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCollection.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCollection.php
@@ -17,8 +17,10 @@ interface FieldDefinitionCollection extends Countable, IteratorAggregate, ArrayA
 {
     /**
      * This method returns the field definition for the given identifier.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\OutOfBoundsException
      */
-    public function get(string $fieldDefinitionIdentifier): ?FieldDefinition;
+    public function get(string $fieldDefinitionIdentifier): FieldDefinition;
 
     /**
      * This method returns true if the field definition for the given identifier exists.
@@ -27,13 +29,17 @@ interface FieldDefinitionCollection extends Countable, IteratorAggregate, ArrayA
 
     /**
      * Return first element of collection.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\OutOfBoundsException
      */
-    public function first(): ?FieldDefinition;
+    public function first(): FieldDefinition;
 
     /**
      * Return last element of collection.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\OutOfBoundsException
      */
-    public function last(): ?FieldDefinition;
+    public function last(): FieldDefinition;
 
     /**
      * Checks whether the collection is empty (contains no elements).

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCollection.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCollection.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\ContentType;
+
+use ArrayAccess;
+use Closure;
+use Countable;
+use IteratorAggregate;
+
+interface FieldDefinitionCollection extends Countable, IteratorAggregate, ArrayAccess
+{
+    /**
+     * This method returns the field definition for the given identifier.
+     *
+     * @param string $fieldDefinitionIdentifier
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
+     */
+    public function get(string $fieldDefinitionIdentifier): ?FieldDefinition;
+
+    /**
+     * This method returns true if the field definition for the given identifier exists.
+     *
+     * @param string $fieldDefinitionIdentifier
+     *
+     * @return bool
+     */
+    public function has(string $fieldDefinitionIdentifier): bool;
+
+    /**
+     * Return first element of collection.
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
+     */
+    public function first(): ?FieldDefinition;
+
+    /**
+     * Return last element of collection.
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
+     */
+    public function last(): ?FieldDefinition;
+
+    /**
+     * Checks whether the collection is empty (contains no elements).
+     *
+     * @return bool TRUE if the collection is empty, FALSE otherwise.
+     */
+    public function isEmpty(): bool;
+
+    /**
+     * Returns all the elements of this collection that satisfy the predicate p.
+     * The order of the elements is preserved.
+     *
+     * @param Closure $p The predicate used for filtering.
+     *
+     * @return FieldDefinitionCollection A collection with the results of the filter operation.
+     */
+    public function filter(Closure $p): FieldDefinitionCollection;
+
+    /**
+     * Returns field definitions with given field type identifier.
+     *
+     * @param string $fieldTypeIdentifier
+     *
+     * @return FieldDefinitionCollection A collection with the results of the filter operation.
+     */
+    public function filterByType(string $fieldTypeIdentifier): FieldDefinitionCollection;
+
+    /**
+     * Returns field definitions with given group.
+     *
+     * @param string $fieldGroup
+     *
+     * @return FieldDefinitionCollection A collection with the results of the filter operation.
+     */
+    public function filterByGroup(string $fieldGroup): FieldDefinitionCollection;
+
+    /**
+     * Applies the given function to each element in the collection and returns
+     * a new collection with the elements returned by the function.
+     *
+     * @param Closure $p The predicate.
+     *
+     * @return array
+     */
+    public function map(Closure $p): array;
+
+    /**
+     * Tests whether the given predicate p holds for all elements of this collection.
+     *
+     * @param Closure $p The predicate.
+     *
+     * @return bool TRUE, if the predicate yields TRUE for all elements, FALSE otherwise.
+     */
+    public function all(Closure $p): bool;
+
+    /**
+     * Tests for the existence of an element that satisfies the given predicate.
+     *
+     * @param Closure $p The predicate.
+     *
+     * @return bool TRUE if the predicate is TRUE for at least one element, FALSE otherwise.
+     */
+    public function any(Closure $p): bool;
+
+    /**
+     * Tests for the existence of an field definition with given field type identifier.
+     *
+     * @param string $fieldTypeIdentifier
+     *
+     * @return bool TRUE if the predicate is TRUE for at least one field definition, FALSE otherwise.
+     */
+    public function anyOfType(string $fieldTypeIdentifier): bool;
+
+    /**
+     * Tests for the existence of an field definition in given field group.
+     *
+     * @param string $fieldGroup
+     *
+     * @return bool TRUE if the predicate is TRUE for at least one field definition, FALSE otherwise.
+     */
+    public function anyInGroup(string $fieldGroup): bool;
+
+    /**
+     * Partitions this collection in two collections according to a predicate.
+     *
+     * @param Closure $p The predicate on which to partition.
+     *
+     * @return FieldDefinitionCollection[] An array with two elements. The first element contains the collection
+     *                      of elements where the predicate returned TRUE, the second element
+     *                      contains the collection of elements where the predicate returned FALSE.
+     */
+    public function partition(Closure $p): array;
+
+    /**
+     * Gets a native PHP array representation of the collection.
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[]
+     */
+    public function toArray(): array;
+}

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCollection.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCollection.php
@@ -17,33 +17,21 @@ interface FieldDefinitionCollection extends Countable, IteratorAggregate, ArrayA
 {
     /**
      * This method returns the field definition for the given identifier.
-     *
-     * @param string $fieldDefinitionIdentifier
-     *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
      */
     public function get(string $fieldDefinitionIdentifier): ?FieldDefinition;
 
     /**
      * This method returns true if the field definition for the given identifier exists.
-     *
-     * @param string $fieldDefinitionIdentifier
-     *
-     * @return bool
      */
     public function has(string $fieldDefinitionIdentifier): bool;
 
     /**
      * Return first element of collection.
-     *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
      */
     public function first(): ?FieldDefinition;
 
     /**
      * Return last element of collection.
-     *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
      */
     public function last(): ?FieldDefinition;
 
@@ -57,87 +45,55 @@ interface FieldDefinitionCollection extends Countable, IteratorAggregate, ArrayA
     /**
      * Returns all the elements of this collection that satisfy the predicate p.
      * The order of the elements is preserved.
-     *
-     * @param Closure $p The predicate used for filtering.
-     *
-     * @return FieldDefinitionCollection A collection with the results of the filter operation.
      */
-    public function filter(Closure $p): FieldDefinitionCollection;
+    public function filter(Closure $predicate): FieldDefinitionCollection;
 
     /**
      * Returns field definitions with given field type identifier.
-     *
-     * @param string $fieldTypeIdentifier
-     *
-     * @return FieldDefinitionCollection A collection with the results of the filter operation.
      */
     public function filterByType(string $fieldTypeIdentifier): FieldDefinitionCollection;
 
     /**
      * Returns field definitions with given group.
-     *
-     * @param string $fieldGroup
-     *
-     * @return FieldDefinitionCollection A collection with the results of the filter operation.
      */
     public function filterByGroup(string $fieldGroup): FieldDefinitionCollection;
 
     /**
      * Applies the given function to each element in the collection and returns
      * a new collection with the elements returned by the function.
-     *
-     * @param Closure $p The predicate.
-     *
-     * @return array
      */
-    public function map(Closure $p): array;
+    public function map(Closure $predicate): array;
 
     /**
-     * Tests whether the given predicate p holds for all elements of this collection.
-     *
-     * @param Closure $p The predicate.
-     *
-     * @return bool TRUE, if the predicate yields TRUE for all elements, FALSE otherwise.
+     * Tests whether the given predicate holds for all elements of this collection.
      */
-    public function all(Closure $p): bool;
+    public function all(Closure $predicate): bool;
 
     /**
      * Tests for the existence of an element that satisfies the given predicate.
-     *
-     * @param Closure $p The predicate.
-     *
-     * @return bool TRUE if the predicate is TRUE for at least one element, FALSE otherwise.
      */
-    public function any(Closure $p): bool;
+    public function any(Closure $predicate): bool;
 
     /**
      * Tests for the existence of an field definition with given field type identifier.
-     *
-     * @param string $fieldTypeIdentifier
-     *
-     * @return bool TRUE if the predicate is TRUE for at least one field definition, FALSE otherwise.
      */
     public function anyOfType(string $fieldTypeIdentifier): bool;
 
     /**
      * Tests for the existence of an field definition in given field group.
-     *
-     * @param string $fieldGroup
-     *
-     * @return bool TRUE if the predicate is TRUE for at least one field definition, FALSE otherwise.
      */
     public function anyInGroup(string $fieldGroup): bool;
 
     /**
      * Partitions this collection in two collections according to a predicate.
      *
-     * @param Closure $p The predicate on which to partition.
+     * Result is an array with two elements. The first element contains the collection
+     * of elements where the predicate returned TRUE, the second element
+     * contains the collection of elements where the predicate returned FALSE.
      *
-     * @return FieldDefinitionCollection[] An array with two elements. The first element contains the collection
-     *                      of elements where the predicate returned TRUE, the second element
-     *                      contains the collection of elements where the predicate returned FALSE.
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection[]
      */
-    public function partition(Closure $p): array;
+    public function partition(Closure $predicate): array;
 
     /**
      * Gets a native PHP array representation of the collection.

--- a/eZ/Publish/Core/Helper/Tests/FieldHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/FieldHelperTest.php
@@ -61,7 +61,7 @@ class FieldHelperTest extends TestCase
         $emptyValue = $textLineFT->getEmptyValue();
         $emptyField = new Field(['fieldDefIdentifier' => $fieldDefIdentifier, 'value' => $emptyValue]);
 
-        $contentType = $this->getMockForAbstractClass(ContentType::class);
+        $contentType = $this->createMock(ContentType::class);
         $fieldDefinition = $this->getMockBuilder(FieldDefinition::class)
             ->setConstructorArgs([['fieldTypeIdentifier' => 'ezstring']])
             ->getMockForAbstractClass();
@@ -107,7 +107,7 @@ class FieldHelperTest extends TestCase
         $nonEmptyValue = new Value('Vive le sucre !!!');
         $emptyField = new Field(['fieldDefIdentifier' => 'ezstring', 'value' => $nonEmptyValue]);
 
-        $contentType = $this->getMockForAbstractClass(ContentType::class);
+        $contentType = $this->createMock(ContentType::class);
         $fieldDefinition = $this->getMockBuilder(FieldDefinition::class)
             ->setConstructorArgs([['fieldTypeIdentifier' => 'ezstring']])
             ->getMockForAbstractClass();

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/ContentExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/ContentExtensionTest.php
@@ -21,6 +21,7 @@ use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -186,7 +187,9 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
                             [
                                 'identifier' => $contentTypeId,
                                 'mainLanguageCode' => 'fre-FR',
-                                'fieldDefinitions' => $this->fieldDefinitions[$contentTypeId],
+                                'fieldDefinitions' => new FieldDefinitionCollection(
+                                    $this->fieldDefinitions[$contentTypeId]
+                                ),
                             ]
                         );
                     }

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
@@ -20,6 +20,7 @@ use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection;
 use Psr\Log\LoggerInterface;
 
 class FieldRenderingExtensionIntegrationTest extends FileSystemTwigIntegrationTestCase
@@ -131,7 +132,9 @@ class FieldRenderingExtensionIntegrationTest extends FileSystemTwigIntegrationTe
                     'id' => $contentTypeIdentifier,
                     'identifier' => $contentTypeIdentifier,
                     'mainLanguageCode' => 'fre-FR',
-                    'fieldDefinitions' => $this->fieldDefinitions[$contentTypeIdentifier],
+                    'fieldDefinitions' => new FieldDefinitionCollection(
+                        $this->fieldDefinitions[$contentTypeIdentifier
+                    ]),
                 ]),
                 'versionInfo' => new VersionInfo(
                     [

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -1282,7 +1282,7 @@ class ContentTypeService implements ContentTypeServiceInterface
         $this->validateInputFieldDefinitionCreateStruct($fieldDefinitionCreateStruct);
         $loadedContentTypeDraft = $this->loadContentTypeDraft($contentTypeDraft->id);
 
-        if ($loadedContentTypeDraft->getFieldDefinition($fieldDefinitionCreateStruct->identifier) !== null) {
+        if ($loadedContentTypeDraft->hasFieldDefinition($fieldDefinitionCreateStruct->identifier)) {
             throw new InvalidArgumentException(
                 '$fieldDefinitionCreateStruct',
                 "Another Field definition with identifier '{$fieldDefinitionCreateStruct->identifier}' exists in the Content Type"
@@ -1311,13 +1311,11 @@ class ContentTypeService implements ContentTypeServiceInterface
         }
 
         if ($fieldType->isSingular()) {
-            foreach ($loadedContentTypeDraft->getFieldDefinitions() as $fieldDefinition) {
-                if ($fieldDefinition->fieldTypeIdentifier === $fieldDefinitionCreateStruct->fieldTypeIdentifier) {
-                    throw new BadStateException(
-                        '$contentTypeDraft',
-                        "The Content Type already contains a Field definition of the singular Field Type '{$fieldDefinition->fieldTypeIdentifier}'"
-                    );
-                }
+            if ($loadedContentTypeDraft->hasFieldDefinitionOfType($fieldDefinitionCreateStruct->fieldTypeIdentifier)) {
+                throw new BadStateException(
+                    '$contentTypeDraft',
+                    "The Content Type already contains a Field definition of the singular Field Type '{$fieldDefinitionCreateStruct->fieldTypeIdentifier}'"
+                );
             }
         }
 
@@ -1474,7 +1472,7 @@ class ContentTypeService implements ContentTypeServiceInterface
             );
         }
 
-        if (count($loadedContentTypeDraft->getFieldDefinitions()) === 0) {
+        if ($loadedContentTypeDraft->getFieldDefinitions()->isEmpty()) {
             throw new InvalidArgumentException(
                 '$contentTypeDraft',
                 'The Content Type draft should have at least one Field definition.'

--- a/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
@@ -24,6 +24,7 @@ use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeDraft;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeGroup;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeGroupProxy;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection;
 use eZ\Publish\SPI\FieldType\FieldType as SPIFieldType;
 use eZ\Publish\SPI\Persistence\Content\Type as SPIContentType;
 use eZ\Publish\SPI\Persistence\Content\Type\Group as SPIContentTypeGroup;
@@ -91,7 +92,7 @@ class ContentTypeDomainMapper
                 'names' => $spiContentType->name,
                 'descriptions' => $spiContentType->description,
                 'contentTypeGroups' => $this->buildContentTypeGroupProxyList($spiContentType->groupIds, $prioritizedLanguages),
-                'fieldDefinitions' => $fieldDefinitions,
+                'fieldDefinitions' => new FieldDefinitionCollection($fieldDefinitions),
                 'id' => $spiContentType->id,
                 'status' => $spiContentType->status,
                 'identifier' => $spiContentType->identifier,

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -22,7 +22,6 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentType as APIContentType;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition as APIFieldDefinition;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct as APIContentCreateStruct;
-use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection;
 use eZ\Publish\Core\Base\Exceptions\ContentFieldValidationException;
 use eZ\Publish\Core\Base\Exceptions\ContentValidationException;
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
@@ -41,6 +40,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection;
 use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
 use eZ\Publish\SPI\FieldType\FieldType as SPIFieldType;
 use eZ\Publish\SPI\Persistence\Content as SPIContent;
@@ -147,7 +147,7 @@ class ContentTest extends BaseServiceMockTest
      * Test for the loadVersionInfo() method, of a draft.
      *
      * @depends testLoadVersionInfoById
-     * @covers  \eZ\Publish\Core\Repository\ContentService::loadVersionInfoById
+     * @covers \eZ\Publish\Core\Repository\ContentService::loadVersionInfoById
      */
     public function testLoadVersionInfoByIdAndVersionNumber()
     {
@@ -362,7 +362,7 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the loadVersionInfo() method.
      *
-     * @covers  \eZ\Publish\Core\Repository\ContentService::loadVersionInfo
+     * @covers \eZ\Publish\Core\Repository\ContentService::loadVersionInfo
      * @depends eZ\Publish\Core\Repository\Tests\Service\Mock\ContentTest::testLoadVersionInfoById
      * @depends eZ\Publish\Core\Repository\Tests\Service\Mock\ContentTest::testLoadVersionInfoByIdThrowsNotFoundException
      * @depends eZ\Publish\Core\Repository\Tests\Service\Mock\ContentTest::testLoadVersionInfoByIdThrowsUnauthorizedExceptionNonPublishedVersion
@@ -1085,6 +1085,7 @@ class ContentTest extends BaseServiceMockTest
      * @param array $languageCodes
      *
      * @return array
+     *
      * @throws \RuntimeException Method is intended to be used only with consistent fixtures
      */
     protected function determineValuesForCreate(
@@ -1189,7 +1190,7 @@ class ContentTest extends BaseServiceMockTest
         $contentType = new ContentType(
             [
                 'id' => 123,
-                'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
+                'fieldDefinitions' => new FieldDefinitionCollection($fieldDefinitions),
                 'nameSchema' => '<nameSchema>',
             ]
         );
@@ -1434,11 +1435,11 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing the simplest use case.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::cloneField
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
-     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::cloneField
+     * @covers \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
+     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentNonRedundantFieldSet1
      */
     public function testCreateContentNonRedundantFieldSet1($mainLanguageCode, $structFields, $spiFields)
@@ -1536,11 +1537,11 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing multiple languages with multiple translatable fields with empty default value.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::cloneField
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
-     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::cloneField
+     * @covers \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
+     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentNonRedundantFieldSet2
      */
     public function testCreateContentNonRedundantFieldSet2($mainLanguageCode, $structFields, $spiFields)
@@ -1748,11 +1749,11 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing multiple languages with multiple translatable fields with empty default value.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::cloneField
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
-     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::cloneField
+     * @covers \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
+     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentNonRedundantFieldSetComplex
      */
     public function testCreateContentNonRedundantFieldSetComplex($mainLanguageCode, $structFields, $spiFields)
@@ -1800,8 +1801,8 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentWithInvalidLanguage
      */
     public function testCreateContentWithInvalidLanguage($mainLanguageCode, $structFields)
@@ -1905,7 +1906,7 @@ class ContentTest extends BaseServiceMockTest
         $contentType = new ContentType(
             [
                 'id' => 123,
-                'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
+                'fieldDefinitions' => new FieldDefinitionCollection($fieldDefinitions),
             ]
         );
         $contentCreateStruct = new ContentCreateStruct(
@@ -1968,9 +1969,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the createContent() method.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentThrowsContentValidationExceptionFieldDefinition
      */
     public function testCreateContentThrowsContentValidationExceptionFieldDefinition($mainLanguageCode, $structFields)
@@ -2006,9 +2007,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the createContent() method.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentThrowsContentValidationExceptionTranslation
      */
     public function testCreateContentThrowsContentValidationExceptionTranslation($mainLanguageCode, $structFields)
@@ -2062,7 +2063,7 @@ class ContentTest extends BaseServiceMockTest
         $contentType = new ContentType(
             [
                 'id' => 123,
-                'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
+                'fieldDefinitions' => new FieldDefinitionCollection($fieldDefinitions),
                 'nameSchema' => '<nameSchema>',
             ]
         );
@@ -2183,9 +2184,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the createContent() method.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentThrowsContentValidationExceptionRequiredField
      */
     public function testCreateContentRequiredField(
@@ -2256,7 +2257,7 @@ class ContentTest extends BaseServiceMockTest
         $contentType = new ContentType(
             [
                 'id' => 123,
-                'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
+                'fieldDefinitions' => new FieldDefinitionCollection($fieldDefinitions),
                 'nameSchema' => '<nameSchema>',
             ]
         );
@@ -2394,9 +2395,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the createContent() method.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentThrowsContentFieldValidationException
      */
     public function testCreateContentThrowsContentFieldValidationException($mainLanguageCode, $structFields)
@@ -2798,10 +2799,10 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the createContent() method.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
-     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
+     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentThrowsContentValidationExceptionTranslation
      */
     public function testCreateContentWithRollback()
@@ -2860,7 +2861,7 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentThrowsBadStateException
      */
     public function testUpdateContentThrowsBadStateException($status)
@@ -3155,7 +3156,7 @@ class ContentTest extends BaseServiceMockTest
             ]
         );
         $contentType = new ContentType([
-            'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
+            'fieldDefinitions' => new FieldDefinitionCollection($fieldDefinitions),
         ]);
 
         $languageHandlerMock->expects($this->any())
@@ -3394,9 +3395,9 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing the simplest use case.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentNonRedundantFieldSet1
      */
     public function testUpdateContentNonRedundantFieldSet1($initialLanguageCode, $structFields, $spiFields)
@@ -3607,9 +3608,9 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing with translatable field.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentNonRedundantFieldSet2
      */
     public function testUpdateContentNonRedundantFieldSet2($initialLanguageCode, $structFields, $spiFields)
@@ -3869,9 +3870,9 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing with new language and untranslatable field.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentNonRedundantFieldSet3
      */
     public function testUpdateContentNonRedundantFieldSet3($initialLanguageCode, $structFields, $spiFields)
@@ -4174,9 +4175,9 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing with empty values.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentNonRedundantFieldSet4
      */
     public function testUpdateContentNonRedundantFieldSet4($initialLanguageCode, $structFields, $spiFields)
@@ -4234,6 +4235,7 @@ class ContentTest extends BaseServiceMockTest
 
     /**
      * @return array
+     *
      * @todo add first field empty
      */
     public function providerForTestUpdateContentNonRedundantFieldSetComplex()
@@ -4553,9 +4555,9 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing more complex cases.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentNonRedundantFieldSetComplex
      */
     public function testUpdateContentNonRedundantFieldSetComplex($initialLanguageCode, $structFields, $spiFields)
@@ -4604,8 +4606,8 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentWithInvalidLanguage
      */
     public function testUpdateContentWithInvalidLanguage($initialLanguageCode, $structFields)
@@ -4720,7 +4722,7 @@ class ContentTest extends BaseServiceMockTest
             ]
         );
         $contentType = new ContentType([
-            'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
+            'fieldDefinitions' => new FieldDefinitionCollection($fieldDefinitions),
         ]);
 
         $languageHandlerMock->expects($this->any())
@@ -4803,9 +4805,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentThrowsContentValidationExceptionFieldDefinition
      */
     public function testUpdateContentThrowsContentValidationExceptionFieldDefinition($initialLanguageCode, $structFields)
@@ -4841,9 +4843,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentThrowsContentValidationExceptionTranslation
      */
     public function testUpdateContentThrowsContentValidationExceptionTranslation($initialLanguageCode, $structFields)
@@ -4911,7 +4913,7 @@ class ContentTest extends BaseServiceMockTest
             ]
         );
         $contentType = new ContentType([
-            'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
+            'fieldDefinitions' => new FieldDefinitionCollection($fieldDefinitions),
         ]);
 
         $languageHandlerMock->expects($this->any())
@@ -5024,9 +5026,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentRequiredField
      */
     public function testUpdateContentRequiredField(
@@ -5124,7 +5126,7 @@ class ContentTest extends BaseServiceMockTest
             ]
         );
         $contentType = new ContentType([
-            'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
+            'fieldDefinitions' => new FieldDefinitionCollection($fieldDefinitions),
         ]);
 
         $languageHandlerMock->expects($this->any())
@@ -5342,9 +5344,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentThrowsContentFieldValidationException
      */
     public function testUpdateContentThrowsContentFieldValidationException($initialLanguageCode, $structFields, $spiField, $allFieldErrors)
@@ -6162,25 +6164,5 @@ class ContentTest extends BaseServiceMockTest
             ->willReturn($this->getPermissionResolverMock());
 
         return $repositoryMock;
-    }
-
-    protected function createFieldDefinitionCollectionMock(array $fieldDefinitions): FieldDefinitionCollection
-    {
-        return new \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection($fieldDefinitions);
-//        $collection = $this->createMock(FieldDefinitionCollection::class);
-//
-//        $collection->method('get')->willReturnMap(
-//            array_map(static function (APIFieldDefinition $fieldDefinition): array {
-//                return [$fieldDefinition->identifier, $fieldDefinition];
-//            }, $fieldDefinitions)
-//        );
-//
-//        $collection->method('has')->willReturnCallback(
-//            static function (string $identifier) use($fieldDefinitions): bool {
-//                return in_array($identifier, array_column($fieldDefinitions, 'identifier'));
-//            }
-//        );
-//
-//        return $collection;
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -22,6 +22,7 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentType as APIContentType;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition as APIFieldDefinition;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct as APIContentCreateStruct;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection;
 use eZ\Publish\Core\Base\Exceptions\ContentFieldValidationException;
 use eZ\Publish\Core\Base\Exceptions\ContentValidationException;
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
@@ -146,7 +147,7 @@ class ContentTest extends BaseServiceMockTest
      * Test for the loadVersionInfo() method, of a draft.
      *
      * @depends testLoadVersionInfoById
-     * @covers \eZ\Publish\Core\Repository\ContentService::loadVersionInfoById
+     * @covers  \eZ\Publish\Core\Repository\ContentService::loadVersionInfoById
      */
     public function testLoadVersionInfoByIdAndVersionNumber()
     {
@@ -361,7 +362,7 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the loadVersionInfo() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::loadVersionInfo
+     * @covers  \eZ\Publish\Core\Repository\ContentService::loadVersionInfo
      * @depends eZ\Publish\Core\Repository\Tests\Service\Mock\ContentTest::testLoadVersionInfoById
      * @depends eZ\Publish\Core\Repository\Tests\Service\Mock\ContentTest::testLoadVersionInfoByIdThrowsNotFoundException
      * @depends eZ\Publish\Core\Repository\Tests\Service\Mock\ContentTest::testLoadVersionInfoByIdThrowsUnauthorizedExceptionNonPublishedVersion
@@ -545,7 +546,7 @@ class ContentTest extends BaseServiceMockTest
 
         $spiContent = new SPIContent([
             'versionInfo' => new VersionInfo([
-                    'contentInfo' => new ContentInfo(['id' => 42, 'contentTypeId' => 123]),
+                'contentInfo' => new ContentInfo(['id' => 42, 'contentTypeId' => 123]),
             ]),
         ]);
         $contentHandler
@@ -1078,14 +1079,13 @@ class ContentTest extends BaseServiceMockTest
      * Returns full, possibly redundant array of field values, indexed by field definition
      * identifier and language code.
      *
-     * @throws \RuntimeException Method is intended to be used only with consistent fixtures
-     *
      * @param string $mainLanguageCode
      * @param \eZ\Publish\API\Repository\Values\Content\Field[] $structFields
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[] $fieldDefinitions
      * @param array $languageCodes
      *
      * @return array
+     * @throws \RuntimeException Method is intended to be used only with consistent fixtures
      */
     protected function determineValuesForCreate(
         $mainLanguageCode,
@@ -1180,7 +1180,6 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit\Framework\MockObject\MockObject $objectStateHandlerMock */
         $objectStateHandlerMock = $this->getPersistenceMock()->objectStateHandler();
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
-        $fieldTypeServiceMock = $this->getFieldTypeServiceMock();
         $domainMapperMock = $this->getDomainMapperMock();
         $relationProcessorMock = $this->getRelationProcessorMock();
         $nameSchemaServiceMock = $this->getNameSchemaServiceMock();
@@ -1190,7 +1189,7 @@ class ContentTest extends BaseServiceMockTest
         $contentType = new ContentType(
             [
                 'id' => 123,
-                'fieldDefinitions' => $fieldDefinitions,
+                'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
                 'nameSchema' => '<nameSchema>',
             ]
         );
@@ -1435,11 +1434,11 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing the simplest use case.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::cloneField
-     * @covers \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
-     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::cloneField
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
+     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentNonRedundantFieldSet1
      */
     public function testCreateContentNonRedundantFieldSet1($mainLanguageCode, $structFields, $spiFields)
@@ -1537,11 +1536,11 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing multiple languages with multiple translatable fields with empty default value.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::cloneField
-     * @covers \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
-     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::cloneField
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
+     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentNonRedundantFieldSet2
      */
     public function testCreateContentNonRedundantFieldSet2($mainLanguageCode, $structFields, $spiFields)
@@ -1749,11 +1748,11 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing multiple languages with multiple translatable fields with empty default value.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::cloneField
-     * @covers \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
-     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::cloneField
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
+     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentNonRedundantFieldSetComplex
      */
     public function testCreateContentNonRedundantFieldSetComplex($mainLanguageCode, $structFields, $spiFields)
@@ -1801,8 +1800,8 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentWithInvalidLanguage
      */
     public function testCreateContentWithInvalidLanguage($mainLanguageCode, $structFields)
@@ -1906,7 +1905,7 @@ class ContentTest extends BaseServiceMockTest
         $contentType = new ContentType(
             [
                 'id' => 123,
-                'fieldDefinitions' => $fieldDefinitions,
+                'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
             ]
         );
         $contentCreateStruct = new ContentCreateStruct(
@@ -1969,9 +1968,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the createContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentThrowsContentValidationExceptionFieldDefinition
      */
     public function testCreateContentThrowsContentValidationExceptionFieldDefinition($mainLanguageCode, $structFields)
@@ -2007,9 +2006,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the createContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentThrowsContentValidationExceptionTranslation
      */
     public function testCreateContentThrowsContentValidationExceptionTranslation($mainLanguageCode, $structFields)
@@ -2056,7 +2055,6 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
-        $fieldTypeServiceMock = $this->getFieldTypeServiceMock();
         $domainMapperMock = $this->getDomainMapperMock();
         $fieldTypeMock = $this->createMock(SPIFieldType::class);
         $permissionResolver = $this->getPermissionResolverMock();
@@ -2064,7 +2062,7 @@ class ContentTest extends BaseServiceMockTest
         $contentType = new ContentType(
             [
                 'id' => 123,
-                'fieldDefinitions' => $fieldDefinitions,
+                'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
                 'nameSchema' => '<nameSchema>',
             ]
         );
@@ -2185,9 +2183,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the createContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentThrowsContentValidationExceptionRequiredField
      */
     public function testCreateContentRequiredField(
@@ -2249,7 +2247,6 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
-        $fieldTypeServiceMock = $this->getFieldTypeServiceMock();
         $domainMapperMock = $this->getDomainMapperMock();
         $relationProcessorMock = $this->getRelationProcessorMock();
         $fieldTypeMock = $this->createMock(SPIFieldType::class);
@@ -2259,7 +2256,7 @@ class ContentTest extends BaseServiceMockTest
         $contentType = new ContentType(
             [
                 'id' => 123,
-                'fieldDefinitions' => $fieldDefinitions,
+                'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
                 'nameSchema' => '<nameSchema>',
             ]
         );
@@ -2397,9 +2394,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the createContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentThrowsContentFieldValidationException
      */
     public function testCreateContentThrowsContentFieldValidationException($mainLanguageCode, $structFields)
@@ -2801,10 +2798,10 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the createContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
-     * @covers \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
-     * @covers \eZ\Publish\Core\Repository\ContentService::createContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getDefaultObjectStates
+     * @covers       \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentThrowsContentValidationExceptionTranslation
      */
     public function testCreateContentWithRollback()
@@ -2863,7 +2860,7 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentThrowsBadStateException
      */
     public function testUpdateContentThrowsBadStateException($status)
@@ -3157,7 +3154,9 @@ class ContentTest extends BaseServiceMockTest
                 'internalFields' => $existingFields,
             ]
         );
-        $contentType = new ContentType(['fieldDefinitions' => $fieldDefinitions]);
+        $contentType = new ContentType([
+            'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
+        ]);
 
         $languageHandlerMock->expects($this->any())
             ->method('loadByLanguageCode')
@@ -3395,9 +3394,9 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing the simplest use case.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentNonRedundantFieldSet1
      */
     public function testUpdateContentNonRedundantFieldSet1($initialLanguageCode, $structFields, $spiFields)
@@ -3608,9 +3607,9 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing with translatable field.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentNonRedundantFieldSet2
      */
     public function testUpdateContentNonRedundantFieldSet2($initialLanguageCode, $structFields, $spiFields)
@@ -3870,9 +3869,9 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing with new language and untranslatable field.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentNonRedundantFieldSet3
      */
     public function testUpdateContentNonRedundantFieldSet3($initialLanguageCode, $structFields, $spiFields)
@@ -4175,9 +4174,9 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing with empty values.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentNonRedundantFieldSet4
      */
     public function testUpdateContentNonRedundantFieldSet4($initialLanguageCode, $structFields, $spiFields)
@@ -4234,9 +4233,8 @@ class ContentTest extends BaseServiceMockTest
     }
 
     /**
-     * @todo add first field empty
-     *
      * @return array
+     * @todo add first field empty
      */
     public function providerForTestUpdateContentNonRedundantFieldSetComplex()
     {
@@ -4555,9 +4553,9 @@ class ContentTest extends BaseServiceMockTest
      *
      * Testing more complex cases.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentNonRedundantFieldSetComplex
      */
     public function testUpdateContentNonRedundantFieldSetComplex($initialLanguageCode, $structFields, $spiFields)
@@ -4606,8 +4604,8 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentWithInvalidLanguage
      */
     public function testUpdateContentWithInvalidLanguage($initialLanguageCode, $structFields)
@@ -4721,7 +4719,9 @@ class ContentTest extends BaseServiceMockTest
                 'internalFields' => [],
             ]
         );
-        $contentType = new ContentType(['fieldDefinitions' => $fieldDefinitions]);
+        $contentType = new ContentType([
+            'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
+        ]);
 
         $languageHandlerMock->expects($this->any())
             ->method('loadByLanguageCode')
@@ -4803,9 +4803,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentThrowsContentValidationExceptionFieldDefinition
      */
     public function testUpdateContentThrowsContentValidationExceptionFieldDefinition($initialLanguageCode, $structFields)
@@ -4841,9 +4841,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentThrowsContentValidationExceptionTranslation
      */
     public function testUpdateContentThrowsContentValidationExceptionTranslation($initialLanguageCode, $structFields)
@@ -4910,7 +4910,9 @@ class ContentTest extends BaseServiceMockTest
                 'internalFields' => $existingFields,
             ]
         );
-        $contentType = new ContentType(['fieldDefinitions' => $fieldDefinitions]);
+        $contentType = new ContentType([
+            'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
+        ]);
 
         $languageHandlerMock->expects($this->any())
             ->method('loadByLanguageCode')
@@ -5022,9 +5024,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentRequiredField
      */
     public function testUpdateContentRequiredField(
@@ -5121,7 +5123,9 @@ class ContentTest extends BaseServiceMockTest
                 'internalFields' => $existingFields,
             ]
         );
-        $contentType = new ContentType(['fieldDefinitions' => $fieldDefinitions]);
+        $contentType = new ContentType([
+            'fieldDefinitions' => $this->createFieldDefinitionCollectionMock($fieldDefinitions),
+        ]);
 
         $languageHandlerMock->expects($this->any())
             ->method('loadByLanguageCode')
@@ -5338,9 +5342,9 @@ class ContentTest extends BaseServiceMockTest
     /**
      * Test for the updateContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
-     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     * @covers       \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
+     * @covers       \eZ\Publish\Core\Repository\ContentService::updateContent
      * @dataProvider providerForTestUpdateContentThrowsContentFieldValidationException
      */
     public function testUpdateContentThrowsContentFieldValidationException($initialLanguageCode, $structFields, $spiField, $allFieldErrors)
@@ -5449,16 +5453,14 @@ class ContentTest extends BaseServiceMockTest
 
         $repository->expects($this->once())
             ->method('getLocationService')
-            ->will($this->returnValue($locationServiceMock))
-        ;
+            ->will($this->returnValue($locationServiceMock));
 
         $locationServiceMock->expects($this->once())
             ->method('loadLocation')
             ->with(
                 $locationCreateStruct->parentLocationId
             )
-            ->will($this->returnValue($location))
-        ;
+            ->will($this->returnValue($location));
 
         $contentInfo->expects($this->any())
             ->method('__get')
@@ -5517,8 +5519,7 @@ class ContentTest extends BaseServiceMockTest
         $locationServiceMock->expects($this->once())
             ->method('loadLocation')
             ->with($locationCreateStruct->parentLocationId)
-            ->will($this->returnValue($location))
-        ;
+            ->will($this->returnValue($location));
 
         $contentInfoMock->expects($this->any())
             ->method('__get')
@@ -5649,8 +5650,7 @@ class ContentTest extends BaseServiceMockTest
         $locationServiceMock->expects($this->once())
             ->method('loadLocation')
             ->with($locationCreateStruct->parentLocationId)
-            ->will($this->returnValue($location))
-        ;
+            ->will($this->returnValue($location));
 
         $contentInfoMock->expects($this->any())
             ->method('__get')
@@ -5773,14 +5773,12 @@ class ContentTest extends BaseServiceMockTest
 
         $repositoryMock->expects($this->once())
             ->method('getLocationService')
-            ->will($this->returnValue($locationServiceMock))
-        ;
+            ->will($this->returnValue($locationServiceMock));
 
         $locationServiceMock->expects($this->once())
             ->method('loadLocation')
             ->with($locationCreateStruct->parentLocationId)
-            ->will($this->returnValue($location))
-        ;
+            ->will($this->returnValue($location));
 
         $contentInfoMock = $this->createMock(APIContentInfo::class);
         $contentInfoMock->expects($this->any())
@@ -5930,7 +5928,7 @@ class ContentTest extends BaseServiceMockTest
 
         $spiContent = new SPIContent([
             'versionInfo' => new VersionInfo([
-                    'contentInfo' => new ContentInfo(['id' => 42, 'contentTypeId' => 123]),
+                'contentInfo' => new ContentInfo(['id' => 42, 'contentTypeId' => 123]),
             ]),
         ]);
 
@@ -6164,5 +6162,25 @@ class ContentTest extends BaseServiceMockTest
             ->willReturn($this->getPermissionResolverMock());
 
         return $repositoryMock;
+    }
+
+    protected function createFieldDefinitionCollectionMock(array $fieldDefinitions): FieldDefinitionCollection
+    {
+        return new \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection($fieldDefinitions);
+//        $collection = $this->createMock(FieldDefinitionCollection::class);
+//
+//        $collection->method('get')->willReturnMap(
+//            array_map(static function (APIFieldDefinition $fieldDefinition): array {
+//                return [$fieldDefinition->identifier, $fieldDefinition];
+//            }, $fieldDefinitions)
+//        );
+//
+//        $collection->method('has')->willReturnCallback(
+//            static function (string $identifier) use($fieldDefinitions): bool {
+//                return in_array($identifier, array_column($fieldDefinitions, 'identifier'));
+//            }
+//        );
+//
+//        return $collection;
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
@@ -354,7 +354,7 @@ class RelationProcessorTest extends BaseServiceMockTest
     {
         $relationProcessor = $this->getPartlyMockedRelationProcessor();
         $contentHandlerMock = $this->getPersistenceMockHandler('Content\\Handler');
-        $contentTypeMock = $this->getMockForAbstractClass(ContentType::class);
+        $contentTypeMock = $this->createMock(ContentType::class);
 
         $contentTypeMock->expects($this->at(0))
             ->method('getFieldDefinition')
@@ -426,7 +426,7 @@ class RelationProcessorTest extends BaseServiceMockTest
     {
         $relationProcessor = $this->getPartlyMockedRelationProcessor();
         $contentHandlerMock = $this->getPersistenceMockHandler('Content\\Handler');
-        $contentTypeMock = $this->getMockForAbstractClass(ContentType::class);
+        $contentTypeMock = $this->createMock(ContentType::class);
 
         $existingRelations = [
             $this->getStubbedRelation(1, Relation::COMMON, null, 10),
@@ -536,7 +536,7 @@ class RelationProcessorTest extends BaseServiceMockTest
     {
         $relationProcessor = $this->getPartlyMockedRelationProcessor();
         $contentHandlerMock = $this->getPersistenceMockHandler('Content\\Handler');
-        $contentTypeMock = $this->getMockForAbstractClass(ContentType::class);
+        $contentTypeMock = $this->createMock(ContentType::class);
 
         $existingRelations = [
             $this->getStubbedRelation(1, Relation::COMMON, null, 10),
@@ -636,7 +636,7 @@ class RelationProcessorTest extends BaseServiceMockTest
             $this->getStubbedRelation(2, Relation::ASSET, 44, 18),
         ];
 
-        $contentTypeMock = $this->getMockForAbstractClass(ContentType::class);
+        $contentTypeMock = $this->createMock(ContentType::class);
         $contentTypeMock
             ->expects($this->at(0))
             ->method('getFieldDefinition')

--- a/eZ/Publish/Core/Repository/Tests/Values/ContentType/ContentTypeTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ContentType/ContentTypeTest.php
@@ -1,25 +1,34 @@
 <?php
 
 /**
- * File containing the ContentTypeTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Tests\Values\ContentType;
 
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection as APIFieldDefinitionCollection;
 use PHPUnit\Framework\TestCase;
 
 class ContentTypeTest extends TestCase
 {
+    private const EXAMPLE_FIELD_DEFINITION_IDENTIFIER = 'example';
+    private const EXAMPLE_FIELD_TYPE_IDENTIFIER = 'ezcustom';
+
     /**
      * @covers \eZ\Publish\Core\Repository\Values\ContentType\ContentType::getProperties
      */
-    public function testObjectProperties()
+    public function testObjectProperties(): void
     {
-        $object = new ContentType(['fieldDefinitions' => []]);
+        $object = new ContentType([
+            'fieldDefinitions' => $this->createMock(APIFieldDefinitionCollection::class),
+        ]);
+
         $properties = $object->attributes();
+
         self::assertNotContains('internalFields', $properties, 'Internal property found ');
         self::assertContains('contentTypeGroups', $properties, 'Property not found');
         self::assertContains('fieldDefinitions', $properties, 'Property not found');
@@ -47,7 +56,112 @@ class ContentTypeTest extends TestCase
             } elseif (!isset($object->$property)) {
                 self::fail("Property '{$property}' does not exist on object, even though it was hinted to be there");
             }
+
             $propertiesHash[$property] = 1;
         }
+    }
+
+    public function testGetFieldDefinition(): void
+    {
+        $fieldDefinition = $this->createMock(FieldDefinition::class);
+
+        $fieldDefinitionCollection = $this->createMock(APIFieldDefinitionCollection::class);
+        $fieldDefinitionCollection
+            ->expects($this->once())
+            ->method('get')
+            ->with(self::EXAMPLE_FIELD_DEFINITION_IDENTIFIER)
+            ->willReturn($fieldDefinition);
+
+        $contentType = new ContentType([
+            'fieldDefinitions' => $fieldDefinitionCollection,
+        ]);
+
+        $this->assertEquals(
+            $fieldDefinition,
+            $contentType->getFieldDefinition(self::EXAMPLE_FIELD_DEFINITION_IDENTIFIER)
+        );
+    }
+
+    public function testHasFieldDefinition(): void
+    {
+        $fieldDefinitionCollection = $this->createMock(APIFieldDefinitionCollection::class);
+        $fieldDefinitionCollection
+            ->expects($this->once())
+            ->method('has')
+            ->with(self::EXAMPLE_FIELD_DEFINITION_IDENTIFIER)
+            ->willReturn(true);
+
+        $contentType = new ContentType([
+            'fieldDefinitions' => $fieldDefinitionCollection,
+        ]);
+
+        $this->assertTrue(
+            $contentType->hasFieldDefinition(self::EXAMPLE_FIELD_DEFINITION_IDENTIFIER)
+        );
+    }
+
+    public function testHasFieldDefinitionOfType(): void
+    {
+        $fieldDefinitionCollection = $this->createMock(APIFieldDefinitionCollection::class);
+        $fieldDefinitionCollection
+            ->expects($this->once())
+            ->method('anyOfType')
+            ->with(self::EXAMPLE_FIELD_TYPE_IDENTIFIER)
+            ->willReturn(true);
+
+        $contentType = new ContentType([
+            'fieldDefinitions' => $fieldDefinitionCollection,
+        ]);
+
+        $this->assertTrue(
+            $contentType->hasFieldDefinitionOfType(self::EXAMPLE_FIELD_TYPE_IDENTIFIER)
+        );
+    }
+
+    public function testGetFieldDefinitionsOfType(): void
+    {
+        $expectedFieldDefinitionCollection = $this->createMock(APIFieldDefinitionCollection::class);
+
+        $fieldDefinitionCollection = $this->createMock(APIFieldDefinitionCollection::class);
+        $fieldDefinitionCollection
+            ->expects($this->once())
+            ->method('filterByType')
+            ->with(self::EXAMPLE_FIELD_TYPE_IDENTIFIER)
+            ->willReturn($expectedFieldDefinitionCollection);
+
+        $contentType = new ContentType([
+            'fieldDefinitions' => $fieldDefinitionCollection,
+        ]);
+
+        $this->assertEquals(
+            $expectedFieldDefinitionCollection,
+            $contentType->getFieldDefinitionsOfType(self::EXAMPLE_FIELD_TYPE_IDENTIFIER)
+        );
+    }
+
+    public function testGetFirstFieldDefinitionOfType(): void
+    {
+        $expectedFieldDefinition = $this->createMock(FieldDefinition::class);
+
+        $filteredFieldDefinitionCollection = $this->createMock(APIFieldDefinitionCollection::class);
+        $filteredFieldDefinitionCollection
+            ->method('first')
+            ->willReturn($expectedFieldDefinition);
+
+        $fieldDefinitionCollection = $this->createMock(APIFieldDefinitionCollection::class);
+        $fieldDefinitionCollection
+            ->expects($this->once())
+            ->method('filterByType')
+            ->with(self::EXAMPLE_FIELD_TYPE_IDENTIFIER)
+            ->willReturn($filteredFieldDefinitionCollection);
+
+        $contentType = new ContentType([
+            'fieldDefinitions' => $fieldDefinitionCollection,
+        ]);
+
+        $this->assertEquals(
+            $expectedFieldDefinition,
+            $contentType->getFirstFieldDefinitionOfType(self::EXAMPLE_FIELD_TYPE_IDENTIFIER)
+        );
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Values/ContentType/ContentTypeTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ContentType/ContentTypeTest.php
@@ -66,6 +66,13 @@ class ContentTypeTest extends TestCase
         $fieldDefinition = $this->createMock(FieldDefinition::class);
 
         $fieldDefinitionCollection = $this->createMock(APIFieldDefinitionCollection::class);
+
+        $fieldDefinitionCollection
+            ->expects($this->once())
+            ->method('has')
+            ->with(self::EXAMPLE_FIELD_DEFINITION_IDENTIFIER)
+            ->willReturn(true);
+
         $fieldDefinitionCollection
             ->expects($this->once())
             ->method('get')

--- a/eZ/Publish/Core/Repository/Tests/Values/ContentType/FieldDefinitionCollectionTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ContentType/FieldDefinitionCollectionTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\Repository\Tests\Values\ContentType;
 
 use Closure;
+use eZ\Publish\API\Repository\Exceptions\OutOfBoundsException;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition as APIFieldDefinition;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection;
@@ -33,13 +34,16 @@ final class FieldDefinitionCollectionTest extends TestCase
     /**
      * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::get
      */
-    public function testGetReturnsNullForNonExistingFieldDefinition(): void
+    public function testGetThrowsOutOfBoundsExceptionForNonExistingFieldDefinition(): void
     {
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage("Field Definition Collection does not contain element with identifier 'Z'");
+
         $collection = new FieldDefinitionCollection(
             $this->createFieldDefinitions('A', 'B', 'C')
         );
 
-        $this->assertNull($collection->get('Z'));
+        $collection->get('Z');
     }
 
     /**
@@ -93,11 +97,13 @@ final class FieldDefinitionCollectionTest extends TestCase
     /**
      * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::first
      */
-    public function testFirstReturnsNullForEmptyCollection(): void
+    public function testFirstThrowsOutOfBoundsExceptionForEmptyCollection(): void
     {
-        $collection = new FieldDefinitionCollection();
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('Field Definition Collection is empty');
 
-        $this->assertNull($collection->first());
+        $collection = new FieldDefinitionCollection();
+        $collection->first();
     }
 
     /**
@@ -127,11 +133,13 @@ final class FieldDefinitionCollectionTest extends TestCase
     /**
      * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::last
      */
-    public function testLastReturnsNullForEmptyCollection(): void
+    public function testLastThrowsOutOfBoundsExceptionForEmptyCollection(): void
     {
-        $collection = new FieldDefinitionCollection();
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessage('Field Definition Collection is empty');
 
-        $this->assertNull($collection->last());
+        $collection = new FieldDefinitionCollection();
+        $collection->last();
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Values/ContentType/FieldDefinitionCollectionTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ContentType/FieldDefinitionCollectionTest.php
@@ -16,6 +16,9 @@ use PHPUnit\Framework\TestCase;
 
 final class FieldDefinitionCollectionTest extends TestCase
 {
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::get
+     */
     public function testGet(): void
     {
         list($a, $b, $c) = $this->createFieldDefinitions('A', 'B', 'C');
@@ -27,6 +30,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertEquals($c, $collection->get('C'));
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::get
+     */
     public function testGetReturnsNullForNonExistingFieldDefinition(): void
     {
         $collection = new FieldDefinitionCollection(
@@ -36,6 +42,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertNull($collection->get('Z'));
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::has
+     */
     public function testHasReturnTrueForExistingFieldDefinition(): void
     {
         $collection = new FieldDefinitionCollection(
@@ -47,6 +56,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertTrue($collection->has('C'));
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::has
+     */
     public function testHasReturnFalseForNonExistingFieldDefinition(): void
     {
         $collection = new FieldDefinitionCollection(
@@ -56,6 +68,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertFalse($collection->has('Z'));
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::isEmpty
+     */
     public function testIsEmptyReturnsTrueForEmptyCollection(): void
     {
         $collection = new FieldDefinitionCollection();
@@ -63,6 +78,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertTrue($collection->isEmpty());
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::isEmpty
+     */
     public function testIsEmptyReturnsFalseForNonEmptyCollection(): void
     {
         $collection = new FieldDefinitionCollection([
@@ -72,6 +90,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertFalse($collection->isEmpty());
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::first
+     */
     public function testFirstReturnsNullForEmptyCollection(): void
     {
         $collection = new FieldDefinitionCollection();
@@ -79,6 +100,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertNull($collection->first());
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::first
+     */
     public function testFirstReturnsFieldDefinitionForNonEmptyCollection(): void
     {
         list($a, $b, $c) = $this->createFieldDefinitions('A', 'B', 'C');
@@ -88,6 +112,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertEquals($a, $collection->first());
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::last
+     */
     public function testLastReturnsFieldDefinitionForNonEmptyCollection(): void
     {
         list($a, $b, $c) = $this->createFieldDefinitions('A', 'B', 'C');
@@ -97,6 +124,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertEquals($c, $collection->last());
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::last
+     */
     public function testLastReturnsNullForEmptyCollection(): void
     {
         $collection = new FieldDefinitionCollection();
@@ -104,6 +134,10 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertNull($collection->last());
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::first
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::last
+     */
     public function testFirstAndLastAreEqualForCollectionWithOneElement(): void
     {
         $fieldDefinition = $this->createFieldDefinition('Example');
@@ -114,6 +148,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertEquals($fieldDefinition, $collection->last());
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::count
+     */
     public function testCountForNonEmptyCollection(): void
     {
         list($a, $b, $c) = $this->createFieldDefinitions('A', 'B', 'C');
@@ -123,6 +160,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertEquals(3, $collection->count());
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::count
+     */
     public function testCountReturnsZeroForEmptyCollection(): void
     {
         $collection = new FieldDefinitionCollection();
@@ -130,6 +170,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertEquals(0, $collection->count());
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::map
+     */
     public function testMap(): void
     {
         $collection = new FieldDefinitionCollection($this->createFieldDefinitions('A', 'B', 'C'));
@@ -141,6 +184,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertEquals(['a', 'b', 'c'], $collection->map($closure));
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::filter
+     */
     public function testFilter(): void
     {
         list($a, $b, $c) = $this->createFieldDefinitions('A', 'B', 'C');
@@ -163,6 +209,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         );
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::filterByType
+     */
     public function testFilterByType(): void
     {
         list($a, $b, $c) = $this->createFieldDefinitionsWith('fieldTypeIdentifier', ['ezstring', 'ezstring', 'ezimage']);
@@ -175,6 +224,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         );
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::filterByGroup
+     */
     public function filterByGroup(): void
     {
         list($a, $b, $c) = $this->createFieldDefinitionsWith('fieldGroup', ['default', 'default', 'seo']);
@@ -187,6 +239,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         );
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::all
+     */
     public function testAll(): void
     {
         $collection = new FieldDefinitionCollection($this->createFieldDefinitions('A', 'B', 'C'));
@@ -198,6 +253,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertFalse($collection->all($this->getContraction()));
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::any
+     */
     public function testAny(): void
     {
         $collection = new FieldDefinitionCollection($this->createFieldDefinitions('A', 'B', 'C'));
@@ -209,6 +267,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertFalse($collection->any($this->getContraction()));
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::anyOfType
+     */
     public function testAnyOfType(): void
     {
         $collection = new FieldDefinitionCollection(
@@ -219,6 +280,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertFalse($collection->anyOfType('ezrichtext'));
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::anyInGroup
+     */
     public function testAnyInGroup(): void
     {
         $collection = new FieldDefinitionCollection(
@@ -229,6 +293,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         $this->assertFalse($collection->anyInGroup('comments'));
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::partition
+     */
     public function testPartition(): void
     {
         list($a, $b, $c) = $this->createFieldDefinitions('A', 'B', 'C');
@@ -260,6 +327,9 @@ final class FieldDefinitionCollectionTest extends TestCase
         );
     }
 
+    /**
+     * @covers \eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection::toArray
+     */
     public function testToArray(): void
     {
         $fieldDefinitions = $this->createFieldDefinitions('A', 'B', 'C');
@@ -289,7 +359,7 @@ final class FieldDefinitionCollectionTest extends TestCase
     /**
      * Returns predicate which test if field definition identifier belongs to given set.
      */
-    public function getIdentifierIsEqualPredicate(string ...$identifiers): Closure
+    private function getIdentifierIsEqualPredicate(string ...$identifiers): Closure
     {
         return static function (APIFieldDefinition $fieldDefinition) use ($identifiers): bool {
             return in_array($fieldDefinition->identifier, $identifiers);
@@ -297,7 +367,7 @@ final class FieldDefinitionCollectionTest extends TestCase
     }
 
     /**
-     * Returns predicate with is always true.
+     * Returns a predicate which is always true.
      */
     private function getTautology(): Closure
     {
@@ -307,7 +377,7 @@ final class FieldDefinitionCollectionTest extends TestCase
     }
 
     /**
-     * Returns predicate with is always false.
+     * Returns a predicate which is always false.
      */
     private function getContraction(): Closure
     {

--- a/eZ/Publish/Core/Repository/Tests/Values/ContentType/FieldDefinitionCollectionTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ContentType/FieldDefinitionCollectionTest.php
@@ -1,0 +1,318 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Repository\Tests\Values\ContentType;
+
+use Closure;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition as APIFieldDefinition;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection;
+use PHPUnit\Framework\TestCase;
+
+final class FieldDefinitionCollectionTest extends TestCase
+{
+    public function testGet(): void
+    {
+        list($a, $b, $c) = $this->createFieldDefinitions('A', 'B', 'C');
+
+        $collection = new FieldDefinitionCollection([$a, $b, $c]);
+
+        $this->assertEquals($a, $collection->get('A'));
+        $this->assertEquals($b, $collection->get('B'));
+        $this->assertEquals($c, $collection->get('C'));
+    }
+
+    public function testGetReturnsNullForNonExistingFieldDefinition(): void
+    {
+        $collection = new FieldDefinitionCollection(
+            $this->createFieldDefinitions('A', 'B', 'C')
+        );
+
+        $this->assertNull($collection->get('Z'));
+    }
+
+    public function testHasReturnTrueForExistingFieldDefinition(): void
+    {
+        $collection = new FieldDefinitionCollection(
+            $this->createFieldDefinitions('A', 'B', 'C')
+        );
+
+        $this->assertTrue($collection->has('A'));
+        $this->assertTrue($collection->has('B'));
+        $this->assertTrue($collection->has('C'));
+    }
+
+    public function testHasReturnFalseForNonExistingFieldDefinition(): void
+    {
+        $collection = new FieldDefinitionCollection(
+            $this->createFieldDefinitions('A', 'B', 'C')
+        );
+
+        $this->assertFalse($collection->has('Z'));
+    }
+
+    public function testIsEmptyReturnsTrueForEmptyCollection(): void
+    {
+        $collection = new FieldDefinitionCollection();
+
+        $this->assertTrue($collection->isEmpty());
+    }
+
+    public function testIsEmptyReturnsFalseForNonEmptyCollection(): void
+    {
+        $collection = new FieldDefinitionCollection([
+            $this->createFieldDefinition('Example'),
+        ]);
+
+        $this->assertFalse($collection->isEmpty());
+    }
+
+    public function testFirstReturnsNullForEmptyCollection(): void
+    {
+        $collection = new FieldDefinitionCollection();
+
+        $this->assertNull($collection->first());
+    }
+
+    public function testFirstReturnsFieldDefinitionForNonEmptyCollection(): void
+    {
+        list($a, $b, $c) = $this->createFieldDefinitions('A', 'B', 'C');
+
+        $collection = new FieldDefinitionCollection([$a, $b, $c]);
+
+        $this->assertEquals($a, $collection->first());
+    }
+
+    public function testLastReturnsFieldDefinitionForNonEmptyCollection(): void
+    {
+        list($a, $b, $c) = $this->createFieldDefinitions('A', 'B', 'C');
+
+        $collection = new FieldDefinitionCollection([$a, $b, $c]);
+
+        $this->assertEquals($c, $collection->last());
+    }
+
+    public function testLastReturnsNullForEmptyCollection(): void
+    {
+        $collection = new FieldDefinitionCollection();
+
+        $this->assertNull($collection->last());
+    }
+
+    public function testFirstAndLastAreEqualForCollectionWithOneElement(): void
+    {
+        $fieldDefinition = $this->createFieldDefinition('Example');
+
+        $collection = new FieldDefinitionCollection([$fieldDefinition]);
+
+        $this->assertEquals($fieldDefinition, $collection->first());
+        $this->assertEquals($fieldDefinition, $collection->last());
+    }
+
+    public function testCountForNonEmptyCollection(): void
+    {
+        list($a, $b, $c) = $this->createFieldDefinitions('A', 'B', 'C');
+
+        $collection = new FieldDefinitionCollection([$a, $b, $c]);
+
+        $this->assertEquals(3, $collection->count());
+    }
+
+    public function testCountReturnsZeroForEmptyCollection(): void
+    {
+        $collection = new FieldDefinitionCollection();
+
+        $this->assertEquals(0, $collection->count());
+    }
+
+    public function testMap(): void
+    {
+        $collection = new FieldDefinitionCollection($this->createFieldDefinitions('A', 'B', 'C'));
+
+        $closure = static function (FieldDefinition $fieldDefinition): string {
+            return strtolower($fieldDefinition->identifier);
+        };
+
+        $this->assertEquals(['a', 'b', 'c'], $collection->map($closure));
+    }
+
+    public function testFilter(): void
+    {
+        list($a, $b, $c) = $this->createFieldDefinitions('A', 'B', 'C');
+
+        $collection = new FieldDefinitionCollection([$a, $b, $c]);
+
+        $this->assertEquals(
+            new FieldDefinitionCollection([$a, $c]),
+            $collection->filter($this->getIdentifierIsEqualPredicate('A', 'C'))
+        );
+
+        $this->assertEquals(
+            new FieldDefinitionCollection(),
+            $collection->filter($this->getContraction())
+        );
+
+        $this->assertEquals(
+            new FieldDefinitionCollection([$a, $b, $c]),
+            $collection->filter($this->getTautology())
+        );
+    }
+
+    public function testFilterByType(): void
+    {
+        list($a, $b, $c) = $this->createFieldDefinitionsWith('fieldTypeIdentifier', ['ezstring', 'ezstring', 'ezimage']);
+
+        $collection = new FieldDefinitionCollection([$a, $b, $c]);
+
+        $this->assertEquals(
+            new FieldDefinitionCollection([$a, $b]),
+            $collection->filterByType('ezstring')
+        );
+    }
+
+    public function filterByGroup(): void
+    {
+        list($a, $b, $c) = $this->createFieldDefinitionsWith('fieldGroup', ['default', 'default', 'seo']);
+
+        $collection = new FieldDefinitionCollection([$a, $b, $c]);
+
+        $this->assertEquals(
+            new FieldDefinitionCollection([$c]),
+            $collection->filterByType('seo')
+        );
+    }
+
+    public function testAll(): void
+    {
+        $collection = new FieldDefinitionCollection($this->createFieldDefinitions('A', 'B', 'C'));
+
+        $this->assertTrue($collection->all($this->getIdentifierIsEqualPredicate('A', 'B', 'C')));
+        $this->assertFalse($collection->all($this->getIdentifierIsEqualPredicate('A')));
+
+        $this->assertTrue($collection->all($this->getTautology()));
+        $this->assertFalse($collection->all($this->getContraction()));
+    }
+
+    public function testAny(): void
+    {
+        $collection = new FieldDefinitionCollection($this->createFieldDefinitions('A', 'B', 'C'));
+
+        $this->assertTrue($collection->any($this->getIdentifierIsEqualPredicate('A')));
+        $this->assertFalse($collection->any($this->getIdentifierIsEqualPredicate('Z')));
+
+        $this->assertTrue($collection->any($this->getTautology()));
+        $this->assertFalse($collection->any($this->getContraction()));
+    }
+
+    public function testAnyOfType(): void
+    {
+        $collection = new FieldDefinitionCollection(
+            $this->createFieldDefinitionsWith('fieldTypeIdentifier', ['ezstring', 'ezstring', 'ezimage'])
+        );
+
+        $this->assertTrue($collection->anyOfType('ezstring'));
+        $this->assertFalse($collection->anyOfType('ezrichtext'));
+    }
+
+    public function testAnyInGroup(): void
+    {
+        $collection = new FieldDefinitionCollection(
+            $this->createFieldDefinitionsWith('fieldGroup', ['default', 'default', 'seo'])
+        );
+
+        $this->assertTrue($collection->anyInGroup('default'));
+        $this->assertFalse($collection->anyInGroup('comments'));
+    }
+
+    public function testPartition(): void
+    {
+        list($a, $b, $c) = $this->createFieldDefinitions('A', 'B', 'C');
+
+        $collection = new FieldDefinitionCollection([$a, $b, $c]);
+
+        $this->assertEquals(
+            [
+                new FieldDefinitionCollection([$a, $c]),
+                new FieldDefinitionCollection([$b]),
+            ],
+            $collection->partition($this->getIdentifierIsEqualPredicate('A', 'C'))
+        );
+
+        $this->assertEquals(
+            [
+                new FieldDefinitionCollection([$a, $b, $c]),
+                new FieldDefinitionCollection(),
+            ],
+            $collection->partition($this->getTautology())
+        );
+
+        $this->assertEquals(
+            [
+                new FieldDefinitionCollection(),
+                new FieldDefinitionCollection([$a, $b, $c]),
+            ],
+            $collection->partition($this->getContraction())
+        );
+    }
+
+    public function testToArray(): void
+    {
+        $fieldDefinitions = $this->createFieldDefinitions('A', 'B', 'C');
+
+        $collection = new FieldDefinitionCollection($fieldDefinitions);
+
+        $this->assertEquals($fieldDefinitions, $collection->toArray());
+    }
+
+    private function createFieldDefinitions(string ...$identifiers): array
+    {
+        return $this->createFieldDefinitionsWith('identifier', $identifiers);
+    }
+
+    private function createFieldDefinitionsWith(string $property, array $values): array
+    {
+        return array_map(function (string $identifier) use ($property): APIFieldDefinition {
+            return $this->createFieldDefinition($identifier, $property);
+        }, $values);
+    }
+
+    private function createFieldDefinition(string $identifier, string $property = 'identifier'): APIFieldDefinition
+    {
+        return new FieldDefinition([$property => $identifier]);
+    }
+
+    /**
+     * Returns predicate which test if field definition identifier belongs to given set.
+     */
+    public function getIdentifierIsEqualPredicate(string ...$identifiers): Closure
+    {
+        return static function (APIFieldDefinition $fieldDefinition) use ($identifiers): bool {
+            return in_array($fieldDefinition->identifier, $identifiers);
+        };
+    }
+
+    /**
+     * Returns predicate with is always true.
+     */
+    private function getTautology(): Closure
+    {
+        return static function (APIFieldDefinition $fieldDefinition): bool {
+            return true;
+        };
+    }
+
+    /**
+     * Returns predicate with is always false.
+     */
+    private function getContraction(): Closure
+    {
+        return static function (APIFieldDefinition $fieldDefinition): bool {
+            return false;
+        };
+    }
+}

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -414,14 +414,7 @@ class UserService implements UserServiceInterface
         }
 
         // Search for the first ezuser field type in content type
-        $userFieldDefinition = null;
-        foreach ($userCreateStruct->contentType->getFieldDefinitions() as $fieldDefinition) {
-            if ($fieldDefinition->fieldTypeIdentifier == 'ezuser') {
-                $userFieldDefinition = $fieldDefinition;
-                break;
-            }
-        }
-
+        $userFieldDefinition = $this->getUserFieldDefinition($userCreateStruct->contentType);
         if ($userFieldDefinition === null) {
             throw new ContentValidationException('the provided Content Type does not contain the ezuser Field Type');
         }
@@ -1199,14 +1192,7 @@ class UserService implements UserServiceInterface
         }
 
         // Search for the first ezuser field type in content type
-        $userFieldDefinition = null;
-        foreach ($context->contentType->getFieldDefinitions() as $fieldDefinition) {
-            if ($fieldDefinition->fieldTypeIdentifier === 'ezuser') {
-                $userFieldDefinition = $fieldDefinition;
-                break;
-            }
-        }
-
+        $userFieldDefinition = $this->getUserFieldDefinition($context->contentType);
         if ($userFieldDefinition === null) {
             throw new ContentValidationException('The provided Content Type does not contain the ezuser Field Type');
         }
@@ -1325,13 +1311,7 @@ class UserService implements UserServiceInterface
 
     private function getUserFieldDefinition(ContentType $contentType): ?FieldDefinition
     {
-        foreach ($contentType->getFieldDefinitions() as $fieldDefinition) {
-            if ($fieldDefinition->fieldTypeIdentifier == 'ezuser') {
-                return $fieldDefinition;
-            }
-        }
-
-        return null;
+        return $contentType->getFirstFieldDefinitionOfType('ezuser');
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Values/ContentType/ContentType.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/ContentType.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType as APIContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection as APIFieldDefinitionCollection;
 use eZ\Publish\Core\Repository\Values\MultiLanguageDescriptionTrait;
 use eZ\Publish\Core\Repository\Values\MultiLanguageNameTrait;
 use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
@@ -17,7 +18,7 @@ use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
  * this class represents a content type value.
  *
  * @property-read \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup[] $contentTypeGroups calls getContentTypeGroups
- * @property-read \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[] $fieldDefinitions calls getFieldDefinitions() or on access getFieldDefinition($fieldDefIdentifier)
+ * @property-read \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection $fieldDefinitions calls getFieldDefinitions() or on access getFieldDefinition($fieldDefIdentifier)
  * @property-read mixed $id the id of the content type
  * @property-read int $status the status of the content type. One of ContentType::STATUS_DEFINED|ContentType::STATUS_DRAFT|ContentType::STATUS_MODIFIED
  * @property-read string $identifier the identifier of the content type
@@ -53,32 +54,15 @@ class ContentType extends APIContentType
     /**
      * Contains the content type field definitions from this type.
      *
-     * @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[]
+     * @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection
      */
-    protected $fieldDefinitions = [];
-
-    /**
-     * Field definitions indexed by identifier.
-     *
-     * @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[]
-     */
-    protected $fieldDefinitionsByIdentifier = [];
-
-    /**
-     * Field definitions indexed by id.
-     *
-     * @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[]
-     */
-    protected $fieldDefinitionsById = [];
+    protected $fieldDefinitions;
 
     public function __construct(array $data = [])
     {
+        $this->fieldDefinitions = new FieldDefinitionCollection();
+
         parent::__construct($data);
-        // fieldDefinitions property comes from $data and is set in the ValueObject constructor
-        foreach ($this->fieldDefinitions as $fieldDefinition) {
-            $this->fieldDefinitionsByIdentifier[$fieldDefinition->identifier] = $fieldDefinition;
-            $this->fieldDefinitionsById[$fieldDefinition->id] = $fieldDefinition;
-        }
     }
 
     /**
@@ -94,42 +78,10 @@ class ContentType extends APIContentType
     /**
      * This method returns the content type field definitions from this type.
      *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[]
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection
      */
-    public function getFieldDefinitions()
+    public function getFieldDefinitions(): APIFieldDefinitionCollection
     {
         return $this->fieldDefinitions;
-    }
-
-    /**
-     * This method returns the field definition for the given identifier.
-     *
-     * @param string $fieldDefinitionIdentifier
-     *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition
-     */
-    public function getFieldDefinition($fieldDefinitionIdentifier)
-    {
-        if (isset($this->fieldDefinitionsByIdentifier[$fieldDefinitionIdentifier])) {
-            return $this->fieldDefinitionsByIdentifier[$fieldDefinitionIdentifier];
-        }
-
-        return null;
-    }
-
-    /**
-     * This method returns the field definition for the given id.
-     *
-     * @param mixed $fieldDefinitionId
-     *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition
-     */
-    public function getFieldDefinitionById($fieldDefinitionId)
-    {
-        if (isset($this->fieldDefinitionsById[$fieldDefinitionId])) {
-            return $this->fieldDefinitionsById[$fieldDefinitionId];
-        }
-
-        return null;
     }
 }

--- a/eZ/Publish/Core/Repository/Values/ContentType/ContentTypeDraft.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/ContentTypeDraft.php
@@ -9,6 +9,8 @@
 namespace eZ\Publish\Core\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft as APIContentTypeDraft;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection as APIFieldDefinitionCollection;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
 
 /**
@@ -127,7 +129,7 @@ class ContentTypeDraft extends APIContentTypeDraft
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[]
      */
-    public function getFieldDefinitions()
+    public function getFieldDefinitions(): APIFieldDefinitionCollection
     {
         return $this->innerContentType->getFieldDefinitions();
     }
@@ -139,20 +141,13 @@ class ContentTypeDraft extends APIContentTypeDraft
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition
      */
-    public function getFieldDefinition($fieldDefinitionIdentifier)
+    public function getFieldDefinition($fieldDefinitionIdentifier): ?FieldDefinition
     {
         return $this->innerContentType->getFieldDefinition($fieldDefinitionIdentifier);
     }
 
-    /**
-     * This method returns the field definition for the given id.
-     *
-     * @param mixed $fieldDefinitionId
-     *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition
-     */
-    public function getFieldDefinitionById($fieldDefinitionId)
+    public function hasFieldDefinition(string $fieldDefinitionIdentifier): bool
     {
-        return $this->innerContentType->getFieldDefinition($fieldDefinitionId);
+        return $this->innerContentType->hasFieldDefinition($fieldDefinitionIdentifier);
     }
 }

--- a/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinitionCollection.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinitionCollection.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Repository\Values\ContentType;
+
+use ArrayIterator;
+use BadMethodCallException;
+use Closure;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection as FieldDefinitionCollectionInterface;
+use Iterator;
+
+final class FieldDefinitionCollection implements FieldDefinitionCollectionInterface
+{
+    /** @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[] */
+    private $fieldDefinitions;
+
+    /**
+     * Field definitions indexed by identifier.
+     *
+     * @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[]
+     */
+    private $fieldDefinitionsByIdentifier;
+
+    public function __construct(iterable $fieldDefinitions = [])
+    {
+        $this->fieldDefinitions = [];
+        $this->fieldDefinitionsByIdentifier = [];
+
+        foreach ($fieldDefinitions as $fieldDefinition) {
+            $this->fieldDefinitions[] = $fieldDefinition;
+            $this->fieldDefinitionsByIdentifier[$fieldDefinition->identifier] = $fieldDefinition;
+        }
+    }
+
+    public function get(string $fieldDefinitionIdentifier): ?FieldDefinition
+    {
+        return $this->fieldDefinitionsByIdentifier[$fieldDefinitionIdentifier] ?? null;
+    }
+
+    public function has(string $fieldDefinitionIdentifier): bool
+    {
+        return array_key_exists($fieldDefinitionIdentifier, $this->fieldDefinitionsByIdentifier);
+    }
+
+    public function first(): ?FieldDefinition
+    {
+        if (($result = reset($this->fieldDefinitions)) !== false) {
+            return $result;
+        }
+
+        return null;
+    }
+
+    public function last(): ?FieldDefinition
+    {
+        if (($result = end($this->fieldDefinitions)) !== false) {
+            return $result;
+        }
+
+        return null;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->fieldDefinitions);
+    }
+
+    public function filter(Closure $p): FieldDefinitionCollectionInterface
+    {
+        return new self(array_filter($this->fieldDefinitions, $p));
+    }
+
+    public function filterByType(string $fieldTypeIdentifier): FieldDefinitionCollectionInterface
+    {
+        return $this->filter($this->getIsTypePredicate($fieldTypeIdentifier));
+    }
+
+    public function filterByGroup(string $fieldGroup): FieldDefinitionCollectionInterface
+    {
+        return $this->filter($this->getInGroupPredicate($fieldGroup));
+    }
+
+    public function map(Closure $p): array
+    {
+        return array_map($p, $this->fieldDefinitions);
+    }
+
+    public function all(Closure $p): bool
+    {
+        foreach ($this->fieldDefinitions as $fieldDefinition) {
+            if (!$p($fieldDefinition)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function any(Closure $p): bool
+    {
+        foreach ($this->fieldDefinitions as $fieldDefinition) {
+            if ($p($fieldDefinition)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function anyOfType(string $fieldTypeIdentifier): bool
+    {
+        return $this->any($this->getIsTypePredicate($fieldTypeIdentifier));
+    }
+
+    public function anyInGroup(string $fieldGroup): bool
+    {
+        return $this->any($this->getInGroupPredicate($fieldGroup));
+    }
+
+    public function partition(Closure $p): array
+    {
+        $matches = $noMatches = [];
+
+        foreach ($this->fieldDefinitions as $fieldDefinition) {
+            if ($p($fieldDefinition)) {
+                $matches[] = $fieldDefinition;
+            } else {
+                $noMatches[] = $fieldDefinition;
+            }
+        }
+
+        return [new self($matches), new self($noMatches)];
+    }
+
+    public function count(): int
+    {
+        return count($this->fieldDefinitions);
+    }
+
+    public function getIterator(): Iterator
+    {
+        return new ArrayIterator($this->fieldDefinitions);
+    }
+
+    public function toArray(): array
+    {
+        return $this->fieldDefinitions;
+    }
+
+    private function getIsTypePredicate(string $fieldTypeIdentifier): Closure
+    {
+        return static function (FieldDefinition $fieldDefinition) use ($fieldTypeIdentifier) {
+            return $fieldDefinition->fieldTypeIdentifier === $fieldTypeIdentifier;
+        };
+    }
+
+    private function getInGroupPredicate(string $fieldGroup): Closure
+    {
+        return static function (FieldDefinition $fieldDefinition) use ($fieldGroup) {
+            return $fieldDefinition->fieldGroup === $fieldGroup;
+        };
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->fieldDefinitions[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->fieldDefinitions[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new BadMethodCallException(self::class . ' is read-only!');
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new BadMethodCallException(self::class . ' is read-only!');
+    }
+}

--- a/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinitionCollection.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinitionCollection.php
@@ -20,13 +20,12 @@ final class FieldDefinitionCollection implements FieldDefinitionCollectionInterf
     /** @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[] */
     private $fieldDefinitions;
 
-    /**
-     * Field definitions indexed by identifier.
-     *
-     * @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[]
-     */
+    /** @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[] */
     private $fieldDefinitionsByIdentifier;
 
+    /**
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[]
+     */
     public function __construct(iterable $fieldDefinitions = [])
     {
         $this->fieldDefinitions = [];
@@ -71,9 +70,9 @@ final class FieldDefinitionCollection implements FieldDefinitionCollectionInterf
         return empty($this->fieldDefinitions);
     }
 
-    public function filter(Closure $p): FieldDefinitionCollectionInterface
+    public function filter(Closure $predicate): FieldDefinitionCollectionInterface
     {
-        return new self(array_filter($this->fieldDefinitions, $p));
+        return new self(array_filter($this->fieldDefinitions, $predicate));
     }
 
     public function filterByType(string $fieldTypeIdentifier): FieldDefinitionCollectionInterface
@@ -86,15 +85,15 @@ final class FieldDefinitionCollection implements FieldDefinitionCollectionInterf
         return $this->filter($this->getInGroupPredicate($fieldGroup));
     }
 
-    public function map(Closure $p): array
+    public function map(Closure $predicate): array
     {
-        return array_map($p, $this->fieldDefinitions);
+        return array_map($predicate, $this->fieldDefinitions);
     }
 
-    public function all(Closure $p): bool
+    public function all(Closure $predicate): bool
     {
         foreach ($this->fieldDefinitions as $fieldDefinition) {
-            if (!$p($fieldDefinition)) {
+            if (!$predicate($fieldDefinition)) {
                 return false;
             }
         }
@@ -102,10 +101,10 @@ final class FieldDefinitionCollection implements FieldDefinitionCollectionInterf
         return true;
     }
 
-    public function any(Closure $p): bool
+    public function any(Closure $predicate): bool
     {
         foreach ($this->fieldDefinitions as $fieldDefinition) {
-            if ($p($fieldDefinition)) {
+            if ($predicate($fieldDefinition)) {
                 return true;
             }
         }
@@ -123,12 +122,12 @@ final class FieldDefinitionCollection implements FieldDefinitionCollectionInterf
         return $this->any($this->getInGroupPredicate($fieldGroup));
     }
 
-    public function partition(Closure $p): array
+    public function partition(Closure $predicate): array
     {
         $matches = $noMatches = [];
 
         foreach ($this->fieldDefinitions as $fieldDefinition) {
-            if ($p($fieldDefinition)) {
+            if ($predicate($fieldDefinition)) {
                 $matches[] = $fieldDefinition;
             } else {
                 $noMatches[] = $fieldDefinition;
@@ -167,22 +166,22 @@ final class FieldDefinitionCollection implements FieldDefinitionCollectionInterf
         };
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->fieldDefinitions[$offset]);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): FieldDefinition
     {
         return $this->fieldDefinitions[$offset];
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         throw new BadMethodCallException(self::class . ' is read-only!');
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new BadMethodCallException(self::class . ' is read-only!');
     }

--- a/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinitionCollection.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinitionCollection.php
@@ -11,9 +11,10 @@ namespace eZ\Publish\Core\Repository\Values\ContentType;
 use ArrayIterator;
 use BadMethodCallException;
 use Closure;
+use Iterator;
+use eZ\Publish\API\Repository\Exceptions\OutOfBoundsException;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection as FieldDefinitionCollectionInterface;
-use Iterator;
 
 final class FieldDefinitionCollection implements FieldDefinitionCollectionInterface
 {
@@ -37,9 +38,15 @@ final class FieldDefinitionCollection implements FieldDefinitionCollectionInterf
         }
     }
 
-    public function get(string $fieldDefinitionIdentifier): ?FieldDefinition
+    public function get(string $fieldDefinitionIdentifier): FieldDefinition
     {
-        return $this->fieldDefinitionsByIdentifier[$fieldDefinitionIdentifier] ?? null;
+        if ($this->has($fieldDefinitionIdentifier)) {
+            return $this->fieldDefinitionsByIdentifier[$fieldDefinitionIdentifier];
+        }
+
+        throw new OutOfBoundsException(
+            sprintf("Field Definition Collection does not contain element with identifier '%s'", $fieldDefinitionIdentifier)
+        );
     }
 
     public function has(string $fieldDefinitionIdentifier): bool
@@ -47,22 +54,22 @@ final class FieldDefinitionCollection implements FieldDefinitionCollectionInterf
         return array_key_exists($fieldDefinitionIdentifier, $this->fieldDefinitionsByIdentifier);
     }
 
-    public function first(): ?FieldDefinition
+    public function first(): FieldDefinition
     {
         if (($result = reset($this->fieldDefinitions)) !== false) {
             return $result;
         }
 
-        return null;
+        throw new OutOfBoundsException('Field Definition Collection is empty');
     }
 
-    public function last(): ?FieldDefinition
+    public function last(): FieldDefinition
     {
         if (($result = end($this->fieldDefinitions)) !== false) {
             return $result;
         }
 
-        return null;
+        throw new OutOfBoundsException('Field Definition Collection is empty');
     }
 
     public function isEmpty(): bool


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31078](https://jira.ez.no/browse/EZP-31078)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** |  `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

### Changelog

1. Introduced `eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection` which takeover responsibility of providing access field definitions:

```php
interface FieldDefinitionCollection extends Countable, IteratorAggregate, ArrayAccess
{
    /**
     * This method returns the field definition for the given identifier.
     *
     * @param string $fieldDefinitionIdentifier
     *
     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
     */
    public function get(string $fieldDefinitionIdentifier): ?FieldDefinition;

    /**
     * This method returns true if the field definition for the given identifier exists.
     *
     * @param string $fieldDefinitionIdentifier
     *
     * @return bool
     */
    public function has(string $fieldDefinitionIdentifier): bool;

    /**
     * Return first element of collection.
     *
     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
     */
    public function first(): ?FieldDefinition;

    /**
     * Return last element of collection.
     *
     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|null
     */
    public function last(): ?FieldDefinition;

    /**
     * Checks whether the collection is empty (contains no elements).
     *
     * @return bool TRUE if the collection is empty, FALSE otherwise.
     */
    public function isEmpty(): bool;

    /**
     * Returns all the elements of this collection that satisfy the predicate p.
     * The order of the elements is preserved.
     *
     * @param Closure $p The predicate used for filtering.
     *
     * @return FieldDefinitionCollection A collection with the results of the filter operation.
     */
    public function filter(Closure $p): FieldDefinitionCollection;

    /**
     * Returns field definitions with given field type identifier.
     *
     * @param string $fieldTypeIdentifier
     *
     * @return FieldDefinitionCollection A collection with the results of the filter operation.
     */
    public function filterByType(string $fieldTypeIdentifier): FieldDefinitionCollection;

    /**
     * Returns field definitions with given group.
     *
     * @param string $fieldGroup
     *
     * @return FieldDefinitionCollection A collection with the results of the filter operation.
     */
    public function filterByGroup(string $fieldGroup): FieldDefinitionCollection;

    /**
     * Applies the given function to each element in the collection and returns
     * a new collection with the elements returned by the function.
     *
     * @param Closure $p The predicate.
     *
     * @return array
     */
    public function map(Closure $p): array;

    /**
     * Tests whether the given predicate p holds for all elements of this collection.
     *
     * @param Closure $p The predicate.
     *
     * @return bool TRUE, if the predicate yields TRUE for all elements, FALSE otherwise.
     */
    public function all(Closure $p): bool;

    /**
     * Tests for the existence of an element that satisfies the given predicate.
     *
     * @param Closure $p The predicate.
     *
     * @return bool TRUE if the predicate is TRUE for at least one element, FALSE otherwise.
     */
    public function any(Closure $p): bool;

    /**
     * Tests for the existence of an field definition with given field type identifier.
     *
     * @param string $fieldTypeIdentifier
     *
     * @return bool TRUE if the predicate is TRUE for at least one field definition, FALSE otherwise.
     */
    public function anyOfType(string $fieldTypeIdentifier): bool;

    /**
     * Tests for the existence of an field definition in given field group.
     *
     * @param string $fieldGroup
     *
     * @return bool TRUE if the predicate is TRUE for at least one field definition, FALSE otherwise.
     */
    public function anyInGroup(string $fieldGroup): bool;

    /**
     * Partitions this collection in two collections according to a predicate.
     *
     * @param Closure $p The predicate on which to partition.
     *
     * @return FieldDefinitionCollection[] An array with two elements. The first element contains the collection
     *                      of elements where the predicate returned TRUE, the second element
     *                      contains the collection of elements where the predicate returned FALSE.
     */
    public function partition(Closure $p): array;

    /**
     * Gets a native PHP array representation of the collection.
     *
     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[]
     */
    public function toArray(): array;
}
``` 

2. Changed return type of `getFieldDefinitions()` from array to `FieldDefinitionCollection`. 

3. Added `eZ\Publish\API\Repository\Values\ContentType\ContentType` methods:
- `hasFieldDefinition($fieldDefinitionIdentifier): bool`
- `hasFieldDefinitionOfType(string $fieldTypeIdentifier): bool`
- `getFieldDefinitionsOfType(string $fieldTypeIdentifier): FieldDefinitionCollection`
- `getFirstFieldDefinitionOfType(string $fieldTypeIdentifier): ?FieldDefinition`

### Use Cases

#### getFirstFieldDefinitionOfType

The typical use case for `getFirstFieldDefinitionOfType` is the search for singular field type (ref. `\eZ\Publish\API\Repository\FieldType::isSingular`). For example: 

https://github.com/ezsystems/ezpublish-kernel/blob/c54917f6bb9b0faebc098c3522b0adfc85719211/eZ/Publish/Core/Repository/UserService.php#L416-L423 

https://github.com/ezsystems/ezpublish-kernel/blob/c849ef16ba5aecb786f61267855e24a5cf62bcf6/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php#L237-L256

#### `hasFieldDefinition` and `hasFieldDefintionWithType`

`hasFieldDefinition` and `hasFieldDefintionWithType` is just syntax sugar which improvs code readability.

```php
if ($contentType->getFieldDefinition('short_description') !== null) {
   # ... 
}
```

VS

```php
if ($contentType->hasFieldDefinition('short_description')) {
   # ... 
}
```

**TODO**:
- [X] Implement feature / fix a bug.
- [x] Update `/doc/bc/changes-8.0.md`
- [ ] Check dependent packages
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
