### PR TITLE
EZP-31203 (1.13): Fixed always using default connection for install Command

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -166,9 +166,9 @@ class InstallPlatformCommand extends Command
      * IMPORTANT: This is done using a command because config has change, so container and all services are different.
      *
      * @param OutputInterface $output
-     * @param null|string $siteaccess
+     * @param string|null $siteaccess
      */
-    private function indexData(OutputInterface $output, string $siteaccess = null)
+    private function indexData(OutputInterface $output, $siteaccess = null)
     {
         $output->writeln(
             sprintf('Search engine re-indexing, executing command ezplatform:reindex')

--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -72,6 +72,7 @@ class InstallPlatformCommand extends Command
         $this->checkDatabase();
 
         $type = $input->getArgument('type');
+        $siteaccess = $input->getOption('siteaccess');
         $installer = $this->getInstaller($type);
         if ($installer === false) {
             $output->writeln(
@@ -87,7 +88,7 @@ class InstallPlatformCommand extends Command
         $installer->importData();
         $installer->importBinaries();
         $this->cacheClear($output);
-        $this->indexData($output);
+        $this->indexData($output, $siteaccess);
     }
 
     private function checkPermissions()
@@ -165,13 +166,20 @@ class InstallPlatformCommand extends Command
      * IMPORTANT: This is done using a command because config has change, so container and all services are different.
      *
      * @param OutputInterface $output
+     * @param null|string $siteaccess
      */
-    private function indexData(OutputInterface $output)
+    private function indexData(OutputInterface $output, string $siteaccess = null)
     {
         $output->writeln(
             sprintf('Search engine re-indexing, executing command ezplatform:reindex')
         );
-        $this->executeCommand($output, 'ezplatform:reindex');
+
+        $command = 'ezplatform:reindex';
+        if ($siteaccess) {
+            $command .= sprintf(' --siteaccess=%s', $siteaccess);
+        }
+
+        $this->executeCommand($output, $command);
     }
 
     /**

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -19,7 +19,7 @@ services:
     ezplatform.installer.install_command:
         class: "%ezplatform.installer.install_command.class%"
         arguments:
-            - "@database_connection"
+            - '@ezpublish.persistence.connection'
             - []
             - '@ezpublish.cache_pool'
             - "%kernel.environment%"


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31203](https://jira.ez.no/browse/EZP-31203)
| **Bug**| yes
| **Target version** | `6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR fixes the wrong connection being used with `ezplatform:install` command.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.