### PR TITLE
[Travis] Fixed REST tests failing for PHP < 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,16 +41,16 @@ matrix:
       env: TEST_CONFIG="phpunit.xml"
     - php: 5.6
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
-    - php: 5.6
-      env: BEHAT_OPTS="--profile=core --tags=~@broken" RUN_INSTALL=1 SYMFONY_ENV=behat SYMFONY_DEBUG=1 COMPOSER_MEMORY_LIMIT=-1
 # 7.0
-    - php: 7.0
-      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" RUN_INSTALL=1 SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
-    - php: 7.0
-      env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" RUN_INSTALL=1 SYMFONY_ENV=behat
     - php: 7.0
       env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
 # 7.1
+    - php: 7.1
+      env: PHP_IMAGE=ezsystems/php:7.1-v1 BEHAT_OPTS="--profile=core --tags=~@broken" RUN_INSTALL=1 SYMFONY_ENV=behat SYMFONY_DEBUG=1 COMPOSER_MEMORY_LIMIT=-1
+    - php: 7.1
+      env: PHP_IMAGE=ezsystems/php:7.1-v1 REST_TEST_CONFIG="phpunit-functional-rest.xml" RUN_INSTALL=1 SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
+    - php: 7.1
+      env: PHP_IMAGE=ezsystems/php:7.1-v1 BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" RUN_INSTALL=1 SYMFONY_ENV=behat
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" CUSTOM_CACHE_POOL="singleredis" REDIS_ENABLE_LZF="true" REDIS_ENABLE_IGBINARY="true" SYMFONY_VERSION="~3.4.26"
 # 7.2

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ViewTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ViewTest.php
@@ -79,7 +79,8 @@ class ViewTest extends TestCase
     <offset>0</offset>
   </Query>
 </ViewInput>
-XML,
+XML
+,
                 'xml',
                 2,
                 [$foo, $bar],
@@ -103,7 +104,8 @@ XML,
     }
   }
 }
-JSON,
+JSON
+,
                 'json',
                 2,
                 [$foo, $bar],
@@ -127,7 +129,8 @@ JSON,
     <offset>0</offset>
   </Query>
 </ViewInput>
-XML,
+XML
+,
                 'xml',
                 1,
                 [$foo, $bar],
@@ -156,7 +159,8 @@ XML,
     }
   }
 }
-JSON,
+JSON
+,
                 'json',
                 2,
                 [$foo, $bar],
@@ -200,7 +204,8 @@ JSON,
     }
   }
 }
-JSON,
+JSON
+,
                 'json',
                 2,
                 [$foo, $bar],


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://jira.ez.no/browse/EZP-31268
| **Bug/Improvement**| issue in tests
| **New feature**    | no
| **Target version** | 6.13, 7.5 (not needed for master, as it requires PHP 7.3)
| **BC breaks**      | no
| **Tests pass**     | should
| **Doc needed**     | no

The REST functional tests job in ezplatform-http-cache is failing: https://travis-ci.org/ezsystems/ezplatform-http-cache/jobs/626775072

This is caused by the usage of heredoc syntax that has been allowed only since PHP 7.3:
https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.heredoc

This PR:
1) b152807f1536141aca4ffac769d51b6075762d45 (to uncover the issue): lowers the PHP versions on which tests (the ones using Docker) are run, so we can detect issues like this one. The change is from PHP 7.3 to PHP 7.2 -  I've considered different versions, but since this is the lowest still supported (according to https://www.php.net/supported-versions.php ) I think we can focus on that in tests.
2) 199ff5c23d30d407c59fef22f23796d936530b07: changes the syntax, so that tests can be run on older PHP versions as well

**TO DO (before merge):**
1. ~~Remove TMP before merging~~
2. [x] Remove redundant commits

*Notes:*
1. The code looks different in 7.5 and will require additional changes when merging upstream

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
