### PR TITLE
Fine-tuned value argument PHPDoc for Ancestor and RemoteId Criteria

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
@@ -22,7 +22,7 @@ class Ancestor extends Criterion
     /**
      * Creates a new Ancestor criterion.
      *
-     * @param string $value Location path string
+     * @param string|string[] $value Location path string
      *
      * @throws \InvalidArgumentException if a non integer or string id is given
      * @throws \InvalidArgumentException if the value type doesn't match the operator

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationRemoteId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationRemoteId.php
@@ -23,7 +23,7 @@ class LocationRemoteId extends Criterion
     /**
      * Creates a new locationRemoteId criterion.
      *
-     * @param int|int[] $value One or more locationRemoteId that must be matched
+     * @param string|string[] $value One or more locationRemoteId that must be matched
      *
      * @throws \InvalidArgumentException if a non numeric id is given
      * @throws \InvalidArgumentException if the value type doesn't match the operator

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/RemoteId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/RemoteId.php
@@ -23,7 +23,7 @@ class RemoteId extends Criterion
     /**
      * Creates a new remoteId criterion.
      *
-     * @param int|int[] $value One or more remoteId that must be matched
+     * @param string|string[] $value One or more remoteId that must be matched
      *
      * @throws \InvalidArgumentException if a non numeric id is given
      * @throws \InvalidArgumentException if the value type doesn't match the operator


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| Improvement
| **New feature**    | no
| **Target version** | `7.5`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | maybe

The value parameter for the `Ancestor` criterion is documented as string, while it also accepts an array of strings.