### PR TITLE
Added missing dependency on symfony/security-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "symfony/translation": "^4.3",
         "symfony/yaml": "^4.3",
         "symfony/security": "^4.3",
+        "symfony/security-bundle": "^4.3",
         "symfony/serializer": "^4.3",
         "symfony/http-kernel": "^4.3",
         "symfony/console": "^4.3",


### PR DESCRIPTION
Added missing dependency coming from
https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php#L93

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
