### PR TITLE
EZP-30769: Registered missing translations commands

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml
@@ -25,3 +25,11 @@ services:
             - '@ezpublish.url_checker'
         tags:
             - { name: console.command }
+
+    JMS\TranslationBundle\Command\ExtractTranslationCommand:
+        tags:
+            - { name: console.command }
+
+    JMS\TranslationBundle\Command\ResourcesListCommand:
+        tags:
+            - { name: console.command }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30769](https://jira.ez.no/browse/EZP-30769)
| **Bug**| yes
| **New feature**    |no
| **Target version** | `master`
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     |no

This PR registers translation commands which are not registered by jms/translation-bundle. This is because we are using behat/bahet in version 3.5.0 which still requires Symfony ClassLoader. It results in that commands are not registered in `JMS/TranslationBundle/DependencyInjection/JMSTranslationExtension.php:36`

```
if (!class_exists('Symfony\Component\ClassLoader\ClassLoader')) {
    $loader->load('console.xml');
}
```


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
