### PR TITLE
EZP-31123: Fixed strict types-related casting issues

### DIFF
--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/DoctrineStorage.php
@@ -255,7 +255,7 @@ class DoctrineStorage extends Gateway
             foreach (array_keys($keywordsToInsert) as $keyword) {
                 $insertQuery->setParameter(':keyword', $keyword);
                 $insertQuery->execute();
-                $keywordIdMap[$keyword] = $this->connection->lastInsertId(
+                $keywordIdMap[$keyword] = (int)$this->connection->lastInsertId(
                     $this->getSequenceName(self::KEYWORD_TABLE, 'id')
                 );
             }

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
@@ -124,7 +124,7 @@ class DoctrineStorage extends Gateway
 
         $query->execute();
 
-        return $this->connection->lastInsertId(
+        return (int)$this->connection->lastInsertId(
             $this->getSequenceName(self::URL_TABLE, 'id')
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -186,7 +186,7 @@ class DoctrineDatabase extends Gateway
 
         $q->prepare()->execute();
 
-        return $this->dbHandler->lastInsertId(
+        return (int)$this->dbHandler->lastInsertId(
             $this->dbHandler->getSequenceName('ezcontentobject', 'id')
         );
     }
@@ -275,7 +275,7 @@ class DoctrineDatabase extends Gateway
 
         $q->prepare()->execute();
 
-        return $this->dbHandler->lastInsertId(
+        return (int)$this->dbHandler->lastInsertId(
             $this->dbHandler->getSequenceName('ezcontentobject_version', 'id')
         );
     }
@@ -673,7 +673,7 @@ HEREDOC;
 
         $q->prepare()->execute();
 
-        return $this->dbHandler->lastInsertId(
+        return (int)$this->dbHandler->lastInsertId(
             $this->dbHandler->getSequenceName('ezcontentobject_attribute', 'id')
         );
     }
@@ -2097,7 +2097,7 @@ HEREDOC;
 
         $q->prepare()->execute();
 
-        return $this->dbHandler->lastInsertId(
+        return (int)$this->dbHandler->lastInsertId(
             $this->dbHandler->getSequenceName('ezcontentobject_link', 'id')
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -742,7 +742,7 @@ HEREDOC;
             $q->bindValue($value->sortKeyInt, null, \PDO::PARAM_INT)
         )->set(
             $this->dbHandler->quoteColumn('sort_key_string'),
-            $q->bindValue(mb_substr($value->sortKeyString, 0, 255))
+            $q->bindValue(mb_substr((string)$value->sortKeyString, 0, 255))
         )->set(
             $this->dbHandler->quoteColumn('language_id'),
             $q->bindValue(
@@ -823,7 +823,7 @@ HEREDOC;
             $q->bindValue($value->sortKeyInt, null, \PDO::PARAM_INT)
         )->set(
             $this->dbHandler->quoteColumn('sort_key_string'),
-            $q->bindValue(mb_substr($value->sortKeyString, 0, 255))
+            $q->bindValue(mb_substr((string)$value->sortKeyString, 0, 255))
         );
     }
 
@@ -1310,7 +1310,7 @@ HEREDOC;
         $statement = $query->prepare();
         $statement->execute();
 
-        return $statement->fetchAll(\PDO::FETCH_COLUMN);
+        return array_map('intval', $statement->fetchAll(\PDO::FETCH_COLUMN));
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -768,7 +768,7 @@ class DoctrineDatabase extends Gateway
             );
         $query->prepare()->execute();
 
-        $location->id = $this->handler->lastInsertId($this->handler->getSequenceName('ezcontentobject_tree', 'node_id'));
+        $location->id = (int)$this->handler->lastInsertId($this->handler->getSequenceName('ezcontentobject_tree', 'node_id'));
 
         $mainLocationId = $createStruct->mainLocationId === true ? $location->id : $createStruct->mainLocationId;
         $location->pathString = $parentNode['path_string'] . $location->id . '/';

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -251,8 +251,8 @@ class Handler implements BaseLocationHandler
             // Copy content
             if (!isset($contentMap[$child['contentobject_id']])) {
                 $content = $this->contentHandler->copy(
-                    $child['contentobject_id'],
-                    $child['contentobject_version'],
+                    (int)$child['contentobject_id'],
+                    (int)$child['contentobject_version'],
                     $newOwnerId
                 );
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
@@ -60,7 +60,7 @@ class DoctrineDatabase extends Gateway
 
         $query->prepare()->execute();
 
-        return $this->dbHandler->lastInsertId(
+        return (int)$this->dbHandler->lastInsertId(
             $this->dbHandler->getSequenceName('ezsection', 'id')
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -158,7 +158,7 @@ class DoctrineDatabase extends Gateway
         );
         $q->prepare()->execute();
 
-        return $this->dbHandler->lastInsertId(
+        return (int)$this->dbHandler->lastInsertId(
             $this->dbHandler->getSequenceName('ezcontentclassgroup', 'id')
         );
     }
@@ -353,14 +353,15 @@ class DoctrineDatabase extends Gateway
         $q->prepare()->execute();
 
         if (empty($typeId)) {
-            $typeId = $this->dbHandler->lastInsertId(
+            $typeId = (int)$this->dbHandler->lastInsertId(
                 $this->dbHandler->getSequenceName('ezcontentclass', 'id')
             );
         }
 
         $this->insertTypeNameData($typeId, $type->status, $type->name);
 
-        return $typeId;
+        // $typeId passed as the argument could still be non-int
+        return (int)$typeId;
     }
 
     /**
@@ -614,9 +615,9 @@ class DoctrineDatabase extends Gateway
 
         $q->prepare()->execute();
 
-        $fieldDefinitionId = $fieldDefinition->id ?? $this->dbHandler->lastInsertId(
+        $fieldDefinitionId = (int)($fieldDefinition->id ?? $this->dbHandler->lastInsertId(
             $this->dbHandler->getSequenceName('ezcontentclass_attribute', 'id')
-        );
+        ));
 
         foreach ($storageFieldDef->multilingualData as $multilingualData) {
             $this->insertFieldDefinitionMultilingualData($fieldDefinitionId, $multilingualData, $status);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -709,7 +709,7 @@ class DoctrineDatabase extends Gateway
         }
         $query->prepare()->execute();
 
-        return $this->dbHandler->lastInsertId($sequence);
+        return (int)$this->dbHandler->lastInsertId($sequence);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
@@ -83,7 +83,7 @@ class DoctrineDatabase extends Gateway
 
         $query->prepare()->execute();
 
-        return $this->dbHandler->lastInsertId(
+        return (int)$this->dbHandler->lastInsertId(
             $this->dbHandler->getSequenceName('ezurlwildcard', 'id')
         );
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31123](https://jira.ez.no/browse/EZP-31123)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5.x` for eZ Platform 2.5.x LTS.
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR is a cumulative fix for strict types casting issues found while working on [EZP-30921](https://jira.ez.no/browse/EZP-30921) and [EZP-31088](https://jira.ez.no/browse/EZP-31088) (and possibly others).

- [x] ~`\eZ\Publish\Core\Persistence\Legacy\Content\Mapper::extractContentInfoFromRow`: `eZ\Publish\SPI\Persistence\Content\ContentInfo::$alwaysAvailable` should be Boolean instead of Integer.~ (fixed via #2850)

### QA

- [x] Behat suite
- [x] Sanity checks. Affected areas:
  - Keyword FT
  - Url FT
  - Urls in RichText.
  - Creating Content
  - Adding new Locations
  - Adding new Sections
  - Adding new Content Types and Field Definitions
  - Adding Url Aliases.
  - Adding Url wildcard aliases (if possible from UI).

**TODO**:
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Wait for Travis.
- [x] Ask for Code Review.
