### PR TITLE
EZP-30865: Fixed creating the same custom URL alias for different language

### DIFF
--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
@@ -95,6 +95,30 @@ class URLAliasServiceTest extends BaseTest
     }
 
     /**
+     * Test for the createUrlAlias() method.
+     *
+     * @see \eZ\Publish\API\Repository\URLAliasService::createUrlAlias()
+     */
+    public function testCreateSameAliasForDiffrentLanguage()
+    {
+        $repository = $this->getRepository();
+        $locationId = $this->generateId('location', 5);
+        $locationService = $repository->getLocationService();
+        $urlAliasService = $repository->getURLAliasService();
+        $location = $locationService->loadLocation($locationId);
+
+        $alias = $urlAliasService->createUrlAlias($location, '/alias', 'eng-US');
+        $updatedAlias = $urlAliasService->createUrlAlias($location, '/alias', 'eng-GB');
+
+        $this->assertPropertiesCorrect(
+            [
+                'languageCodes' => ['eng-US', 'eng-GB'],
+            ],
+            $updatedAlias
+        );
+    }
+
+    /**
      * @param array $testData
      *
      * @depends testCreateUrlAlias

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -441,6 +441,15 @@ class Handler implements UrlAliasHandlerInterface
                 $topElementMD5,
                 $data
             );
+        // adding existing alias to diffrent laquage version
+        } elseif ($row['action'] == $action && !((int)$row['lang_mask'] & $languageId)) {
+            $data['link'] = $id = $row['id'];
+            $data['lang_mask'] = $row['lang_mask'] | $languageId | (int)$alwaysAvailable;
+            $this->gateway->updateRow(
+                $parentId,
+                $topElementMD5,
+                $data
+            );
         } else {
             throw new ForbiddenException("Path '%path%' already exists for the given language", ['%path%' => $path]);
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -441,8 +441,8 @@ class Handler implements UrlAliasHandlerInterface
                 $topElementMD5,
                 $data
             );
-        // adding existing alias to diffrent laquage version
-        } elseif ($row['action'] == $action && !((int)$row['lang_mask'] & $languageId)) {
+        } elseif ($row['action'] == $action && 0 === ((int)$row['lang_mask'] & $languageId)) {
+            // add another language to the same custom alias
             $data['link'] = $id = $row['id'];
             $data['lang_mask'] = $row['lang_mask'] | $languageId | (int)$alwaysAvailable;
             $this->gateway->updateRow(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
@@ -2270,6 +2270,57 @@ class UrlAliasHandlerTest extends TestCase
      * @group create
      * @group custom
      */
+    public function testCreateCustomUrlAliasAddLanguage()
+    {
+        $handler = $this->getHandler();
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/publish_base.php');
+
+        $countBeforeReusing = $this->countRows();
+        $handler->createCustomUrlAlias(
+            314,
+            'path314',
+            false,
+            'eng-GB',
+            true
+        );
+
+        self::assertEquals(
+            $countBeforeReusing,
+            $this->countRows()
+        );
+        self::assertEquals(
+            new UrlAlias(
+                [
+                    'id' => '0-fdbbfa1e24e78ef56cb16ba4482c7771',
+                    'type' => UrlAlias::LOCATION,
+                    'destination' => '314',
+                    'languageCodes' => ['cro-HR', 'eng-GB'],
+                    'pathData' => [
+                        [
+                            'always-available' => true,
+                            'translations' => [
+                                'cro-HR' => 'path314',
+                                'eng-GB' => 'path314',
+                            ],
+                        ],
+                    ],
+                    'alwaysAvailable' => true,
+                    'isHistory' => false,
+                    'isCustom' => true,
+                    'forward' => false,
+                ]
+            ),
+            $handler->lookup('path314')
+        );
+    }
+
+    /**
+     * Test for the createUrlAlias() method.
+     *
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Handler::createUrlAlias
+     * @group create
+     * @group custom
+     */
     public function testCreateCustomUrlAliasReusesHistoryOfDifferentLanguage()
     {
         $handler = $this->getHandler();


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30865](https://jira.ez.no/browse/EZP-30865)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

added support for attaching language to existing urlaliases in :
`eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php`

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
