### PR TITLE
EZP-31113: Implemented indexing subtree after assigning Section to it

### DIFF
--- a/eZ/Publish/Core/Search/Common/Slot/AssignSectionToSubtree.php
+++ b/eZ/Publish/Core/Search/Common/Slot/AssignSectionToSubtree.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Search\Common\Slot;
+
+use eZ\Publish\Core\Search\Common\Slot;
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\Core\SignalSlot\Signal\SectionService\AssignSectionToSubtreeSignal;
+
+class AssignSectionToSubtree extends AbstractSubtree
+{
+    public function receive(Signal $signal)
+    {
+        if (!$signal instanceof AssignSectionToSubtreeSignal) {
+            return;
+        }
+
+        $this->indexSubtree($signal->locationId);
+    }
+}

--- a/eZ/Publish/Core/Search/Common/Slot/AssignSectionToSubtree.php
+++ b/eZ/Publish/Core/Search/Common/Slot/AssignSectionToSubtree.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Search\Common\Slot;
 
-use eZ\Publish\Core\Search\Common\Slot;
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Signal\SectionService\AssignSectionToSubtreeSignal;
 

--- a/eZ/Publish/Core/settings/search_engines/elasticsearch/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/elasticsearch/slots.yml
@@ -25,7 +25,6 @@ parameters:
     ezpublish.search.elasticsearch.slot.delete_translation.class: eZ\Publish\Core\Search\Common\Slot\DeleteTranslation
     ezpublish.search.elasticsearch.slot.assign_section.class: eZ\Publish\Core\Search\Common\Slot\AssignSection
 
-
 services:
     ezpublish.search.elasticsearch.slot:
         class: "%ezpublish.search.elasticsearch.slot.class%"
@@ -188,3 +187,8 @@ services:
         parent: ezpublish.search.elasticsearch.slot
         tags:
             - {name: ezpublish.search.elasticsearch.slot, signal: ContentService\RevealContentSignal}
+            -
+    eZ\Publish\Core\Search\Common\Slot\AssignSectionToSubtree:
+        parent: ezpublish.search.elasticsearch.slot
+        tags:
+            - {name: ezpublish.search.elasticsearch.slot, signal: SectionService\AssignSectionToSubtreeSignal}

--- a/eZ/Publish/Core/settings/search_engines/legacy/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/slots.yml
@@ -124,3 +124,8 @@ services:
         parent: ezpublish.search.legacy.slot
         tags:
             - {name: ezpublish.search.legacy.slot, signal: ContentService\RevealContentSignal}
+
+    eZ\Publish\Core\Search\Common\Slot\AssignSectionToSubtree:
+        parent: ezpublish.search.legacy.slot
+        tags:
+            - {name: ezpublish.search.legacy.slot, signal: SectionService\AssignSectionToSubtreeSignal}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31113](https://jira.ez.no/browse/EZP-31113)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.5`/`master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

`AssignSectionToSubtreeSignal` is not handled properly in both search implementations as well as in HTTP cache. 

_Note_: These changes will be removed on merge-up and the second PR targeting master will be created. 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [ ] Drop changes on merge-up.
- [ ] Create a new PR using events instead (for `master`).