### PR TITLE
EZEE-2876: Fixed invalid list order being returned by AbstractInMemoryHandler

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -655,6 +655,30 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
+     * Test for the loadLocationList() method.
+     *
+     * Ensures the list is returned in the same order as passed IDs array.
+     *
+     * @covers \eZ\Publish\API\Repository\LocationService::loadLocationList
+     */
+    public function testLoadLocationListInCorrectOrder()
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $cachedLocationId = 2;
+        $locationIdsToLoad = [43, $cachedLocationId, 5];
+
+        // Call loadLocation to cache it in memory as it might possibly affect list order
+        $locationService->loadLocation($cachedLocationId);
+
+        $locations = $locationService->loadLocationList($locationIdsToLoad);
+        $locationIds = array_column($locations, 'id');
+
+        self::assertEquals($locationIdsToLoad, $locationIds);
+    }
+
+    /**
      * Test for the loadLocationByRemoteId() method.
      *
      * @see \eZ\Publish\API\Repository\LocationService::loadLocationByRemoteId()

--- a/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
@@ -206,7 +206,7 @@ abstract class AbstractInMemoryHandler
         }
 
         // Generate unique cache keys and check if in-memory
-        $list = [];
+        $list = array_flip($ids);
         $cacheKeys = [];
         $cacheKeysToIdMap = [];
         foreach (array_unique($ids) as $id) {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-2876](https://jira.ez.no/browse/EZEE-2876)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.5` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

When loading multiple values from In Memory cache, results might come in different order. This is caused by implementation of `\eZ\Publish\Core\Persistence\Cache\AbstractInMemoryHandler::getMultipleCacheValues` which first gets elements from InMemory cache (hits) and appends cache misses to the end of the list. This affects results of `LocationService::loadLocationList` which should always return the results in particular order.

The fix is actually simple, instead of preparing empty `$list` array, use array which has `$ids` as indexes, making `$list[$id] = ...;` operations not append but actually replace elements. All invalid elements are `unset()` before returning list. 


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests. 
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
