### PR TITLE
EZP-31290: Removed the required '@' prefix on custom view matchers

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/ServiceAwareMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/ServiceAwareMatcherFactory.php
@@ -38,10 +38,10 @@ final class ServiceAwareMatcherFactory extends ClassNameMatcherFactory
      */
     protected function getMatcher($matcherIdentifier)
     {
-        if (strpos($matcherIdentifier, '@') === 0) {
-            return $this->viewMatcherRegistry->getMatcher(substr($matcherIdentifier, 1));
+        try {
+            return $this->viewMatcherRegistry->getMatcher($matcherIdentifier);
+        } catch (\eZ\Publish\API\Repository\Exceptions\NotFoundException $e) {
+            return parent::getMatcher($matcherIdentifier);
         }
-
-        return parent::getMatcher($matcherIdentifier);
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31290](https://jira.ez.no/browse/EZP-31290)
| **Bug/Improvement**| bug
| **New feature**    | yes/no
| **Target version** | `8.x` / `master`
| **BC breaks**      | yes, but no
| **Tests pass**     | maybe
| **Doc needed**     | maybe

Custom, service based view matchers were changed in kernel v8 to require an `@` prefix. It turns out that it wasn't necessary in earlier versions, as the matcher's name would be [searched for as is in the container](https://github.com/ezsystems/ezpublish-kernel/blob/7.5/eZ/Bundle/EzPublishCoreBundle/Matcher/ServiceAwareMatcherFactory.php#L28-L30). This change removes the check & handling of that prefix.
