### PR TITLE
EZP-31046: Improved ChainConfigResolver by extracting code to separate config resolvers

### DIFF
--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -17,7 +17,8 @@ Changes affecting version compatibility with former or future versions.
 * The following configuration nodes are not available anymore:
     * `ezpublish.<scope>.ezpage.*`
     * `ezpublish.<scope>.block_view.*`
-
+    * `ezpublish.siteaccess.relation_map` is replaced by `getSiteAccessesRelation` method from `eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessService` 
+    
 * REST Client has been dropped.
 
 * REST Server implementation and Common namespace have been removed in favor of
@@ -268,6 +269,8 @@ Changes affecting version compatibility with former or future versions.
 * `ezpublish.field_type_collection.factory` has been removed in favor of `eZ\Publish\Core\FieldType\FieldTypeRegistry`
 
 * `ezpublish.persistence.external_storage_registry.factory`
+
+* `ezpublish.config.resolver.core` has been removed. `eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ChainConfigResolver` should be used instead
 
 ## Changed behavior
 

--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -17,7 +17,7 @@ Changes affecting version compatibility with former or future versions.
 * The following configuration nodes are not available anymore:
     * `ezpublish.<scope>.ezpage.*`
     * `ezpublish.<scope>.block_view.*`
-    * `ezpublish.siteaccess.relation_map` is replaced by `getSiteAccessesRelation` method from `eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessService` 
+    * `ezpublish.siteaccess.relation_map` has been replaced by `getSiteAccessesRelation` method from `eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessService` 
     
 * REST Client has been dropped.
 

--- a/eZ/Bundle/EzPublishCoreBundle/Cache/Warmer/ConfigResolverCleanup.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Cache/Warmer/ConfigResolverCleanup.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Cache\Warmer;
 
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ChainConfigResolver;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
@@ -26,7 +27,6 @@ class ConfigResolverCleanup implements CacheWarmerInterface
 
     public function warmUp($cacheDir)
     {
-        $this->container->set('ezpublish.config.resolver.core', null);
-        $this->container->set('ezpublish.config.resolver.chain', null);
+        $this->container->set(ChainConfigResolver::class, null);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ChainConfigResolverPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ChainConfigResolverPass.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
 
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ChainConfigResolver;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -22,11 +23,11 @@ class ChainConfigResolverPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('ezpublish.config.resolver.chain')) {
+        if (!$container->hasDefinition(ChainConfigResolver::class)) {
             return;
         }
 
-        $chainResolver = $container->getDefinition('ezpublish.config.resolver.chain');
+        $chainResolver = $container->getDefinition(ChainConfigResolver::class);
 
         foreach ($container->findTaggedServiceIds('ezpublish.config.resolver') as $id => $attributes) {
             $priority = isset($attributes[0]['priority']) ? (int)$attributes[0]['priority'] : 0;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ChainConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ChainConfigResolver.php
@@ -68,17 +68,11 @@ class ChainConfigResolver implements ConfigResolverInterface
     }
 
     /**
-     * Returns value for $paramName, in $namespace.
-     *
-     * @param string $paramName The parameter name, without $prefix and the current scope (i.e. siteaccess name).
-     * @param string $namespace Namespace for the parameter name. If null, the default namespace should be used.
-     * @param string $scope The scope you need $paramName value for.
+     * @return mixed
      *
      * @throws \eZ\Publish\Core\MVC\Exception\ParameterNotFoundException
-     *
-     * @return mixed
      */
-    public function getParameter($paramName, $namespace = null, $scope = null)
+    public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)
     {
         foreach ($this->getAllResolvers() as $resolver) {
             try {
@@ -92,16 +86,7 @@ class ChainConfigResolver implements ConfigResolverInterface
         throw new ParameterNotFoundException($paramName, $namespace);
     }
 
-    /**
-     * Checks if $paramName exists in $namespace.
-     *
-     * @param string $paramName
-     * @param string $namespace If null, the default namespace should be used.
-     * @param string $scope The scope you need $paramName value for.
-     *
-     * @return bool
-     */
-    public function hasParameter($paramName, $namespace = null, $scope = null)
+    public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
     {
         foreach ($this->getAllResolvers() as $resolver) {
             $hasParameter = $resolver->hasParameter($paramName, $namespace, $scope);
@@ -113,12 +98,7 @@ class ChainConfigResolver implements ConfigResolverInterface
         return false;
     }
 
-    /**
-     * Changes the default namespace to look parameter into.
-     *
-     * @param string $defaultNamespace
-     */
-    public function setDefaultNamespace($defaultNamespace)
+    public function setDefaultNamespace(string $defaultNamespace): void
     {
         foreach ($this->getAllResolvers() as $resolver) {
             $resolver->setDefaultNamespace($defaultNamespace);
@@ -130,7 +110,7 @@ class ChainConfigResolver implements ConfigResolverInterface
      *
      * @throws \LogicException
      */
-    public function getDefaultNamespace()
+    public function getDefaultNamespace(): string
     {
         throw new \LogicException('getDefaultNamespace() is not supported by the ChainConfigResolver');
     }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ChainConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ChainConfigResolver.php
@@ -83,7 +83,7 @@ class ChainConfigResolver implements ConfigResolverInterface
         }
 
         // Finally throw a ParameterNotFoundException since the chain resolver couldn't find any valid resolver for demanded parameter
-        throw new ParameterNotFoundException($paramName, $namespace);
+        throw new ParameterNotFoundException($paramName, $namespace, [$scope]);
     }
 
     public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -115,17 +115,7 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
         return $this->undefinedStrategy;
     }
 
-    /**
-     * Checks if $paramName exists in $namespace.
-     *
-     * @param string $paramName
-     * @param string $namespace If null, the default namespace should be used.
-     * @param string $scope The scope you need $paramName value for. It's typically the siteaccess name.
-     *                      If null, the current siteaccess name will be used.
-     *
-     * @return bool
-     */
-    public function hasParameter($paramName, $namespace = null, $scope = null)
+    public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
     {
         $namespace = $namespace ?: $this->defaultNamespace;
         $scope = $scope ?: $this->getDefaultScope();
@@ -154,18 +144,11 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
     }
 
     /**
-     * Returns value for $paramName, in $namespace.
-     *
-     * @param string $paramName The parameter name, without $prefix and the current scope (i.e. siteaccess name).
-     * @param string $namespace Namespace for the parameter name. If null, the default namespace will be used.
-     * @param string $scope The scope you need $paramName value for. It's typically the siteaccess name.
-     *                      If null, the current siteaccess name will be used.
+     * @return mixed
      *
      * @throws \eZ\Publish\Core\MVC\Exception\ParameterNotFoundException
-     *
-     * @return mixed
      */
-    public function getParameter($paramName, $namespace = null, $scope = null)
+    public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)
     {
         $this->logTooEarlyLoadedListIfNeeded($paramName);
 
@@ -218,25 +201,17 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
         }
     }
 
-    /**
-     * Changes the default namespace to look parameter into.
-     *
-     * @param string $defaultNamespace
-     */
-    public function setDefaultNamespace($defaultNamespace)
+    public function setDefaultNamespace(string $defaultNamespace): void
     {
         $this->defaultNamespace = $defaultNamespace;
     }
 
-    /**
-     * @return string
-     */
-    public function getDefaultNamespace()
+    public function getDefaultNamespace(): string
     {
         return $this->defaultNamespace;
     }
 
-    public function getDefaultScope()
+    public function getDefaultScope(): string
     {
         return $this->defaultScope ?: $this->siteAccess->name;
     }
@@ -244,7 +219,7 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
     /**
      * @param string $scope The default "scope" aka siteaccess name, as opposed to the self::SCOPE_DEFAULT.
      */
-    public function setDefaultScope($scope)
+    public function setDefaultScope(string $scope): void
     {
         $this->defaultScope = $scope;
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/ContainerConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/ContainerConfigResolver.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * @property-read \Symfony\Component\DependencyInjection\ContainerInterface $container
+ */
+abstract class ContainerConfigResolver implements ConfigResolverInterface, ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /** @var string */
+    private $scope;
+
+    /** @var string */
+    private $defaultNamespace;
+
+    public function __construct(string $scope, string $defaultNamespace)
+    {
+        $this->scope = $scope;
+        $this->defaultNamespace = $defaultNamespace;
+    }
+
+    public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)
+    {
+        [$namespace, $scope] = $this->resolveNamespaceAndScope($namespace, $scope);
+        $scopeRelativeParamName = $this->getScopeRelativeParamName($paramName, $namespace, $scope);
+        if ($this->container->hasParameter($scopeRelativeParamName)) {
+            return $this->container->getParameter($scopeRelativeParamName);
+        }
+
+        throw new ParameterNotFoundException($paramName, $namespace, [$scope]);
+    }
+
+    public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
+    {
+        return $this->container->hasParameter($this->resolveScopeRelativeParamName($paramName, $namespace, $scope));
+    }
+
+    public function getDefaultNamespace(): string
+    {
+        return $this->defaultNamespace;
+    }
+
+    public function setDefaultNamespace(string $defaultNamespace): void
+    {
+        $this->defaultNamespace = $defaultNamespace;
+    }
+
+    private function resolveScopeRelativeParamName(string $paramName, string $namespace = null, string $scope = null): string
+    {
+        return $this->getScopeRelativeParamName($paramName, ...$this->resolveNamespaceAndScope($namespace, $scope));
+    }
+
+    private function resolveNamespaceAndScope(string $namespace = null, string $scope = null): array
+    {
+        return [$namespace ?: $this->getDefaultNamespace(), $scope ?? $this->scope];
+    }
+
+    private function getScopeRelativeParamName(string $paramName, string $namespace, string $scope): string
+    {
+        return "$namespace.$scope.$paramName";
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/ContainerConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/ContainerConfigResolver.php
@@ -13,9 +13,6 @@ use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-/**
- * @property-read \Symfony\Component\DependencyInjection\ContainerInterface $container
- */
 abstract class ContainerConfigResolver implements ConfigResolverInterface, ContainerAwareInterface
 {
     use ContainerAwareTrait;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolver.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
 
+/**
+ * @internal
+ */
 class DefaultScopeConfigResolver extends ContainerConfigResolver
 {
     private const SCOPE_NAME = 'default';

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
+
+class DefaultScopeConfigResolver extends ContainerConfigResolver
+{
+    private const SCOPE_NAME = 'default';
+
+    public function __construct(string $defaultNamespace)
+    {
+        parent::__construct(self::SCOPE_NAME, $defaultNamespace);
+    }
+
+    public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
+    {
+        return parent::hasParameter($paramName, $namespace, self::SCOPE_NAME);
+    }
+
+    public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)
+    {
+        return parent::getParameter($paramName, $namespace, self::SCOPE_NAME);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolver.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
 
+/**
+ * @internal
+ */
 class GlobalScopeConfigResolver extends ContainerConfigResolver
 {
     private const SCOPE_NAME = 'global';

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
+
+class GlobalScopeConfigResolver extends ContainerConfigResolver
+{
+    private const SCOPE_NAME = 'global';
+
+    public function __construct(string $defaultNamespace)
+    {
+        parent::__construct(self::SCOPE_NAME, $defaultNamespace);
+    }
+
+    public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
+    {
+        return parent::hasParameter($paramName, $namespace, self::SCOPE_NAME);
+    }
+
+    public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)
+    {
+        return parent::getParameter($paramName, $namespace, self::SCOPE_NAME);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessConfigResolver.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessConfigResolver.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
+
+use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
+use eZ\Publish\Core\MVC\Symfony\Configuration\VersatileScopeInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
+
+abstract class SiteAccessConfigResolver implements VersatileScopeInterface, SiteAccessAware
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface */
+    protected $siteAccessProvider;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess */
+    protected $currentSiteAccess;
+
+    /** @var string */
+    protected $defaultScope;
+
+    /** @var string */
+    protected $defaultNamespace;
+
+    public function __construct(
+        SiteAccess\SiteAccessProviderInterface $siteAccessProvider,
+        string $defaultNamespace
+    ) {
+        $this->siteAccessProvider = $siteAccessProvider;
+        $this->defaultNamespace = $defaultNamespace;
+    }
+
+    public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
+    {
+        [$namespace, $scope] = $this->resolveNamespaceAndScope($namespace, $scope);
+        if (!$this->isSiteAccessScope($scope)) {
+            return false;
+        }
+
+        $siteAccess = $this->siteAccessProvider->getSiteAccess($scope);
+        if (!$this->isSiteAccessSupported($siteAccess)) {
+            return false;
+        }
+
+        return $this->doHasParameter($siteAccess, $namespace, $scope);
+    }
+
+    public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)
+    {
+        [$namespace, $scope] = $this->resolveNamespaceAndScope($namespace, $scope);
+
+        if (!$this->isSiteAccessScope($scope)) {
+            throw new ParameterNotFoundException($paramName, $namespace, [$scope]);
+        }
+
+        $siteAccess = $this->siteAccessProvider->getSiteAccess($scope);
+        if (!$this->isSiteAccessSupported($siteAccess)) {
+            throw new ParameterNotFoundException($paramName, $namespace, [$scope]);
+        }
+
+        return $this->doGetParameter($siteAccess, $paramName, $namespace);
+    }
+
+    public function getDefaultNamespace(): string
+    {
+        return $this->defaultNamespace;
+    }
+
+    public function setDefaultNamespace($defaultNamespace): void
+    {
+        $this->defaultNamespace = $defaultNamespace;
+    }
+
+    public function getDefaultScope(): string
+    {
+        return $this->defaultScope ?: $this->currentSiteAccess->name;
+    }
+
+    public function setDefaultScope(string $scope): void
+    {
+        $this->defaultScope = $scope;
+    }
+
+    public function setSiteAccess(SiteAccess $siteAccess = null): void
+    {
+        $this->currentSiteAccess = $siteAccess;
+    }
+
+    protected function isSiteAccessScope(string $scope): bool
+    {
+        return $this->siteAccessProvider->isDefined($scope);
+    }
+
+    /**
+     * Returns true if current config provider supports given Site Access.
+     */
+    protected function isSiteAccessSupported(SiteAccess $siteAccess): bool
+    {
+        return true;
+    }
+
+    protected function resolveScopeRelativeParamName(string $paramName, ?string $namespace = null, ?string $scope = null): string
+    {
+        return $this->getScopeRelativeParamName($paramName, ...$this->resolveNamespaceAndScope($namespace, $scope));
+    }
+
+    protected function resolveNamespaceAndScope(?string $namespace = null, ?string $scope = null): array
+    {
+        return [$namespace ?: $this->getDefaultNamespace(), $scope ?: $this->getDefaultScope()];
+    }
+
+    protected function getScopeRelativeParamName(string $paramName, string $namespace, string $scope): string
+    {
+        return "$namespace.$scope.$paramName";
+    }
+
+    abstract protected function doHasParameter(SiteAccess $siteAccess, string $paramName, string $namespace): bool;
+
+    abstract protected function doGetParameter(SiteAccess $siteAccess, string $paramName, string $namespace);
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessConfigResolver.php
@@ -35,7 +35,7 @@ abstract class SiteAccessConfigResolver implements VersatileScopeInterface, Site
         $this->defaultNamespace = $defaultNamespace;
     }
 
-    public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
+    final public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
     {
         [$namespace, $scope] = $this->resolveNamespaceAndScope($namespace, $scope);
         if (!$this->isSiteAccessScope($scope)) {
@@ -47,10 +47,10 @@ abstract class SiteAccessConfigResolver implements VersatileScopeInterface, Site
             return false;
         }
 
-        return $this->doHasParameter($siteAccess, $namespace, $scope);
+        return $this->resolverHasParameter($siteAccess, $namespace, $scope);
     }
 
-    public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)
+    final public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)
     {
         [$namespace, $scope] = $this->resolveNamespaceAndScope($namespace, $scope);
 
@@ -63,7 +63,7 @@ abstract class SiteAccessConfigResolver implements VersatileScopeInterface, Site
             throw new ParameterNotFoundException($paramName, $namespace, [$scope]);
         }
 
-        return $this->doGetParameter($siteAccess, $paramName, $namespace);
+        return $this->getParameterFromResolver($siteAccess, $paramName, $namespace);
     }
 
     public function getDefaultNamespace(): string
@@ -119,7 +119,7 @@ abstract class SiteAccessConfigResolver implements VersatileScopeInterface, Site
         return "$namespace.$scope.$paramName";
     }
 
-    abstract protected function doHasParameter(SiteAccess $siteAccess, string $paramName, string $namespace): bool;
+    abstract protected function resolverHasParameter(SiteAccess $siteAccess, string $paramName, string $namespace): bool;
 
-    abstract protected function doGetParameter(SiteAccess $siteAccess, string $paramName, string $namespace);
+    abstract protected function getParameterFromResolver(SiteAccess $siteAccess, string $paramName, string $namespace);
 }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessConfigResolver.php
@@ -47,7 +47,7 @@ abstract class SiteAccessConfigResolver implements VersatileScopeInterface, Site
             return false;
         }
 
-        return $this->resolverHasParameter($siteAccess, $namespace, $scope);
+        return $this->resolverHasParameter($siteAccess, $paramName, $namespace);
     }
 
     final public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
+
+use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * @property-read \Symfony\Component\DependencyInjection\ContainerInterface $container
+ */
+class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
+{
+    use ContainerAwareTrait;
+
+    protected function doHasParameter(SiteAccess $siteAccess, string $paramName, string $namespace): bool
+    {
+        foreach ($siteAccess->groups as $group) {
+            $groupScopeParamName = $this->resolveScopeRelativeParamName($paramName, $namespace, $group->getName());
+            if ($this->container->hasParameter($groupScopeParamName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function doGetParameter(SiteAccess $siteAccess, string $paramName, string $namespace)
+    {
+        $triedScopes = [];
+
+        foreach ($siteAccess->groups as $group) {
+            $groupScopeParamName = $this->resolveScopeRelativeParamName($paramName, $namespace, $group->getName());
+            if ($this->container->hasParameter($groupScopeParamName)) {
+                return $this->container->getParameter($groupScopeParamName);
+            }
+
+            $triedScopes[] = $group->getName();
+        }
+
+        throw new ParameterNotFoundException($paramName, $namespace, $triedScopes);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
@@ -14,6 +14,8 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @property-read \Symfony\Component\DependencyInjection\ContainerInterface $container
+ *
+ * @internal
  */
 class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
 {

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
@@ -21,7 +21,7 @@ class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
 {
     use ContainerAwareTrait;
 
-    protected function doHasParameter(SiteAccess $siteAccess, string $paramName, string $namespace): bool
+    protected function resolverHasParameter(SiteAccess $siteAccess, string $paramName, string $namespace): bool
     {
         foreach ($siteAccess->groups as $group) {
             $groupScopeParamName = $this->resolveScopeRelativeParamName($paramName, $namespace, $group->getName());
@@ -33,7 +33,7 @@ class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
         return false;
     }
 
-    protected function doGetParameter(SiteAccess $siteAccess, string $paramName, string $namespace)
+    protected function getParameterFromResolver(SiteAccess $siteAccess, string $paramName, string $namespace)
     {
         $triedScopes = [];
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolver.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
+
+use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Provider\StaticSiteAccessProvider;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * @property-read \Symfony\Component\DependencyInjection\ContainerInterface $container
+ */
+class StaticSiteAccessConfigResolver extends SiteAccessConfigResolver
+{
+    use ContainerAwareTrait;
+
+    protected function doHasParameter(SiteAccess $siteAccess, string $paramName, string $namespace): bool
+    {
+        return $this->container->hasParameter(
+            $this->resolveScopeRelativeParamName($paramName, $namespace, $siteAccess->name)
+        );
+    }
+
+    protected function doGetParameter(SiteAccess $siteAccess, string $paramName, string $namespace)
+    {
+        $scopeRelativeParamName = $this->getScopeRelativeParamName($paramName, $namespace, $siteAccess->name);
+        if ($this->container->hasParameter($scopeRelativeParamName)) {
+            return $this->container->getParameter($scopeRelativeParamName);
+        }
+
+        throw new ParameterNotFoundException($paramName, $namespace, [$siteAccess->name]);
+    }
+
+    protected function isSiteAccessSupported(SiteAccess $siteAccess): bool
+    {
+        return StaticSiteAccessProvider::class === $siteAccess->provider;
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolver.php
@@ -11,6 +11,8 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @property-read \Symfony\Component\DependencyInjection\ContainerInterface $container
+ *
+ * @internal
  */
 class StaticSiteAccessConfigResolver extends SiteAccessConfigResolver
 {

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolver.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
@@ -18,14 +22,14 @@ class StaticSiteAccessConfigResolver extends SiteAccessConfigResolver
 {
     use ContainerAwareTrait;
 
-    protected function doHasParameter(SiteAccess $siteAccess, string $paramName, string $namespace): bool
+    protected function resolverHasParameter(SiteAccess $siteAccess, string $paramName, string $namespace): bool
     {
         return $this->container->hasParameter(
             $this->resolveScopeRelativeParamName($paramName, $namespace, $siteAccess->name)
         );
     }
 
-    protected function doGetParameter(SiteAccess $siteAccess, string $paramName, string $namespace)
+    protected function getParameterFromResolver(SiteAccess $siteAccess, string $paramName, string $namespace)
     {
         $scopeRelativeParamName = $this->getScopeRelativeParamName($paramName, $namespace, $siteAccess->name);
         if ($this->container->hasParameter($scopeRelativeParamName)) {

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
@@ -26,8 +26,8 @@ services:
     ezpublish.config_scope_listener:
         class: eZ\Bundle\EzPublishCoreBundle\EventListener\ConfigScopeListener
         arguments:
-            - "@ezpublish.config.resolver.core"
-            - "@ezpublish.view_manager"
+            $configResolvers: !tagged ezpublish.config.resolver
+            $viewManager: '@ezpublish.view_manager'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -15,9 +15,7 @@ services:
         class: eZ\Publish\Core\MVC\Symfony\SiteAccess
         arguments: ["%ezpublish.siteaccess.default.name%", 'uninitialized']
 
-    ezpublish.config.resolver.default:
-        public: true
-        class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\DefaultScopeConfigResolver
+    eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\DefaultScopeConfigResolver:
         arguments:
             - '%ezpublish.config.default_scope%'
         calls:
@@ -26,8 +24,7 @@ services:
         tags:
             - { name: ezpublish.config.resolver, priority: 0 }
 
-    ezpublish.config.resolver.siteaccess_group:
-        class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\SiteAccessGroupConfigResolver
+    eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\SiteAccessGroupConfigResolver:
         arguments:
             - '@ezpublish.siteaccess.provider'
             - '%ezpublish.config.default_scope%'
@@ -38,8 +35,7 @@ services:
         tags:
             - { name: ezpublish.config.resolver, priority: 50 }
 
-    ezpublish.config.resolver.siteaccess_static:
-        class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\StaticSiteAccessConfigResolver
+    eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\StaticSiteAccessConfigResolver:
         arguments:
             - '@ezpublish.siteaccess.provider'
             - '%ezpublish.config.default_scope%'
@@ -50,9 +46,7 @@ services:
         tags:
             - { name: ezpublish.config.resolver, priority: 100 }
 
-    ezpublish.config.resolver.global:
-        public: true
-        class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\GlobalScopeConfigResolver
+    eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\GlobalScopeConfigResolver:
         arguments:
             - '%ezpublish.config.default_scope%'
         calls:
@@ -61,13 +55,12 @@ services:
         tags:
             - { name: ezpublish.config.resolver, priority: 255 }
 
-    ezpublish.config.resolver.chain:
+    eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ChainConfigResolver:
         public: true # @todo should be private
-        class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ChainConfigResolver
 
     ezpublish.config.resolver:
         public: true # @todo should be private
-        alias: ezpublish.config.resolver.chain
+        alias: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ChainConfigResolver
 
     ezpublish.config.dynamic_setting.parser:
         class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\DynamicSettingParser

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -15,16 +15,51 @@ services:
         class: eZ\Publish\Core\MVC\Symfony\SiteAccess
         arguments: ["%ezpublish.siteaccess.default.name%", 'uninitialized']
 
-    ezpublish.config.resolver.core:
-        public: true # @todo should be private
-        class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver
-        arguments: ["@?logger", "%ezpublish.siteaccess.groups_by_siteaccess%", "%ezpublish.config.default_scope%"]
+    ezpublish.config.resolver.default:
+        public: true
+        class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\DefaultScopeConfigResolver
+        arguments:
+            - '%ezpublish.config.default_scope%'
         calls:
-            - [setSiteAccess, ["@ezpublish.siteaccess"]]
-            - [setContainer, ["@service_container"]]
+            - [setContainer, ['@service_container']]
         lazy: true
         tags:
-            - { name: ezpublish.config.resolver, priority: 200 }
+            - { name: ezpublish.config.resolver, priority: 0 }
+
+    ezpublish.config.resolver.siteaccess_group:
+        class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\SiteAccessGroupConfigResolver
+        arguments:
+            - '@ezpublish.siteaccess.provider'
+            - '%ezpublish.config.default_scope%'
+        calls:
+            - [setSiteAccess, ['@ezpublish.siteaccess']]
+            - [setContainer, ['@service_container']]
+        lazy: true
+        tags:
+            - { name: ezpublish.config.resolver, priority: 50 }
+
+    ezpublish.config.resolver.siteaccess_static:
+        class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\StaticSiteAccessConfigResolver
+        arguments:
+            - '@ezpublish.siteaccess.provider'
+            - '%ezpublish.config.default_scope%'
+        calls:
+            - [setSiteAccess, ['@ezpublish.siteaccess']]
+            - [setContainer, ['@service_container']]
+        lazy: true
+        tags:
+            - { name: ezpublish.config.resolver, priority: 100 }
+
+    ezpublish.config.resolver.global:
+        public: true
+        class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\GlobalScopeConfigResolver
+        arguments:
+            - '%ezpublish.config.default_scope%'
+        calls:
+            - [setContainer, ['@service_container']]
+        lazy: true
+        tags:
+            - { name: ezpublish.config.resolver, priority: 255 }
 
     ezpublish.config.resolver.chain:
         public: true # @todo should be private

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Cache/Warmer/ConfigResolverCleanupTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Cache/Warmer/ConfigResolverCleanupTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Cache\Warmer;
 
 use eZ\Bundle\EzPublishCoreBundle\Cache\Warmer\ConfigResolverCleanup;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ChainConfigResolver;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\DependencyInjection\Container;
@@ -23,16 +24,13 @@ class ConfigResolverCleanupTest extends TestCase
     public function testWarmup()
     {
         $container = new Container();
-        $container->set('ezpublish.config.resolver.core', new stdClass());
-        $container->set('ezpublish.config.resolver.chain', new stdClass());
-        self::assertTrue($container->initialized('ezpublish.config.resolver.core'));
-        self::assertTrue($container->initialized('ezpublish.config.resolver.chain'));
+        $container->set(ChainConfigResolver::class, new stdClass());
+        self::assertTrue($container->initialized(ChainConfigResolver::class));
 
         $warmer = new ConfigResolverCleanup();
         $warmer->setContainer($container);
         $warmer->warmUp('my_cache_dir');
 
-        self::assertFalse($container->initialized('ezpublish.config.resolver.core'));
-        self::assertFalse($container->initialized('ezpublish.config.resolver.chain'));
+        self::assertFalse($container->initialized(ChainConfigResolver::class));
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ChainConfigResolverPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ChainConfigResolverPassTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ChainConfigResolverPass;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ChainConfigResolver;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -19,7 +20,7 @@ class ChainConfigResolverPassTest extends AbstractCompilerPassTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->setDefinition('ezpublish.config.resolver.chain', new Definition());
+        $this->setDefinition(ChainConfigResolver::class, new Definition());
     }
 
     /**
@@ -54,7 +55,7 @@ class ChainConfigResolverPassTest extends AbstractCompilerPassTestCase
         $this->compile();
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'ezpublish.config.resolver.chain',
+            ChainConfigResolver::class,
             'addResolver',
             [new Reference($serviceId), $expectedPriority]
         );

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
@@ -1,13 +1,21 @@
 <?php
 
 /**
- * File containing the AbstractParserTestCase class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser;
 
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ChainConfigResolver;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\DefaultScopeConfigResolver;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\GlobalScopeConfigResolver;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\SiteAccessGroupConfigResolver;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver\StaticSiteAccessConfigResolver;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Provider\StaticSiteAccessProvider;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccessGroup;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 
 abstract class AbstractParserTestCase extends AbstractExtensionTestCase
@@ -22,8 +30,66 @@ abstract class AbstractParserTestCase extends AbstractExtensionTestCase
      */
     protected function assertConfigResolverParameterValue($parameterName, $expectedValue, $scope, $assertSame = true)
     {
-        $configResolver = $this->container->get('ezpublish.config.resolver.core');
+        $chainConfigResolver = $this->getConfigResolver();
         $assertMethod = $assertSame ? 'assertSame' : 'assertEquals';
-        $this->$assertMethod($expectedValue, $configResolver->getParameter($parameterName, 'ezsettings', $scope));
+        $this->$assertMethod($expectedValue, $chainConfigResolver->getParameter($parameterName, 'ezsettings', $scope));
+    }
+
+    protected function getConfigResolver(): ConfigResolverInterface
+    {
+        $chainConfigResolver = new ChainConfigResolver();
+        $siteAccessProvider = $this->getSiteAccessProviderMock();
+
+        $configResolvers = [
+            new DefaultScopeConfigResolver('default'),
+            new SiteAccessGroupConfigResolver($siteAccessProvider, 'default'),
+            new StaticSiteAccessConfigResolver($siteAccessProvider, 'default'),
+            new GlobalScopeConfigResolver('default'),
+        ];
+
+        foreach ($configResolvers as $priority => $configResolver) {
+            $configResolver->setContainer($this->container);
+            $chainConfigResolver->addResolver($configResolver, $priority);
+        }
+
+        return $chainConfigResolver;
+    }
+
+    protected function getSiteAccessProviderMock(): SiteAccessProviderInterface
+    {
+        $siteAccessProvider = $this->createMock(SiteAccessProviderInterface::class);
+        $siteAccessProvider
+            ->method('isDefined')
+            ->willReturnMap([
+                ['ezdemo_site', true],
+                ['fre', true],
+                ['fre2', true],
+                ['ezdemo_site_admin', true],
+            ]);
+        $siteAccessProvider
+            ->method('getSiteAccess')
+            ->willReturnMap([
+                ['ezdemo_site', $this->getSiteAccess('ezdemo_site', StaticSiteAccessProvider::class, ['ezdemo_group', 'ezdemo_frontend_group'])],
+                ['fre', $this->getSiteAccess('fre', StaticSiteAccessProvider::class, ['ezdemo_group', 'ezdemo_frontend_group'])],
+                ['fre2', $this->getSiteAccess('fre', StaticSiteAccessProvider::class, ['ezdemo_group', 'ezdemo_frontend_group'])],
+                ['ezdemo_site_admin', $this->getSiteAccess('ezdemo_site_admin', StaticSiteAccessProvider::class, ['ezdemo_group'])],
+            ]);
+
+        return $siteAccessProvider;
+    }
+
+    /**
+     * @param string[] $groupNames
+     */
+    protected function getSiteAccess(string $name, string $provider, array $groupNames): SiteAccess
+    {
+        $siteAccess = new SiteAccess($name, SiteAccess::DEFAULT_MATCHING_TYPE, null, $provider);
+        $siteAccessGroups = [];
+        foreach ($groupNames as $groupName) {
+            $siteAccessGroups[] = new SiteAccessGroup($groupName);
+        }
+        $siteAccess->groups = $siteAccessGroups;
+
+        return $siteAccess;
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/TemplatesTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/TemplatesTest.php
@@ -11,6 +11,8 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\FieldDefinitionSettingsTemplates;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\FieldTemplates;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Provider\StaticSiteAccessProvider;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface;
 use Symfony\Component\Yaml\Yaml;
 
 class TemplatesTest extends AbstractParserTestCase
@@ -64,6 +66,27 @@ class TemplatesTest extends AbstractParserTestCase
             'ezdemo_site_admin',
             false
         );
+    }
+
+    protected function getSiteAccessProviderMock(): SiteAccessProviderInterface
+    {
+        $siteAccessProvider = $this->createMock(SiteAccessProviderInterface::class);
+        $siteAccessProvider
+            ->method('isDefined')
+            ->willReturnMap([
+                ['ezdemo_site', true],
+                ['fre', true],
+                ['ezdemo_site_admin', true],
+            ]);
+        $siteAccessProvider
+            ->method('getSiteAccess')
+            ->willReturnMap([
+                ['ezdemo_site', $this->getSiteAccess('ezdemo_site', StaticSiteAccessProvider::class, ['ezdemo_group', 'ezdemo_frontend_group'])],
+                ['fre', $this->getSiteAccess('fre', StaticSiteAccessProvider::class, ['ezdemo_group', 'ezdemo_frontend_group'])],
+                ['ezdemo_site_admin', $this->getSiteAccess('ezdemo_site_admin', StaticSiteAccessProvider::class, ['ezdemo_group'])],
+            ]);
+
+        return $siteAccessProvider;
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -108,23 +108,6 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                 $groupsBySiteaccess[$member][] = $groupName;
             }
         }
-        $this->assertContainerBuilderHasParameter('ezpublish.siteaccess.groups_by_siteaccess', $groupsBySiteaccess);
-
-        $relatedSiteAccesses = ['ezdemo_site', 'eng', 'fre', 'ezdemo_site_admin'];
-        $this->assertContainerBuilderHasParameter(
-            'ezpublish.siteaccess.relation_map',
-            [
-                // Empty string is the default repository name
-                '' => [
-                    // 2 is the default rootLocationId
-                    2 => $relatedSiteAccesses,
-                ],
-            ]
-        );
-
-        $this->assertContainerBuilderHasParameter('ezsettings.ezdemo_site.related_siteaccesses', $relatedSiteAccesses);
-        $this->assertContainerBuilderHasParameter('ezsettings.eng.related_siteaccesses', $relatedSiteAccesses);
-        $this->assertContainerBuilderHasParameter('ezsettings.fre.related_siteaccesses', $relatedSiteAccesses);
     }
 
     public function testSiteAccessNoConfiguration()
@@ -698,85 +681,6 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
             $expectedRepositories,
             $this->container->getParameter('ezpublish.repositories')
         );
-    }
-
-    public function testRelatedSiteAccesses()
-    {
-        $mainRepo = 'main';
-        $fooRepo = 'foo';
-        $rootLocationId1 = 123;
-        $rootLocationId2 = 456;
-        $rootLocationId3 = 2;
-        $config = [
-            'siteaccess' => [
-                'default_siteaccess' => 'ezdemo_site',
-                'list' => ['ezdemo_site', 'eng', 'fre', 'ezdemo_site2', 'eng2', 'ezdemo_site3', 'fre3'],
-                'groups' => [
-                    'ezdemo_group' => ['ezdemo_site', 'eng', 'fre'],
-                    'ezdemo_group2' => ['ezdemo_site2', 'eng2'],
-                    'ezdemo_group3' => ['ezdemo_site3', 'fre3'],
-                ],
-                'match' => [],
-            ],
-            'repositories' => [
-                $mainRepo => ['engine' => 'legacy', 'connection' => 'default'],
-                $fooRepo => ['engine' => 'bar', 'connection' => 'blabla'],
-            ],
-            'system' => [
-                'ezdemo_group' => [
-                    'repository' => $mainRepo,
-                    'content' => [
-                        'tree_root' => ['location_id' => $rootLocationId1],
-                    ],
-                ],
-                'ezdemo_group2' => [
-                    'repository' => $mainRepo,
-                    'content' => [
-                        'tree_root' => ['location_id' => $rootLocationId2],
-                    ],
-                ],
-                'ezdemo_group3' => [
-                    'repository' => $fooRepo,
-                ],
-            ],
-        ] + $this->siteaccessConfig;
-
-        // Injecting needed config parsers.
-        $refExtension = new ReflectionObject($this->extension);
-        $refMethod = $refExtension->getMethod('getMainConfigParser');
-        $refMethod->setAccessible(true);
-        $refMethod->invoke($this->extension);
-        $refParser = $refExtension->getProperty('mainConfigParser');
-        $refParser->setAccessible(true);
-        /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigParser $parser */
-        $parser = $refParser->getValue($this->extension);
-        $parser->setConfigParsers([new Common(), new Content()]);
-
-        $this->load($config);
-
-        $relatedSiteAccesses1 = ['ezdemo_site', 'eng', 'fre'];
-        $relatedSiteAccesses2 = ['ezdemo_site2', 'eng2'];
-        $relatedSiteAccesses3 = ['ezdemo_site3', 'fre3'];
-        $expectedRelationMap = [
-            $mainRepo => [
-                $rootLocationId1 => $relatedSiteAccesses1,
-                $rootLocationId2 => $relatedSiteAccesses2,
-            ],
-            $fooRepo => [
-                $rootLocationId3 => $relatedSiteAccesses3,
-            ],
-        ];
-        $this->assertContainerBuilderHasParameter('ezpublish.siteaccess.relation_map', $expectedRelationMap);
-
-        $this->assertContainerBuilderHasParameter('ezsettings.ezdemo_site.related_siteaccesses', $relatedSiteAccesses1);
-        $this->assertContainerBuilderHasParameter('ezsettings.eng.related_siteaccesses', $relatedSiteAccesses1);
-        $this->assertContainerBuilderHasParameter('ezsettings.fre.related_siteaccesses', $relatedSiteAccesses1);
-
-        $this->assertContainerBuilderHasParameter('ezsettings.ezdemo_site2.related_siteaccesses', $relatedSiteAccesses2);
-        $this->assertContainerBuilderHasParameter('ezsettings.eng2.related_siteaccesses', $relatedSiteAccesses2);
-
-        $this->assertContainerBuilderHasParameter('ezsettings.ezdemo_site3.related_siteaccesses', $relatedSiteAccesses3);
-        $this->assertContainerBuilderHasParameter('ezsettings.fre3.related_siteaccesses', $relatedSiteAccesses3);
     }
 
     public function testRegisteredPolicies()

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConfigScopeListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConfigScopeListenerTest.php
@@ -70,7 +70,7 @@ class ConfigScopeListenerTest extends TestCase
                 ->with($siteAccess);
         }
 
-        $listener = new ConfigScopeListener($this->configResolver, $this->viewManager);
+        $listener = new ConfigScopeListener([$this->configResolver], $this->viewManager);
         $listener->setViewProviders($this->viewProviders);
         $listener->onConfigScopeChange($event);
         $this->assertSame($siteAccess, $event->getSiteAccess());

--- a/eZ/Publish/Core/MVC/ConfigResolverInterface.php
+++ b/eZ/Publish/Core/MVC/ConfigResolverInterface.php
@@ -28,30 +28,24 @@ interface ConfigResolverInterface
      *
      * @return mixed
      */
-    public function getParameter($paramName, $namespace = null, $scope = null);
+    public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null);
 
     /**
      * Checks if $paramName exists in $namespace.
      *
-     * @param string $paramName
-     * @param string $namespace If null, the default namespace should be used.
+     * @param string $paramName The parameter name, without $prefix and the current scope (i.e. siteaccess name).
+     * @param string $namespace Namespace for the parameter name. If null, the default namespace should be used.
      * @param string $scope The scope you need $paramName value for.
-     *
-     * @return bool
      */
-    public function hasParameter($paramName, $namespace = null, $scope = null);
+    public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool;
 
     /**
      * Changes the default namespace to look parameter into.
-     *
-     * @param string $defaultNamespace
      */
-    public function setDefaultNamespace($defaultNamespace);
+    public function setDefaultNamespace(string $defaultNamespace): void;
 
     /**
      * Returns the current default namespace.
-     *
-     * @return string
      */
-    public function getDefaultNamespace();
+    public function getDefaultNamespace(): string;
 }

--- a/eZ/Publish/Core/MVC/Symfony/Configuration/VersatileScopeInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Configuration/VersatileScopeInterface.php
@@ -15,17 +15,7 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
  */
 interface VersatileScopeInterface extends ConfigResolverInterface
 {
-    /**
-     * Returns current default scope.
-     *
-     * @return string
-     */
-    public function getDefaultScope();
+    public function getDefaultScope(): string;
 
-    /**
-     * Sets a new default scope.
-     *
-     * @param string $scope
-     */
-    public function setDefaultScope($scope);
+    public function setDefaultScope(string $scope): void;
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31046](https://jira.ez.no/browse/EZP-31046)
| **Bug/Improvement**|no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Related to**     | https://github.com/ezsystems/ezplatform-richtext/pull/92

This PR improves ChainConfigResolver by extracting code to separate config resolvers (default, site access, site access group and global resolver). In addition, it adds type hints to Configresolver, removed Site Access relation handling (which is replaced by a dedicated method in SiteAccessService in the previous PR).


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
