### PR TITLE
[Composer] Added missing ext-dom requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "require": {
         "php": "^7.1",
         "ext-ctype": "*",
+        "ext-dom": "*",
         "ext-fileinfo": "*",
         "ext-intl": "*",
         "ext-json": "*",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Discovered while working on [EZP-30806](https://jira.ez.no/browse/EZP-30806)
| **Bug/Improvement**| yes
| **Target version** | `7.5`, `master (8.0@dev)`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR adds to the `composer.json` `require` section the `ext-dom` extension. 

It's a DX improvement. Static analysis reports it as missing which slightly slows down development when stopping to investigate the highlighted issue. Moreover if composer is used on a system w/o that extension, it will be immediately reported.

## Doc

Seems [requirements page](https://doc.ezplatform.com/en/2.5/getting_started/requirements/#other-supported-setups) is missing information that `dom` extension is required.

## QA

- ~let's check if `composer install` works with `dom` extension disabled right now. Maybe there's other dependency that requires it,~
- ~let's check that `composer install` when requiring this dev branch for `ezpublish-kernel` reports missing dom extension (depends on a result of the previous test).~

**TODO**:
- [x] Add `ext-dom` to `composer.json`.
- [x] Ask for Code Review.
