### PR TITLE
Fixed Query Controller tests

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/query_controller.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/query_controller.feature
@@ -92,7 +92,7 @@ Scenario: A content view can be configured to run and render a query and return 
       }
       """
     When I view a content matched by the view configuration above
-    Then the Query results assigned to the "children" twig variable is a "Pagerfanta" object
+    Then the Query results assigned to the "children" twig variable is a "Pagerfanta\Pagerfanta" object
 
 Scenario: A content view can be configured to run and render a query return a PagerFanta Object and set limit and page name
     Given a content item that matches the view configuration block below


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| no
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Requires: https://github.com/ezsystems/BehatBundle/pull/114

After Symfony 4.4.0 release the Query Controller tests stopped passing, because the `dump` HTML output has changed. This PR changes the dependency from Symfony's `{{ dump }} ` function to something that is completely in our control.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [ ] *BEFORE MERGE*: Remove TMP commit
