### PR TITLE
EZP-30806: Fixed processing REST logical op. input with list of objects

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ViewTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ViewTest.php
@@ -8,54 +8,104 @@
  */
 namespace eZ\Bundle\EzPublishRestBundle\Tests\Functional;
 
+use stdClass;
+
 class ViewTest extends TestCase
 {
+    /** @var array */
+    private static $createdContentRemoteIds = [];
+
     /**
      * Covers POST /views.
+     *
+     * @dataProvider providerForTestViewRequest
+     *
+     * @param string $body
+     * @param string $format
+     * @param int $expectedResultsCount
+     * @param \stdClass[] $contentDataList list of items containing name and remoteId properties
      */
-    public function testViewRequestWithOrStatement()
+    public function testViewRequest($body, $format, $expectedResultsCount, array $contentDataList)
     {
-        $fooRemoteId = md5('View test content foo');
-        $barRemoteId = md5('View test content bar');
-        $this->createFolder('View test content foo', '/api/ezp/v2/content/locations/1/2', $fooRemoteId);
-        $this->createFolder('View test content bar', '/api/ezp/v2/content/locations/1/2', $barRemoteId);
+        $this->createTestContentItems($contentDataList);
 
-        $request = $this->createHttpRequest('POST', '/api/ezp/v2/views', 'ViewInput+xml', 'View+json');
-        $body = <<< XML
+        // search for Content
+        $request = $this->createHttpRequest(
+            'POST',
+            '/api/ezp/v2/views',
+            "ViewInput+{$format}",
+            'View+json'
+        );
+        $request->setContent($body);
+        $response = $this->sendHttpRequest($request);
+        $responseData = json_decode($response->getContent(), true);
+
+        self::assertEquals($expectedResultsCount, $responseData['View']['Result']['count']);
+    }
+
+    /**
+     * Data provider for testViewRequestWithOrStatement.
+     *
+     * @return array
+     */
+    public function providerForTestViewRequest()
+    {
+        $foo = new stdClass();
+        $foo->name = uniqid('View test content foo');
+        $foo->remoteId = md5($foo->name);
+
+        $bar = new stdClass();
+        $bar->name = uniqid('View test content bar');
+        $bar->remoteId = md5($bar->name);
+
+        return [
+            [
+                <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <ViewInput>
   <identifier>TitleView</identifier>
   <Query>
     <Filter>
         <OR>
-            <ContentRemoteIdCriterion>{$fooRemoteId}</ContentRemoteIdCriterion>
-            <ContentRemoteIdCriterion>{$barRemoteId}</ContentRemoteIdCriterion>
+            <ContentRemoteIdCriterion>{$foo->remoteId}</ContentRemoteIdCriterion>
+            <ContentRemoteIdCriterion>{$bar->remoteId}</ContentRemoteIdCriterion>
         </OR>
     </Filter>
     <limit>10</limit>
     <offset>0</offset>
   </Query>
 </ViewInput>
-XML;
-        $request->setContent($body);
-        $response = $this->sendHttpRequest($request);
-        $responseData = json_decode($response->getContent(), true);
-
-        self::assertEquals(2, $responseData['View']['Result']['count']);
+XML,
+                'xml',
+                2,
+                [$foo, $bar],
+            ],
+            [
+                <<< JSON
+{
+  "ViewInput": {
+    "identifier": "TitleView",
+    "Query": {
+      "Filter": {
+        "OR": {
+          "ContentRemoteIdCriterion": [
+            "{$foo->remoteId}",
+            "{$bar->remoteId}"
+          ]
+        }
+      },
+      "limit": "10",
+      "offset": "0"
     }
-
-    /**
-     * Covers POST /views.
-     *
-     * @depends testViewRequestWithOrStatement
-     */
-    public function testViewRequestWithAndStatement()
-    {
-        $fooRemoteId = md5('View test content foo');
-        $barRemoteId = md5('View test content bar');
-
-        $request = $this->createHttpRequest('POST', '/api/ezp/v2/views', 'ViewInput+xml', 'View+json');
-        $body = <<< XML
+  }
+}
+JSON,
+                'json',
+                2,
+                [$foo, $bar],
+            ],
+            [
+                <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <ViewInput>
   <identifier>TitleView</identifier>
@@ -63,21 +113,41 @@ XML;
     <Filter>
         <AND>
             <OR>
-                <ContentRemoteIdCriterion>{$fooRemoteId}</ContentRemoteIdCriterion>
-                <ContentRemoteIdCriterion>{$barRemoteId}</ContentRemoteIdCriterion>
+                <ContentRemoteIdCriterion>{$foo->remoteId}</ContentRemoteIdCriterion>
+                <ContentRemoteIdCriterion>{$bar->remoteId}</ContentRemoteIdCriterion>
             </OR>
-            <ContentRemoteIdCriterion>{$fooRemoteId}</ContentRemoteIdCriterion>
+            <ContentRemoteIdCriterion>{$foo->remoteId}</ContentRemoteIdCriterion>
         </AND>
     </Filter>
     <limit>10</limit>
     <offset>0</offset>
   </Query>
 </ViewInput>
-XML;
-        $request->setContent($body);
-        $response = $this->sendHttpRequest($request);
-        $responseData = json_decode($response->getContent(), true);
+XML,
+                'xml',
+                1,
+                [$foo, $bar],
+            ],
+        ];
+    }
 
-        self::assertEquals(1, $responseData['View']['Result']['count']);
+    /**
+     * @param \stdClass[] $contentDataList
+     */
+    private function createTestContentItems(array $contentDataList)
+    {
+        foreach ($contentDataList as $contentData) {
+            // skip creating already created items
+            if (in_array($contentData->remoteId, self::$createdContentRemoteIds)) {
+                continue;
+            }
+
+            $this->createFolder(
+                $contentData->name,
+                '/api/ezp/v2/content/locations/1/2',
+                $contentData->remoteId
+            );
+            self::$createdContentRemoteIds[] = $contentData->remoteId;
+        }
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ViewTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ViewTest.php
@@ -12,7 +12,7 @@ use stdClass;
 
 class ViewTest extends TestCase
 {
-    /** @var array */
+    /** @var string[] */
     private static $createdContentRemoteIds = [];
 
     /**

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ViewTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ViewTest.php
@@ -40,6 +40,10 @@ class ViewTest extends TestCase
         $response = $this->sendHttpRequest($request);
         $responseData = json_decode($response->getContent(), true);
 
+        if (isset($responseData['ErrorMessage'])) {
+            self::fail(var_export($responseData, true));
+        }
+
         self::assertEquals($expectedResultsCount, $responseData['View']['Result']['count']);
     }
 
@@ -126,6 +130,35 @@ JSON,
 XML,
                 'xml',
                 1,
+                [$foo, $bar],
+            ],
+            [
+                <<< JSON
+{
+  "ViewInput": {
+    "identifier": "TitleView",
+    "public": true,
+    "Query": {
+      "Filter": {
+        "OR": [
+          {
+            "ContentRemoteIdCriterion": "{$foo->remoteId}"
+          },
+          {
+            "ContentRemoteIdCriterion": "{$bar->remoteId}"
+          }
+        ]
+      },
+      "FacetBuilders": {},
+      "SortClauses": {},
+      "limit": 1000,
+      "offset": 0
+    }
+  }
+}
+JSON,
+                'json',
+                2,
                 [$foo, $bar],
             ],
         ];

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ViewTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ViewTest.php
@@ -161,6 +161,50 @@ JSON,
                 2,
                 [$foo, $bar],
             ],
+            [
+                <<< JSON
+{
+  "ViewInput": {
+    "identifier": "udw-locations-by-parent-location-id-1",
+    "public": false,
+    "Query": {
+      "Criteria": {},
+      "FacetBuilders": {},
+      "SortClauses": {},
+      "Filter": {
+        "AND": [
+          {
+            "OR": [
+              {
+                "ContentTypeIdentifierCriterion": "folder"
+              },
+              {
+                "ContentTypeIdentifierCriterion": "article"
+              }
+            ]
+          },
+          {
+            "OR": [
+              {
+                "ContentRemoteIdCriterion": "{$foo->remoteId}"
+              },
+              {
+                "ContentRemoteIdCriterion": "{$bar->remoteId}"
+              }
+            ]
+          }
+        ]
+      },
+      "limit": 50,
+      "offset": 0
+    }
+  }
+}
+JSON,
+                'json',
+                2,
+                [$foo, $bar],
+            ],
         ];
     }
 

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LogicalOperator.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LogicalOperator.php
@@ -114,10 +114,7 @@ class LogicalOperator extends Criterion
                     $criteriaByType[$criterionType] = [];
                 }
 
-                $criteriaByType[$criterionType] = array_merge(
-                    $criteriaByType[$criterionType],
-                    !is_array($value) ? [$value] : $value
-                );
+                $criteriaByType[$criterionType][] = $value;
             }
         }
 

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LogicalOperator.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LogicalOperator.php
@@ -38,7 +38,16 @@ class LogicalOperator extends Criterion
     protected function getFlattenedCriteriaData(array $criteriaByType)
     {
         if ($this->isZeroBasedArray($criteriaByType)) {
+            $oldFormat = $criteriaByType;
             $criteriaByType = $this->normalizeCriteriaByType($criteriaByType);
+            @trigger_error(
+                sprintf(
+                    'REST View: Passing criteria as a list of objects to a logical operator is deprecated and will cause Bad Request error in eZ Platform 3.0. Instead of "%s" provide "%s"',
+                    json_encode($oldFormat),
+                    json_encode($criteriaByType)
+                ),
+                E_USER_DEPRECATED
+            );
         }
 
         $criteria = [];

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LogicalOperator.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LogicalOperator.php
@@ -37,6 +37,10 @@ class LogicalOperator extends Criterion
      */
     protected function getFlattenedCriteriaData(array $criteriaByType)
     {
+        if ($this->isZeroBasedArray($criteriaByType)) {
+            $criteriaByType = $this->normalizeCriteriaByType($criteriaByType);
+        }
+
         $criteria = [];
         foreach ($criteriaByType as $type => $criterion) {
             if (!is_array($criterion) || !$this->isZeroBasedArray($criterion)) {
@@ -66,5 +70,47 @@ class LogicalOperator extends Criterion
         reset($value);
 
         return empty($value) || key($value) === 0;
+    }
+
+    /**
+     * Normalize list of criteria to be provided as the expected criterion type to its value map.
+     *
+     * Changes:
+     * <code>
+     * [
+     *  0 => "CriterionType1" => "<value1>",
+     *  1 => "CriterionType1" => "<value2>",
+     *  2 => "CriterionType2" => "<value3>",
+     * ]
+     * </code>
+     * into:
+     * <code>
+     * [
+     *  "CriterionType1" => ["<value1>", "<value2>"],
+     *  "CriterionType2" => ["<value3>"],
+     * ]
+     * </code>
+     *
+     * @param array $criterionList zero-based list of criteria
+     *
+     * @return array map of criterion types to their values
+     */
+    private function normalizeCriteriaByType(array $criterionList)
+    {
+        $criteriaByType = [];
+        foreach ($criterionList as $criterion) {
+            foreach ($criterion as $criterionType => $value) {
+                if (!isset($criteriaByType[$criterionType])) {
+                    $criteriaByType[$criterionType] = [];
+                }
+
+                $criteriaByType[$criterionType] = array_merge(
+                    $criteriaByType[$criterionType],
+                    !is_array($value) ? [$value] : $value
+                );
+            }
+        }
+
+        return $criteriaByType;
     }
 }

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LogicalOperator.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LogicalOperator.php
@@ -42,7 +42,8 @@ class LogicalOperator extends Criterion
             $criteriaByType = $this->normalizeCriteriaByType($criteriaByType);
             @trigger_error(
                 sprintf(
-                    'REST View: Passing criteria as a list of objects to a logical operator is deprecated and will cause Bad Request error in eZ Platform 3.0. Instead of "%s" provide "%s"',
+                    'REST View: Passing criteria as a list of objects to a logical operator is deprecated ' .
+                    'and will cause Bad Request error in eZ Platform 3.0. Instead of "%s" provide "%s"',
                     json_encode($oldFormat),
                     json_encode($criteriaByType)
                 ),

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/BaseTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/BaseTest.php
@@ -120,7 +120,7 @@ abstract class BaseTest extends ParentBaseTest
     /**
      * Must return the tested parser object.
      *
-     * @return \eZ\Publish\Core\REST\Server\Input\Parser\Base
+     * @return \eZ\Publish\Core\REST\Common\Input\Parser
      */
     abstract protected function internalGetParser();
 }

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Criterion/LogicalAndTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Criterion/LogicalAndTest.php
@@ -1,33 +1,30 @@
 <?php
 
 /**
- * File containing a test class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\REST\Common\Input\Parser as InputParser;
+use eZ\Publish\Core\REST\Common\Exceptions\Parser as ParserException;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Server\Input\Parser;
-use eZ\Publish\Core\REST\Server\Tests\Input\Parser\BaseTest;
 
-class LogicalAndTest extends BaseTest
+class LogicalAndTest extends LogicalOperatorTestCase
 {
     /**
-     * Logical parsing of AND statement.
+     * Data provider for LogicalOr::parse test.
      *
-     * @dataProvider getPayloads
+     * @see testParse
      *
      * Notice regarding multiple criteria of same type:
      *
-     * The XML decoder of EZ is not creating numeric arrays, instead using the tag as the array key. See
-     * variable $logicalAndParsedFromXml. This causes the ContentTypeIdentifierCriterion-Tag to appear as one-element
-     * (type numeric array) and two criteria configuration inside. The logical or parser will take care
-     * of this and return a flatt LogicalAnd criterion with 3 criteria inside.
+     * The XML decoder of eZ is not creating numeric arrays, instead using the tag as the array key.
+     * This causes the ContentTypeIdentifierCriterion Tag to appear as one-element
+     * (type numeric array) and two criteria configuration inside. The logical AND parser will take
+     * care of this and return a flat LogicalAnd criterion with 3 criteria inside for the following
+     * payload:
      *
      * ```
      * <AND>
@@ -40,38 +37,6 @@ class LogicalAndTest extends BaseTest
      *   </Field>
      * </AND>
      * ```
-     * @param $expectedNumberOfCriteria
-     * @param array $payload
-     */
-    public function testParseLogicalAnd($payload, $expectedNumberOfCriteria)
-    {
-        $criterionMock = $this->createMock(Criterion::class);
-
-        $parserMock = $this->createMock(InputParser::class);
-        $parserMock->method('parse')->willReturn($criterionMock);
-
-        $result = $this->internalGetParser()->parse(
-            $payload,
-            new ParsingDispatcher(
-                [
-                    'application/vnd.ez.api.internal.criterion.ContentTypeIdentifier' => $parserMock,
-                    'application/vnd.ez.api.internal.criterion.Field' => $parserMock,
-                    // to test parsing nested combined logical criteria
-                    'application/vnd.ez.api.internal.criterion.LogicalOr' => new Parser\Criterion\LogicalOr(),
-                ]
-            )
-        );
-
-        self::assertInstanceOf(Content\Query\Criterion\LogicalAnd::class, $result);
-        self::assertCount($expectedNumberOfCriteria, (array)$result->criteria);
-    }
-
-    /**
-     * Data provider for testParseLogicalAnd.
-     *
-     * @see testParseLogicalAnd
-     *
-     * @return array
      */
     public function getPayloads()
     {
@@ -143,19 +108,22 @@ class LogicalAndTest extends BaseTest
         ];
     }
 
-    /**
-     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
-     */
     public function testThrowsExceptionOnInvalidAndStatement()
     {
+        $this->expectException(ParserException::class);
         $this->internalGetParser()->parse(['AND' => 'Should be an array'], new ParsingDispatcher());
     }
 
     /**
-     * @return Parser\Criterion\LogicalAnd
+     * @return \eZ\Publish\Core\REST\Server\Input\Parser\Criterion\LogicalAnd
      */
     protected function internalGetParser()
     {
         return new Parser\Criterion\LogicalAnd();
+    }
+
+    protected function getCriterionClass()
+    {
+        return Content\Query\Criterion\LogicalAnd::class;
     }
 }

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Criterion/LogicalAndTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Criterion/LogicalAndTest.php
@@ -56,6 +56,8 @@ class LogicalAndTest extends BaseTest
                 [
                     'application/vnd.ez.api.internal.criterion.ContentTypeIdentifier' => $parserMock,
                     'application/vnd.ez.api.internal.criterion.Field' => $parserMock,
+                    // to test parsing nested combined logical criteria
+                    'application/vnd.ez.api.internal.criterion.LogicalOr' => new Parser\Criterion\LogicalOr(),
                 ]
             )
         );
@@ -89,6 +91,54 @@ class LogicalAndTest extends BaseTest
                     ],
                 ],
                 3,
+            ],
+            'Combined AND with nested OR Criterion' => [
+                [
+                    'AND' => [
+                        [
+                            'OR' => [
+                                'ContentTypeIdentifierCriterion' => [
+                                    'article',
+                                    'folder',
+                                ],
+                            ],
+                        ],
+                        [
+                            'OR' => [
+                                'ContentTypeIdentifierCriterion' => [
+                                    'forum',
+                                    'board',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                2,
+            ],
+            'Combined AND with nested OR Criterion using old format' => [
+                [
+                    'AND' => [
+                        [
+                            'OR' => [
+                                [
+                                    'ContentTypeIdentifierCriterion' => [
+                                        'article',
+                                        'folder',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'OR' => [
+                                'ContentTypeIdentifierCriterion' => [
+                                    'forum',
+                                    'board',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                2,
             ],
         ];
     }

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Criterion/LogicalOperatorTestCase.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Criterion/LogicalOperatorTestCase.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\REST\Common\Input\Parser as InputParser;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Server\Input\Parser;
+use eZ\Publish\Core\REST\Server\Tests\Input\Parser\BaseTest;
+use PHPUnit_Framework_MockObject_MockObject;
+
+/**
+ * @internal for internal use by tests
+ */
+abstract class LogicalOperatorTestCase extends BaseTest
+{
+    /**
+     * Data provider for testParse.
+     *
+     * @see testParse
+     *
+     * @return array data sets
+     */
+    abstract public function getPayloads();
+
+    /**
+     * @return string
+     */
+    abstract protected function getCriterionClass();
+
+    /**
+     * @covers \eZ\Publish\Core\REST\Server\Input\Parser\Criterion\LogicalOperator::parse
+     *
+     * @dataProvider getPayloads
+     *
+     * @param array $payload
+     * @param int $expectedNumberOfCriteria
+     */
+    public function testParse($payload, $expectedNumberOfCriteria)
+    {
+        $criterionMock = $this->createMock(Criterion::class);
+
+        $parserMock = $this->createMock(InputParser::class);
+        $parserMock->method('parse')->willReturn($criterionMock);
+
+        $result = $this->internalGetParser()->parse(
+            $payload,
+            $this->buildParsingDispatcher($parserMock)
+        );
+
+        self::assertInstanceOf($this->getCriterionClass(), $result);
+        self::assertCount($expectedNumberOfCriteria, (array)$result->criteria);
+    }
+
+    /**
+     * @return \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher
+     */
+    protected function buildParsingDispatcher(PHPUnit_Framework_MockObject_MockObject $parserMock)
+    {
+        return new ParsingDispatcher(
+            [
+                // to test parsing nested combined logical criteria
+                'application/vnd.ez.api.internal.criterion.LogicalOr' => new Parser\Criterion\LogicalOr(),
+                'application/vnd.ez.api.internal.criterion.LogicalAnd' => new Parser\Criterion\LogicalAnd(),
+                'application/vnd.ez.api.internal.criterion.ContentTypeIdentifier' => $parserMock,
+                'application/vnd.ez.api.internal.criterion.ContentRemoteId' => new Parser\Criterion\ContentRemoteId(),
+                'application/vnd.ez.api.internal.criterion.Field' => $parserMock,
+            ]
+        );
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Criterion/LogicalOrTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Criterion/LogicalOrTest.php
@@ -1,31 +1,29 @@
 <?php
 
 /**
- * File containing a test class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content;
+use eZ\Publish\Core\REST\Common\Exceptions\Parser as ParserException;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Server\Input\Parser;
-use eZ\Publish\Core\REST\Server\Tests\Input\Parser\BaseTest;
 
-class LogicalOrTest extends BaseTest
+class LogicalOrTest extends LogicalOperatorTestCase
 {
     /**
-     * Test parsing of OR statement.
+     * Data provider for LogicalOr::parse test.
      *
-     * @dataProvider getPayloads
+     * @see testParse
      *
      * Notice regarding multiple criteria of same type:
      *
-     * The XML decoder of EZ is not creating numeric arrays, instead using the tag as the array key. See
-     * variable $logicalOrParsedFromXml. This causes the Field Tag to appear as one-element
-     * (type numeric array) and two criteria configuration inside. The logical or parser will take care
-     * of this and return a flatt LogicalOr criterion with 4 criteria inside.
+     * The XML decoder of eZ is not creating numeric arrays, instead using the tag as the array key.
+     * This causes the Field Tag to appear as one-element (type numeric array) and two criteria
+     * configuration inside. The logical OR parser will take care of this and return a flat
+     * LogicalOr criterion with 4 criteria inside for the following payload:
      *
      * ```
      * <OR>
@@ -43,27 +41,7 @@ class LogicalOrTest extends BaseTest
      *   </Field>
      * </OR>
      * ```
-     *
-     * @param array $payload
-     * @param int $expectedNumberOfCriteria
      */
-    public function testParseLogicalOr($payload, $expectedNumberOfCriteria)
-    {
-        $criterionMock = $this->createMock(Content\Query\Criterion::class);
-
-        $parserMock = $this->createMock(\eZ\Publish\Core\REST\Common\Input\Parser::class);
-        $parserMock->method('parse')->willReturn($criterionMock);
-
-        $result = $this->internalGetParser()->parse($payload, new ParsingDispatcher([
-            'application/vnd.ez.api.internal.criterion.ContentTypeIdentifier' => $parserMock,
-            'application/vnd.ez.api.internal.criterion.Field' => $parserMock,
-            'application/vnd.ez.api.internal.criterion.ContentRemoteId' => new Parser\Criterion\ContentRemoteId(),
-        ]));
-
-        self::assertInstanceOf(Content\Query\Criterion\LogicalOr::class, $result);
-        self::assertCount($expectedNumberOfCriteria, (array)$result->criteria);
-    }
-
     public function getPayloads()
     {
         return [
@@ -106,19 +84,22 @@ class LogicalOrTest extends BaseTest
         ];
     }
 
-    /**
-     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
-     */
     public function testThrowsExceptionOnInvalidAndStatement()
     {
+        $this->expectException(ParserException::class);
         $this->internalGetParser()->parse(['OR' => 'Wrong type'], new ParsingDispatcher());
     }
 
     /**
-     * @return Parser\Criterion\LogicalOr
+     * @return \eZ\Publish\Core\REST\Server\Input\Parser\Criterion\LogicalOr
      */
     protected function internalGetParser()
     {
         return new Parser\Criterion\LogicalOr();
+    }
+
+    protected function getCriterionClass()
+    {
+        return Content\Query\Criterion\LogicalOr::class;
     }
 }

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Criterion/LogicalOrTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Criterion/LogicalOrTest.php
@@ -57,7 +57,7 @@ class LogicalOrTest extends BaseTest
         $result = $this->internalGetParser()->parse($payload, new ParsingDispatcher([
             'application/vnd.ez.api.internal.criterion.ContentTypeIdentifier' => $parserMock,
             'application/vnd.ez.api.internal.criterion.Field' => $parserMock,
-            'application/vnd.ez.api.internal.criterion.ContentRemoteIdCriterion' => $parserMock,
+            'application/vnd.ez.api.internal.criterion.ContentRemoteId' => new Parser\Criterion\ContentRemoteId(),
         ]));
 
         self::assertInstanceOf(Content\Query\Criterion\LogicalOr::class, $result);
@@ -89,6 +89,19 @@ class LogicalOrTest extends BaseTest
                     ],
                 ],
                 4,
+            ],
+            'Simple OR with ContentRemoteIdCriterion' => [
+                [
+                    'OR' => [
+                        [
+                            'ContentRemoteIdCriterion' => 'remote_id1',
+                        ],
+                        [
+                            'ContentRemoteIdCriterion' => 'remote_id2',
+                        ],
+                    ],
+                ],
+                2,
             ],
         ];
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30806](https://jira.ez.no/browse/EZP-30806)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`, `7.5` (#2886), `master (8.0@dev)`
| **BC breaks**      | no
| **Tests pass**     | [yes](https://travis-ci.org/ezsystems/ezpublish-kernel/builds/617188988)
| **Doc needed**     | #2879

### TL;DR;

See 879d769 for the fix and df4b6f9 for deprecation.

### Summary
This PR fixes a regression introduced via #2527 for the following REST view payload:
``` json
{
  "ViewInput": {
    "identifier": "test",
    "public": true,
    "LocationQuery": {
      "Filter": {
        "OR": [
          {
            "ContentTypeIdentifierCriterion": "folder"
          },
          {
            "ContentTypeIdentifierCriterion": "article"
          }
        ]
      },
      "FacetBuilders": {},
      "SortClauses": {},
      "limit": 1000,
      "offset": 0
    }
  }
}
```

Please note that using this format is not recommended. It wasn't discovered when testing #2879 because the proper way to query Content using multiple Criteria of the same type is:
```  json
{
  "ViewInput": {
    "identifier": "test",
    "ContentQuery": {
      "Filter": {
          "OR": {
            "ContentTypeIdentifierCriterion": [
              "folder",
              "article"
            ]
          }
      },
      "limit": "1000",
      "offset": "0",
      "SortClauses": {}
    }
  }
}
```

It is so because this is the way the following XML is directly transformed to the above JSON:
``` xml
<?xml version="1.0" encoding="UTF-8" ?>
<ViewInput>
  <identifier>test</identifier>
  <ContentQuery>
    <Filter>
      <OR>
        <ContentTypeIdentifierCriterion>folder</ContentTypeIdentifierCriterion>
        <ContentTypeIdentifierCriterion>article</ContentTypeIdentifierCriterion>
      </OR>
    </Filter>
    <limit>1000</limit>
    <offset>0</offset>
    <SortClauses />
  </ContentQuery>
</ViewInput>
```

The JSON payload which resulted in an error would be transformed to XML as:
``` xml
<?xml version="1.0" encoding="UTF-8" ?>
	<ViewInput>
		<identifier>test</identifier>
		<public>true</public>
		<LocationQuery>
			<Filter>
				<OR>
					<ContentTypeIdentifierCriterion>folder</ContentTypeIdentifierCriterion>
				</OR>
				<OR>
					<ContentTypeIdentifierCriterion>article</ContentTypeIdentifierCriterion>
				</OR>
			</Filter>
			<FacetBuilders />
			<SortClauses />
			<limit>1000</limit>
			<offset>0</offset>
		</LocationQuery>
	</ViewInput>
```

which doesn't make much sense, though it works.

Therefore the above way of providing payload has been deprecated and will cause Bad Request HTTP error in eZ Platform 3.0.

### QA

- [ ] Check that regression is gone.
- [ ] Check that deprecation message is logged in application logs when using the payload which causes issues.
- [ ] Test various combinations of logical operators.

**TODO**:
- [x] Create PR with changes for `7.5` and up (#2886)
- [x] Fix failing tests (https://travis-ci.org/ezsystems/ezpublish-kernel/builds/617188988).
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
