### PR TITLE
EZP-31115: Added `isHidden` flag to `ContentInfo` in REST response

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -307,6 +307,7 @@ XML Example
                         <mainLanguageCode>eng-GB</mainLanguageCode>
                         <currentVersionNo>9</currentVersionNo>
                         <alwaysAvailable>true</alwaysAvailable>
+                        <isHidden>false</isHidden>
                         <status>PUBLISHED</status>
                         <ObjectStates media-type="application/vnd.ez.api.ContentObjectStates+xml" href="/api/ezp/v2/content/objects/1/objectstates"/>
                     </Content>

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
@@ -180,6 +180,12 @@ class RestContent extends ValueObjectVisitor
         $generator->endValueElement('alwaysAvailable');
 
         $generator->startValueElement(
+            'isHidden',
+            $this->serializeBool($generator, $contentInfo->isHidden)
+        );
+        $generator->endValueElement('isHidden');
+
+        $generator->startValueElement(
             'status',
             $this->getStatusString($contentInfo->status)
         );

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTest.php
@@ -114,6 +114,7 @@ class RestContentTest extends ValueObjectVisitorBaseTest
                     'mainLanguageCode' => 'eng-US',
                     'mainLocationId' => 'location23',
                     'contentTypeId' => 'contentType23',
+                    'isHidden' => true,
                 ]
             ),
             new Values\Content\Location(
@@ -353,6 +354,16 @@ class RestContentTest extends ValueObjectVisitorBaseTest
     public function testAlwaysAvailableCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/Content/alwaysAvailable[text()="true"]');
+    }
+
+    /**
+     * @param \DOMDocument $dom
+     *
+     * @depends testVisitWithoutEmbeddedVersion
+     */
+    public function testIsHiddenCorrect(\DOMDocument $dom)
+    {
+        $this->assertXPath($dom, '/Content/isHidden[text()="true"]');
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31115](https://jira.ez.no/browse/EZP-31115)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Added `isHidden` flag to `ContentInfo` in REST response

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
