### PR TITLE
[6.7] Fixed failing CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "twig/twig": "~1.35|~2.4"
     },
     "require-dev": {
+        "doctrine/dbal": "<2.10.0",
         "friendsofphp/php-cs-fixer": "2.15.3",
         "phpunit/phpunit": "^4.8.35",
         "matthiasnoback/symfony-dependency-injection-test": "~0.7.6",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "twig/twig": "~1.35|~2.4"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.15.0",
+        "friendsofphp/php-cs-fixer": "2.15.3",
         "phpunit/phpunit": "^4.8.35",
         "matthiasnoback/symfony-dependency-injection-test": "~0.7.6",
         "mockery/mockery": "~0.9.10",


### PR DESCRIPTION
|            |  |
| ------------------ | ------------------
| **Target version** | `6.7`, `6.13`, `7.5`, `master (8.0@dev)`

There are two outstanding issues related to the latest releases of PHP-CS-Fixer and `Doctrine\DBAL`.

1. #2857: Due to php-cs-fixer RuleSets being unstable, even for patch releases, the package version needs to be locked at `2.15.3` for now.
In the future we'd need to create our own list of rules (see /ezsystems/ezplatform-code-style#3), to avoid using RuleSets (except maybe PSR2).
Ideally we should create our own RuleSet, but AFAICS custom rule sets are not exposed by php-cs-fixer config factory ATM.

2. The `2.10.0` release of `doctrine/dbal` introduced strict return types on e.g. `QueryBuilder`. Unfortunately [old PHPUnit 4.8.x can't handle mocking of such classes properly](https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/607067288#L751). This applies to `6.7` branch only which won't be maintained much (EOM approaching in November), we can just limit `doctrine/dbal` to `<2.10.0`.

**TODO**:
- [x] Require strictly version 2.15.3 of PHP-CS-Fixer.
- [x] Restrict doctrine/dbal to `<2.10.0`.
- [x] Wait for Travis.