### PR TITLE
EZP-31114: Added "skip-indexing" option for install command

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Connection;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -61,6 +62,12 @@ class InstallPlatformCommand extends Command
             InputArgument::REQUIRED,
             'The type of install. Available options: ' . implode(', ', array_keys($this->installers))
         );
+        $this->addOption(
+            'disable-index',
+            null,
+            InputOption::VALUE_NONE,
+            'Disable index'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -86,7 +93,10 @@ class InstallPlatformCommand extends Command
         $installer->importData();
         $installer->importBinaries();
         $this->cacheClear($output);
-        $this->indexData($output);
+
+        if (!$input->getOption('disable-index')) {
+            $this->indexData($output);
+        }
     }
 
     private function checkPermissions()

--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -63,10 +63,10 @@ class InstallPlatformCommand extends Command
             'The type of install. Available options: ' . implode(', ', array_keys($this->installers))
         );
         $this->addOption(
-            'disable-index',
+            'skip-indexing',
             null,
             InputOption::VALUE_NONE,
-            'Disable index'
+            'Skip indexing (ezplaform:reindex)'
         );
     }
 
@@ -94,7 +94,7 @@ class InstallPlatformCommand extends Command
         $installer->importBinaries();
         $this->cacheClear($output);
 
-        if (!$input->getOption('disable-index')) {
+        if (!$input->getOption('skip-indexing')) {
             $this->indexData($output);
         }
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31114](https://jira.ez.no/browse/EZP-31114)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`/`8.x` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Added `--disable-index` option for `ezplatform:install` command. 

**TODO**:
- [x] Ask for Code Review.
