### PR TITLE
Typo in rest-api-v2.rst

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -2704,7 +2704,7 @@ The above example has the following JSON equivalent.
     }
 
 Note that the structure for ContentTypeIdentifierCriterion with multiple values is slightly
-different in JSON format, because the parser excepts keys to be unique.
+different in JSON format, because the parser expects keys to be unique.
 
 List views
 ``````````


### PR DESCRIPTION
Correcting typo in `rest-api-v2.rst`.
