### PR TITLE
EZP-30754: Fixed handling always available flag for ContentInfo update

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -695,4 +695,44 @@ abstract class BaseTest extends TestCase
 
         return $contentService->publishVersion($contentDraft->versionInfo);
     }
+
+    /**
+     * @param string $identifier Content Type identifier
+     * @param string $mainTranslation main translation language code
+     * @param array $fieldsToDefine a map of field definition identifiers to their field type identifiers
+     * @param bool $alwaysAvailable default always available
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    protected function createContentType(
+        $identifier,
+        $mainTranslation,
+        array $fieldsToDefine,
+        $alwaysAvailable = true
+    ) {
+        $contentTypeService = $this->getRepository(false)->getContentTypeService();
+        $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct($identifier);
+        $contentTypeCreateStruct->mainLanguageCode = $mainTranslation;
+        $contentTypeCreateStruct->names = [$mainTranslation => $identifier];
+        $contentTypeCreateStruct->defaultAlwaysAvailable = $alwaysAvailable;
+        foreach ($fieldsToDefine as $fieldDefinitionIdentifier => $fieldTypeIdentifier) {
+            $fieldDefinitionCreateStruct = $contentTypeService->newFieldDefinitionCreateStruct(
+                $fieldDefinitionIdentifier,
+                $fieldTypeIdentifier
+            );
+            $contentTypeCreateStruct->addFieldDefinition($fieldDefinitionCreateStruct);
+        }
+        $contentTypeService->publishContentTypeDraft(
+            $contentTypeService->createContentType(
+                $contentTypeCreateStruct,
+                [$contentTypeService->loadContentTypeGroupByIdentifier('Content')]
+            )
+        );
+
+        return $contentTypeService->loadContentTypeByIdentifier($identifier);
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -34,6 +34,9 @@ use Exception;
  */
 class ContentServiceTest extends BaseContentServiceTest
 {
+    const ENG_GB = 'eng-GB';
+    const ENG_US = 'eng-US';
+
     /**
      * Test for the newContentCreateStruct() method.
      *
@@ -2185,6 +2188,71 @@ XML
         self::assertEquals(
             $contentMetadataUpdate->alwaysAvailable,
             $reloadedFolder->contentInfo->alwaysAvailable
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\ContentService::updateContentMetadata
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testUpdateContentMainTranslation()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+
+        // create a Content Type which is not always available by default
+        $contentType = $this->createContentType(
+            'test_t',
+            self::ENG_GB,
+            [
+                'name' => 'ezstring',
+            ],
+            false
+        );
+
+        $contentCreate = $contentService->newContentCreateStruct(
+            $contentType,
+            self::ENG_US
+        );
+        $contentCreate->setField('name', 'My Content');
+        $content = $contentService->publishVersion(
+            $contentService->createContent(
+                $contentCreate,
+                [$locationService->newLocationCreateStruct(2)]
+            )->getVersionInfo()
+        );
+        // perform sanity check
+        self::assertFalse($content->contentInfo->alwaysAvailable);
+
+        $updateStruct = $contentService->newContentMetadataUpdateStruct();
+        $updateStruct->mainLanguageCode = self::ENG_GB;
+
+        $contentService->updateContentMetadata($content->contentInfo, $updateStruct);
+
+        $reloadedContent = $contentService->loadContent($content->id);
+        self::assertEquals(self::ENG_GB, $reloadedContent->contentInfo->mainLanguageCode);
+
+        // check that other properties remained unchanged
+        self::assertStructPropertiesCorrect(
+            $content->contentInfo,
+            $reloadedContent->contentInfo,
+            [
+                'id',
+                'contentTypeId',
+                'name',
+                'sectionId',
+                'currentVersionNo',
+                'published',
+                'ownerId',
+                'alwaysAvailable',
+                'remoteId',
+                'mainLocationId',
+                'status',
+            ]
         );
     }
 

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -2164,6 +2164,31 @@ XML
     }
 
     /**
+     * @covers \eZ\Publish\API\Repository\ContentService::updateContentMetadata
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testUpdateContentAlwaysAvailable()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $folder = $this->createFolder(['eng-GB' => 'Folder'], 2);
+
+        $contentMetadataUpdate = $contentService->newContentMetadataUpdateStruct();
+        $contentMetadataUpdate->alwaysAvailable = !$folder->contentInfo->alwaysAvailable;
+        $contentService->updateContentMetadata($folder->contentInfo, $contentMetadataUpdate);
+
+        $reloadedFolder = $contentService->loadContent($folder->id);
+        self::assertEquals(
+            $contentMetadataUpdate->alwaysAvailable,
+            $reloadedFolder->contentInfo->alwaysAvailable
+        );
+    }
+
+    /**
      * Test for the deleteContent() method.
      *
      * @see \eZ\Publish\API\Repository\ContentService::deleteContent()

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -336,7 +336,10 @@ class DoctrineDatabase extends Gateway
                 $query->createNamedParameter($contentId, PDO::PARAM_INT, ':contentId')
             )
         );
-        $query->execute();
+
+        if (!empty($query->getQueryPart('set'))) {
+            $query->execute();
+        }
 
         // Handle alwaysAvailable flag update separately as it's a more complex task and has impact on several tables
         if (isset($struct->alwaysAvailable) || isset($struct->mainLanguageId)) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -290,45 +290,28 @@ class DoctrineDatabase extends Gateway
      */
     public function updateContent($contentId, MetadataUpdateStruct $struct, VersionInfo $prePublishVersionInfo = null)
     {
-        $q = $this->dbHandler->createUpdateQuery();
-        $q->update($this->dbHandler->quoteTable('ezcontentobject'));
+        $query = $this->connection->createQueryBuilder();
+        $query->update('ezcontentobject');
 
-        if (isset($struct->name)) {
-            $q->set(
-                $this->dbHandler->quoteColumn('name'),
-                $q->bindValue($struct->name, null, \PDO::PARAM_STR)
+        $fieldsForUpdateMap = [
+            'name' => ['value' => $struct->name, 'type' => PDO::PARAM_STR],
+            'initial_language_id' => ['value' => $struct->mainLanguageId, 'type' => PDO::PARAM_INT],
+            'modified' => ['value' => $struct->modificationDate, 'type' => PDO::PARAM_INT],
+            'owner_id' => ['value' => $struct->ownerId, 'type' => PDO::PARAM_INT],
+            'published' => ['value' => $struct->publicationDate, 'type' => PDO::PARAM_INT],
+            'remote_id' => ['value' => $struct->remoteId, 'type' => PDO::PARAM_STR],
+        ];
+
+        foreach ($fieldsForUpdateMap as $fieldName => $field) {
+            if (null === $field['value']) {
+                continue;
+            }
+            $query->set(
+                $fieldName,
+                $query->createNamedParameter($field['value'], $field['type'], ":{$fieldName}")
             );
         }
-        if (isset($struct->mainLanguageId)) {
-            $q->set(
-                $this->dbHandler->quoteColumn('initial_language_id'),
-                $q->bindValue($struct->mainLanguageId, null, \PDO::PARAM_INT)
-            );
-        }
-        if (isset($struct->modificationDate)) {
-            $q->set(
-                $this->dbHandler->quoteColumn('modified'),
-                $q->bindValue($struct->modificationDate, null, \PDO::PARAM_INT)
-            );
-        }
-        if (isset($struct->ownerId)) {
-            $q->set(
-                $this->dbHandler->quoteColumn('owner_id'),
-                $q->bindValue($struct->ownerId, null, \PDO::PARAM_INT)
-            );
-        }
-        if (isset($struct->publicationDate)) {
-            $q->set(
-                $this->dbHandler->quoteColumn('published'),
-                $q->bindValue($struct->publicationDate, null, \PDO::PARAM_INT)
-            );
-        }
-        if (isset($struct->remoteId)) {
-            $q->set(
-                $this->dbHandler->quoteColumn('remote_id'),
-                $q->bindValue($struct->remoteId, null, \PDO::PARAM_STR)
-            );
-        }
+
         if ($prePublishVersionInfo !== null) {
             $languages = [];
             foreach ($prePublishVersionInfo->languageCodes as $languageCodes) {
@@ -336,24 +319,24 @@ class DoctrineDatabase extends Gateway
                     $languages[$languageCodes] = true;
                 }
             }
-
             $languages['always-available'] = isset($struct->alwaysAvailable) ? $struct->alwaysAvailable :
                 $prePublishVersionInfo->contentInfo->alwaysAvailable;
 
             $mask = $this->languageMaskGenerator->generateLanguageMask($languages);
 
-            $q->set(
-                $this->dbHandler->quoteColumn('language_mask'),
-                $q->bindValue($mask, null, \PDO::PARAM_INT)
+            $query->set(
+                'language_mask',
+                $query->createNamedParameter($mask, PDO::PARAM_INT, ':languageMask')
             );
         }
-        $q->where(
-            $q->expr->eq(
-                $this->dbHandler->quoteColumn('id'),
-                $q->bindValue($contentId, null, \PDO::PARAM_INT)
+
+        $query->where(
+            $query->expr()->eq(
+                'id',
+                $query->createNamedParameter($contentId, PDO::PARAM_INT, ':contentId')
             )
         );
-        $q->prepare()->execute();
+        $query->execute();
 
         // Handle alwaysAvailable flag update separately as it's a more complex task and has impact on several tables
         if (isset($struct->alwaysAvailable) || isset($struct->mainLanguageId)) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -410,7 +410,7 @@ class DoctrineDatabase extends Gateway
         // everywhere needed
         $contentInfoRow = $this->loadContentInfo($contentId);
         if (!isset($alwaysAvailable)) {
-            $alwaysAvailable = (bool)$contentInfoRow['language_mask'] & 1;
+            $alwaysAvailable = 1 === ($contentInfoRow['language_mask'] & 1);
         }
 
         /** @var $q \eZ\Publish\Core\Persistence\Database\UpdateQuery */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -254,7 +254,7 @@ class Mapper
         $contentInfo->ownerId = (int)$row["{$prefix}owner_id"];
         $contentInfo->publicationDate = (int)$row["{$prefix}published"];
         $contentInfo->modificationDate = (int)$row["{$prefix}modified"];
-        $contentInfo->alwaysAvailable = (int)$row["{$prefix}language_mask"] & 1;
+        $contentInfo->alwaysAvailable = 1 === ($row["{$prefix}language_mask"] & 1);
         $contentInfo->mainLanguageCode = $this->languageHandler->load($row["{$prefix}initial_language_id"])->languageCode;
         $contentInfo->remoteId = $row["{$prefix}remote_id"];
         $contentInfo->mainLocationId = ($row["{$treePrefix}main_node_id"] !== null ? (int)$row["{$treePrefix}main_node_id"] : null);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30754](https://jira.ez.no/browse/EZP-30754)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`, `7.5`, `master (8.0@dev)`
| **BC breaks**      | no
| **Tests pass**     | TBD
| **Doc needed**     | no

This PR fixes two separate issues, related to handling of the always available flag, which occur during ContentInfo (Content metadata) update.

The first issue is about updating only the always available flag and nothing else, as reported via kaliop-uk/ezmigrationbundle#209 and [EZP-30754](https://jira.ez.no/browse/EZP-30754).
To solve that we need to check if there's anything to update before trying to execute database update.
It's not easy with our own database abstraction layer, therefore this PR refactors `\eZ\Publish\Core\Persistence\Legacy\Content\Gateway\DoctrineDatabase::updateContent` to rely on `\Doctrine\DBAL` QueryBuilder for that.

The second issue is about fixing erroneous type casting when setting always available flag, both in Legacy Storage Persistence Content Mapper and in the `Content\Gateway\DoctrineDatabase::updateAlwaysAvailableFlag` method. The latter mistake caused `ContentInfo::alwaysAvailable` being always set to `true` during main Translation update, regardless of the actual state.

Implemented also integration tests covering both updating main translation and always available flag only. Those are the special cases handled by different path of code.

### QA

The second issue is reproducible only on the API level unfortunately. Content Info after updating main language code (via `ContentMetadataUpdateStruct`) has always available flag always set to true.
To see the bug you could use `app:test` command available on my 1.13-based branch: https://github.com/alongosz/ezplatform/tree/ezp-30754-cmd-for-qa
(observe that `alwaysAvailable` changes though updateStruct didn't touch it).

**TODO**:
- [ ] Merge up: add `is_hidden` column.
- [x] Refactor Content GW (`\eZ\Publish\Core\Persistence\Legacy\Content\Gateway\DoctrineDatabase`) `updateContent` method to rely on `\Doctrine\DBAL` Query Builder.
- [x] Add checking if there's anything to update before executing update query in the `updateContent` method.
- [x] Fix setting always available flag in the Persistence mapper and `updateAlwaysAvailableFlag`. 
- [x] Implement tests.
- [x] See if CI passes.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
