### PR TITLE
EZP-31203: Fixed wrong connection being used for database creation when SiteAccess option is used

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryConfigurationProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryConfigurationProvider.php
@@ -18,6 +18,7 @@ class RepositoryConfigurationProvider
 {
     private const REPOSITORY_STORAGE = 'storage';
     private const REPOSITORY_CONNECTION = 'connection';
+    private const DEFAULT_CONNECTION_NAME = 'default';
 
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;
@@ -59,6 +60,8 @@ class RepositoryConfigurationProvider
     {
         $repositoryConfig = $this->getRepositoryConfig();
 
-        return $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION];
+        return $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION]
+            ? $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION]
+            : self::DEFAULT_CONNECTION_NAME;
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryConfigurationProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryConfigurationProvider.php
@@ -16,6 +16,9 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
  */
 class RepositoryConfigurationProvider
 {
+    private const REPOSITORY_STORAGE = 'storage';
+    private const REPOSITORY_CONNECTION = 'connection';
+
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;
 
@@ -50,5 +53,12 @@ class RepositoryConfigurationProvider
         }
 
         return ['alias' => $repositoryAlias] + $this->repositories[$repositoryAlias];
+    }
+
+    public function getStorageConnectionName(): string
+    {
+        $repositoryConfig = $this->getRepositoryConfig();
+
+        return $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION];
     }
 }

--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -136,8 +136,7 @@ class InstallPlatformCommand extends Command
         );
         try {
             $bufferedOutput = new BufferedOutput();
-            $repositoryConfig = $this->repositoryConfigurationProvider->getRepositoryConfig();
-            $connectionName = $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION];
+            $connectionName = $this->getCurrentConnectionName();
             $command = sprintf('doctrine:database:create --if-not-exists --connection=%s', $connectionName);
             $this->executeCommand($bufferedOutput, $command);
             $output->writeln($bufferedOutput->fetch());
@@ -254,5 +253,12 @@ class InstallPlatformCommand extends Command
         if (!$process->isSuccessful()) {
             throw new \RuntimeException(sprintf('An error occurred when executing the "%s" command.', escapeshellarg($cmd)));
         }
+    }
+
+    private function getCurrentConnectionName(): string
+    {
+        $repositoryConfig = $this->repositoryConfigurationProvider->getRepositoryConfig();
+
+        return $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION];
     }
 }

--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -22,9 +22,6 @@ use Symfony\Component\Process\PhpExecutableFinder;
 
 class InstallPlatformCommand extends Command
 {
-    private const REPOSITORY_STORAGE = 'storage';
-    private const REPOSITORY_CONNECTION = 'connection';
-
     /** @var \Doctrine\DBAL\Connection */
     private $db;
 
@@ -136,7 +133,7 @@ class InstallPlatformCommand extends Command
         );
         try {
             $bufferedOutput = new BufferedOutput();
-            $connectionName = $this->getCurrentConnectionName();
+            $connectionName = $this->repositoryConfigurationProvider->getStorageConnectionName();
             $command = sprintf('doctrine:database:create --if-not-exists --connection=%s', $connectionName);
             $this->executeCommand($bufferedOutput, $command);
             $output->writeln($bufferedOutput->fetch());
@@ -253,12 +250,5 @@ class InstallPlatformCommand extends Command
         if (!$process->isSuccessful()) {
             throw new \RuntimeException(sprintf('An error occurred when executing the "%s" command.', escapeshellarg($cmd)));
         }
-    }
-
-    private function getCurrentConnectionName(): string
-    {
-        $repositoryConfig = $this->repositoryConfigurationProvider->getRepositoryConfig();
-
-        return $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION];
     }
 }

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -38,5 +38,6 @@ services:
             - []
             - '@ezpublish.cache_pool'
             - "%kernel.environment%"
+            - '@ezpublish.api.repository_configuration_provider'
         tags:
             - { name: console.command, command: ezplatform:install }


### PR DESCRIPTION
This PR is a followup for https://github.com/ezsystems/ezpublish-kernel/pull/2900 which adds an additional connection parameter for `doctrine:database-create` so correct database is created when `ezplatform:install` command is executed using SiteAccess with connection different than default.