### PR TITLE
[CS] Forced to use php-cs-fixer v2.15.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "twig/twig": "~1.35|~2.4"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.15.0",
+        "friendsofphp/php-cs-fixer": "2.15.3",
         "phpunit/phpunit": "^4.8.35",
         "matthiasnoback/symfony-dependency-injection-test": "~0.7.6",
         "mockery/mockery": "~0.9.10",


### PR DESCRIPTION
|            |  |
| ------------------ | ------------------
| **Target version** | `6.7`, `6.13`, `7.5`, `master (8.0@dev)`

Due to php-cs-fixer RuleSets being unstable, even for patch releases (see e.g.: FriendsOfPHP/PHP-CS-Fixer#4606), the package version needs to be locked at `2.15.3` for now.

In the future we'd need to create our own list of rules, to avoid using RuleSets (except maybe PSR2).
Ideally we should create our own RuleSet, but AFAICS custom rule sets are not exposed by php-cs-fixer config factory ATM.

**TODO**:
- [ ] Fix QueryBuilder mocking issue