### PR TITLE
EZP-31279: Injected content domain mappers into the Repository

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -13,6 +13,7 @@ use eZ\Publish\Core\Repository\Permission\LimitationService;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
 use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use eZ\Publish\Core\Repository\Helper\RelationProcessor;
+use eZ\Publish\Core\Repository\Mapper;
 use eZ\Publish\Core\Search\Common\BackgroundIndexer;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy;
@@ -69,6 +70,7 @@ class RepositoryFactory implements ContainerAwareInterface
         PasswordHashServiceInterface $passwordHashService,
         ThumbnailStrategy $thumbnailStrategy,
         ProxyDomainMapperFactoryInterface $proxyDomainMapperFactory,
+        Mapper\ContentTypeDomainMapper $contentTypeDomainMapper,
         LimitationService $limitationService
     ): Repository {
         $config = $this->container->get('ezpublish.api.repository_configuration_provider')->getRepositoryConfig();
@@ -82,6 +84,7 @@ class RepositoryFactory implements ContainerAwareInterface
             $passwordHashService,
             $thumbnailStrategy,
             $proxyDomainMapperFactory,
+            $contentTypeDomainMapper,
             $limitationService,
             [
                 'role' => [

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -70,6 +70,7 @@ class RepositoryFactory implements ContainerAwareInterface
         PasswordHashServiceInterface $passwordHashService,
         ThumbnailStrategy $thumbnailStrategy,
         ProxyDomainMapperFactoryInterface $proxyDomainMapperFactory,
+        Mapper\ContentDomainMapper $contentDomainMapper,
         Mapper\ContentTypeDomainMapper $contentTypeDomainMapper,
         LimitationService $limitationService
     ): Repository {
@@ -84,6 +85,7 @@ class RepositoryFactory implements ContainerAwareInterface
             $passwordHashService,
             $thumbnailStrategy,
             $proxyDomainMapperFactory,
+            $contentDomainMapper,
             $contentTypeDomainMapper,
             $limitationService,
             [

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -58,6 +58,7 @@ class RepositoryFactory implements ContainerAwareInterface
         PasswordHashServiceInterface $passwordHashService,
         ThumbnailStrategy $thumbnailStrategy,
         ProxyDomainMapperFactoryInterface $proxyDomainMapperFactory,
+        Mapper\ContentDomainMapper $contentDomainMapper,
         Mapper\ContentTypeDomainMapper $contentTypeDomainMapper,
         LimitationService $limitationService
     ): Repository {
@@ -70,6 +71,7 @@ class RepositoryFactory implements ContainerAwareInterface
             $passwordHashService,
             $thumbnailStrategy,
             $proxyDomainMapperFactory,
+            $contentDomainMapper,
             $contentTypeDomainMapper,
             $limitationService,
             [

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -11,6 +11,7 @@ use eZ\Publish\Core\Repository\Permission\LimitationService;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
 use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use eZ\Publish\Core\Repository\Helper\RelationProcessor;
+use eZ\Publish\Core\Repository\Mapper;
 use eZ\Publish\Core\Search\Common\BackgroundIndexer;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy;
@@ -57,6 +58,7 @@ class RepositoryFactory implements ContainerAwareInterface
         PasswordHashServiceInterface $passwordHashService,
         ThumbnailStrategy $thumbnailStrategy,
         ProxyDomainMapperFactoryInterface $proxyDomainMapperFactory,
+        Mapper\ContentTypeDomainMapper $contentTypeDomainMapper,
         LimitationService $limitationService
     ): Repository {
         return new $this->repositoryClass(
@@ -68,6 +70,7 @@ class RepositoryFactory implements ContainerAwareInterface
             $passwordHashService,
             $thumbnailStrategy,
             $proxyDomainMapperFactory,
+            $contentTypeDomainMapper,
             $limitationService,
             [
                 'role' => [

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -61,8 +61,8 @@ class ContentTypeService implements ContentTypeServiceInterface
     /** @var array */
     protected $settings;
 
-    /** @var \eZ\Publish\Core\Repository\Helper\DomainMapper */
-    protected $domainMapper;
+    /** @var \eZ\Publish\Core\Repository\Mapper\ContentDomainMapper */
+    protected $contentDomainMapper;
 
     /** @var \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper */
     protected $contentTypeDomainMapper;
@@ -79,7 +79,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      * @param \eZ\Publish\API\Repository\Repository $repository
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
      * @param \eZ\Publish\SPI\Persistence\User\Handler $userHandler
-     * @param \eZ\Publish\Core\Repository\Helper\DomainMapper $domainMapper
+     * @param \eZ\Publish\Core\Repository\Mapper\ContentDomainMapper $contentDomainMapper
      * @param \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper $contentTypeDomainMapper
      * @param \eZ\Publish\Core\FieldType\FieldTypeRegistry $fieldTypeRegistry
      * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
@@ -89,7 +89,7 @@ class ContentTypeService implements ContentTypeServiceInterface
         RepositoryInterface $repository,
         Handler $contentTypeHandler,
         UserHandler $userHandler,
-        Helper\DomainMapper $domainMapper,
+        Mapper\ContentDomainMapper $contentDomainMapper,
         Helper\ContentTypeDomainMapper $contentTypeDomainMapper,
         FieldTypeRegistry $fieldTypeRegistry,
         PermissionResolver $permissionResolver,
@@ -98,7 +98,7 @@ class ContentTypeService implements ContentTypeServiceInterface
         $this->repository = $repository;
         $this->contentTypeHandler = $contentTypeHandler;
         $this->userHandler = $userHandler;
-        $this->domainMapper = $domainMapper;
+        $this->contentDomainMapper = $contentDomainMapper;
         $this->contentTypeDomainMapper = $contentTypeDomainMapper;
         $this->fieldTypeRegistry = $fieldTypeRegistry;
         // Union makes sure default settings are ignored if provided in argument
@@ -363,7 +363,7 @@ class ContentTypeService implements ContentTypeServiceInterface
         }
 
         if ($contentTypeCreateStruct->names !== null) {
-            $this->domainMapper->validateTranslatedList(
+            $this->contentDomainMapper->validateTranslatedList(
                 $contentTypeCreateStruct->names,
                 '$contentTypeCreateStruct->names'
             );
@@ -381,20 +381,20 @@ class ContentTypeService implements ContentTypeServiceInterface
         // Optional properties
 
         if ($contentTypeCreateStruct->descriptions !== null) {
-            $this->domainMapper->validateTranslatedList(
+            $this->contentDomainMapper->validateTranslatedList(
                 $contentTypeCreateStruct->descriptions,
                 '$contentTypeCreateStruct->descriptions'
             );
         }
 
-        if ($contentTypeCreateStruct->defaultSortField !== null && !$this->domainMapper->isValidLocationSortField($contentTypeCreateStruct->defaultSortField)) {
+        if ($contentTypeCreateStruct->defaultSortField !== null && !$this->contentDomainMapper->isValidLocationSortField($contentTypeCreateStruct->defaultSortField)) {
             throw new InvalidArgumentValue(
                 '$contentTypeCreateStruct->defaultSortField',
                 $contentTypeCreateStruct->defaultSortField
             );
         }
 
-        if ($contentTypeCreateStruct->defaultSortOrder !== null && !$this->domainMapper->isValidLocationSortOrder($contentTypeCreateStruct->defaultSortOrder)) {
+        if ($contentTypeCreateStruct->defaultSortOrder !== null && !$this->contentDomainMapper->isValidLocationSortOrder($contentTypeCreateStruct->defaultSortOrder)) {
             throw new InvalidArgumentValue(
                 '$contentTypeCreateStruct->defaultSortOrder',
                 $contentTypeCreateStruct->defaultSortOrder
@@ -554,14 +554,14 @@ class ContentTypeService implements ContentTypeServiceInterface
         // Optional properties
 
         if ($fieldDefinitionCreateStruct->names !== null) {
-            $this->domainMapper->validateTranslatedList(
+            $this->contentDomainMapper->validateTranslatedList(
                 $fieldDefinitionCreateStruct->names,
                 $argumentName . '->names'
             );
         }
 
         if ($fieldDefinitionCreateStruct->descriptions !== null) {
-            $this->domainMapper->validateTranslatedList(
+            $this->contentDomainMapper->validateTranslatedList(
                 $fieldDefinitionCreateStruct->descriptions,
                 $argumentName . '->descriptions'
             );
@@ -777,7 +777,7 @@ class ContentTypeService implements ContentTypeServiceInterface
         }
 
         if ($contentTypeCreateStruct->remoteId === null) {
-            $contentTypeCreateStruct->remoteId = $this->domainMapper->getUniqueHash($contentTypeCreateStruct);
+            $contentTypeCreateStruct->remoteId = $this->contentDomainMapper->getUniqueHash($contentTypeCreateStruct);
         }
 
         $spiContentTypeCreateStruct = new SPIContentTypeCreateStruct(

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -64,7 +64,7 @@ class ContentTypeService implements ContentTypeServiceInterface
     /** @var \eZ\Publish\Core\Repository\Mapper\ContentDomainMapper */
     protected $contentDomainMapper;
 
-    /** @var \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper */
+    /** @var \eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper */
     protected $contentTypeDomainMapper;
 
     /** @var \eZ\Publish\Core\FieldType\FieldTypeRegistry */
@@ -80,7 +80,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
      * @param \eZ\Publish\SPI\Persistence\User\Handler $userHandler
      * @param \eZ\Publish\Core\Repository\Mapper\ContentDomainMapper $contentDomainMapper
-     * @param \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper $contentTypeDomainMapper
+     * @param \eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper $contentTypeDomainMapper
      * @param \eZ\Publish\Core\FieldType\FieldTypeRegistry $fieldTypeRegistry
      * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
      * @param array $settings
@@ -90,7 +90,7 @@ class ContentTypeService implements ContentTypeServiceInterface
         Handler $contentTypeHandler,
         UserHandler $userHandler,
         Mapper\ContentDomainMapper $contentDomainMapper,
-        Helper\ContentTypeDomainMapper $contentTypeDomainMapper,
+        Mapper\ContentTypeDomainMapper $contentTypeDomainMapper,
         FieldTypeRegistry $fieldTypeRegistry,
         PermissionResolver $permissionResolver,
         array $settings = []

--- a/eZ/Publish/Core/Repository/Helper/NameSchemaService.php
+++ b/eZ/Publish/Core/Repository/Helper/NameSchemaService.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Repository\Helper;
 
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\Core\FieldType\FieldTypeRegistry;
+use eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
@@ -51,7 +52,7 @@ class NameSchemaService
     /** @var \eZ\Publish\SPI\Persistence\Content\Type\Handler */
     protected $contentTypeHandler;
 
-    /** @var \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper */
+    /** @var \eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper */
     protected $contentTypeDomainMapper;
 
     /** @var \eZ\Publish\Core\Repository\Helper\FieldTypeRegistry */
@@ -64,7 +65,7 @@ class NameSchemaService
      * Constructs a object to resolve $nameSchema with $contentVersion fields values.
      *
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
-     * @param \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper $contentTypeDomainMapper
+     * @param \eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper $contentTypeDomainMapper
      * @param \eZ\Publish\Core\FieldType\FieldTypeRegistry $fieldTypeRegistry
      * @param array $settings
      */

--- a/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
@@ -9,7 +9,6 @@ namespace eZ\Publish\Core\Repository\Mapper;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
 use eZ\Publish\Core\FieldType\FieldTypeRegistry;
-use eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperInterface;
 use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
@@ -57,7 +56,7 @@ class ContentDomainMapper
     /** @var \eZ\Publish\SPI\Persistence\Content\Type\Handler */
     protected $contentTypeHandler;
 
-    /** @var \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper */
+    /** @var \eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper */
     protected $contentTypeDomainMapper;
 
     /** @var \eZ\Publish\SPI\Persistence\Content\Language\Handler */
@@ -78,7 +77,7 @@ class ContentDomainMapper
      * @param \eZ\Publish\SPI\Persistence\Content\Handler $contentHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
-     * @param \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper $contentTypeDomainMapper
+     * @param \eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper $contentTypeDomainMapper
      * @param \eZ\Publish\SPI\Persistence\Content\Language\Handler $contentLanguageHandler
      * @param \eZ\Publish\Core\FieldType\FieldTypeRegistry $fieldTypeRegistry
      * @param \eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy $thumbnailStrategy

--- a/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
@@ -42,7 +42,7 @@ use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy;
  *
  * @internal Meant for internal use by Repository.
  */
-class ContentDomainMapper
+class ContentDomainMapper extends ProxyAwareDomainMapper
 {
     const MAX_LOCATION_PRIORITY = 2147483647;
     const MIN_LOCATION_PRIORITY = -2147483648;
@@ -68,21 +68,6 @@ class ContentDomainMapper
     /** @var \eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy */
     private $thumbnailStrategy;
 
-    /** @var \eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperInterface */
-    private $proxyFactory;
-
-    /**
-     * Setups service with reference to repository.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Handler $contentHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
-     * @param \eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper $contentTypeDomainMapper
-     * @param \eZ\Publish\SPI\Persistence\Content\Language\Handler $contentLanguageHandler
-     * @param \eZ\Publish\Core\FieldType\FieldTypeRegistry $fieldTypeRegistry
-     * @param \eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy $thumbnailStrategy
-     * @param \eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperInterface $proxyFactory
-     */
     public function __construct(
         ContentHandler $contentHandler,
         LocationHandler $locationHandler,
@@ -91,7 +76,7 @@ class ContentDomainMapper
         LanguageHandler $contentLanguageHandler,
         FieldTypeRegistry $fieldTypeRegistry,
         ThumbnailStrategy $thumbnailStrategy,
-        ProxyDomainMapperInterface $proxyFactory
+        ?ProxyDomainMapperInterface $proxyFactory = null
     ) {
         $this->contentHandler = $contentHandler;
         $this->locationHandler = $locationHandler;
@@ -100,7 +85,7 @@ class ContentDomainMapper
         $this->contentLanguageHandler = $contentLanguageHandler;
         $this->fieldTypeRegistry = $fieldTypeRegistry;
         $this->thumbnailStrategy = $thumbnailStrategy;
-        $this->proxyFactory = $proxyFactory;
+        parent::__construct($proxyFactory);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
@@ -1,16 +1,15 @@
 <?php
 
 /**
- * File containing the DomainMapper class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\Repository\Helper;
+namespace eZ\Publish\Core\Repository\Mapper;
 
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
 use eZ\Publish\Core\FieldType\FieldTypeRegistry;
+use eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperInterface;
 use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
@@ -40,11 +39,11 @@ use DateTime;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy;
 
 /**
- * DomainMapper is an internal service.
+ * ContentDomainMapper is an internal service.
  *
  * @internal Meant for internal use by Repository.
  */
-class DomainMapper
+class ContentDomainMapper
 {
     const MAX_LOCATION_PRIORITY = 2147483647;
     const MIN_LOCATION_PRIORITY = -2147483648;

--- a/eZ/Publish/Core/Repository/Mapper/ContentTypeDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentTypeDomainMapper.php
@@ -39,7 +39,7 @@ use DateTime;
  *
  * @internal Meant for internal use by Repository.
  */
-class ContentTypeDomainMapper
+class ContentTypeDomainMapper extends ProxyAwareDomainMapper
 {
     /** @var \eZ\Publish\SPI\Persistence\Content\Type\Handler */
     protected $contentTypeHandler;
@@ -50,27 +50,16 @@ class ContentTypeDomainMapper
     /** @var \eZ\Publish\Core\FieldType\FieldTypeRegistry */
     protected $fieldTypeRegistry;
 
-    /** @var \eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapper */
-    protected $proxyFactory;
-
-    /**
-     * Setups service with reference to repository.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\Language\Handler $contentLanguageHandler
-     * @param \eZ\Publish\Core\FieldType\FieldTypeRegistry $fieldTypeRegistry
-     * @param \eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapper $proxyFactory
-     */
     public function __construct(
         SPITypeHandler $contentTypeHandler,
         SPILanguageHandler $contentLanguageHandler,
         FieldTypeRegistry $fieldTypeRegistry,
-        ProxyDomainMapperInterface $proxyFactory
+        ?ProxyDomainMapperInterface $proxyFactory = null
     ) {
         $this->contentTypeHandler = $contentTypeHandler;
         $this->contentLanguageHandler = $contentLanguageHandler;
         $this->fieldTypeRegistry = $fieldTypeRegistry;
-        $this->proxyFactory = $proxyFactory;
+        parent::__construct($proxyFactory);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Mapper/ContentTypeDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentTypeDomainMapper.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace eZ\Publish\Core\Repository\Helper;
+namespace eZ\Publish\Core\Repository\Mapper;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType as APIContentType;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup as APIContentTypeGroup;
@@ -260,7 +260,7 @@ class ContentTypeDomainMapper
      * Builds SPIFieldDefinition object using API FieldDefinitionUpdateStruct
      * and API FieldDefinition.
      *
-     * @deprecated use \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper::buildSPIFieldDefinitionFromUpdateStruct()
+     * @deprecated use \eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper::buildSPIFieldDefinitionFromUpdateStruct()
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException if validator configuration or
      *         field setting do not validate
@@ -445,7 +445,7 @@ class ContentTypeDomainMapper
     /**
      * Builds SPIFieldDefinition object using API FieldDefinitionCreateStruct.
      *
-     * @deprecated use \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper::buildSPIFieldDefinitionFromCreateStruct()
+     * @deprecated use \eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper::buildSPIFieldDefinitionFromCreateStruct()
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException if validator configuration or
      *         field setting do not validate

--- a/eZ/Publish/Core/Repository/Mapper/ProxyAwareDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ProxyAwareDomainMapper.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Repository\Mapper;
+
+use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperInterface;
+
+/**
+ * @internal For internal use by Domain Mappers
+ *
+ * Common abstraction for domain mappers providing properties loaded via proxy.
+ */
+abstract class ProxyAwareDomainMapper
+{
+    /** @var \eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperInterface */
+    protected $proxyFactory;
+
+    public function __construct(?ProxyDomainMapperInterface $proxyFactory = null)
+    {
+        $this->proxyFactory = $proxyFactory;
+    }
+
+    /**
+     * Setter for Proxy Factory to work around cyclic dependency issue on Repository.
+     *
+     * Note: to be resolved by Repository decoupling.
+     */
+    final public function setProxyFactory(ProxyDomainMapperInterface $proxyFactory): void
+    {
+        $this->proxyFactory = $proxyFactory;
+    }
+}

--- a/eZ/Publish/Core/Repository/ProxyFactory/ProxyDomainMapper.php
+++ b/eZ/Publish/Core/Repository/ProxyFactory/ProxyDomainMapper.php
@@ -30,7 +30,7 @@ final class ProxyDomainMapper implements ProxyDomainMapperInterface
     /** @var \ProxyManager\Factory\LazyLoadingValueHolderFactory */
     private $proxyGenerator;
 
-    public function __construct(Repository $repository, ProxyGenerator $proxyGenerator)
+    public function __construct(Repository $repository, ProxyGeneratorInterface $proxyGenerator)
     {
         $this->repository = $repository;
         $this->proxyGenerator = $proxyGenerator;

--- a/eZ/Publish/Core/Repository/ProxyFactory/ProxyDomainMapperFactory.php
+++ b/eZ/Publish/Core/Repository/ProxyFactory/ProxyDomainMapperFactory.php
@@ -15,10 +15,10 @@ use eZ\Publish\API\Repository\Repository;
  */
 final class ProxyDomainMapperFactory implements ProxyDomainMapperFactoryInterface
 {
-    /** @var \eZ\Publish\Core\Repository\ProxyFactory\ProxyGenerator */
+    /** @var \eZ\Publish\Core\Repository\ProxyFactory\ProxyGeneratorInterface */
     private $proxyGenerator;
 
-    public function __construct(ProxyGenerator $proxyGenerator)
+    public function __construct(ProxyGeneratorInterface $proxyGenerator)
     {
         $this->proxyGenerator = $proxyGenerator;
     }

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -197,11 +197,7 @@ class Repository implements RepositoryInterface
     /** @var \eZ\Publish\Core\Repository\Mapper\ContentDomainMapper */
     protected $contentDomainMapper;
 
-    /**
-     * Instance of content type domain mapper.
-     *
-     * @var \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper
-     */
+    /** @var \eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper */
     protected $contentTypeDomainMapper;
 
     /**
@@ -773,16 +769,14 @@ class Repository implements RepositoryInterface
      * Get ContentType Domain Mapper.
      *
      * @todo Move out from this & other repo instances when services becomes proper services in DIC terms using factory.
-     *
-     * @return \eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper
      */
-    protected function getContentTypeDomainMapper()
+    protected function getContentTypeDomainMapper(): Mapper\ContentTypeDomainMapper
     {
         if ($this->contentTypeDomainMapper !== null) {
             return $this->contentTypeDomainMapper;
         }
 
-        $this->contentTypeDomainMapper = new Helper\ContentTypeDomainMapper(
+        $this->contentTypeDomainMapper = new Mapper\ContentTypeDomainMapper(
             $this->persistenceHandler->contentTypeHandler(),
             $this->persistenceHandler->contentLanguageHandler(),
             $this->fieldTypeRegistry,

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -234,6 +234,7 @@ class Repository implements RepositoryInterface
         PasswordHashServiceInterface $passwordHashGenerator,
         ThumbnailStrategy $thumbnailStrategy,
         ProxyDomainMapperFactoryInterface $proxyDomainMapperFactory,
+        Mapper\ContentTypeDomainMapper $contentTypeDomainMapper,
         LimitationService $limitationService,
         array $serviceSettings = [],
         ?LoggerInterface $logger = null
@@ -246,6 +247,7 @@ class Repository implements RepositoryInterface
         $this->passwordHashService = $passwordHashGenerator;
         $this->thumbnailStrategy = $thumbnailStrategy;
         $this->proxyDomainMapperFactory = $proxyDomainMapperFactory;
+        $this->contentTypeDomainMapper = $contentTypeDomainMapper;
         $this->limitationService = $limitationService;
 
         $this->serviceSettings = $serviceSettings + [
@@ -353,7 +355,7 @@ class Repository implements RepositoryInterface
             $this->persistenceHandler->contentTypeHandler(),
             $this->persistenceHandler->userHandler(),
             $this->getContentDomainMapper(),
-            $this->getContentTypeDomainMapper(),
+            $this->contentTypeDomainMapper,
             $this->fieldTypeRegistry,
             $this->getPermissionResolver(),
             $this->serviceSettings['contentType']
@@ -689,7 +691,7 @@ class Repository implements RepositoryInterface
 
         $this->nameSchemaService = new Helper\NameSchemaService(
             $this->persistenceHandler->contentTypeHandler(),
-            $this->getContentTypeDomainMapper(),
+            $this->contentTypeDomainMapper,
             $this->fieldTypeRegistry,
             $this->serviceSettings['nameSchema']
         );
@@ -744,7 +746,7 @@ class Repository implements RepositoryInterface
             $this->persistenceHandler->contentHandler(),
             $this->persistenceHandler->locationHandler(),
             $this->persistenceHandler->contentTypeHandler(),
-            $this->getContentTypeDomainMapper(),
+            $this->contentTypeDomainMapper,
             $this->persistenceHandler->contentLanguageHandler(),
             $this->fieldTypeRegistry,
             $this->thumbnailStrategy,
@@ -763,27 +765,6 @@ class Repository implements RepositoryInterface
         $this->proxyDomainMapper = $this->proxyDomainMapperFactory->create($this);
 
         return $this->proxyDomainMapper;
-    }
-
-    /**
-     * Get ContentType Domain Mapper.
-     *
-     * @todo Move out from this & other repo instances when services becomes proper services in DIC terms using factory.
-     */
-    protected function getContentTypeDomainMapper(): Mapper\ContentTypeDomainMapper
-    {
-        if ($this->contentTypeDomainMapper !== null) {
-            return $this->contentTypeDomainMapper;
-        }
-
-        $this->contentTypeDomainMapper = new Mapper\ContentTypeDomainMapper(
-            $this->persistenceHandler->contentTypeHandler(),
-            $this->persistenceHandler->contentLanguageHandler(),
-            $this->fieldTypeRegistry,
-            $this->getProxyDomainMapper()
-        );
-
-        return $this->contentTypeDomainMapper;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -194,12 +194,8 @@ class Repository implements RepositoryInterface
     /** @var \eZ\Publish\Core\Repository\Helper\RoleDomainMapper */
     protected $roleDomainMapper;
 
-    /**
-     * Instance of domain mapper.
-     *
-     * @var \eZ\Publish\Core\Repository\Helper\DomainMapper
-     */
-    protected $domainMapper;
+    /** @var \eZ\Publish\Core\Repository\Mapper\ContentDomainMapper */
+    protected $contentDomainMapper;
 
     /**
      * Instance of content type domain mapper.
@@ -308,7 +304,7 @@ class Repository implements RepositoryInterface
         $this->contentService = new ContentService(
             $this,
             $this->persistenceHandler,
-            $this->getDomainMapper(),
+            $this->getContentDomainMapper(),
             $this->getRelationProcessor(),
             $this->getNameSchemaService(),
             $this->fieldTypeRegistry,
@@ -360,7 +356,7 @@ class Repository implements RepositoryInterface
             $this,
             $this->persistenceHandler->contentTypeHandler(),
             $this->persistenceHandler->userHandler(),
-            $this->getDomainMapper(),
+            $this->getContentDomainMapper(),
             $this->getContentTypeDomainMapper(),
             $this->fieldTypeRegistry,
             $this->getPermissionResolver(),
@@ -386,7 +382,7 @@ class Repository implements RepositoryInterface
         $this->locationService = new LocationService(
             $this,
             $this->persistenceHandler,
-            $this->getDomainMapper(),
+            $this->getContentDomainMapper(),
             $this->getNameSchemaService(),
             $this->getPermissionCriterionResolver(),
             $this->getPermissionResolver(),
@@ -643,7 +639,7 @@ class Repository implements RepositoryInterface
         $this->searchService = new SearchService(
             $this,
             $this->searchHandler,
-            $this->getDomainMapper(),
+            $this->getContentDomainMapper(),
             $this->getPermissionCriterionResolver(),
             $this->backgroundIndexer,
             $this->serviceSettings['search']
@@ -742,13 +738,13 @@ class Repository implements RepositoryInterface
      *
      * @return \eZ\Publish\Core\Repository\Helper\DomainMapper
      */
-    protected function getDomainMapper()
+    protected function getContentDomainMapper(): Mapper\ContentDomainMapper
     {
-        if ($this->domainMapper !== null) {
-            return $this->domainMapper;
+        if ($this->contentDomainMapper !== null) {
+            return $this->contentDomainMapper;
         }
 
-        $this->domainMapper = new Helper\DomainMapper(
+        $this->contentDomainMapper = new Mapper\ContentDomainMapper(
             $this->persistenceHandler->contentHandler(),
             $this->persistenceHandler->locationHandler(),
             $this->persistenceHandler->contentTypeHandler(),
@@ -759,7 +755,7 @@ class Repository implements RepositoryInterface
             $this->getProxyDomainMapper()
         );
 
-        return $this->domainMapper;
+        return $this->contentDomainMapper;
     }
 
     protected function getProxyDomainMapper(): ProxyDomainMapperInterface

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -234,6 +234,7 @@ class Repository implements RepositoryInterface
         PasswordHashServiceInterface $passwordHashGenerator,
         ThumbnailStrategy $thumbnailStrategy,
         ProxyDomainMapperFactoryInterface $proxyDomainMapperFactory,
+        Mapper\ContentDomainMapper $contentDomainMapper,
         Mapper\ContentTypeDomainMapper $contentTypeDomainMapper,
         LimitationService $limitationService,
         array $serviceSettings = [],
@@ -247,6 +248,7 @@ class Repository implements RepositoryInterface
         $this->passwordHashService = $passwordHashGenerator;
         $this->thumbnailStrategy = $thumbnailStrategy;
         $this->proxyDomainMapperFactory = $proxyDomainMapperFactory;
+        $this->contentDomainMapper = $contentDomainMapper;
         $this->contentTypeDomainMapper = $contentTypeDomainMapper;
         $this->limitationService = $limitationService;
 
@@ -302,7 +304,7 @@ class Repository implements RepositoryInterface
         $this->contentService = new ContentService(
             $this,
             $this->persistenceHandler,
-            $this->getContentDomainMapper(),
+            $this->contentDomainMapper,
             $this->getRelationProcessor(),
             $this->getNameSchemaService(),
             $this->fieldTypeRegistry,
@@ -354,7 +356,7 @@ class Repository implements RepositoryInterface
             $this,
             $this->persistenceHandler->contentTypeHandler(),
             $this->persistenceHandler->userHandler(),
-            $this->getContentDomainMapper(),
+            $this->contentDomainMapper,
             $this->contentTypeDomainMapper,
             $this->fieldTypeRegistry,
             $this->getPermissionResolver(),
@@ -380,7 +382,7 @@ class Repository implements RepositoryInterface
         $this->locationService = new LocationService(
             $this,
             $this->persistenceHandler,
-            $this->getContentDomainMapper(),
+            $this->contentDomainMapper,
             $this->getNameSchemaService(),
             $this->getPermissionCriterionResolver(),
             $this->getPermissionResolver(),
@@ -637,7 +639,7 @@ class Repository implements RepositoryInterface
         $this->searchService = new SearchService(
             $this,
             $this->searchHandler,
-            $this->getContentDomainMapper(),
+            $this->contentDomainMapper,
             $this->getPermissionCriterionResolver(),
             $this->backgroundIndexer,
             $this->serviceSettings['search']
@@ -727,33 +729,6 @@ class Repository implements RepositoryInterface
     protected function getRelationProcessor()
     {
         return $this->relationProcessor;
-    }
-
-    /**
-     * Get Content Domain Mapper.
-     *
-     * @todo Move out from this & other repo instances when services becomes proper services in DIC terms using factory.
-     *
-     * @return \eZ\Publish\Core\Repository\Helper\DomainMapper
-     */
-    protected function getContentDomainMapper(): Mapper\ContentDomainMapper
-    {
-        if ($this->contentDomainMapper !== null) {
-            return $this->contentDomainMapper;
-        }
-
-        $this->contentDomainMapper = new Mapper\ContentDomainMapper(
-            $this->persistenceHandler->contentHandler(),
-            $this->persistenceHandler->locationHandler(),
-            $this->persistenceHandler->contentTypeHandler(),
-            $this->contentTypeDomainMapper,
-            $this->persistenceHandler->contentLanguageHandler(),
-            $this->fieldTypeRegistry,
-            $this->thumbnailStrategy,
-            $this->getProxyDomainMapper()
-        );
-
-        return $this->contentDomainMapper;
     }
 
     protected function getProxyDomainMapper(): ProxyDomainMapperInterface

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -23,7 +23,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Repository as APIRepository;
 use eZ\Publish\Core\Repository\Values\User\User;
 use eZ\Publish\Core\Repository\FieldTypeService;
-use eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper;
+use eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper;
 use eZ\Publish\SPI\Persistence\Handler;
 
 /**
@@ -55,7 +55,7 @@ abstract class Base extends TestCase
      */
     private $spiMockHandlers = [];
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper */
+    /** @var \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper */
     private $contentTypeDomainMapperMock;
 
     /** @var \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Permission\LimitationService */
@@ -159,7 +159,7 @@ abstract class Base extends TestCase
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper
+     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper
      */
     protected function getContentTypeDomainMapperMock()
     {

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -7,6 +7,7 @@
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
 use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\Core\Repository\Mapper\ContentDomainMapper;
 use eZ\Publish\Core\Repository\Permission\LimitationService;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
 use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
@@ -58,6 +59,9 @@ abstract class Base extends TestCase
     /** @var \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper */
     private $contentTypeDomainMapperMock;
 
+    /** @var \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Mapper\ContentDomainMapper */
+    private $contentDomainMapperMock;
+
     /** @var \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Permission\LimitationService */
     private $limitationServiceMock;
 
@@ -80,6 +84,7 @@ abstract class Base extends TestCase
                 $this->createMock(PasswordHashServiceInterface::class),
                 $this->getThumbnailStrategy(),
                 $this->createMock(ProxyDomainMapperFactoryInterface::class),
+                $this->getContentDomainMapperMock(),
                 $this->getContentTypeDomainMapperMock(),
                 $this->getLimitationServiceMock(),
                 $serviceSettings,
@@ -157,6 +162,18 @@ abstract class Base extends TestCase
         }
 
         return $this->permissionResolverMock;
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Mapper\ContentDomainMapper
+     */
+    protected function getContentDomainMapperMock(): MockObject
+    {
+        if (!isset($this->contentDomainMapperMock)) {
+            $this->contentDomainMapperMock = $this->createMock(ContentDomainMapper::class);
+        }
+
+        return $this->contentDomainMapperMock;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -80,6 +80,7 @@ abstract class Base extends TestCase
                 $this->createMock(PasswordHashServiceInterface::class),
                 $this->getThumbnailStrategy(),
                 $this->createMock(ProxyDomainMapperFactoryInterface::class),
+                $this->getContentTypeDomainMapperMock(),
                 $this->getLimitationServiceMock(),
                 $serviceSettings,
             );

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -31,7 +31,7 @@ use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\Core\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
-use eZ\Publish\Core\Repository\Helper\DomainMapper;
+use eZ\Publish\Core\Repository\Mapper\ContentDomainMapper;
 use eZ\Publish\Core\Repository\Helper\RelationProcessor;
 use eZ\Publish\Core\Repository\Helper\NameSchemaService;
 use eZ\Publish\API\Repository\Values\Content\Field;
@@ -55,6 +55,7 @@ use eZ\Publish\SPI\Persistence\Content\MetadataUpdateStruct as SPIMetadataUpdate
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
 use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Mock test case for Content service.
@@ -76,7 +77,7 @@ class ContentTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Persistence\Handler $persistenceHandlerMock */
         $persistenceHandlerMock = $this->getPersistenceMockHandler('Handler');
-        $domainMapperMock = $this->getDomainMapperMock();
+        $contentDomainMapperMock = $this->getContentDomainMapperMock();
         $relationProcessorMock = $this->getRelationProcessorMock();
         $nameSchemaServiceMock = $this->getNameSchemaServiceMock();
         $fieldTypeRegistryMock = $this->getFieldTypeRegistryMock();
@@ -86,7 +87,7 @@ class ContentTest extends BaseServiceMockTest
         $service = new ContentService(
             $repositoryMock,
             $persistenceHandlerMock,
-            $domainMapperMock,
+            $contentDomainMapperMock,
             $relationProcessorMock,
             $nameSchemaServiceMock,
             $fieldTypeRegistryMock,
@@ -105,7 +106,7 @@ class ContentTest extends BaseServiceMockTest
         $contentServiceMock = $this->getPartlyMockedContentService(['loadContentInfo']);
         /** @var \PHPUnit\Framework\MockObject\MockObject $contentHandler */
         $contentHandler = $this->getPersistenceMock()->contentHandler();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $versionInfoMock = $this->createMock(APIVersionInfo::class);
         $permissionResolver = $this->getPermissionResolverMock();
 
@@ -155,7 +156,7 @@ class ContentTest extends BaseServiceMockTest
         $contentServiceMock = $this->getPartlyMockedContentService(['loadContentInfo']);
         /** @var \PHPUnit_Framework_MockObject_MockObject $contentHandler */
         $contentHandler = $this->getPersistenceMock()->contentHandler();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock->expects($this->any())
@@ -236,7 +237,7 @@ class ContentTest extends BaseServiceMockTest
         $contentServiceMock = $this->getPartlyMockedContentService();
         /** @var \PHPUnit\Framework\MockObject\MockObject $contentHandler */
         $contentHandler = $this->getPersistenceMock()->contentHandler();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $versionInfoMock = $this->createMock(APIVersionInfo::class);
         $permissionResolver = $this->getPermissionResolverMock();
 
@@ -279,7 +280,7 @@ class ContentTest extends BaseServiceMockTest
         $contentServiceMock = $this->getPartlyMockedContentService();
         /** @var \PHPUnit\Framework\MockObject\MockObject $contentHandler */
         $contentHandler = $this->getPersistenceMock()->contentHandler();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $versionInfoMock = $this->createMock(APIVersionInfo::class);
         $permissionResolver = $this->getPermissionResolverMock();
 
@@ -324,7 +325,7 @@ class ContentTest extends BaseServiceMockTest
         $contentServiceMock = $this->getPartlyMockedContentService();
         /** @var \PHPUnit\Framework\MockObject\MockObject $contentHandler */
         $contentHandler = $this->getPersistenceMock()->contentHandler();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $versionInfoMock = $this->createMock(APIVersionInfo::class);
         $permissionResolver = $this->getPermissionResolverMock();
 
@@ -1181,7 +1182,7 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit\Framework\MockObject\MockObject $objectStateHandlerMock */
         $objectStateHandlerMock = $this->getPersistenceMock()->objectStateHandler();
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $relationProcessorMock = $this->getRelationProcessorMock();
         $nameSchemaServiceMock = $this->getNameSchemaServiceMock();
         $permissionResolverMock = $this->getPermissionResolverMock();
@@ -1815,7 +1816,7 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $permissionResolver = $this->getPermissionResolverMock();
 
         $contentType = new ContentType(
@@ -2056,7 +2057,7 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $fieldTypeMock = $this->createMock(SPIFieldType::class);
         $permissionResolver = $this->getPermissionResolverMock();
 
@@ -2248,7 +2249,7 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $relationProcessorMock = $this->getRelationProcessorMock();
         $fieldTypeMock = $this->createMock(SPIFieldType::class);
         $languageCodes = $this->determineLanguageCodesForCreate($mainLanguageCode, $structFields);
@@ -2476,7 +2477,7 @@ class ContentTest extends BaseServiceMockTest
         $locationServiceMock = $this->getLocationServiceMock();
         /** @var \PHPUnit\Framework\MockObject\MockObject $handlerMock */
         $handlerMock = $this->getPersistenceMock()->contentHandler();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $spiLocationCreateStruct = new SPILocation\CreateStruct();
         $parentLocation = new Location(['contentInfo' => new ContentInfo(['sectionId' => 1])]);
 
@@ -2589,7 +2590,7 @@ class ContentTest extends BaseServiceMockTest
         $mockedService = $this->getPartlyMockedContentService();
         $locationServiceMock = $this->getLocationServiceMock();
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $permissionResolver = $this->getPermissionResolverMock();
         /** @var \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
@@ -2746,7 +2747,7 @@ class ContentTest extends BaseServiceMockTest
         $mockedService = $this->getPartlyMockedContentService();
         /** @var \PHPUnit\Framework\MockObject\MockObject $handlerMock */
         $handlerMock = $this->getPersistenceMock()->contentHandler();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
 
         $this->mockGetDefaultObjectStates();
         $this->mockSetDefaultObjectStates();
@@ -3120,7 +3121,7 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $relationProcessorMock = $this->getRelationProcessorMock();
         $nameSchemaServiceMock = $this->getNameSchemaServiceMock();
         $fieldTypeMock = $this->createMock(SPIFieldType::class);
@@ -5555,7 +5556,7 @@ class ContentTest extends BaseServiceMockTest
 
         /** @var \PHPUnit\Framework\MockObject\MockObject $contentHandlerMock */
         $contentHandlerMock = $this->getPersistenceMock()->contentHandler();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
 
         $repositoryMock->expects($this->once())->method('beginTransaction');
         $repositoryMock->expects($this->once())->method('commit');
@@ -5683,7 +5684,7 @@ class ContentTest extends BaseServiceMockTest
 
         /** @var \PHPUnit\Framework\MockObject\MockObject $contentHandlerMock */
         $contentHandlerMock = $this->getPersistenceMock()->contentHandler();
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
 
         $repositoryMock->expects($this->once())->method('beginTransaction');
         $repositoryMock->expects($this->once())->method('commit');
@@ -5844,7 +5845,7 @@ class ContentTest extends BaseServiceMockTest
 
         $content = $this->createMock(APIContent::class);
 
-        $this->getDomainMapperMock()
+        $this->getContentDomainMapperMock()
             ->expects($this->once())
             ->method('buildContentDomainObject')
             ->with($spiContent, $contentType, $translations ?? [], $useAlwaysAvailable)
@@ -6047,18 +6048,18 @@ class ContentTest extends BaseServiceMockTest
             ->with(123, 456, ['eng-GB']);
     }
 
-    protected $domainMapperMock;
+    protected $contentDomainMapperMock;
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Helper\DomainMapper
+     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Mapper\ContentDomainMapper
      */
-    protected function getDomainMapperMock()
+    protected function getContentDomainMapperMock(): MockObject
     {
-        if (!isset($this->domainMapperMock)) {
-            $this->domainMapperMock = $this->createMock(DomainMapper::class);
+        if (!isset($this->contentDomainMapperMock)) {
+            $this->contentDomainMapperMock = $this->createMock(ContentDomainMapper::class);
         }
 
-        return $this->domainMapperMock;
+        return $this->contentDomainMapperMock;
     }
 
     protected $relationProcessorMock;
@@ -6138,7 +6139,7 @@ class ContentTest extends BaseServiceMockTest
                     [
                         $this->getRepositoryMock(),
                         $this->getPersistenceMock(),
-                        $this->getDomainMapperMock(),
+                        $this->getContentDomainMapperMock(),
                         $this->getRelationProcessorMock(),
                         $this->getNameSchemaServiceMock(),
                         $this->getFieldTypeRegistryMock(),

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -31,7 +31,6 @@ use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\Core\Repository\Values\Content\ContentUpdateStruct;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
-use eZ\Publish\Core\Repository\Mapper\ContentDomainMapper;
 use eZ\Publish\Core\Repository\Helper\RelationProcessor;
 use eZ\Publish\Core\Repository\Helper\NameSchemaService;
 use eZ\Publish\API\Repository\Values\Content\Field;
@@ -6046,20 +6045,6 @@ class ContentTest extends BaseServiceMockTest
         $urlAliasHandlerMock->expects($this->once())
             ->method('archiveUrlAliasesForDeletedTranslations')
             ->with(123, 456, ['eng-GB']);
-    }
-
-    protected $contentDomainMapperMock;
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Mapper\ContentDomainMapper
-     */
-    protected function getContentDomainMapperMock(): MockObject
-    {
-        if (!isset($this->contentDomainMapperMock)) {
-            $this->contentDomainMapperMock = $this->createMock(ContentDomainMapper::class);
-        }
-
-        return $this->contentDomainMapperMock;
     }
 
     protected $relationProcessorMock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
@@ -15,7 +15,7 @@ use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperInterface;
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
-use eZ\Publish\Core\Repository\Helper\DomainMapper;
+use eZ\Publish\Core\Repository\Mapper\ContentDomainMapper;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
@@ -25,7 +25,7 @@ use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo as SPIVersionInfo;
 
 /**
- * Mock test case for internal DomainMapper.
+ * Mock test case for internal ContentDomainMapper.
  */
 class DomainMapperTest extends BaseServiceMockTest
 {
@@ -38,7 +38,7 @@ class DomainMapperTest extends BaseServiceMockTest
     private const EXAMPLE_CREATOR_ID = 23;
 
     /**
-     * @covers \eZ\Publish\Core\Repository\Helper\DomainMapper::buildVersionInfoDomainObject
+     * @covers \eZ\Publish\Core\Repository\Mapper\ContentDomainMapper::buildVersionInfoDomainObject
      * @dataProvider providerForBuildVersionInfo
      */
     public function testBuildVersionInfo(SPIVersionInfo $spiVersionInfo)
@@ -46,18 +46,18 @@ class DomainMapperTest extends BaseServiceMockTest
         $languageHandlerMock = $this->getLanguageHandlerMock();
         $languageHandlerMock->expects($this->never())->method('load');
 
-        $versionInfo = $this->getDomainMapper()->buildVersionInfoDomainObject($spiVersionInfo);
+        $versionInfo = $this->getContentDomainMapper()->buildVersionInfoDomainObject($spiVersionInfo);
 
         $this->assertInstanceOf(APIVersionInfo::class, $versionInfo);
     }
 
     /**
-     * @covers \eZ\Publish\Core\Repository\Helper\DomainMapper::buildLocationWithContent
+     * @covers \eZ\Publish\Core\Repository\Mapper\ContentDomainMapper::buildLocationWithContent
      */
     public function testBuildLocationWithContentForRootLocation()
     {
         $spiRootLocation = new Location(['id' => 1, 'parentId' => 1]);
-        $apiRootLocation = $this->getDomainMapper()->buildLocationWithContent($spiRootLocation, null);
+        $apiRootLocation = $this->getContentDomainMapper()->buildLocationWithContent($spiRootLocation, null);
 
         $legacyDateTime = new DateTime();
         $legacyDateTime->setTimestamp(1030968000);
@@ -98,7 +98,7 @@ class DomainMapperTest extends BaseServiceMockTest
     }
 
     /**
-     * @covers \eZ\Publish\Core\Repository\Helper\DomainMapper::buildLocationWithContent
+     * @covers \eZ\Publish\Core\Repository\Mapper\ContentDomainMapper::buildLocationWithContent
      */
     public function testBuildLocationWithContentThrowsInvalidArgumentException()
     {
@@ -107,7 +107,7 @@ class DomainMapperTest extends BaseServiceMockTest
 
         $nonRootLocation = new Location(['id' => 2, 'parentId' => 1]);
 
-        $this->getDomainMapper()->buildLocationWithContent($nonRootLocation, null);
+        $this->getContentDomainMapper()->buildLocationWithContent($nonRootLocation, null);
     }
 
     public function testBuildLocationWithContentIsAlignedWithBuildLocation()
@@ -115,8 +115,8 @@ class DomainMapperTest extends BaseServiceMockTest
         $spiRootLocation = new Location(['id' => 1, 'parentId' => 1]);
 
         $this->assertEquals(
-            $this->getDomainMapper()->buildLocationWithContent($spiRootLocation, null),
-            $this->getDomainMapper()->buildLocation($spiRootLocation)
+            $this->getContentDomainMapper()->buildLocationWithContent($spiRootLocation, null),
+            $this->getContentDomainMapper()->buildLocation($spiRootLocation)
         );
     }
 
@@ -219,7 +219,7 @@ class DomainMapperTest extends BaseServiceMockTest
     }
 
     /**
-     * @covers \eZ\Publish\Core\Repository\Helper\DomainMapper::buildLocationDomainObjectsOnSearchResult
+     * @covers \eZ\Publish\Core\Repository\Mapper\ContentDomainMapper::buildLocationDomainObjectsOnSearchResult
      * @dataProvider providerForBuildLocationDomainObjectsOnSearchResult
      *
      * @param array $locationHits
@@ -248,7 +248,7 @@ class DomainMapperTest extends BaseServiceMockTest
         }
 
         $spiResult = clone $result;
-        $missingLocations = $this->getDomainMapper()->buildLocationDomainObjectsOnSearchResult($result, $languageFilter);
+        $missingLocations = $this->getContentDomainMapper()->buildLocationDomainObjectsOnSearchResult($result, $languageFilter);
         $this->assertIsArray($missingLocations);
 
         if (!$missing) {
@@ -263,13 +263,13 @@ class DomainMapperTest extends BaseServiceMockTest
     }
 
     /**
-     * Returns DomainMapper.
+     * Returns ContentDomainMapper.
      *
-     * @return \eZ\Publish\Core\Repository\Helper\DomainMapper
+     * @return \eZ\Publish\Core\Repository\Mapper\ContentDomainMapper
      */
-    protected function getDomainMapper()
+    protected function getContentDomainMapper(): ContentDomainMapper
     {
-        return new DomainMapper(
+        return new ContentDomainMapper(
             $this->getContentHandlerMock(),
             $this->getPersistenceMockHandler('Content\\Location\\Handler'),
             $this->getTypeHandlerMock(),

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
@@ -9,7 +9,7 @@
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
 use eZ\Publish\Core\Repository\ContentService;
-use eZ\Publish\Core\Repository\Helper\DomainMapper;
+use eZ\Publish\Core\Repository\Mapper\ContentDomainMapper;
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\Core\Repository\SearchService;
 use eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver;
@@ -35,7 +35,7 @@ class SearchTest extends BaseServiceMockTest
 {
     protected $repositoryMock;
 
-    protected $domainMapperMock;
+    protected $contentDomainMapperMock;
 
     protected $permissionsCriterionResolverMock;
 
@@ -49,14 +49,14 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $domainMapperMock = $this->getDomainMapperMock();
+        $contentDomainMapperMock = $this->getContentDomainMapperMock();
         $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $settings = ['teh setting'];
 
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
-            $domainMapperMock,
+            $contentDomainMapperMock,
             $permissionsCriterionResolverMock,
             new NullIndexer(),
             $settings
@@ -108,7 +108,7 @@ class SearchTest extends BaseServiceMockTest
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
-            $this->getDomainMapperMock(),
+            $this->getContentDomainMapperMock(),
             $permissionsCriterionResolverMock,
             new NullIndexer(),
             []
@@ -156,7 +156,7 @@ class SearchTest extends BaseServiceMockTest
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
-            $this->getDomainMapperMock(),
+            $this->getContentDomainMapperMock(),
             $permissionsCriterionResolverMock,
             new NullIndexer(),
             []
@@ -191,7 +191,7 @@ class SearchTest extends BaseServiceMockTest
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
-            $this->getDomainMapperMock(),
+            $this->getContentDomainMapperMock(),
             $permissionsCriterionResolverMock,
             new NullIndexer(),
             []
@@ -228,7 +228,7 @@ class SearchTest extends BaseServiceMockTest
             ->setConstructorArgs([
                 $this->getRepositoryMock(),
                 $this->getSPIMockHandler('Search\\Handler'),
-                $mapper = $this->getDomainMapperMock(),
+                $mapper = $this->getContentDomainMapperMock(),
                 $this->getPermissionCriterionResolverMock(),
                 $indexer,
             ])->setMethods(['internalFindContentInfo'])
@@ -271,7 +271,7 @@ class SearchTest extends BaseServiceMockTest
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
-            $mapper = $this->getDomainMapperMock(),
+            $mapper = $this->getContentDomainMapperMock(),
             $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock(),
             new NullIndexer(),
             []
@@ -332,7 +332,7 @@ class SearchTest extends BaseServiceMockTest
     {
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $service = new SearchService(
             $this->getRepositoryMock(),
@@ -409,7 +409,7 @@ class SearchTest extends BaseServiceMockTest
         $service = new SearchService(
             $this->getRepositoryMock(),
             $searchHandlerMock,
-            $mapper = $this->getDomainMapperMock(),
+            $mapper = $this->getContentDomainMapperMock(),
             $permissionsCriterionResolverMock,
             new NullIndexer(),
             []
@@ -449,7 +449,7 @@ class SearchTest extends BaseServiceMockTest
     {
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $service = new SearchService(
             $this->getRepositoryMock(),
             $searchHandlerMock,
@@ -526,7 +526,7 @@ class SearchTest extends BaseServiceMockTest
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
-            $this->getDomainMapperMock(),
+            $this->getContentDomainMapperMock(),
             $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock(),
             new NullIndexer(),
             []
@@ -564,7 +564,7 @@ class SearchTest extends BaseServiceMockTest
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
-            $this->getDomainMapperMock(),
+            $this->getContentDomainMapperMock(),
             $permissionsCriterionResolverMock,
             new NullIndexer(),
             []
@@ -595,7 +595,7 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $service = new SearchService(
             $repositoryMock,
@@ -660,7 +660,7 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $service = new SearchService(
             $repositoryMock,
@@ -731,7 +731,7 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $service = new SearchService(
             $repositoryMock,
@@ -806,7 +806,7 @@ class SearchTest extends BaseServiceMockTest
             ->setConstructorArgs([
                 $this->getRepositoryMock(),
                 $searchHandler = $this->getSPIMockHandler('Search\\Handler'),
-                $mapper = $this->getDomainMapperMock(),
+                $mapper = $this->getContentDomainMapperMock(),
                 $this->getPermissionCriterionResolverMock(),
                 $indexer,
             ])->setMethods(['addPermissionsCriterion'])
@@ -856,7 +856,7 @@ class SearchTest extends BaseServiceMockTest
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
-            $this->getDomainMapperMock(),
+            $this->getContentDomainMapperMock(),
             $permissionsCriterionResolverMock,
             new NullIndexer(),
             []
@@ -885,7 +885,7 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $domainMapperMock = $this->getDomainMapperMock();
+        $domainMapperMock = $this->getContentDomainMapperMock();
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
@@ -946,18 +946,18 @@ class SearchTest extends BaseServiceMockTest
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Helper\DomainMapper
+     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Mapper\ContentDomainMapper
      */
-    protected function getDomainMapperMock()
+    protected function getContentDomainMapperMock()
     {
-        if (!isset($this->domainMapperMock)) {
-            $this->domainMapperMock = $this
-                ->getMockBuilder(DomainMapper::class)
+        if (!isset($this->contentDomainMapperMock)) {
+            $this->contentDomainMapperMock = $this
+                ->getMockBuilder(ContentDomainMapper::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         }
 
-        return $this->domainMapperMock;
+        return $this->contentDomainMapperMock;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
@@ -9,7 +9,6 @@
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
 use eZ\Publish\Core\Repository\ContentService;
-use eZ\Publish\Core\Repository\Mapper\ContentDomainMapper;
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\Core\Repository\SearchService;
 use eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver;
@@ -943,21 +942,6 @@ class SearchTest extends BaseServiceMockTest
             $endResult,
             $result
         );
-    }
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Mapper\ContentDomainMapper
-     */
-    protected function getContentDomainMapperMock()
-    {
-        if (!isset($this->contentDomainMapperMock)) {
-            $this->contentDomainMapperMock = $this
-                ->getMockBuilder(ContentDomainMapper::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-        }
-
-        return $this->contentDomainMapperMock;
     }
 
     /**

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -24,6 +24,7 @@ services:
             - '@eZ\Publish\Core\Repository\User\PasswordHashService'
             - '@eZ\Publish\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'
             - '@eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactory'
+            - '@eZ\Publish\Core\Repository\Mapper\ContentDomainMapper'
             - '@eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper'
             - '@eZ\Publish\Core\Repository\Permission\LimitationService'
         lazy: true

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -148,3 +148,13 @@ services:
             $contentTypeHandler: '@ezpublish.spi.persistence.content_type_handler'
             $contentLanguageHandler: '@ezpublish.spi.persistence.language_handler'
             $fieldTypeRegistry: '@eZ\Publish\Core\FieldType\FieldTypeRegistry'
+
+    eZ\Publish\Core\Repository\Mapper\ContentDomainMapper:
+        arguments:
+            $contentHandler: '@ezpublish.spi.persistence.content_handler'
+            $locationHandler: '@ezpublish.spi.persistence.location_handler'
+            $contentTypeHandler: '@ezpublish.spi.persistence.content_type_handler'
+            $contentTypeDomainMapper: '@eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper'
+            $contentLanguageHandler: '@ezpublish.spi.persistence.language_handler'
+            $fieldTypeRegistry: '@eZ\Publish\Core\FieldType\FieldTypeRegistry'
+            $thumbnailStrategy: '@eZ\Publish\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -127,6 +127,7 @@ services:
         calls:
             - ['setLogger', ['@?logger']]
 
+    # Domain mappers and proxies
     eZ\Publish\Core\Repository\ProxyFactory\ProxyGenerator:
         arguments:
             $proxyCacheDir: '%ezplatform.kernel.proxy_cache_dir%'
@@ -138,19 +139,31 @@ services:
         arguments:
             $proxyGenerator: '@eZ\Publish\Core\Repository\ProxyFactory\ProxyGeneratorInterface'
 
-    # Permission-related
-    eZ\Publish\Core\Repository\Permission\LimitationService:
+    eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapper:
+        factory: ['@eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactory', 'create']
         arguments:
-            $limitationTypes: !tagged_iterator { tag: ezpublish.limitationType, index_by: alias }
+            $repository: '@ezpublish.api.inner_repository'
+
+    eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperInterface:
+        alias: 'eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapper'
 
     # Mappers
+    eZ\Publish\Core\Repository\Mapper\ProxyAwareDomainMapper:
+        abstract: true
+        calls:
+            -   method: setProxyFactory
+                arguments:
+                    $proxyFactory: '@eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperInterface'
+
     eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper:
+        parent: eZ\Publish\Core\Repository\Mapper\ProxyAwareDomainMapper
         arguments:
             $contentTypeHandler: '@ezpublish.spi.persistence.content_type_handler'
             $contentLanguageHandler: '@ezpublish.spi.persistence.language_handler'
             $fieldTypeRegistry: '@eZ\Publish\Core\FieldType\FieldTypeRegistry'
 
     eZ\Publish\Core\Repository\Mapper\ContentDomainMapper:
+        parent: eZ\Publish\Core\Repository\Mapper\ProxyAwareDomainMapper
         arguments:
             $contentHandler: '@ezpublish.spi.persistence.content_handler'
             $locationHandler: '@ezpublish.spi.persistence.location_handler'
@@ -159,3 +172,8 @@ services:
             $contentLanguageHandler: '@ezpublish.spi.persistence.language_handler'
             $fieldTypeRegistry: '@eZ\Publish\Core\FieldType\FieldTypeRegistry'
             $thumbnailStrategy: '@eZ\Publish\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'
+
+    # Permission-related
+    eZ\Publish\Core\Repository\Permission\LimitationService:
+        arguments:
+            $limitationTypes: !tagged_iterator { tag: ezpublish.limitationType, index_by: alias }

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -140,3 +140,10 @@ services:
     eZ\Publish\Core\Repository\Permission\LimitationService:
         arguments:
             $limitationTypes: !tagged_iterator { tag: ezpublish.limitationType, index_by: alias }
+
+    # Mappers
+    eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper:
+        arguments:
+            $contentTypeHandler: '@ezpublish.spi.persistence.content_type_handler'
+            $contentLanguageHandler: '@ezpublish.spi.persistence.language_handler'
+            $fieldTypeRegistry: '@eZ\Publish\Core\FieldType\FieldTypeRegistry'

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -24,6 +24,7 @@ services:
             - '@eZ\Publish\Core\Repository\User\PasswordHashService'
             - '@eZ\Publish\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'
             - '@eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactory'
+            - '@eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper'
             - '@eZ\Publish\Core\Repository\Permission\LimitationService'
         lazy: true
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31279](https://jira.ez.no/browse/EZP-31279)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | no (internal Service)
| **Tests pass**     | yes
| **Doc needed**     | no

### Summary

This PR makes Content Type and Content domain mappers injectable Symfony Services and injects them into the Repository instead of building them on the fly.

Moreover those mappers were moved into the proper namespace:
- `\eZ\Publish\Core\Repository\Helper\ContentTypeDomainMapper`
   into `\eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper`,
- `\eZ\Publish\Core\Repository\Helper\DomainMapper` 
   into `eZ\Publish\Core\Repository\Mapper\ContentDomainMapper` (also renamed for better clarity).

Please see distinct commits for all the changes.

### Background

It's a part of a larger decoupling story. The major issue with the current architecture is a lot of cyclic dependencies and a lot of changes needed to modify direct dependencies of Repository. The good example is Content Thumbnail feature which has been implemented recently. To inject `ThumbnailStrategy` service into the `ContentDomainMapper` we had to modify: `RepositoryFactory` (x2), `Repository`, related tests and the domain mapper itself. This is very much not SOLID and causes cyclic dependency issues. With the changes from this PR `ThumbnailStrategy` can be removed from `Repository` as a follow-up. This is just one example of course.

### QA

- [x] Sanities for Content and Content Types manipulation.
- [x] Regression tests against ezsystems/ezpublish-kernel#2844

You can use the [`qa-cumulative-ezp-31278-31279-decouple-content-mappers-limitation-svc`](https://github.com/ezsystems/ezpublish-kernel/tree/qa-cumulative-ezp-31278-31279-decouple-content-mappers-limitation-svc) branch to test both #2913 and #2914 

**TODO**:
- [x] Wait for Travis
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
