### PR TITLE
Ensure that all services ids used in compiler passes tests are defined

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ChainRoutingPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ChainRoutingPassTest.php
@@ -71,6 +71,9 @@ class ChainRoutingPassTest extends AbstractCompilerPassTestCase
     {
         $defaultRouter = new Definition();
         $this->setDefinition('router.default', $defaultRouter);
+        $this->setDefinition('ezpublish.siteaccess', new Definition());
+        $this->setDefinition('ezpublish.config.resolver', new Definition());
+        $this->setDefinition('ezpublish.siteaccess_router', new Definition());
 
         $resolverDef = new Definition();
         $serviceId = 'some_service_id';

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/FragmentPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/FragmentPassTest.php
@@ -40,6 +40,7 @@ class FragmentPassTest extends AbstractCompilerPassTestCase
         $this->setDefinition('fragment.renderer.esi', $esiRendererDef);
         $this->setDefinition('fragment.renderer.hinclude', $hincludeRendererDef);
         $this->setDefinition('ezpublish.decorated_fragment_renderer', $decoratedFragmentRendererDef);
+        $this->setDefinition('ezpublish.fragment_listener.factory', new Definition());
 
         $this->compile();
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SecurityPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SecurityPassTest.php
@@ -24,6 +24,10 @@ class SecurityPassTest extends AbstractCompilerPassTestCase
         $this->setDefinition('security.authentication.provider.anonymous', new Definition());
         $this->setDefinition('security.http_utils', new Definition());
         $this->setDefinition('security.authentication.success_handler', new Definition());
+        $this->setDefinition('ezpublish.config.resolver', new Definition());
+        $this->setDefinition('ezpublish.siteaccess', new Definition());
+        $this->setDefinition('eZ\Publish\API\Repository\PermissionResolver', new Definition());
+        $this->setDefinition('eZ\Publish\API\Repository\UserService', new Definition());
     }
 
     protected function registerCompilerPass(ContainerBuilder $container): void

--- a/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/Compiler/IOConfigurationPassTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/Compiler/IOConfigurationPassTest.php
@@ -32,6 +32,8 @@ class IOConfigurationPassTest extends AbstractCompilerPassTestCase
 
         $this->container->setDefinition('ezpublish.core.io.binarydata_handler.registry', new Definition());
         $this->container->setDefinition('ezpublish.core.io.metadata_handler.registry', new Definition());
+        $this->container->setDefinition('ezpublish.core.io.binarydata_handler.flysystem.default', new Definition());
+        $this->container->setDefinition('ezpublish.core.io.metadata_handler.flysystem.default', new Definition());
     }
 
     protected function registerCompilerPass(ContainerBuilder $container): void

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/GenericFieldTypeConverterPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/GenericFieldTypeConverterPassTest.php
@@ -26,6 +26,7 @@ class GenericFieldTypeConverterPassTest extends AbstractCompilerPassTestCase
         parent::setUp();
 
         $this->setDefinition(FieldValueConverterRegistryPass::CONVERTER_REGISTRY_SERVICE_ID, new Definition());
+        $this->setDefinition(GenericFieldTypeConverterPass::GENERIC_CONVERTER_SERVICE_ID, new Definition());
     }
 
     protected function registerCompilerPass(ContainerBuilder $container): void


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | -
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     |  yes, except behat (not related)
| **Doc needed**     | no

Ensured that all services ids used in unit tests based on `\Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase` are defined in the Dependency Injection Container (if it's possible)

Otherwise `CheckExceptionOnInvalidReferenceBehaviorPass` introduced in `symfony/dependency-injection` 4.4.0 will throw  an exception:

```
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException : The service "ezpublish.console_event_listener" has a dependency on a non-existent service "event_dispatcher"
```

Ref. https://github.com/symfony/dependency-injection/commit/984abde5dc63c33f4bdb34a6d6e679f97a9f8dee#diff-d1495bbb40eb514ac02928c4dc93f840

Issue discovered in https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/615452469. 

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
