### PR TITLE
EZP-31084: Memory exhausted / timeout on too many items in the trash - part 1

### DIFF
--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -685,7 +685,42 @@ class TrashServiceTest extends BaseTrashServiceTest
     }
 
     /**
+     * Test for the findTrashItems() method for it's result structure.
+     *
+     * @see \eZ\Publish\API\Repository\TrashService::findTrashItems()
+     * @depends eZ\Publish\API\Repository\Tests\TrashServiceTest::testTrash
+     */
+    public function testFindTrashItemsLimits()
+    {
+        $repository = $this->getRepository();
+        $trashService = $repository->getTrashService();
+
+        /* BEGIN: Use Case */
+        $this->createTrashItem();
+
+        // Create a search query for all trashed items
+        $query = new Query();
+        $query->limit = 2;
+
+        // Load all trashed locations
+        $searchResult = $trashService->findTrashItems($query);
+        /* END: Use Case */
+
+        $this->assertInstanceOf(
+            SearchResult::class,
+            $searchResult
+        );
+
+        // 4 trashed locations from the sub tree, but only 2 in results
+        $this->assertCount(2, $searchResult->items);
+        $this->assertEquals(4, $searchResult->count);
+        $this->assertEquals(4, $searchResult->totalCount);
+    }
+
+    /**
      * Test for the findTrashItems() method.
+     *
+     * @todo Should probably be on TrashServiceAuthorizationTest.
      *
      * @see \eZ\Publish\API\Repository\TrashService::findTrashItems()
      * @depends \eZ\Publish\API\Repository\Tests\TrashServiceTest::testFindTrashItems

--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -695,7 +695,6 @@ class TrashServiceTest extends BaseTrashServiceTest
         $repository = $this->getRepository();
         $trashService = $repository->getTrashService();
 
-        /* BEGIN: Use Case */
         $this->createTrashItem();
 
         // Create a search query for all trashed items
@@ -704,7 +703,6 @@ class TrashServiceTest extends BaseTrashServiceTest
 
         // Load all trashed locations
         $searchResult = $trashService->findTrashItems($query);
-        /* END: Use Case */
 
         $this->assertInstanceOf(
             SearchResult::class,
@@ -719,8 +717,6 @@ class TrashServiceTest extends BaseTrashServiceTest
 
     /**
      * Test for the findTrashItems() method.
-     *
-     * @todo Should probably be on TrashServiceAuthorizationTest.
      *
      * @see \eZ\Publish\API\Repository\TrashService::findTrashItems()
      * @depends \eZ\Publish\API\Repository\Tests\TrashServiceTest::testFindTrashItems

--- a/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
@@ -220,7 +220,10 @@ class TrashHandlerTest extends AbstractCacheHandlerTest
         $innerHandler
             ->expects($this->once())
             ->method('findTrashItems')
-            ->will($this->returnValue([new Trashed(['id' => $trashedId, 'contentId' => $contentId])]));
+            ->willReturn(new Location\Trash\TrashResult([
+                'items' => [new Trashed(['id' => $trashedId, 'contentId' => $contentId])],
+                'totalCount' => 1,
+            ]));
 
         $this->persistenceHandlerMock
             ->method($handlerMethodName)

--- a/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
@@ -17,6 +17,8 @@ use eZ\Publish\SPI\Persistence\Content\Relation;
  */
 class TrashHandler extends AbstractHandler implements TrashHandlerInterface
 {
+    private const EMPTY_TRASH_BULK_SIZE = 100;
+
     /**
      * {@inheritdoc}
      */
@@ -115,7 +117,7 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
         $tags = [];
 
         do {
-            $trashedItems = $this->persistenceHandler->trashHandler()->findTrashItems(null, 0, 100);
+            $trashedItems = $this->persistenceHandler->trashHandler()->findTrashItems(null, 0, self::EMPTY_TRASH_BULK_SIZE);
             foreach ($trashedItems as $trashedItem) {
                 $reverseRelations = $this->persistenceHandler->contentHandler()->loadReverseRelations($trashedItem->contentId);
 
@@ -127,7 +129,7 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
                 $tags['location-' . $trashedItem->id] = true;
                 $tags['location-path-' . $trashedItem->id] = true;
             }
-        } while ($trashedItems->totalCount > 100);
+        } while ($trashedItems->totalCount > self::EMPTY_TRASH_BULK_SIZE);
 
         $return = $this->persistenceHandler->trashHandler()->emptyTrash();
 

--- a/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
@@ -112,7 +112,7 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
 
         // We can not use the return value of emptyTrash method because, in the next step, we are not able
         // to fetch the reverse relations of deleted content.
-        $trashedItems = $this->persistenceHandler->trashHandler()->findTrashItems();
+        $trashedItems = $this->persistenceHandler->trashHandler()->findTrashItems();// TODO: This won't work on large trash basket, we'll need to page it.
 
         $tags = [];
         foreach ($trashedItems as $trashedItem) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -122,6 +122,8 @@ abstract class Gateway
     /**
      * Updated subtree modification time for all nodes on path.
      *
+     * @deprecated Not supposed to be in use anymore.
+     *
      * @param string $pathString
      * @param int|null $timestamp
      */
@@ -324,6 +326,11 @@ abstract class Gateway
      * @return array
      */
     abstract public function listTrashed($offset, $limit, array $sort = null);
+
+    /**
+     * Count trashed items.
+     */
+    abstract public function countTrashed(): int;
 
     /**
      * Removes trashed element identified by $id from trash.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1366,8 +1366,9 @@ class DoctrineDatabase extends Gateway
 
     public function countTrashed(): int
     {
+        $dbPlatform = $this->connection->getDatabasePlatform();
         $query = $this->connection->createQueryBuilder()
-            ->select('COUNT(node_id) as count')
+            ->select($dbPlatform->getCountExpression('node_id'))
             ->from('ezcontentobject_trash');
 
         return $query->execute()->fetchColumn();

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1364,6 +1364,15 @@ class DoctrineDatabase extends Gateway
         return $rows;
     }
 
+    public function countTrashed(): int
+    {
+        $query = $this->connection->createQueryBuilder()
+            ->select('COUNT(node_id) as count')
+            ->from('ezcontentobject_trash');
+
+        return $query->execute()->fetchColumn();
+    }
+
     /**
      * Removes every entries in the trash.
      * Will NOT remove associated content objects nor attributes.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -316,6 +316,15 @@ class ExceptionConversion extends Gateway
         }
     }
 
+    public function countTrashed(): int
+    {
+        try {
+            return $this->innerGateway->countTrashed();
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
+        }
+    }
+
     public function removeElementFromTrash($id)
     {
         try {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
@@ -202,10 +202,12 @@ class Handler implements BaseTrashHandler
     public function emptyTrash()
     {
         $resultList = new TrashItemDeleteResultList();
-        $trashedItems = $this->findTrashItems();// TODO: This won't work on large trash basket, we'll need to page it.
-        foreach ($trashedItems as $item) {
-            $resultList->items[] = $this->delete($item);
-        }
+        do {
+            $trashedItems = $this->findTrashItems(null, 0, 100);
+            foreach ($trashedItems as $item) {
+                $resultList->items[] = $this->delete($item);
+            }
+        } while ($trashedItems->totalCount > 100);
 
         $this->locationGateway->cleanupTrash();
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
@@ -179,7 +179,7 @@ class Handler implements BaseTrashHandler
         // @TODO: This only works for direct SPI usage, any API/UI usage needs criteria to be taken into account so we
         //        respect user rights here.
         $totalCount = $this->locationGateway->countTrashed();
-        if (!$totalCount) {
+        if ($totalCount === 0) {
             return new TrashResult();
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
@@ -24,6 +24,8 @@ use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper
  */
 class Handler implements BaseTrashHandler
 {
+    private const EMPTY_TRASH_BULK_SIZE = 100;
+
     /**
      * Location handler.
      *
@@ -203,11 +205,11 @@ class Handler implements BaseTrashHandler
     {
         $resultList = new TrashItemDeleteResultList();
         do {
-            $trashedItems = $this->findTrashItems(null, 0, 100);
+            $trashedItems = $this->findTrashItems(null, 0, self::EMPTY_TRASH_BULK_SIZE);
             foreach ($trashedItems as $item) {
                 $resultList->items[] = $this->delete($item);
             }
-        } while ($trashedItems->totalCount > 100);
+        } while ($trashedItems->totalCount > self::EMPTY_TRASH_BULK_SIZE);
 
         $this->locationGateway->cleanupTrash();
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTrashTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTrashTest.php
@@ -217,6 +217,27 @@ class DoctrineDatabaseTrashTest extends LanguageAwareTestCase
     }
 
     /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\DoctrineDatabase::countTrashed
+     */
+    public function testCountTrashed()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
+        $handler = $this->getLocationGateway();
+
+        $this->assertEquals(
+            0,
+            $handler->countTrashed()
+        );
+
+        $this->trashSubtree();
+
+        $this->assertEquals(
+            8,
+            $handler->countTrashed()
+        );
+    }
+
+    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\DoctrineDatabase::listTrashed
      */
     public function testListEmptyTrash()

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -313,7 +313,7 @@ class TrashService implements TrashServiceInterface
         $spiTrashResult = $this->persistenceHandler->trashHandler()->findTrashItems(
             $query->filter,
             $query->offset !== null && $query->offset > 0 ? (int)$query->offset : 0,
-            $query->limit !== null && $query->limit >= 1 ? (int)$query->limit : null,
+            $query->limit !== null && $query->limit >= 0 ? (int)$query->limit : null,
             $query->sortClauses
         );
 

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -310,17 +310,15 @@ class TrashService implements TrashServiceInterface
             throw new InvalidArgumentValue('query->limit', $query->limit, 'Query');
         }
 
-        $spiTrashItems = $this->persistenceHandler->trashHandler()->findTrashItems(
+        $spiTrashResult = $this->persistenceHandler->trashHandler()->findTrashItems(
             $query->filter,
             $query->offset !== null && $query->offset > 0 ? (int)$query->offset : 0,
             $query->limit !== null && $query->limit >= 1 ? (int)$query->limit : null,
             $query->sortClauses
         );
 
-        $trashItems = $this->buildDomainTrashItems($spiTrashItems);
-        $searchResult = new SearchResult();
-        $searchResult->totalCount = $searchResult->count = count($trashItems);
-        $searchResult->items = $trashItems;
+        $trashItems = $this->buildDomainTrashItems($spiTrashResult->items);
+        $searchResult = new SearchResult(['items' => $trashItems, 'totalCount' => $spiTrashResult->totalCount]);
 
         return $searchResult;
     }

--- a/eZ/Publish/SPI/Persistence/Content/Location/Trash/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Trash/Handler.php
@@ -59,16 +59,19 @@ interface Handler
     public function recover($trashedId, $newParentId);
 
     /**
-     * Returns an array of all trashed locations satisfying the $criterion (if provided),
-     * sorted with SortClause objects contained in $sort (if any).
+     * Returns all trashed locations satisfying the $criterion (if provided), sorted with $sort (if any).
+     *
      * If no criterion is provided (null), no filter is applied.
+     *
+     * TrashResult->totalCount will ignore limit and offset and representing the total amount of trashed items
+     * matching the criterion.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param int $offset Offset to start listing from, 0 by default
      * @param int $limit Limit for the listing. Null by default (no limit)
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
      *
-     * @return \eZ\Publish\SPI\Persistence\Content\Location\Trashed[]
+     * @return \eZ\Publish\SPI\Persistence\Content\Location\Trashed[]|\eZ\Publish\SPI\Persistence\Content\Location\Trash\TrashResult
      */
     public function findTrashItems(Criterion $criterion = null, $offset = 0, $limit = null, array $sort = null);
 

--- a/eZ/Publish/SPI/Persistence/Content/Location/Trash/TrashResult.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Trash/TrashResult.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\Persistence\Content\Location\Trash;
+
+use ArrayIterator;
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+class TrashResult extends ValueObject implements \IteratorAggregate
+{
+    /**
+     * The total number of Trash items matching criteria (ignores offset & limit arguments).
+     *
+     * @var int
+     */
+    public $totalCount = 0;
+
+    /**
+     * The value objects found for the query.
+     *
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Trashed[]
+     */
+    public $items = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->items);
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31084](https://jira.ez.no/browse/EZP-31084)
| **Bug/Improvement**| yes
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Reports from customer**s** that trash exceeds memory use _or_ timeouts on large amounts of trash.

This PR solves part 1 of this:
- Provide a way for SPI to be able to tell how many items there are in trash, without having to set limit= 0 and load the whole trash basket into basket.
- Use this to fix `emptyTrash()` function in `Persistence/Legacy` and in `Persistence/Cache` to avoid the issues memory/timeout issue there

**Follow up fixes to solve the overall user issues around this**:
- Find a way to take into account criterion so at a minimum permissions are taken into account _(so total count will be right for UI)_
- Adapt Admin UI to remove limit:0 hack in order to fix issue when trying to browse trash
- Add a cronjob by default in the system to delete trash items after 30 days in trash

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.

**QA**:
The following can be a way to test this change:
- On install with lots of trash content _(Support has command to generate)_, call API `emptyTrash()`, before this patch it should run out of memory once you reach a certain amount of trash items.
