### PR TITLE
EZP-31127: Skipped non-existing Content Types in ContentTypeIdentifier criterion

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -140,12 +140,32 @@ class SearchServiceTest extends BaseTest
             ],
             7 => [
                 [
+                    'filter' => new Criterion\ContentTypeIdentifier(
+                        'user',
+                        'invalid'
+                    ),
+                    'sortClauses' => [new SortClause\ContentId()],
+                ],
+                $fixtureDir . 'ContentTypeId.php',
+            ],
+            8 => [
+                [
+                    'filter' => new Criterion\ContentTypeIdentifier(
+                        'invalid1',
+                        'invalid2'
+                    ),
+                    'sortClauses' => [new SortClause\ContentId()],
+                ],
+                $fixtureDir . 'MatchNone.php',
+            ],
+            9 => [
+                [
                     'filter' => new Criterion\MatchNone(),
                     'sortClauses' => [new SortClause\ContentId()],
                 ],
                 $fixtureDir . 'MatchNone.php',
             ],
-            8 => [
+            10 => [
                 [
                     'filter' => new Criterion\ContentTypeGroupId(
                         2
@@ -154,7 +174,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'ContentTypeGroupId.php',
             ],
-            9 => [
+            11 => [
                 [
                     'filter' => new Criterion\DateMetadata(
                         Criterion\DateMetadata::MODIFIED,
@@ -165,7 +185,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'DateMetadataGt.php',
             ],
-            10 => [
+            12 => [
                 [
                     'filter' => new Criterion\DateMetadata(
                         Criterion\DateMetadata::MODIFIED,
@@ -176,7 +196,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'DateMetadataGte.php',
             ],
-            11 => [
+            13 => [
                 [
                     'filter' => new Criterion\DateMetadata(
                         Criterion\DateMetadata::MODIFIED,
@@ -188,7 +208,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'DateMetadataLte.php',
             ],
-            12 => [
+            14 => [
                 [
                     'filter' => new Criterion\DateMetadata(
                         Criterion\DateMetadata::MODIFIED,
@@ -199,7 +219,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'DateMetadataIn.php',
             ],
-            13 => [
+            15 => [
                 [
                     'filter' => new Criterion\DateMetadata(
                         Criterion\DateMetadata::MODIFIED,
@@ -210,7 +230,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'DateMetadataBetween.php',
             ],
-            14 => [
+            16 => [
                 [
                     'filter' => new Criterion\DateMetadata(
                         Criterion\DateMetadata::CREATED,
@@ -221,7 +241,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'DateMetadataCreated.php',
             ],
-            15 => [
+            17 => [
                 [
                     'filter' => new Criterion\CustomField(
                         'user_group_name_value_s',
@@ -232,7 +252,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'Field.php',
             ],
-            16 => [
+            18 => [
                 [
                     'filter' => new Criterion\CustomField(
                         'user_group_name_value_s',
@@ -243,7 +263,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'Field.php',
             ],
-            17 => [
+            19 => [
                 [
                     'filter' => new Criterion\CustomField(
                         'user_group_name_value_s',
@@ -254,7 +274,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'CustomFieldLt.php',
             ],
-            18 => [
+            20 => [
                 [
                     'filter' => new Criterion\CustomField(
                         'user_group_name_value_s',
@@ -265,7 +285,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'CustomFieldLte.php',
             ],
-            19 => [
+            21 => [
                 [
                     'filter' => new Criterion\CustomField(
                         'user_group_name_value_s',
@@ -276,7 +296,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'CustomFieldGt.php',
             ],
-            20 => [
+            22 => [
                 [
                     'filter' => new Criterion\CustomField(
                         'user_group_name_value_s',
@@ -287,7 +307,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'CustomFieldGte.php',
             ],
-            21 => [
+            23 => [
                 [
                     'filter' => new Criterion\CustomField(
                         'user_group_name_value_s',
@@ -298,7 +318,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'CustomFieldBetween.php',
             ],
-            22 => [
+            24 => [
                 [
                     'filter' => new Criterion\RemoteId(
                         ['f5c88a2209584891056f987fd965b0ba', 'faaeb9be3bd98ed09f606fc16d144eca']
@@ -307,7 +327,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'RemoteId.php',
             ],
-            23 => [
+            25 => [
                 [
                     'filter' => new Criterion\SectionId(
                         [2]
@@ -316,7 +336,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'SectionId.php',
             ],
-            24 => [
+            26 => [
                 [
                     'filter' => new Criterion\Field(
                         'name',
@@ -327,7 +347,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'Field.php',
             ],
-            25 => [
+            27 => [
                 [
                     'filter' => new Criterion\Field(
                         'name',
@@ -338,7 +358,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'FieldIn.php',
             ],
-            26 => [
+            28 => [
                 [
                     'filter' => new Criterion\DateMetadata(
                         Criterion\DateMetadata::MODIFIED,
@@ -349,7 +369,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'FieldBetween.php',
             ],
-            27 => [
+            29 => [
                 [
                     'filter' => new Criterion\LogicalOr(
                         [
@@ -369,7 +389,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'FieldOr.php',
             ],
-            28 => [
+            30 => [
                 [
                     'filter' => new Criterion\Subtree(
                         '/1/5/'
@@ -378,7 +398,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'Subtree.php',
             ],
-            29 => [
+            31 => [
                 [
                     'filter' => new Criterion\LocationId(
                         [1, 2, 5]
@@ -387,7 +407,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'LocationId.php',
             ],
-            30 => [
+            32 => [
                 [
                     'filter' => new Criterion\ParentLocationId(
                         [1]
@@ -396,7 +416,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'ParentLocationId.php',
             ],
-            31 => [
+            33 => [
                 [
                     'filter' => new Criterion\LocationRemoteId(
                         ['3f6d92f8044aed134f32153517850f5a', 'f3e90596361e31d496d4026eb624c983']
@@ -405,7 +425,7 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'LocationRemoteId.php',
             ],
-            32 => [
+            34 => [
                 [
                     // There is no Status Criterion anymore, this should match all published as well
                     'filter' => new Criterion\Subtree(
@@ -435,38 +455,10 @@ class SearchServiceTest extends BaseTest
                     );
                 },
             ],
-            33 => [
-                [
-                    'filter' => new Criterion\UserMetadata(
-                        Criterion\UserMetadata::MODIFIER,
-                        Criterion\Operator::EQ,
-                        14
-                    ),
-                    'sortClauses' => [
-                        new SortClause\ContentId(),
-                    ],
-                    'limit' => 50,
-                ],
-                $fixtureDir . 'UserMetadata.php',
-            ],
-            34 => [
-                [
-                    'filter' => new Criterion\UserMetadata(
-                        Criterion\UserMetadata::MODIFIER,
-                        Criterion\Operator::IN,
-                        [14]
-                    ),
-                    'sortClauses' => [
-                        new SortClause\ContentId(),
-                    ],
-                    'limit' => 50,
-                ],
-                $fixtureDir . 'UserMetadata.php',
-            ],
             35 => [
                 [
                     'filter' => new Criterion\UserMetadata(
-                        Criterion\UserMetadata::OWNER,
+                        Criterion\UserMetadata::MODIFIER,
                         Criterion\Operator::EQ,
                         14
                     ),
@@ -480,7 +472,7 @@ class SearchServiceTest extends BaseTest
             36 => [
                 [
                     'filter' => new Criterion\UserMetadata(
-                        Criterion\UserMetadata::OWNER,
+                        Criterion\UserMetadata::MODIFIER,
                         Criterion\Operator::IN,
                         [14]
                     ),
@@ -494,9 +486,9 @@ class SearchServiceTest extends BaseTest
             37 => [
                 [
                     'filter' => new Criterion\UserMetadata(
-                        Criterion\UserMetadata::GROUP,
+                        Criterion\UserMetadata::OWNER,
                         Criterion\Operator::EQ,
-                        12
+                        14
                     ),
                     'sortClauses' => [
                         new SortClause\ContentId(),
@@ -508,9 +500,9 @@ class SearchServiceTest extends BaseTest
             38 => [
                 [
                     'filter' => new Criterion\UserMetadata(
-                        Criterion\UserMetadata::GROUP,
+                        Criterion\UserMetadata::OWNER,
                         Criterion\Operator::IN,
-                        [12]
+                        [14]
                     ),
                     'sortClauses' => [
                         new SortClause\ContentId(),
@@ -524,7 +516,7 @@ class SearchServiceTest extends BaseTest
                     'filter' => new Criterion\UserMetadata(
                         Criterion\UserMetadata::GROUP,
                         Criterion\Operator::EQ,
-                        4
+                        12
                     ),
                     'sortClauses' => [
                         new SortClause\ContentId(),
@@ -538,7 +530,7 @@ class SearchServiceTest extends BaseTest
                     'filter' => new Criterion\UserMetadata(
                         Criterion\UserMetadata::GROUP,
                         Criterion\Operator::IN,
-                        [4]
+                        [12]
                     ),
                     'sortClauses' => [
                         new SortClause\ContentId(),
@@ -548,6 +540,34 @@ class SearchServiceTest extends BaseTest
                 $fixtureDir . 'UserMetadata.php',
             ],
             41 => [
+                [
+                    'filter' => new Criterion\UserMetadata(
+                        Criterion\UserMetadata::GROUP,
+                        Criterion\Operator::EQ,
+                        4
+                    ),
+                    'sortClauses' => [
+                        new SortClause\ContentId(),
+                    ],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'UserMetadata.php',
+            ],
+            42 => [
+                [
+                    'filter' => new Criterion\UserMetadata(
+                        Criterion\UserMetadata::GROUP,
+                        Criterion\Operator::IN,
+                        [4]
+                    ),
+                    'sortClauses' => [
+                        new SortClause\ContentId(),
+                    ],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'UserMetadata.php',
+            ],
+            43 => [
                 [
                     'filter' => new Criterion\Ancestor(
                         [

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
@@ -83,6 +83,10 @@ class ContentTypeIdentifier extends CriterionHandler
             }
         }
 
+        if (count($idList) === 0) {
+            return $query->expr->not($query->bindValue('1'));
+        }
+
         return $query->expr->in(
             $this->dbHandler->quoteColumn('contentclass_id', 'ezcontentobject'),
             $idList

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
@@ -13,6 +13,7 @@ use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+eZ\Publish\Core\Persistence\Legacy\Exception\TypeNotFound;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 
 /**
@@ -75,7 +76,11 @@ class ContentTypeIdentifier extends CriterionHandler
         $idList = [];
 
         foreach ($criterion->value as $identifier) {
-            $idList[] = $this->contentTypeHandler->loadByIdentifier($identifier)->id;
+            try {
+                $idList[] = $this->contentTypeHandler->loadByIdentifier($identifier)->id;
+            } catch (TypeNotFound $e) {
+                // Skip non-existing content types
+            }
         }
 
         return $query->expr->in(

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
@@ -15,6 +15,8 @@ use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Content type criterion handler.
@@ -29,18 +31,26 @@ class ContentTypeIdentifier extends CriterionHandler
     protected $contentTypeHandler;
 
     /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $logger;
+
+    /**
      * Construct from handler handler.
      *
      * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     * @param \Psr\Log\LoggerInterface|null $logger
      */
     public function __construct(
         DatabaseHandler $dbHandler,
-        ContentTypeHandler $contentTypeHandler
+        ContentTypeHandler $contentTypeHandler,
+        LoggerInterface $logger = null
     ) {
         parent::__construct($dbHandler);
 
         $this->contentTypeHandler = $contentTypeHandler;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /**
@@ -74,13 +84,24 @@ class ContentTypeIdentifier extends CriterionHandler
         array $languageSettings
     ) {
         $idList = [];
+        $invalidIdentifiers = [];
 
         foreach ($criterion->value as $identifier) {
             try {
                 $idList[] = $this->contentTypeHandler->loadByIdentifier($identifier)->id;
             } catch (NotFoundException $e) {
-                // Skip non-existing content types
+                // Skip non-existing content types, but track for code below
+                $invalidIdentifiers[] = $identifier;
             }
+        }
+
+        if (count($invalidIdentifiers) > 0) {
+            $this->logger->warning(
+                sprintf(
+                    'Invalid content type identifiers provided for ContentTypeIdentifier criterion: %s',
+                    implode(', ', $invalidIdentifiers)
+                )
+            );
         }
 
         if (count($idList) === 0) {

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
-eZ\Publish\Core\Persistence\Legacy\Exception\TypeNotFound;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 
 /**
@@ -78,7 +78,7 @@ class ContentTypeIdentifier extends CriterionHandler
         foreach ($criterion->value as $identifier) {
             try {
                 $idList[] = $this->contentTypeHandler->loadByIdentifier($identifier)->id;
-            } catch (TypeNotFound $e) {
+            } catch (NotFoundException $e) {
                 // Skip non-existing content types
             }
         }

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -112,6 +112,7 @@ services:
         arguments:
             - "@ezpublish.api.storage_engine.legacy.dbhandler"
             - "@ezpublish.spi.persistence.content_type_handler"
+            - "@?logger"
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31127](https://jira.ez.no/browse/EZP-31127)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Makes it possible to use non existent content type identifiers in the criterion (e.g. when coming from an outside DB field, where the content type might be deleted in the meantime).

Otherwise, you'd have to use `ContentTypeId` and load the IDs yourself.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
