### PR TITLE
EZP-31203: Fixed always using default connection for install Command

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -19,7 +19,7 @@ services:
     ezplatform.installer.install_command:
         class: "%ezplatform.installer.install_command.class%"
         arguments:
-            - "@database_connection"
+            - '@ezpublish.persistence.connection'
             - []
             - '@ezpublish.cache_pool'
             - "%kernel.environment%"


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31203](https://jira.ez.no/browse/EZP-31203)
| **Bug**| yes
| **Target version** | `6.13`/`7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR fixes the wrong connection being used with `ezplatform:install` command.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
