### PR TITLE
EZP-31251: Introduced base exception for PAPI

### DIFF
--- a/eZ/Publish/API/Repository/Exceptions/BadStateException.php
+++ b/eZ/Publish/API/Repository/Exceptions/BadStateException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\BadStateException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 /**

--- a/eZ/Publish/API/Repository/Exceptions/ContentFieldValidationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/ContentFieldValidationException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 /**

--- a/eZ/Publish/API/Repository/Exceptions/ContentTypeFieldDefinitionValidationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/ContentTypeFieldDefinitionValidationException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 /**

--- a/eZ/Publish/API/Repository/Exceptions/ContentTypeValidationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/ContentTypeValidationException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\ContentTypeValidationException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 /**

--- a/eZ/Publish/API/Repository/Exceptions/ContentValidationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/ContentValidationException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\ContentValidationException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 /**

--- a/eZ/Publish/API/Repository/Exceptions/Exception.php
+++ b/eZ/Publish/API/Repository/Exceptions/Exception.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Exceptions;
+
+use Throwable;
+
+/**
+ * Marker interface for all Repository related exceptions.
+ */
+interface Exception extends Throwable
+{
+}

--- a/eZ/Publish/API/Repository/Exceptions/ForbiddenException.php
+++ b/eZ/Publish/API/Repository/Exceptions/ForbiddenException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\ForbiddenException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;

--- a/eZ/Publish/API/Repository/Exceptions/ForbiddenException.php
+++ b/eZ/Publish/API/Repository/Exceptions/ForbiddenException.php
@@ -9,11 +9,12 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Exceptions;
 
 use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;
+use Exception;
 
 /**
  * An Exception which is thrown if an operation cannot be performed by a service
  * although the current user would have permission to perform this action.
  */
-abstract class ForbiddenException extends \Exception implements RepositoryException
+abstract class ForbiddenException extends Exception implements RepositoryException
 {
 }

--- a/eZ/Publish/API/Repository/Exceptions/ForbiddenException.php
+++ b/eZ/Publish/API/Repository/Exceptions/ForbiddenException.php
@@ -8,12 +8,12 @@
  */
 namespace eZ\Publish\API\Repository\Exceptions;
 
-use Exception;
+use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;
 
 /**
  * An Exception which is thrown if an operation cannot be performed by a service
  * although the current user would have permission to perform this action.
  */
-abstract class ForbiddenException extends Exception
+abstract class ForbiddenException extends \Exception implements RepositoryException
 {
 }

--- a/eZ/Publish/API/Repository/Exceptions/InvalidArgumentException.php
+++ b/eZ/Publish/API/Repository/Exceptions/InvalidArgumentException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\InvalidArgumentException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 /**

--- a/eZ/Publish/API/Repository/Exceptions/InvalidVariationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/InvalidVariationException.php
@@ -8,11 +8,9 @@
  */
 namespace eZ\Publish\API\Repository\Exceptions;
 
-use Exception;
-
 class InvalidVariationException extends InvalidArgumentException
 {
-    public function __construct($variationName, $variationType, $code = 0, Exception $previous = null)
+    public function __construct($variationName, $variationType, $code = 0, \Exception $previous = null)
     {
         parent::__construct("Invalid variation '$variationName' for $variationType", $code, $previous);
     }

--- a/eZ/Publish/API/Repository/Exceptions/InvalidVariationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/InvalidVariationException.php
@@ -8,9 +8,11 @@ declare(strict_types=1);
 
 namespace eZ\Publish\API\Repository\Exceptions;
 
+use Exception;
+
 class InvalidVariationException extends InvalidArgumentException
 {
-    public function __construct($variationName, $variationType, $code = 0, \Exception $previous = null)
+    public function __construct($variationName, $variationType, $code = 0, Exception $previous = null)
     {
         parent::__construct("Invalid variation '$variationName' for $variationType", $code, $previous);
     }

--- a/eZ/Publish/API/Repository/Exceptions/InvalidVariationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/InvalidVariationException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the InvalidVariationException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 class InvalidVariationException extends InvalidArgumentException

--- a/eZ/Publish/API/Repository/Exceptions/LimitationValidationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/LimitationValidationException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\LimitationValidationException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 /**

--- a/eZ/Publish/API/Repository/Exceptions/NotFoundException.php
+++ b/eZ/Publish/API/Repository/Exceptions/NotFoundException.php
@@ -8,12 +8,12 @@
  */
 namespace eZ\Publish\API\Repository\Exceptions;
 
-use Exception;
+use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;
 
 /**
  * This Exception is thrown if an object referenced by an id or identifier
  * could not be found in the repository.
  */
-abstract class NotFoundException extends Exception
+abstract class NotFoundException extends \Exception implements RepositoryException
 {
 }

--- a/eZ/Publish/API/Repository/Exceptions/NotFoundException.php
+++ b/eZ/Publish/API/Repository/Exceptions/NotFoundException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\NotFoundException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;

--- a/eZ/Publish/API/Repository/Exceptions/NotFoundException.php
+++ b/eZ/Publish/API/Repository/Exceptions/NotFoundException.php
@@ -9,11 +9,12 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Exceptions;
 
 use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;
+use Exception;
 
 /**
  * This Exception is thrown if an object referenced by an id or identifier
  * could not be found in the repository.
  */
-abstract class NotFoundException extends \Exception implements RepositoryException
+abstract class NotFoundException extends Exception implements RepositoryException
 {
 }

--- a/eZ/Publish/API/Repository/Exceptions/NotImplementedException.php
+++ b/eZ/Publish/API/Repository/Exceptions/NotImplementedException.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace eZ\Publish\API\Repository\Exceptions;
 
+use Exception;
+
 /**
  * This Exception is thrown if a feature has not been implemented
  * _intentionally_. The main purpose is the search handler, where some features
@@ -22,7 +24,7 @@ class NotImplementedException extends ForbiddenException
      * @param int $code
      * @param \Exception|null $previous
      */
-    public function __construct($feature, $code = 0, \Exception $previous = null)
+    public function __construct($feature, $code = 0, Exception $previous = null)
     {
         parent::__construct("Intentionally not implemented: {$feature}", $code, $previous);
     }

--- a/eZ/Publish/API/Repository/Exceptions/NotImplementedException.php
+++ b/eZ/Publish/API/Repository/Exceptions/NotImplementedException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\NotImplementedException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 /**

--- a/eZ/Publish/API/Repository/Exceptions/PropertyNotFoundException.php
+++ b/eZ/Publish/API/Repository/Exceptions/PropertyNotFoundException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\PropertyNotFoundException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;

--- a/eZ/Publish/API/Repository/Exceptions/PropertyNotFoundException.php
+++ b/eZ/Publish/API/Repository/Exceptions/PropertyNotFoundException.php
@@ -8,12 +8,12 @@
  */
 namespace eZ\Publish\API\Repository\Exceptions;
 
-use Exception;
+use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;
 
 /**
  * This Exception is thrown if an accessed property in a value object was not found.
  */
-class PropertyNotFoundException extends Exception
+class PropertyNotFoundException extends \Exception implements RepositoryException
 {
     /**
      * Generates: Property '{$propertyName}' not found.
@@ -22,7 +22,7 @@ class PropertyNotFoundException extends Exception
      * @param string|null $className Optionally to specify class in abstract/parent classes
      * @param \Exception|null $previous
      */
-    public function __construct($propertyName, $className = null, Exception $previous = null)
+    public function __construct($propertyName, $className = null, \Exception $previous = null)
     {
         if ($className === null) {
             parent::__construct("Property '{$propertyName}' not found", 0, $previous);

--- a/eZ/Publish/API/Repository/Exceptions/PropertyNotFoundException.php
+++ b/eZ/Publish/API/Repository/Exceptions/PropertyNotFoundException.php
@@ -9,11 +9,12 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Exceptions;
 
 use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;
+use Exception;
 
 /**
  * This Exception is thrown if an accessed property in a value object was not found.
  */
-class PropertyNotFoundException extends \Exception implements RepositoryException
+class PropertyNotFoundException extends Exception implements RepositoryException
 {
     /**
      * Generates: Property '{$propertyName}' not found.
@@ -22,7 +23,7 @@ class PropertyNotFoundException extends \Exception implements RepositoryExceptio
      * @param string|null $className Optionally to specify class in abstract/parent classes
      * @param \Exception|null $previous
      */
-    public function __construct($propertyName, $className = null, \Exception $previous = null)
+    public function __construct($propertyName, $className = null, Exception $previous = null)
     {
         if ($className === null) {
             parent::__construct("Property '{$propertyName}' not found", 0, $previous);

--- a/eZ/Publish/API/Repository/Exceptions/PropertyReadOnlyException.php
+++ b/eZ/Publish/API/Repository/Exceptions/PropertyReadOnlyException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\PropertyReadOnlyException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;

--- a/eZ/Publish/API/Repository/Exceptions/PropertyReadOnlyException.php
+++ b/eZ/Publish/API/Repository/Exceptions/PropertyReadOnlyException.php
@@ -9,11 +9,12 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Exceptions;
 
 use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;
+use Exception;
 
 /**
  * This Exception is thrown on a write attempt in a read only property in a value object.
  */
-class PropertyReadOnlyException extends \Exception implements RepositoryException
+class PropertyReadOnlyException extends Exception implements RepositoryException
 {
     /**
      * Generates: Property '{$propertyName}' is readonly[ on class '{$className}'].
@@ -22,7 +23,7 @@ class PropertyReadOnlyException extends \Exception implements RepositoryExceptio
      * @param string|null $className Optionally to specify class in abstract/parent classes
      * @param \Exception|null $previous
      */
-    public function __construct($propertyName, $className = null, \Exception $previous = null)
+    public function __construct($propertyName, $className = null, Exception $previous = null)
     {
         if ($className === null) {
             parent::__construct("Property '{$propertyName}' is readonly", 0, $previous);

--- a/eZ/Publish/API/Repository/Exceptions/PropertyReadOnlyException.php
+++ b/eZ/Publish/API/Repository/Exceptions/PropertyReadOnlyException.php
@@ -8,12 +8,12 @@
  */
 namespace eZ\Publish\API\Repository\Exceptions;
 
-use Exception;
+use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;
 
 /**
  * This Exception is thrown on a write attempt in a read only property in a value object.
  */
-class PropertyReadOnlyException extends Exception
+class PropertyReadOnlyException extends \Exception implements RepositoryException
 {
     /**
      * Generates: Property '{$propertyName}' is readonly[ on class '{$className}'].
@@ -22,7 +22,7 @@ class PropertyReadOnlyException extends Exception
      * @param string|null $className Optionally to specify class in abstract/parent classes
      * @param \Exception|null $previous
      */
-    public function __construct($propertyName, $className = null, Exception $previous = null)
+    public function __construct($propertyName, $className = null, \Exception $previous = null)
     {
         if ($className === null) {
             parent::__construct("Property '{$propertyName}' is readonly", 0, $previous);

--- a/eZ/Publish/API/Repository/Exceptions/UnauthorizedException.php
+++ b/eZ/Publish/API/Repository/Exceptions/UnauthorizedException.php
@@ -8,11 +8,11 @@
  */
 namespace eZ\Publish\API\Repository\Exceptions;
 
-use Exception;
+use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;
 
 /**
  * This Exception is thrown if the user has is not allowed to perform a service operation.
  */
-abstract class UnauthorizedException extends Exception
+abstract class UnauthorizedException extends \Exception implements RepositoryException
 {
 }

--- a/eZ/Publish/API/Repository/Exceptions/UnauthorizedException.php
+++ b/eZ/Publish/API/Repository/Exceptions/UnauthorizedException.php
@@ -9,10 +9,11 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Exceptions;
 
 use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;
+use Exception;
 
 /**
  * This Exception is thrown if the user has is not allowed to perform a service operation.
  */
-abstract class UnauthorizedException extends \Exception implements RepositoryException
+abstract class UnauthorizedException extends Exception implements RepositoryException
 {
 }

--- a/eZ/Publish/API/Repository/Exceptions/UnauthorizedException.php
+++ b/eZ/Publish/API/Repository/Exceptions/UnauthorizedException.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Exceptions\UnauthorizedException class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Exceptions;
 
 use eZ\Publish\API\Repository\Exceptions\Exception as RepositoryException;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31251](https://jira.ez.no/browse/EZP-31251)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | ?
| **Doc needed**     | no

Introduced `eZ\Publish\API\Repository\Exceptions\Exception` in https://github.com/ezsystems/ezpublish-kernel/pull/2905/commits/11a76e04266ac3d65bfec9ed1d6fb4dedda19a5b be able to distinguish PAPI related exceptions form others. 

Additionally unified file headers in `eZ\Publish\API\Repository\Exceptions` namespace (see  https://github.com/ezsystems/ezpublish-kernel/pull/2905/commits/6402af0e4fd783855162250827d3455d4b7e1df3)

**TODO**:
- [X] Implement feature / fix a bug.
- [ ] ~Implement tests~.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
