### PR TITLE
EZP-31125: Added TranslatedName to Content/ContentInfo in REST response

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -297,6 +297,7 @@ XML Example
                     <Content media-type="application/vnd.ez.api.ContentInfo+xml" href="/api/ezp/v2/content/objects/1" remoteId="9459d3c29e15006e45197295722c7ade" id="1">
                         <ContentType media-type="application/vnd.ez.api.ContentType+xml" href="/api/ezp/v2/content/types/1"/>
                         <Name>eZ Platform</Name>
+                        <TranslatedName>eZ Platform</TranslatedName>
                         <Versions media-type="application/vnd.ez.api.VersionList+xml" href="/api/ezp/v2/content/objects/1/versions"/>
                         <CurrentVersion media-type="application/vnd.ez.api.Version+xml" href="/api/ezp/v2/content/objects/1/currentversion"/>
                         <Section media-type="application/vnd.ez.api.Section+xml" href="/api/ezp/v2/content/sections/1"/>
@@ -372,6 +373,7 @@ JSON Example
                                     "_href": "/api/ezp/v2/content/types/1"
                                 },
                                 "Name": "eZ Platform",
+                                "TranslatedName": "eZ Platform",
                                 "Versions": {
                                     "_media-type": "application/vnd.ez.api.VersionList+json",
                                     "_href": "/api/ezp/v2/content/objects/1/versions"
@@ -825,6 +827,7 @@ XML Example
       media-type="application/vnd.ez.api.Content+xml" remoteId="remoteId12345678" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <ContentType href="/content/types/10" media-type="application/vnd.ez.api.ContentType+xml" />
       <Name>This is a title</Name>
+      <TranslatedName>This is a title</TranslatedName>
       <Versions href="/content/objects/23/versions" media-type="application/vnd.ez.api.VersionList+xml" />
       <CurrentVersion href="/content/objects/23/currentversion"
         media-type="application/vnd.ez.api.Version+xml">
@@ -1129,6 +1132,7 @@ XML Example
       media-type="application/vnd.ez.api.Content+xml" remoteId="qwert123">
       <ContentType href="/content/types/10" media-type="application/vnd.ez.api.ContentType+xml" />
       <Name>This is a title</Name>
+      <TranslatedName>This is a title</TranslatedName>
       <Versions href="/content/objects/23/versions" media-type="application/vnd.ez.api.VersionList+xml" />
       <CurrentVersion href="/content/objects/23/currentversion"
         media-type="application/vnd.ez.api.Version+xml"/>
@@ -1226,6 +1230,7 @@ In this example
       media-type="application/vnd.ez.api.Content+xml" remoteId="qwert4321">
       <ContentType href="/content/types/10" media-type="application/vnd.ez.api.ContentType+xml" />
       <Name>This is a title</Name>
+      <TranslatedName>This is a title</TranslatedName>
       <Versions href="/content/objects/23/versions" media-type="application/vnd.ez.api.VersionList+xml" />
       <CurrentVersion href="/content/objects/23/currentversion"
         media-type="application/vnd.ez.api.Version+xml"/>

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -311,12 +311,14 @@ services:
     ezpublish_rest.output.value_object_visitor.RestContent:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestContent.class%"
+        arguments: ['@ezpublish.translation_helper']
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\RestContent }
 
     ezpublish_rest.output.value_object_visitor.CreatedContent:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedContent.class%"
+        arguments: ['@ezpublish.translation_helper']
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\CreatedContent }
 

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
@@ -40,7 +40,7 @@ class RestContent extends ValueObjectVisitor
     {
         $restContent = $data;
         $contentInfo = $restContent->contentInfo;
-        $contentName = $this->translationHelper->getTranslatedContentNameByContentInfo($contentInfo);
+        $translatedContentName = $this->translationHelper->getTranslatedContentNameByContentInfo($contentInfo);
         $contentType = $restContent->contentType;
         $mainLocation = $restContent->mainLocation;
         $currentVersion = $restContent->currentVersion;
@@ -79,7 +79,7 @@ class RestContent extends ValueObjectVisitor
         $generator->startValueElement('Name', $contentInfo->name);
         $generator->endValueElement('Name');
 
-        $generator->startValueElement('TranslatedName', $contentName);
+        $generator->startValueElement('TranslatedName', $translatedContentName);
         $generator->endValueElement('TranslatedName');
 
         $generator->startObjectElement('Versions', 'VersionList');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\Base\Exceptions\BadStateException as CoreBadStateException;
+use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
@@ -20,6 +21,14 @@ use eZ\Publish\Core\REST\Server\Values\Version as VersionValue;
  */
 class RestContent extends ValueObjectVisitor
 {
+    /** @var \eZ\Publish\Core\Helper\TranslationHelper */
+    private $translationHelper;
+
+    public function __construct(TranslationHelper $translationHelper)
+    {
+        $this->translationHelper = $translationHelper;
+    }
+
     /**
      * Visit struct returned by controllers.
      *
@@ -31,6 +40,7 @@ class RestContent extends ValueObjectVisitor
     {
         $restContent = $data;
         $contentInfo = $restContent->contentInfo;
+        $contentName = $this->translationHelper->getTranslatedContentNameByContentInfo($contentInfo);
         $contentType = $restContent->contentType;
         $mainLocation = $restContent->mainLocation;
         $currentVersion = $restContent->currentVersion;
@@ -68,6 +78,9 @@ class RestContent extends ValueObjectVisitor
 
         $generator->startValueElement('Name', $contentInfo->name);
         $generator->endValueElement('Name');
+
+        $generator->startValueElement('TranslatedName', $contentName);
+        $generator->endValueElement('TranslatedName');
 
         $generator->startObjectElement('Versions', 'VersionList');
         $generator->startAttribute(


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31125](https://jira.ez.no/browse/EZP-31125)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.x`
| **BC breaks**      | no
| **Tests pass**     | ?
| **Doc needed**     | no

Added `TranslatedName` property to Content/ContentInfo in REST response which contains content name translated according to current site access setting.

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Update REST specification (https://github.com/ezsystems/ezpublish-kernel/pull/2885/commits/efeb80456a432fa7536967669b72727c9ad80650)
- [x] Mirror PR in https://github.com/ezsystems/ezplatform-rest (https://github.com/ezsystems/ezplatform-rest/pull/29)
- [x] Ask for Code Review.
