### PR TITLE
EZP-31109: Implemented SearchField for ezuser FieldType

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -17,6 +17,7 @@ use eZ\Publish\API\Repository\Tests\PHPUnitConstraint\ValidationErrorOccurs as P
 use eZ\Publish\API\Repository\Tests\SetupFactory\Legacy;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\API\Repository\Values\User\User;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\API\Repository\Repository;
@@ -441,15 +442,17 @@ abstract class BaseTest extends TestCase
     /**
      * Create a user using given data.
      *
-     * @param string $login
-     * @param string $firstName
-     * @param string $lastName
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup|null $userGroup optional user group, Editor by default
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\User
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    protected function createUser($login, $firstName, $lastName, UserGroup $userGroup = null)
-    {
+    protected function createUser(
+        string $login,
+        string $firstName,
+        string $lastName,
+        UserGroup $userGroup = null,
+        ?string $email = null
+    ): User {
         $repository = $this->getRepository();
 
         $userService = $repository->getUserService();
@@ -458,9 +461,10 @@ abstract class BaseTest extends TestCase
         }
 
         // Instantiate a create struct with mandatory properties
+        $email = $email ?? "{$login}@example.com";
         $userCreate = $userService->newUserCreateStruct(
             $login,
-            "{$login}@example.com",
+            $email,
             'secret',
             'eng-US'
         );

--- a/eZ/Publish/API/Repository/Tests/SearchService/FieldType/SearchableUserTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/FieldType/SearchableUserTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\SearchService\FieldType;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
+
+final class SearchableUserTest extends BaseTest
+{
+    private $searchService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->searchService = $this->getRepository()->getSearchService();
+    }
+
+    /**
+     * @dataProvider providerForTestFindUserByEmail
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \ErrorException
+     */
+    public function testFindUserByEmail(string $email, string $searchInput): void
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        // create extra data (not to be found) to check system sanity
+        if ($this->getSetupFactory() instanceof LegacySolrSetupFactory) {
+            // exact match (see the data provider) is supported by Solr only
+            $this->createUser('jane', 'Jane', 'Smith', null, 'jane@subdomain.example.com');
+        } else {
+            $this->createUser('jane', 'Jane', 'Smith', null, 'jane@anything.org');
+        }
+
+        // create the actual user to be found
+        $user = $this->createUser('john', 'John', 'Doe', null, $email);
+
+        $this->refreshSearch($repository);
+
+        $userContent = $contentService->loadContent($user->id);
+        $query = new Query();
+        $query->query = new Query\Criterion\FullText($searchInput);
+
+        $results = $this->searchService->findContent($query);
+        self::assertEquals(1, $results->totalCount);
+        self::assertEquals($userContent, $results->searchHits[0]->valueObject);
+    }
+
+    public function providerForTestFindUserByEmail(): array
+    {
+        return [
+            ['john@example.com', '"john@example.com"'],
+            ['john@example.com', '"@example.com"'],
+        ];
+    }
+}

--- a/eZ/Publish/Core/FieldType/User/SearchField.php
+++ b/eZ/Publish/Core/FieldType/User/SearchField.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\FieldType\User;
+
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\Search;
+
+final class SearchField implements Indexable
+{
+    public function getIndexData(Field $field, FieldDefinition $fieldDefinition): array
+    {
+        return [
+            new Search\Field(
+                'fulltext_email',
+                $field->value->externalData['email'],
+                new Search\FieldType\FullTextField()
+            ),
+        ];
+    }
+
+    public function getIndexDefinition(): array
+    {
+        return [
+            'fulltext_email' => new Search\FieldType\FullTextField(),
+        ];
+    }
+
+    public function getDefaultMatchField()
+    {
+        return 'fulltext_email';
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
+    }
+}

--- a/eZ/Publish/Core/FieldType/User/Type.php
+++ b/eZ/Publish/Core/FieldType/User/Type.php
@@ -138,6 +138,11 @@ class Type extends FieldType
         return new Value();
     }
 
+    public function isSearchable()
+    {
+        return true;
+    }
+
     /**
      * Inspects given $inputValue and potentially converts it into a dedicated value object.
      *

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -141,11 +141,13 @@ services:
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezimageasset}
 
+    eZ\Publish\Core\FieldType\User\SearchField:
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezuser}
 
     ezpublish.fieldType.indexable.unindexed:
         class: "%ezpublish.fieldType.indexable.unindexed.class%"
         tags:
-            - {name: ezpublish.fieldType.indexable, alias: ezuser}
             - {name: ezpublish.fieldType.indexable, alias: ezenum}
             - {name: ezpublish.fieldType.indexable, alias: ezidentifier}
             - {name: ezpublish.fieldType.indexable, alias: ezinisetting}

--- a/phpunit-integration-legacy-solr.xml
+++ b/phpunit-integration-legacy-solr.xml
@@ -58,6 +58,7 @@
             <file>eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php</file>
+            <directory>eZ/Publish/API/Repository/Tests/SearchService</directory>
         </testsuite>
         <testsuite name="eZ\Publish\API\Repository\Tests\Regression">
             <directory>eZ/Publish/API/Repository/Tests/Regression/</directory>

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -59,6 +59,7 @@
             <file>eZ/Publish/API/Repository/Tests/BookmarkServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/NotificationServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/UserPreferenceServiceTest.php</file>
+            <directory>eZ/Publish/API/Repository/Tests/SearchService</directory>
         </testsuite>
         <testsuite name="eZ\Publish\API\Repository\Tests\Regression">
             <directory>eZ/Publish/API/Repository/Tests/Regression/</directory>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31109](https://jira.ez.no/browse/EZP-31109)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `7.5`+ for eZ Platform 2.5.x LTS
| **BC breaks**      | no
| **Tests pass**     | TBD
| **Doc needed**     | yes

This PR implements `SearchField` to index, as a Full Text, user e-mails.

It's recommended to use Solr in case of searching for e-mails to use exact match (in quotes). Search phrases like `"@example.com"` should return all e-mails in the domain `example.com`. For LSE and/or no quotes Search Engine will return all Content items matching all parts of the token: "@", "example", "com".

## Known issues

While for existing Field Types "User account" Field is not searchable by default (requires explicit action), it's not possible to make "is searchable" checkbox unchecked by default when adding a new Field to a Content Type in AdminUI.

Work in progress: I've determined that for `"@example.com"` exact search phrase, a user with an email `"something@not-example.com"` is also found on Solr, which is rather not expected. Need to investigate more.

## Doc

1. Works best with Solr.
2. Make sure to check if users are not readable by anonymous users before making ezuser Field definition searchable.

## QA

1. Creating specific users and searching for e-mails via AdminUI
2. Authorization test: check that users w/o permission to read user subtree are not able to find users by-email (especially for anonymous user on fronted - maybe using front-end search or REST, TBD - ask me when testing ;) ) 

**TODO**:
- [x] Make ezuser searchable, implement Indexable SearchField.
- [x] Implement tests.
- [ ] Investigate issue with Solr search returning unwanted result (mentioned in the "known issues").
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
