### PR TITLE
Removed 2nd parameter on SecurityListener::hasAccess calls

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
@@ -170,7 +170,7 @@ class SecurityListener implements EventSubscriberInterface
             return;
         }
 
-        if (!$this->hasAccess($siteAccess, $originalUser->getUsername())) {
+        if (!$this->hasAccess($siteAccess)) {
             throw new UnauthorizedSiteAccessException($siteAccess, $originalUser->getUsername());
         }
     }
@@ -203,7 +203,7 @@ class SecurityListener implements EventSubscriberInterface
         if (
             // Leave access to login route, so that user can attempt re-authentication.
             $request->attributes->get('_route') !== 'login'
-            && !$this->hasAccess($siteAccess, $token->getUsername())
+            && !$this->hasAccess($siteAccess)
         ) {
             throw new UnauthorizedSiteAccessException($siteAccess, $token->getUsername());
         }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-XXXXX](https://jira.ez.no/browse/EZP-XXXXX)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`

Currently protected function *hasAcces*  is  called twice with unneeded 2nd paramter $username.
(technically not an error - but not intended I guess)


**TODO**:
- [x] Implement feature / fix a bug.
- [ ] ~Implement tests.~
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
