### PR TITLE
EZP-31084: Fix infinitive loop in cache emptyTrash()

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
@@ -218,11 +218,12 @@ class TrashHandlerTest extends AbstractCacheHandlerTest
         $innerHandler = $this->createMock($this->getHandlerClassName());
 
         $innerHandler
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('findTrashItems')
             ->willReturn(new Location\Trash\TrashResult([
                 'items' => [new Trashed(['id' => $trashedId, 'contentId' => $contentId])],
-                'totalCount' => 1,
+                // trigger the bulk loading several times to have some minimal coverage on the loop exit logic
+                'totalCount' => 101,
             ]));
 
         $this->persistenceHandlerMock
@@ -232,7 +233,7 @@ class TrashHandlerTest extends AbstractCacheHandlerTest
         $contentHandlerMock = $this->createMock(ContentHandler::class);
 
         $contentHandlerMock
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('loadReverseRelations')
             ->with($contentId)
             ->will($this->returnValue([new Relation(['sourceContentId' => $relationSourceContentId])]));

--- a/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
@@ -115,9 +115,9 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
         // We can not use the return value of emptyTrash method because, in the next step, we are not able
         // to fetch the reverse relations of deleted content.
         $tags = [];
-
+        $offset = 0;
         do {
-            $trashedItems = $this->persistenceHandler->trashHandler()->findTrashItems(null, 0, self::EMPTY_TRASH_BULK_SIZE);
+            $trashedItems = $this->persistenceHandler->trashHandler()->findTrashItems(null, $offset, self::EMPTY_TRASH_BULK_SIZE);
             foreach ($trashedItems as $trashedItem) {
                 $reverseRelations = $this->persistenceHandler->contentHandler()->loadReverseRelations($trashedItem->contentId);
 
@@ -129,7 +129,9 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
                 $tags['location-' . $trashedItem->id] = true;
                 $tags['location-path-' . $trashedItem->id] = true;
             }
-        } while ($trashedItems->totalCount > self::EMPTY_TRASH_BULK_SIZE);
+            $offset += self::EMPTY_TRASH_BULK_SIZE;
+            // Once offset is larger then total count we can exit
+        } while ($trashedItems->totalCount > $offset);
 
         $return = $this->persistenceHandler->trashHandler()->emptyTrash();
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31084](https://jira.ez.no/browse/EZP-31084)
| **Bug/Improvement**| yes
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Attempt to fix issue found in #2847 by @mnocon.
