### PR TITLE
EZP-30936: Added option to create content draft in provided Language

### DIFF
--- a/doc/upgrade/7.5.md
+++ b/doc/upgrade/7.5.md
@@ -1,3 +1,8 @@
 # Upgrade steps from 7.4 to 7.5
 
 See `doc/bc/changes-7.5.md` for requirements changes and deprecations.
+
+# Creating content draft
+
+Method `\eZ\Publish\API\Repository\ContentService::createContentDraft` now accepts new language 
+parameter for target language of newly created draft.

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -243,10 +243,16 @@ interface ContentService
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
      * @param \eZ\Publish\API\Repository\Values\User\User $creator Used as creator of the draft if given - otherwise uses current-user
+     * @param \eZ\Publish\API\Repository\Values\Content\Language|null if not set the draft is created with the initialLanguage code of the source version or if not present with the main language.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content - the newly created content draft
      */
-    public function createContentDraft(ContentInfo $contentInfo, VersionInfo $versionInfo = null, User $creator = null);
+    public function createContentDraft(
+        ContentInfo $contentInfo,
+        VersionInfo $versionInfo = null,
+        User $creator = null,
+        ?Language $language = null
+    );
 
     /**
      * Counts drafts for a user.

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -6286,6 +6286,92 @@ XML
         );
     }
 
+    public function testCopyTranslationsFromInvalidPublishedContentToDraft()
+    {
+        $contentTypeService = $this->getRepository()->getContentTypeService();
+
+        // Create content type for testing
+        $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct('test_copy_translation');
+        $contentTypeCreateStruct->mainLanguageCode = 'eng-US';
+        $contentTypeCreateStruct->names = ['eng-US' => 'Test Content Type for Copy Translations'];
+        $fieldDefinition = $contentTypeService->newFieldDefinitionCreateStruct('name', 'ezstring');
+        $fieldDefinition->position = 1;
+        $contentTypeCreateStruct->addFieldDefinition($fieldDefinition);
+        $contentTypeService->publishContentTypeDraft(
+            $contentTypeService->createContentType(
+                $contentTypeCreateStruct,
+                [$contentTypeService->loadContentTypeGroupByIdentifier('Content')]
+            )
+        );
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('test_copy_translation');
+
+        // Create entry content
+        $contentDraft = $this->createContentDraft(
+            'test_copy_translation',
+            $this->generateId('location', 2),
+            [
+                'name' => 'Folder US',
+            ]
+        );
+        $publishedContent = $this->contentService->publishVersion($contentDraft->versionInfo);
+
+        // Create translation draft that would act as an OLD version
+        $deDraft = $this->contentService->createContentDraft($publishedContent->contentInfo);
+        $contentUpdateStruct = new ContentUpdateStruct([
+            'initialLanguageCode' => self::GER_DE,
+            'fields' => $contentDraft->getFields(),
+        ]);
+
+        $contentUpdateStruct->setField('name', 'Folder GER', self::GER_DE);
+        $deContent = $this->contentService->updateContent($deDraft->versionInfo, $contentUpdateStruct);
+
+        // Update published version, as copying is only done when there is a diff between published and draft
+        $gbDraft = $this->contentService->createContentDraft($publishedContent->contentInfo);
+        $contentUpdateStruct = new ContentUpdateStruct([
+            'initialLanguageCode' => self::ENG_US,
+        ]);
+        $contentUpdateStruct->setField('name', 'Folder US 2', self::ENG_US);
+
+        $gbContent = $this->contentService->updateContent($gbDraft->versionInfo, $contentUpdateStruct);
+        $this->contentService->publishVersion($gbContent->versionInfo);
+
+        // Update content type with new required field
+        $contentTypeDraft = $contentTypeService->createContentTypeDraft($contentType);
+        $fieldDefinition = $contentTypeService->newFieldDefinitionCreateStruct('req_field', 'ezstring');
+        $fieldDefinition->position = 2;
+        $fieldDefinition->isRequired = true;
+        $contentTypeService->addFieldDefinition($contentTypeDraft, $fieldDefinition);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+
+        // Reload previous german draft, it is now in invalid state for both ENG_US and GER_DE
+        $invalidContentDraft = $this->contentService->loadContent($deContent->id, null, $deContent->versionInfo->versionNo);
+        $contentUpdateStruct = new ContentUpdateStruct([
+            'initialLanguageCode' => self::GER_DE,
+        ]);
+        $contentUpdateStruct->setField('req_field', 'Required field DE', self::GER_DE);
+
+        $this->contentService->updateContent($invalidContentDraft->versionInfo, $contentUpdateStruct);
+        $this->contentService->publishVersion($invalidContentDraft->versionInfo, [self::GER_DE]);
+
+        $publishedContent = $this->contentService->loadContent($deContent->id, null, $deContent->versionInfo->versionNo);
+
+        $this->assertEquals(
+            [
+                self::GER_DE => 'Folder GER',
+                self::ENG_US => 'Folder US 2',
+            ],
+            $publishedContent->fields['name']
+        );
+        // Missing values were copied from last updated draft
+        $this->assertEquals(
+            [
+                self::GER_DE => 'Required field DE',
+                self::ENG_US => 'Required field DE',
+            ],
+            $publishedContent->fields['req_field']
+        );
+    }
+
     /**
      * Create structure of parent folders with Locations to be used for Content hide/reveal tests.
      *

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -1142,8 +1142,7 @@ class ContentServiceTest extends BaseContentServiceTest
     /**
      * Test for the createContentDraft() method with given language for new draft.
      *
-     * @see \eZ\Publish\API\Repository\ContentService::createContentDraft()
-     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testPublishVersion
+     * @covers \eZ\Publish\API\Repository\ContentService::createContentDraft()
      * @group user
      */
     public function testCreateContentDraftInOtherLanguage()

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -1142,8 +1142,7 @@ class ContentServiceTest extends BaseContentServiceTest
     /**
      * Test for the createContentDraft() method with given language for new draft.
      *
-     * @covers \eZ\Publish\API\Repository\ContentService::createContentDraft()
-     * @group user
+     * @covers \eZ\Publish\API\Repository\ContentService::createContentDraft
      */
     public function testCreateContentDraftInOtherLanguage()
     {

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -1140,6 +1140,31 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
+     * Test for the createContentDraft() method with given language for new draft.
+     *
+     * @see \eZ\Publish\API\Repository\ContentService::createContentDraft()
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testPublishVersion
+     * @group user
+     */
+    public function testCreateContentDraftInOtherLanguage()
+    {
+        $content = $this->createContentVersion1();
+
+        $language = $this->getRepository()->getContentLanguageService()->loadLanguage('eng-GB');
+
+        // Now we create a new draft from the published content
+        $draftedContent = $this->contentService->createContentDraft(
+            $content->contentInfo,
+            null,
+            null,
+            $language
+        );
+
+        $this->assertEquals('eng-US', $content->versionInfo->initialLanguageCode);
+        $this->assertEquals('eng-GB', $draftedContent->versionInfo->initialLanguageCode);
+    }
+
+    /**
      * Test for the createContentDraft() method.
      *
      * Test that editor has access to edit own draft.

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -83,10 +83,10 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
     /**
      * {@inheritdoc}
      */
-    public function createDraftFromVersion($contentId, $srcVersion, $userId)
+    public function createDraftFromVersion($contentId, $srcVersion, $userId, ?string $languageCode = null)
     {
         $this->logger->logCall(__METHOD__, ['content' => $contentId, 'version' => $srcVersion, 'user' => $userId]);
-        $draft = $this->persistenceHandler->contentHandler()->createDraftFromVersion($contentId, $srcVersion, $userId);
+        $draft = $this->persistenceHandler->contentHandler()->createDraftFromVersion($contentId, $srcVersion, $userId, $languageCode);
         $this->cache->invalidateTags(["content-{$contentId}-version-list"]);
 
         return $draft;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -254,10 +254,11 @@ class Handler implements BaseContentHandler
      * @param mixed $contentId
      * @param mixed $srcVersion
      * @param mixed $userId
+     * @param string|null $languageCode
      *
      * @return \eZ\Publish\SPI\Persistence\Content
      */
-    public function createDraftFromVersion($contentId, $srcVersion, $userId)
+    public function createDraftFromVersion($contentId, $srcVersion, $userId, ?string $languageCode = null)
     {
         $content = $this->load($contentId, $srcVersion);
 
@@ -265,7 +266,8 @@ class Handler implements BaseContentHandler
         $content->versionInfo = $this->mapper->createVersionInfoForContent(
             $content,
             $this->contentGateway->getLastVersionNumber($contentId) + 1,
-            $userId
+            $userId,
+            $languageCode
         );
         $content->versionInfo->id = $this->contentGateway->insertVersion(
             $content->versionInfo,

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -127,10 +127,11 @@ class Mapper
      * @param \eZ\Publish\SPI\Persistence\Content $content
      * @param mixed $versionNo
      * @param mixed $userId
+     * @param string|null $languageCode
      *
      * @return \eZ\Publish\SPI\Persistence\Content\VersionInfo
      */
-    public function createVersionInfoForContent(Content $content, $versionNo, $userId)
+    public function createVersionInfoForContent(Content $content, $versionNo, $userId, ?string $languageCode = null)
     {
         $versionInfo = new VersionInfo();
 
@@ -138,7 +139,7 @@ class Mapper
         $versionInfo->versionNo = $versionNo;
         $versionInfo->creatorId = $userId;
         $versionInfo->status = VersionInfo::STATUS_DRAFT;
-        $versionInfo->initialLanguageCode = $content->versionInfo->initialLanguageCode;
+        $versionInfo->initialLanguageCode = $languageCode ?? $content->versionInfo->initialLanguageCode;
         $versionInfo->creationDate = time();
         $versionInfo->modificationDate = $versionInfo->creationDate;
         $versionInfo->names = is_object($content->versionInfo) ? $content->versionInfo->names : [];

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -442,11 +442,16 @@ class ContentService implements APIContentService, Sessionable
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
      * @param \eZ\Publish\API\Repository\Values\User\User $user if set given user is used to create the draft - otherwise the current user is used
+     * @param \eZ\Publish\API\Repository\Values\Content\Language|null if not set the draft is created with the initialLanguage code of the source version or if not present with the main language.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content - the newly created content draft
      */
-    public function createContentDraft(ContentInfo $contentInfo, VersionInfo $versionInfo = null, User $user = null)
-    {
+    public function createContentDraft(
+        ContentInfo $contentInfo,
+        VersionInfo $versionInfo = null,
+        User $creator = null,
+        ?Language $language = null
+    ) {
         throw new \Exception('@todo: Implement.');
     }
 

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1670,7 +1670,7 @@ class ContentService implements ContentServiceInterface
         $updateStruct->initialLanguageCode = $versionInfo->initialLanguageCode;
 
         $contentToPublish = $this->internalLoadContent($contendId, null, $versionInfo->versionNo);
-        $fallback = [];
+        $fallbackUpdateStruct = $this->newContentUpdateStruct();
 
         foreach ($currentContent->getFields() as $field) {
             $fieldDefinition = $contentType->getFieldDefinition($field->fieldDefIdentifier);
@@ -1695,11 +1695,11 @@ class ContentService implements ContentServiceInterface
                 } else {
                     $value = $contentToPublish->getFieldValue($field->fieldDefIdentifier, $versionInfo->initialLanguageCode);
                 }
-                $fallback[] = [
-                    'fieldDefIdentifier' => $field->fieldDefIdentifier,
-                    'value' => $value,
-                    'languageCode' => $field->languageCode,
-                ];
+                $fallbackUpdateStruct->setField(
+                    $field->fieldDefIdentifier,
+                    $value,
+                    $field->languageCode
+                );
                 continue;
             }
 
@@ -1716,8 +1716,8 @@ class ContentService implements ContentServiceInterface
         }
 
         // Do fallback only if content needs to be updated
-        foreach ($fallback as $fallbackStruct) {
-            $updateStruct->setField($fallbackStruct['fieldDefIdentifier'], $fallbackStruct['value'], $fallbackStruct['languageCode']);
+        foreach ($fallbackUpdateStruct->fields as $fallbackField) {
+            $updateStruct->setField($fallbackField->fieldDefIdentifier, $fallbackField->value, $fallbackField->languageCode);
         }
 
         $this->updateContent($versionInfo, $updateStruct);

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1124,8 +1124,8 @@ class ContentService implements ContentServiceInterface
             $creator = $this->repository->getCurrentUserReference();
         }
 
-        $fallbackLanguageCode = $versionInfo ? $versionInfo->initialLanguageCode : $contentInfo->mainLanguageCode;
-        $languageCode = $language ? $language->languageCode : $fallbackLanguageCode;
+        $fallbackLanguageCode = $versionInfo->initialLanguageCode ?? $contentInfo->mainLanguageCode;
+        $languageCode = $language->languageCode ?? $fallbackLanguageCode;
 
         if (!$this->repository->getPermissionResolver()->canUser(
             'content',

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1703,7 +1703,9 @@ class ContentService implements ContentServiceInterface
                 continue;
             }
 
-            if ($fieldType->toHash($newValue) === $fieldType->toHash($field->value)) {
+            if ($newValue !== null
+                && $field->value !== null
+                && $fieldType->toHash($newValue) === $fieldType->toHash($field->value)) {
                 continue;
             }
 

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1669,12 +1669,38 @@ class ContentService implements ContentServiceInterface
         $updateStruct = $this->newContentUpdateStruct();
         $updateStruct->initialLanguageCode = $versionInfo->initialLanguageCode;
 
+        $contentToPublish = $this->internalLoadContent($contendId, null, $versionInfo->versionNo);
         foreach ($currentContent->getFields() as $field) {
             $fieldDefinition = $contentType->getFieldDefinition($field->fieldDefIdentifier);
 
-            if ($fieldDefinition->isTranslatable && in_array($field->languageCode, $languagesToCopy)) {
+            $newValue = $contentToPublish->getFieldValue(
+                $fieldDefinition->identifier,
+                $field->languageCode
+            );
+
+            if ($newValue == $field->value) {
+                continue;
+            }
+
+            $fieldType = $this->fieldTypeRegistry->getFieldType(
+                $fieldDefinition->fieldTypeIdentifier
+            );
+
+            if ($fieldDefinition->isRequired && $fieldType->isEmptyValue($field->value)) {
+                if (!$fieldType->isEmptyValue($fieldDefinition->defaultValue)) {
+                    $updateStruct->setField($field->fieldDefIdentifier, $fieldDefinition->defaultValue, $field->languageCode);
+                }
+                continue;
+            }
+
+            if ($fieldDefinition->isTranslatable && \in_array($field->languageCode, $languagesToCopy)) {
                 $updateStruct->setField($field->fieldDefIdentifier, $field->value, $field->languageCode);
             }
+        }
+
+        // Nothing to copy, skip update
+        if (empty($updateStruct->fields)) {
+            return;
         }
 
         $this->updateContent($versionInfo, $updateStruct);

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1703,7 +1703,7 @@ class ContentService implements ContentServiceInterface
                 continue;
             }
 
-            if ($newValue == $field->value) {
+            if ($fieldType->toHash($newValue) === $fieldType->toHash($field->value)) {
                 continue;
             }
 

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -129,9 +129,13 @@ class ContentService implements ContentServiceInterface
         return $this->service->deleteContent($contentInfo);
     }
 
-    public function createContentDraft(ContentInfo $contentInfo, VersionInfo $versionInfo = null, User $user = null)
-    {
-        return $this->service->createContentDraft($contentInfo, $versionInfo, $user);
+    public function createContentDraft(
+        ContentInfo $contentInfo,
+        VersionInfo $versionInfo = null,
+        User $creator = null,
+        ?Language $language = null
+    ) {
+        return $this->service->createContentDraft($contentInfo, $versionInfo, $creator, $language);
     }
 
     public function countContentDrafts(?User $user = null): int

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
@@ -7,6 +7,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentDraftList;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\RelationList;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
@@ -40,6 +41,7 @@ class ContentServiceTest extends AbstractServiceTest
         $locationCreateStruct = new LocationCreateStruct();
         $user = new User();
         $contentType = new ContentType();
+        $language = new Language();
 
         // string $method, array $arguments, bool $return = true
         return [
@@ -64,6 +66,7 @@ class ContentServiceTest extends AbstractServiceTest
             ['createContentDraft', [$contentInfo]],
             ['createContentDraft', [$contentInfo, $versionInfo]],
             ['createContentDraft', [$contentInfo, $versionInfo, $user]],
+            ['createContentDraft', [$contentInfo, $versionInfo, $user, $language]],
 
             ['countContentDrafts', []],
             ['countContentDrafts', [$user]],

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -341,6 +341,7 @@ class ContentService implements ContentServiceInterface
                     'versionNo' => ($versionInfo !== null ? $versionInfo->versionNo : null),
                     'newVersionNo' => $returnValue->getVersionInfo()->versionNo,
                     'userId' => ($creator !== null ? $creator->id : null),
+                    'languageCode' => $returnValue->getVersionInfo()->initialLanguageCode,
                 ]
             )
         );

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -323,19 +323,24 @@ class ContentService implements ContentServiceInterface
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
      * @param \eZ\Publish\API\Repository\Values\User\User $user if set given user is used to create the draft - otherwise the current user is used
+     * @param \eZ\Publish\API\Repository\Values\Content\Language|null if not set the draft is created with the initialLanguage code of the source version or if not present with the main language.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content - the newly created content draft
      */
-    public function createContentDraft(ContentInfo $contentInfo, VersionInfo $versionInfo = null, User $user = null)
-    {
-        $returnValue = $this->service->createContentDraft($contentInfo, $versionInfo, $user);
+    public function createContentDraft(
+        ContentInfo $contentInfo,
+        VersionInfo $versionInfo = null,
+        User $creator = null,
+        ?Language $language = null
+    ) {
+        $returnValue = $this->service->createContentDraft($contentInfo, $versionInfo, $creator, $language);
         $this->signalDispatcher->emit(
             new CreateContentDraftSignal(
                 [
                     'contentId' => $contentInfo->id,
                     'versionNo' => ($versionInfo !== null ? $versionInfo->versionNo : null),
                     'newVersionNo' => $returnValue->getVersionInfo()->versionNo,
-                    'userId' => ($user !== null ? $user->id : null),
+                    'userId' => ($creator !== null ? $creator->id : null),
                 ]
             )
         );

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -333,20 +333,20 @@ class ContentService implements ContentServiceInterface
         User $creator = null,
         ?Language $language = null
     ) {
-        $returnValue = $this->service->createContentDraft($contentInfo, $versionInfo, $creator, $language);
+        $contentDraft = $this->service->createContentDraft($contentInfo, $versionInfo, $creator, $language);
         $this->signalDispatcher->emit(
             new CreateContentDraftSignal(
                 [
                     'contentId' => $contentInfo->id,
                     'versionNo' => ($versionInfo !== null ? $versionInfo->versionNo : null),
-                    'newVersionNo' => $returnValue->getVersionInfo()->versionNo,
+                    'newVersionNo' => $contentDraft->getVersionInfo()->versionNo,
                     'userId' => ($creator !== null ? $creator->id : null),
-                    'languageCode' => $returnValue->getVersionInfo()->initialLanguageCode,
+                    'languageCode' => $contentDraft->getVersionInfo()->initialLanguageCode,
                 ]
             )
         );
 
-        return $returnValue;
+        return $contentDraft;
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/Signal/ContentService/CreateContentDraftSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/ContentService/CreateContentDraftSignal.php
@@ -43,10 +43,6 @@ class CreateContentDraftSignal extends Signal
      */
     public $newVersionNo;
 
-    /**
-     * Language Code of created draft.
-     *
-     * @var string
-     */
+    /** @var string */
     public $languageCode;
 }

--- a/eZ/Publish/Core/SignalSlot/Signal/ContentService/CreateContentDraftSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/ContentService/CreateContentDraftSignal.php
@@ -42,4 +42,11 @@ class CreateContentDraftSignal extends Signal
      * @var int
      */
     public $newVersionNo;
+
+    /**
+     * Language Code of created draft.
+     *
+     * @var string
+     */
+    public $languageCode;
 }

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
@@ -38,7 +38,7 @@ class ContentServiceTest extends ServiceTest
         $contentId = 42;
         $versionNo = 2;
         $remoteId = md5('One Ring to rule them all');
-        $language = 'fre-FR';
+        $languageCode = 'fre-FR';
         $userId = 14;
         $userVersionNo = 5;
         $copiedContentId = 43;
@@ -62,6 +62,7 @@ class ContentServiceTest extends ServiceTest
         $contentInfo = $this->getContentInfo($contentId, $remoteId);
         $versionInfo = $this->getVersionInfo($contentInfo, $versionNo);
         $content = $this->getContent($versionInfo);
+        $language = $this->getLanguage($languageCode);
 
         $user = $this->getUser($userId, md5('Sauron'), $userVersionNo);
         $usersDraft = [$versionInfo];
@@ -113,25 +114,25 @@ class ContentServiceTest extends ServiceTest
             ],
             [
                 'loadContentByContentInfo',
-                [$contentInfo, [$language], $versionNo, true],
+                [$contentInfo, [$languageCode], $versionNo, true],
                 $content,
                 0,
             ],
             [
                 'loadContentByVersionInfo',
-                [$versionInfo, [$language], true],
+                [$versionInfo, [$languageCode], true],
                 $content,
                 0,
             ],
             [
                 'loadContent',
-                [$contentId, [$language], $versionNo, true],
+                [$contentId, [$languageCode], $versionNo, true],
                 $content,
                 0,
             ],
             [
                 'loadContentByRemoteId',
-                [$remoteId, [$language], $versionNo, true],
+                [$remoteId, [$languageCode], $versionNo, true],
                 $content,
                 0,
             ],
@@ -164,7 +165,7 @@ class ContentServiceTest extends ServiceTest
             ],
             [
                 'createContentDraft',
-                [$contentInfo, $versionInfo, $user],
+                [$contentInfo, $versionInfo, $user, $language],
                 $content,
                 1,
                 ContentServiceSignals\CreateContentDraftSignal::class,
@@ -290,15 +291,15 @@ class ContentServiceTest extends ServiceTest
             ],
             [
                 'deleteTranslation',
-                [$contentInfo, $language],
+                [$contentInfo, $languageCode],
                 null,
                 2,
                 DeleteTranslationSignal::class,
-                ['contentId' => $contentId, 'languageCode' => $language],
+                ['contentId' => $contentId, 'languageCode' => $languageCode],
             ],
             [
                 'newContentCreateStruct',
-                [$contentType, $language],
+                [$contentType, $languageCode],
                 [$contentCreateStruct],
                 0,
             ],

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
@@ -60,7 +60,7 @@ class ContentServiceTest extends ServiceTest
             ]
         );
         $contentInfo = $this->getContentInfo($contentId, $remoteId);
-        $versionInfo = $this->getVersionInfo($contentInfo, $versionNo);
+        $versionInfo = $this->getVersionInfo($contentInfo, $versionNo, $languageCode);
         $content = $this->getContent($versionInfo);
         $language = $this->getLanguage($languageCode);
 
@@ -174,6 +174,7 @@ class ContentServiceTest extends ServiceTest
                     'versionNo' => $versionNo,
                     'newVersionNo' => $content->getVersionInfo()->versionNo,
                     'userId' => $userId,
+                    'languageCode' => $language->languageCode,
                 ],
             ],
             [

--- a/eZ/Publish/Core/SignalSlot/Tests/ServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ServiceTest.php
@@ -200,7 +200,7 @@ abstract class ServiceTest extends TestCase
         );
     }
 
-    protected function getLanguage(string $languageCode)
+    protected function getLanguage(string $languageCode): Language
     {
         return new Language(
             [

--- a/eZ/Publish/Core/SignalSlot/Tests/ServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ServiceTest.php
@@ -122,15 +122,17 @@ abstract class ServiceTest extends TestCase
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
      * @param int $versionNo
+     * @param string|null $languageCode
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo
      */
-    protected function getVersionInfo(ContentInfo $contentInfo, $versionNo)
+    protected function getVersionInfo(ContentInfo $contentInfo, int $versionNo, ?string $languageCode = null): VersionInfo
     {
         return new VersionInfo(
             [
                 'contentInfo' => $contentInfo,
                 'versionNo' => $versionNo,
+                'initialLanguageCode' => $languageCode,
             ]
         );
     }

--- a/eZ/Publish/Core/SignalSlot/Tests/ServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\Core\Repository\Values\User\User;
 use eZ\Publish\Core\Repository\Values\User\UserGroup;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -193,6 +194,15 @@ abstract class ServiceTest extends TestCase
                         $groupVersioNo
                     )
                 ),
+            ]
+        );
+    }
+
+    protected function getLanguage(string $languageCode)
+    {
+        return new Language(
+            [
+                'languageCode' => $languageCode,
             ]
         );
     }

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -43,10 +43,11 @@ interface Handler
      * @param mixed $contentId
      * @param mixed $srcVersion
      * @param mixed $userId
+     * @param string|null $languageCode
      *
      * @return \eZ\Publish\SPI\Persistence\Content
      */
-    public function createDraftFromVersion($contentId, $srcVersion, $userId);
+    public function createDraftFromVersion($contentId, $srcVersion, $userId, ?string $languageCode = null);
 
     /**
      * Returns the raw data of a content object identified by $id, in a struct.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30936](https://jira.ez.no/browse/EZP-30936)
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `7.5` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

As updating content without provided fields still try to fetch and validate them in order to provider proper name for content, most viable solution instead of updating content with only language, is to allow to instantly create draft in wanted language.

usage:
https://github.com/ezsystems/ezplatform-admin-ui/pull/1134

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
