### PR TITLE
EZP-31275: Added tests for SearchService findLocations method covering IsEmpty Criterion

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
@@ -240,7 +240,7 @@ class SearchServiceLocationTest extends BaseTest
             $result->searchHits[0]->valueObject->id
         );
     }
-    
+
     /**
      * Test for the findLocations() method.
      *

--- a/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
@@ -56,7 +56,7 @@ class SearchServiceLocationTest extends BaseTest
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content[]
      */
-    protected function createMovieContent()
+    protected function createMovieContent(): array
     {
         $movies = [];
 

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -1289,12 +1289,12 @@ class SearchServiceTest extends BaseTest
     /**
      * Test for the findContent() method.
      *
-     * @param \eZ\Publish\API\Repository\Values\Content\Content[]
      * @see \eZ\Publish\API\Repository\SearchService::findContent()
-     * @depends \eZ\Publish\API\Repository\Tests\SearchServiceTest::testFieldIsEmpty
      */
-    public function testFieldIsNotEmpty(array $testContents)
+    public function testFieldIsNotEmpty()
     {
+        $testContents = $this->createMovieContent();
+
         $query = new Query(
             [
                 'query' => new Criterion\IsFieldEmpty(


### PR DESCRIPTION
This PR adds test so IsEmpty Critertion is checked for `SearchService::findLocations` as well.
Also (a little out-of-scope) fixes one test for `findContent` which was never executed :P

Followup for: https://github.com/ezsystems/ezplatform-solr-search-engine/pull/164