### PR TITLE
EZP-31258: Use "inset" for "scaledown" aliases to avoid undesired image cropping

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleDownOnlyFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleDownOnlyFilterLoader.php
@@ -37,7 +37,7 @@ class ScaleDownOnlyFilterLoader extends FilterLoaderWrapped
             $image,
             [
                 'size' => $options,
-                'mode' => ImageInterface::THUMBNAIL_INSET,
+                'mode' => 'inset',
             ]
         );
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoader.php
@@ -27,7 +27,7 @@ class ScaleHeightDownOnlyFilterLoader extends FilterLoaderWrapped
             $image,
             [
                 'size' => [null, $options[0]],
-                'mode' => ImageInterface::THUMBNAIL_INSET,
+                'mode' => 'inset',
             ]
         );
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoader.php
@@ -27,7 +27,7 @@ class ScaleWidthDownOnlyFilterLoader extends FilterLoaderWrapped
             $image,
             [
                 'size' => [$options[0], null],
-                'mode' => ImageInterface::THUMBNAIL_INSET,
+                'mode' => 'inset',
             ]
         );
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleDownOnlyFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleDownOnlyFilterLoaderTest.php
@@ -57,7 +57,7 @@ class ScaleDownOnlyFilterLoaderTest extends TestCase
         $this->innerLoader
             ->expects($this->once())
             ->method('load')
-            ->with($image, $this->equalTo(['size' => $options, 'mode' => ImageInterface::THUMBNAIL_INSET]))
+            ->with($image, $this->equalTo(['size' => $options, 'mode' => 'inset']))
             ->will($this->returnValue($image));
 
         $this->assertSame($image, $this->loader->load($image, $options));

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoaderTest.php
@@ -47,7 +47,7 @@ class ScaleHeightDownOnlyFilterLoaderTest extends TestCase
         $this->innerLoader
             ->expects($this->once())
             ->method('load')
-            ->with($image, $this->equalTo(['size' => [null, $height], 'mode' => ImageInterface::THUMBNAIL_INSET]))
+            ->with($image, $this->equalTo(['size' => [null, $height], 'mode' => 'inset']))
             ->will($this->returnValue($image));
 
         $this->assertSame($image, $this->loader->load($image, [$height]));

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoaderTest.php
@@ -47,7 +47,7 @@ class ScaleWidthDownOnlyFilterLoaderTest extends TestCase
         $this->innerLoader
             ->expects($this->once())
             ->method('load')
-            ->with($image, $this->equalTo(['size' => [$width, null], 'mode' => ImageInterface::THUMBNAIL_INSET]))
+            ->with($image, $this->equalTo(['size' => [$width, null], 'mode' => 'inset']))
             ->will($this->returnValue($image));
 
         $this->assertSame($image, $this->loader->load($image, [$width]));


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31258](https://jira.ez.no/browse/EZP-31258)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | no

All "scaledown" aliases (https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml#L174) are using the "outbound" thumbnail mode. This is because the Liip thumbnail filter loader is expecting the text "inset" (https://github.com/liip/LiipImagineBundle/blob/master/Imagine/Filter/Loader/ThumbnailFilterLoader.php#L25) instead of "ImageInterface::THUMBNAIL_INSET" (https://github.com/ezsystems/ezpublish-kernel/blob/7.5/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoader.php#L30). As a result, the image aliases are subject to undesirable cropping.