### PR TITLE
EZP-31088: Refactored Language GW to use Doctrine\DBAL

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LanguageServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LanguageServiceTest.php
@@ -489,9 +489,6 @@ class LanguageServiceTest extends BaseTest
      */
     public function testDeleteLanguage()
     {
-        $this->expectException(\eZ\Publish\Core\Base\Exceptions\NotFoundException::class);
-        $this->expectExceptionMessage('Could not find \'Language\' with identifier \'eng-NZ\'');
-
         $repository = $this->getRepository();
         $languageService = $repository->getContentLanguageService();
 
@@ -513,6 +510,9 @@ class LanguageServiceTest extends BaseTest
 
         // +1 -1
         $this->assertEquals($beforeCount, count($languageService->loadLanguages()));
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage('Could not find \'Language\' with identifier \'eng-NZ\'');
 
         // ensure just created & deleted language doesn't exist
         $languageService->loadLanguage($languageCreateEnglish->languageCode);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Language;
 
 use eZ\Publish\SPI\Persistence\Content\Language;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway.php
@@ -15,6 +15,32 @@ use eZ\Publish\SPI\Persistence\Content\Language;
  */
 abstract class Gateway
 {
+    public const CONTENT_LANGUAGE_TABLE = 'ezcontent_language';
+
+    /**
+     * A map of language-related table name to its language column.
+     *
+     * The first column is considered to be a language bitmask.
+     * The second, optional, column is an explicit language id.
+     *
+     * It depends on the schema defined in
+     * <code>eZ/Bundle/EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml</code>
+     */
+    public const MULTILINGUAL_TABLES_COLUMNS = [
+        'ezcobj_state' => ['language_mask', 'default_language_id'],
+        'ezcobj_state_group_language' => ['language_id'],
+        'ezcobj_state_group' => ['language_mask', 'default_language_id'],
+        'ezcobj_state_language' => ['language_id'],
+        'ezcontentclass_attribute_ml' => ['language_id'],
+        'ezcontentclass_name' => ['language_id'],
+        'ezcontentclass' => ['language_mask', 'initial_language_id'],
+        'ezcontentobject_attribute' => ['language_id'],
+        'ezcontentobject_name' => ['language_id'],
+        'ezcontentobject_version' => ['language_mask', 'initial_language_id'],
+        'ezcontentobject' => ['language_mask', 'initial_language_id'],
+        'ezurlalias_ml' => ['lang_mask'],
+    ];
+
     /**
      * Inserts the given $language.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the Language Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -11,7 +9,9 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\Language;
 use eZ\Publish\SPI\Persistence\Content\Language;
 
 /**
- * Language Handler.
+ * Content Model language gateway.
+ *
+ * @internal For internal use by Persistence Handlers.
  */
 abstract class Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway.php
@@ -42,23 +42,17 @@ abstract class Gateway
     ];
 
     /**
-     * Inserts the given $language.
-     *
-     * @param Language $language
-     *
-     * @return int ID of the new language
+     * Insert the given $language.
      */
-    abstract public function insertLanguage(Language $language);
+    abstract public function insertLanguage(Language $language): int;
 
     /**
-     * Updates the data of the given $language.
-     *
-     * @param Language $language
+     * Update the data of the given $language.
      */
-    abstract public function updateLanguage(Language $language);
+    abstract public function updateLanguage(Language $language): void;
 
     /**
-     * Loads data list for the Language with $ids.
+     * Load data list for the Language with $ids.
      *
      * @param int[] $ids
      *
@@ -67,7 +61,7 @@ abstract class Gateway
     abstract public function loadLanguageListData(array $ids): iterable;
 
     /**
-     * Loads data list for Languages by $languageCodes (eg: eng-GB).
+     * Load data list for Languages by $languageCodes (eg: eng-GB).
      *
      * @param string[] $languageCodes
      *
@@ -76,25 +70,17 @@ abstract class Gateway
     abstract public function loadLanguageListDataByLanguageCode(array $languageCodes): iterable;
 
     /**
-     * Loads the data for all languages.
-     *
-     * @return string[][]
+     * Load the data for all languages.
      */
-    abstract public function loadAllLanguagesData();
+    abstract public function loadAllLanguagesData(): array;
 
     /**
-     * Deletes the language with $id.
-     *
-     * @param int $id
+     * Delete the language with $id.
      */
-    abstract public function deleteLanguage($id);
+    abstract public function deleteLanguage(int $id): void;
 
     /**
      * Check whether a language may be deleted.
-     *
-     * @param int $id
-     *
-     * @return bool
      */
-    abstract public function canDeleteLanguage($id);
+    abstract public function canDeleteLanguage(int $id): bool;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/DoctrineDatabase.php
@@ -55,14 +55,7 @@ final class DoctrineDatabase extends Gateway
         $this->dbPlatform = $this->connection->getDatabasePlatform();
     }
 
-    /**
-     * Inserts the given $language.
-     *
-     * @param Language $language
-     *
-     * @return int ID of the new language
-     */
-    public function insertLanguage(Language $language)
+    public function insertLanguage(Language $language): int
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -105,9 +98,9 @@ final class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Sets columns in $query from $language.
+     * Set columns for $query based on $language.
      */
-    private function setLanguageQueryParameters(QueryBuilder $query, Language $language)
+    private function setLanguageQueryParameters(QueryBuilder $query, Language $language): void
     {
         $query
             ->setParameter('language_code', $language->languageCode, ParameterType::STRING)
@@ -115,12 +108,7 @@ final class DoctrineDatabase extends Gateway
             ->setParameter('disabled', (int)!$language->isEnabled, ParameterType::INTEGER);
     }
 
-    /**
-     * Updates the data of the given $language.
-     *
-     * @param Language $language
-     */
-    public function updateLanguage(Language $language)
+    public function updateLanguage(Language $language): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -141,9 +129,6 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function loadLanguageListData(array $ids): iterable
     {
         $query = $this->createFindQuery();
@@ -154,9 +139,6 @@ final class DoctrineDatabase extends Gateway
         return $query->execute()->fetchAll();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function loadLanguageListDataByLanguageCode(array $languageCodes): iterable
     {
         $query = $this->createFindQuery();
@@ -168,7 +150,7 @@ final class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Creates a Language find query.
+     * Build a Language find (fetch) query.
      */
     private function createFindQuery(): QueryBuilder
     {
@@ -180,24 +162,14 @@ final class DoctrineDatabase extends Gateway
         return $query;
     }
 
-    /**
-     * Loads the data for all languages.
-     *
-     * @return string[][]
-     */
-    public function loadAllLanguagesData()
+    public function loadAllLanguagesData(): array
     {
         $query = $this->createFindQuery();
 
         return $query->execute()->fetchAll();
     }
 
-    /**
-     * Deletes the language with $id.
-     *
-     * @param int $id
-     */
-    public function deleteLanguage($id)
+    public function deleteLanguage(int $id): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -212,14 +184,7 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Check whether a language may be deleted.
-     *
-     * @param int $id
-     *
-     * @return bool
-     */
-    public function canDeleteLanguage($id)
+    public function canDeleteLanguage(int $id): bool
     {
         // note: at some point this should be delegated to specific gateways
         foreach (self::MULTILINGUAL_TABLES_COLUMNS as $tableName => $columns) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/DoctrineDatabase.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase Language Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -18,8 +16,12 @@ use RuntimeException;
 
 /**
  * Doctrine database based Language Gateway.
+ *
+ * @internal Gateway implementation is considered internal. Use Persistence Language Handler instead.
+ *
+ * @see \eZ\Publish\SPI\Persistence\Content\Language\Handler
  */
-class DoctrineDatabase extends Gateway
+final class DoctrineDatabase extends Gateway
 {
     /**
      * Database handler.
@@ -27,14 +29,14 @@ class DoctrineDatabase extends Gateway
      * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      * @deprecated Start to use DBAL $connection instead.
      */
-    protected $dbHandler;
+    private $dbHandler;
 
     /**
      * The native Doctrine connection.
      *
      * @var \Doctrine\DBAL\Connection
      */
-    protected $connection;
+    private $connection;
 
     /** @var \Doctrine\DBAL\Platforms\AbstractPlatform */
     private $dbPlatform;
@@ -105,7 +107,7 @@ class DoctrineDatabase extends Gateway
     /**
      * Sets columns in $query from $language.
      */
-    protected function setLanguageQueryParameters(QueryBuilder $query, Language $language)
+    private function setLanguageQueryParameters(QueryBuilder $query, Language $language)
     {
         $query
             ->setParameter('language_code', $language->languageCode, ParameterType::STRING)
@@ -168,7 +170,7 @@ class DoctrineDatabase extends Gateway
     /**
      * Creates a Language find query.
      */
-    protected function createFindQuery(): QueryBuilder
+    private function createFindQuery(): QueryBuilder
     {
         $query = $this->connection->createQueryBuilder();
         $query

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/DoctrineDatabase.php
@@ -152,9 +152,7 @@ final class DoctrineDatabase extends Gateway
 
     public function loadAllLanguagesData(): array
     {
-        $query = $this->createFindQuery();
-
-        return $query->execute()->fetchAll();
+        return $this->createFindQuery()->execute()->fetchAll();
     }
 
     public function deleteLanguage(int $id): void

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/DoctrineDatabase.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway;
 use eZ\Publish\SPI\Persistence\Content\Language;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use RuntimeException;
 
 /**
@@ -24,14 +23,6 @@ use RuntimeException;
 final class DoctrineDatabase extends Gateway
 {
     /**
-     * Database handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     * @deprecated Start to use DBAL $connection instead.
-     */
-    private $dbHandler;
-
-    /**
      * The native Doctrine connection.
      *
      * @var \Doctrine\DBAL\Connection
@@ -42,16 +33,11 @@ final class DoctrineDatabase extends Gateway
     private $dbPlatform;
 
     /**
-     * Creates a new Doctrine database Section Gateway.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
-     *
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function __construct(DatabaseHandler $dbHandler)
+    public function __construct(Connection $connection)
     {
-        $this->dbHandler = $dbHandler;
-        $this->connection = $dbHandler->getConnection();
+        $this->connection = $connection;
         $this->dbPlatform = $this->connection->getDatabasePlatform();
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/DoctrineDatabase.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway;
 
 use Doctrine\DBAL\Connection;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/ExceptionConversion.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway;
 
 use eZ\Publish\Core\Base\Exceptions\DatabaseException;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/ExceptionConversion.php
@@ -12,12 +12,15 @@ use eZ\Publish\SPI\Persistence\Content\Language;
 use Doctrine\DBAL\DBALException;
 use PDOException;
 
-class ExceptionConversion extends Gateway
+/**
+ * @internal Internal exception conversion layer.
+ */
+final class ExceptionConversion extends Gateway
 {
     /**
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway
      */
-    protected $innerGateway;
+    private $innerGateway;
 
     /**
      * Creates a new exception conversion gateway around $innerGateway.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/ExceptionConversion.php
@@ -32,7 +32,7 @@ final class ExceptionConversion extends Gateway
         $this->innerGateway = $innerGateway;
     }
 
-    public function insertLanguage(Language $language)
+    public function insertLanguage(Language $language): int
     {
         try {
             return $this->innerGateway->insertLanguage($language);
@@ -41,10 +41,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function updateLanguage(Language $language)
+    public function updateLanguage(Language $language): void
     {
         try {
-            return $this->innerGateway->updateLanguage($language);
+            $this->innerGateway->updateLanguage($language);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
@@ -68,7 +68,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadAllLanguagesData()
+    public function loadAllLanguagesData(): array
     {
         try {
             return $this->innerGateway->loadAllLanguagesData();
@@ -77,16 +77,16 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function deleteLanguage($id)
+    public function deleteLanguage(int $id): void
     {
         try {
-            return $this->innerGateway->deleteLanguage($id);
+            $this->innerGateway->deleteLanguage($id);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function canDeleteLanguage($id)
+    public function canDeleteLanguage(int $id): bool
     {
         try {
             return $this->innerGateway->canDeleteLanguage($id);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/Gateway/DoctrineDatabaseTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File contains: eZ\Publish\Core\Persistence\Legacy\Tests\Content\Language\Gateway\DoctrineDatabaseTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -38,7 +36,6 @@ class DoctrineDatabaseTest extends TestCase
 
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\DoctrineDatabase::insertLanguage
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\DoctrineDatabase::setCommonLanguageColumns
      */
     public function testInsertLanguage()
     {
@@ -80,7 +77,7 @@ class DoctrineDatabaseTest extends TestCase
 
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\DoctrineDatabase::updateLanguage
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\DoctrineDatabase::setCommonLanguageColumns
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\DoctrineDatabase::setLanguageQueryParameters
      */
     public function testUpdateLanguage()
     {
@@ -193,15 +190,15 @@ class DoctrineDatabaseTest extends TestCase
     }
 
     /**
-     * Returns a ready to test DoctrineDatabase gateway.
+     * Return a ready to test DoctrineDatabase gateway.
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\DoctrineDatabase
+     * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getDatabaseGateway()
+    protected function getDatabaseGateway(): DoctrineDatabase
     {
         if (!isset($this->databaseGateway)) {
             $this->databaseGateway = new DoctrineDatabase(
-                $this->getDatabaseHandler()
+                $this->getDatabaseConnection()
             );
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/Gateway/DoctrineDatabaseTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File contains: eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlAlias\Gateway\DoctrineDatabaseTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -514,22 +512,19 @@ class DoctrineDatabaseTest extends TestCase
     }
 
     /**
-     * Returns the DoctrineDatabase gateway to test.
+     * Return the DoctrineDatabase gateway to test.
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\DoctrineDatabase
+     * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getGateway()
+    protected function getGateway(): DoctrineDatabase
     {
         if (!isset($this->gateway)) {
-            $databaseHandler = $this->getDatabaseHandler();
             $languageHandler = new LanguageHandler(
-                new LanguageGateway(
-                    $databaseHandler
-                ),
+                new LanguageGateway($this->getDatabaseConnection()),
                 new LanguageMapper()
             );
             $this->gateway = new DoctrineDatabase(
-                $databaseHandler,
+                $this->getDatabaseHandler(),
                 new LanguageMaskGenerator($languageHandler)
             );
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File contains: eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlAliasHandlerTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -5402,14 +5400,14 @@ class UrlAliasHandlerTest extends TestCase
     }
 
     /**
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\Language\Handler
+     * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getLanguageHandler()
+    protected function getLanguageHandler(): LanguageHandler
     {
         if (!isset($this->languageHandler)) {
             $this->languageHandler = new LanguageHandler(
                 new LanguageGateway(
-                    $this->getDatabaseHandler()
+                    $this->getDatabaseConnection()
                 ),
                 new LanguageMapper()
             );

--- a/eZ/Publish/Core/settings/storage_engines/legacy/language.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/language.yml
@@ -2,7 +2,7 @@ services:
     ezpublish.persistence.legacy.language.gateway.inner:
         class: eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\DoctrineDatabase
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - "@ezpublish.api.storage_engine.legacy.connection"
 
     ezpublish.persistence.legacy.language.gateway.exception_conversion:
         class: eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\ExceptionConversion


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31088](https://jira.ez.no/browse/EZP-31088)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR refactors Content Language gateway to rely on `\Doctrine\DBAL\Connection` instead of our own deprecated `DatabaseHandler`.

Affected implementation:
- `\eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway`
- `\eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\DoctrineDatabase`
- `\eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\ExceptionConversion`

Additionally strict types were introduced to the all Language gateway methods and forced via `declare(strict_types=1)` as it seems in this case it doesn't cause issues.

The Language gateway implementations were marked as `@internal` and `final`. The abstract Gateway class has been marked as `@internal`.

What could stand out here is a major refactoring done to the 
`\eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway\DoctrineDatabase::canDeleteLanguage` 
method. The queries build there follow a very specific pattern, so the code was unified. From the architecture point of view it should be delegated (e.g. dispatched) to other gateways which are responsible for handling specific parts of the system. However for now it's out of scope and would conflict with the other changes to those gateways which need to be done first.

**TODO**:
- [x] Refactor Content Language gateway to use Doctrine\DBAL.
- [x] Replace DatabaseHandler GW constructor argument with the Connection.
- [x] Introduce strict types to Content Language gateway methods.
- [x] Force strict types for Content Language gateway classes.
- [x] Mark Content Language gateway classes as `final` and `@internal`.
- [x] Align tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
