### PR TITLE
EZP-31235: Fixed validating translation list for publishing in LanguageLimitation

### DIFF
--- a/eZ/Publish/Core/Limitation/LanguageLimitation/ContentTranslationEvaluator.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitation/ContentTranslationEvaluator.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Limitation\LanguageLimitation;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\Core\Limitation\LanguageLimitationType;
+use eZ\Publish\SPI\Limitation\Target;
+
+/**
+ * @internal for internal use by LanguageLimitation
+ */
+final class ContentTranslationEvaluator implements VersionTargetEvaluator
+{
+    public function accept(Target\Version $targetVersion): bool
+    {
+        return !empty($targetVersion->allLanguageCodesList);
+    }
+
+    /**
+     * Allow access if any of the given language codes for translations matches any of the limitation values.
+     */
+    public function evaluate(Target\Version $targetVersion, Limitation $limitationValue): ?bool
+    {
+        $matchingTranslations = array_intersect(
+            $targetVersion->allLanguageCodesList,
+            $limitationValue->limitationValues
+        );
+
+        return empty($matchingTranslations)
+            ? LanguageLimitationType::ACCESS_DENIED
+            : LanguageLimitationType::ACCESS_GRANTED;
+    }
+}

--- a/eZ/Publish/Core/Limitation/LanguageLimitation/NewDraftEvaluator.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitation/NewDraftEvaluator.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Limitation\LanguageLimitation;
+
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\Core\Limitation\LanguageLimitationType;
+use eZ\Publish\SPI\Limitation\Target;
+
+/**
+ * @internal for internal use by LanguageLimitation
+ */
+final class NewDraftEvaluator implements VersionTargetEvaluator
+{
+    public function accept(Target\Version $targetVersion): bool
+    {
+        return $targetVersion->newStatus === VersionInfo::STATUS_DRAFT;
+    }
+
+    public function evaluate(Target\Version $targetVersion, Limitation $limitationValue): ?bool
+    {
+        return LanguageLimitationType::ACCESS_GRANTED;
+    }
+}

--- a/eZ/Publish/Core/Limitation/LanguageLimitation/VersionPublishingEvaluator.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitation/VersionPublishingEvaluator.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Limitation\LanguageLimitation;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\Core\Limitation\LanguageLimitationType;
+use eZ\Publish\SPI\Limitation\Target;
+
+/**
+ * @internal for internal use by LanguageLimitation
+ */
+final class VersionPublishingEvaluator implements VersionTargetEvaluator
+{
+    public function accept(Target\Version $targetVersion): bool
+    {
+        return !empty($targetVersion->forPublishLanguageCodesList);
+    }
+
+    /**
+     * Evaluate publishing a specific translation of a Version.
+     */
+    public function evaluate(Target\Version $targetVersion, Limitation $limitationValue): ?bool
+    {
+        $diff = array_diff(
+            $targetVersion->forPublishLanguageCodesList,
+            $limitationValue->limitationValues
+        );
+
+        return empty($diff)
+            ? LanguageLimitationType::ACCESS_GRANTED
+            : LanguageLimitationType::ACCESS_DENIED;
+    }
+}

--- a/eZ/Publish/Core/Limitation/LanguageLimitation/VersionTargetEvaluator.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitation/VersionTargetEvaluator.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Limitation\LanguageLimitation;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\SPI\Limitation\Target;
+
+/**
+ * @internal for internal use by LanguageLimitation
+ */
+interface VersionTargetEvaluator
+{
+    public function accept(Target\Version $targetVersion): bool;
+
+    public function evaluate(Target\Version $targetVersion, Limitation $limitationValue): ?bool;
+}

--- a/eZ/Publish/Core/Limitation/LanguageLimitation/VersionTranslationUpdateEvaluator.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitation/VersionTranslationUpdateEvaluator.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Limitation\LanguageLimitation;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\Core\Limitation\LanguageLimitationType;
+use eZ\Publish\SPI\Limitation\Target;
+
+/**
+ * @internal for internal use by LanguageLimitation
+ */
+final class VersionTranslationUpdateEvaluator implements VersionTargetEvaluator
+{
+    public function accept(Target\Version $targetVersion): bool
+    {
+        return
+            !empty($targetVersion->forUpdateLanguageCodesList)
+            || null !== $targetVersion->forUpdateInitialLanguageCode;
+    }
+
+    public function evaluate(Target\Version $targetVersion, Limitation $limitationValue): ?bool
+    {
+        $accessVote = LanguageLimitationType::ACCESS_ABSTAIN;
+
+        if (!empty($targetVersion->forUpdateLanguageCodesList)) {
+            $diff = array_diff(
+                $targetVersion->forUpdateLanguageCodesList,
+                $limitationValue->limitationValues
+            );
+            $accessVote = empty($diff)
+                ? LanguageLimitationType::ACCESS_GRANTED
+                : LanguageLimitationType::ACCESS_DENIED;
+        }
+
+        if (
+            $accessVote !== LanguageLimitationType::ACCESS_DENIED
+            && null !== $targetVersion->forUpdateInitialLanguageCode
+        ) {
+            $accessVote = in_array(
+                $targetVersion->forUpdateInitialLanguageCode,
+                $limitationValue->limitationValues
+            )
+                ? LanguageLimitationType::ACCESS_GRANTED
+                : LanguageLimitationType::ACCESS_DENIED;
+        }
+
+        return $accessVote;
+    }
+}

--- a/eZ/Publish/Core/Limitation/LanguageLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitationType.php
@@ -269,7 +269,7 @@ class LanguageLimitationType implements SPITargetAwareLimitationType
         }
 
         // intent to publish Version in specified languages
-        if (!empty($version->forPublishLanguageCodesList) || null !== $version->forPublishLanguageCodesList) {
+        if (!empty($version->forPublishLanguageCodesList)) {
             $diff = array_diff($version->forPublishLanguageCodesList, $value->limitationValues);
             $accessVote = empty($diff) ? self::ACCESS_GRANTED : self::ACCESS_DENIED;
         }

--- a/eZ/Publish/Core/settings/limitations/language.yml
+++ b/eZ/Publish/Core/settings/limitations/language.yml
@@ -1,0 +1,12 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+    _instanceof:
+        eZ\Publish\Core\Limitation\LanguageLimitation\VersionTargetEvaluator:
+            tags:
+                - { name: ezplatform.limitation.language.version_target_evaluator }
+
+    eZ\Publish\Core\Limitation\LanguageLimitation\:
+        resource: '../../Limitation/LanguageLimitation/*'

--- a/eZ/Publish/Core/settings/roles.yml
+++ b/eZ/Publish/Core/settings/roles.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: limitations/language.yml }
+
 parameters:
     ezpublish.api.role.limitation_type.blocking.class: eZ\Publish\Core\Limitation\BlockingLimitationType
     ezpublish.api.role.limitation_type.content_type.class: eZ\Publish\Core\Limitation\ContentTypeLimitationType
@@ -30,8 +33,9 @@ services:
     ezpublish.api.role.limitation_type.language:
         class: "%ezpublish.api.role.limitation_type.language.class%"
         arguments:
-            - "@ezpublish.spi.persistence.language_handler"
-            - "@ezpublish.spi.persistence.content_handler"
+            $persistenceLanguageHandler: '@ezpublish.spi.persistence.language_handler'
+            $persistenceContentHandler: '@ezpublish.spi.persistence.content_handler'
+            $versionTargetEvaluators: !tagged ezplatform.limitation.language.version_target_evaluator
         tags:
             - {name: ezpublish.limitationType, alias: Language}
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31235](https://jira.ez.no/browse/EZP-31235)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5.6` for eZ Platform `v2.5.8 LTS`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

There's been a bug in validation of translation (language codes) list for publishing in LanguageLimitation which caused a regression to a result of evaluation for version translation update.

The fix itself was as simple as:
``` diff
-        if (!empty($version->forPublishLanguageCodesList) || null !== $version->forPublishLanguageCodesList) {
+        if (!empty($version->forPublishLanguageCodesList)) {
```
because the property `forPublishLanguageCodesList` is never going to be `null` (defaults to `[]`).

However this also proved that cognitive complexity of the method `LanguageLimitationType::evaluateVersionTarget` is too high so a refactoring is in order.
Instead of adding new "`if-else`" cases, a `VersionTargetEvaluator` strategy was injected to stop violating open-closed principle of SOLID. 

The change also included returning `ACCESS_DENIED` for each evaluator which returned that value, which should be done in the first place to avoid the bug.

Please review commit by commit to have a better understanding what has happened.

### QA

Regression tests against:
- [x] [EZP-30997](https://jira.ez.no/browse/EZP-30997).
- [x] [EZP-31235](https://jira.ez.no/browse/EZP-31235).
- [x] [EZP-30131](https://jira.ez.no/browse/EZP-30131)

**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
