### PR TITLE
EZP-31203 (7.5) - In Multirepository setup Installer always use a default Database connection for checking if the database exists

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -9,6 +9,7 @@
 namespace EzSystems\PlatformInstallerBundle\Command;
 
 use Doctrine\DBAL\Connection;
+use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -36,21 +37,28 @@ class InstallPlatformCommand extends Command
     /** @var \EzSystems\PlatformInstallerBundle\Installer\Installer[] */
     private $installers = [];
 
+    /** @var \eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider */
+    private $repositoryConfigurationProvider;
+
     const EXIT_GENERAL_DATABASE_ERROR = 4;
     const EXIT_PARAMETERS_NOT_FOUND = 5;
     const EXIT_UNKNOWN_INSTALL_TYPE = 6;
     const EXIT_MISSING_PERMISSIONS = 7;
+    const REPOSITORY_STORAGE = 'storage';
+    const REPOSITORY_CONNECTION = 'connection';
 
     public function __construct(
         Connection $db,
         array $installers,
         CacheItemPoolInterface $cachePool,
-        $environment
+        $environment,
+        RepositoryConfigurationProvider $repositoryConfigurationProvider
     ) {
         $this->db = $db;
         $this->installers = $installers;
         $this->cachePool = $cachePool;
         $this->environment = $environment;
+        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
         parent::__construct();
     }
 
@@ -126,7 +134,10 @@ class InstallPlatformCommand extends Command
         );
         try {
             $bufferedOutput = new BufferedOutput();
-            $this->executeCommand($bufferedOutput, 'doctrine:database:create --if-not-exists');
+            $repositoryConfig = $this->repositoryConfigurationProvider->getRepositoryConfig();
+            $connectionName = $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION];
+            $command = sprintf('doctrine:database:create --if-not-exists --connection=%s', $connectionName);
+            $this->executeCommand($bufferedOutput, $command);
             $output->writeln($bufferedOutput->fetch());
         } catch (\RuntimeException $exception) {
             $this->output->writeln(

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -34,9 +34,10 @@ services:
     ezplatform.installer.install_command:
         class: "%ezplatform.installer.install_command.class%"
         arguments:
-            - "@database_connection"
+            - '@ezpublish.persistence.connection'
             - []
             - '@ezpublish.cache_pool'
             - "%kernel.environment%"
+            - '@ezpublish.api.repository_configuration_provider'
         tags:
             - { name: console.command, command: ezplatform:install }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31203](https://jira.ez.no/browse/EZP-31203)
| **Bug**| yes
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR fixes the wrong connection being used with `ezplatform:install` command.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
