### PR TITLE
EZP-31320: Fixed issue when `default` Site Access is unmatched

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
@@ -43,7 +43,7 @@ class SiteAccess extends ValueObject
     /**
      * The name of the provider from which Site Access comes.
      *
-     * @var string
+     * @var string|null
      */
     public $provider;
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessService.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessService.php
@@ -58,11 +58,7 @@ class SiteAccessService implements SiteAccessServiceInterface, SiteAccessAware
 
     public function getCurrent(): ?SiteAccess
     {
-        if ($this->siteAccess === null) {
-            return null;
-        }
-
-        return $this->get($this->siteAccess->name);
+        return $this->siteAccess ?? null;
     }
 
     public function getSiteAccessesRelation(?SiteAccess $siteAccess = null): array

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/SiteAccessServiceTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/SiteAccessServiceTest.php
@@ -9,14 +9,20 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Tests;
 
 use ArrayIterator;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Provider\StaticSiteAccessProvider;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessService;
 use PHPUnit\Framework\TestCase;
 
 class SiteAccessServiceTest extends TestCase
 {
+    private const EXISTING_SA_NAME = 'existing_sa';
+    private const UNDEFINED_SA_NAME = 'undefined_sa';
+    private const SA_GROUP = 'group';
+
     /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $provider;
 
@@ -44,17 +50,51 @@ class SiteAccessServiceTest extends TestCase
 
     public function testGetCurrentSiteAccess(): void
     {
-        $this->provider
-            ->method('isDefined')
-            ->with('current')
-            ->willReturn(true);
+        $service = new SiteAccessService(
+            $this->createMock(SiteAccessProviderInterface::class),
+            $this->createMock(ConfigResolverInterface::class)
+        );
 
-        $this->provider
-            ->method('getSiteAccess')
-            ->with('current')
-            ->willReturn($this->siteAccess);
+        self::assertNull($service->getCurrent());
 
-        $this->assertSame($this->siteAccess, $this->getSiteAccessService()->getCurrent());
+        $siteAccess = new SiteAccess('default');
+        $service->setSiteAccess($siteAccess);
+        self::assertSame($siteAccess, $service->getCurrent());
+
+        $service->setSiteAccess(null);
+        self::assertNull($service->getCurrent());
+    }
+
+    public function testGetSiteAccess(): void
+    {
+        $staticSiteAccessProvider = new StaticSiteAccessProvider(
+            [self::EXISTING_SA_NAME],
+            [self::EXISTING_SA_NAME => [self::SA_GROUP]],
+        );
+        $service = new SiteAccessService(
+            $staticSiteAccessProvider,
+            $this->createMock(ConfigResolverInterface::class)
+        );
+
+        self::assertEquals(
+            self::EXISTING_SA_NAME,
+            $service->get(self::EXISTING_SA_NAME)->name
+        );
+    }
+
+    public function testGetSiteAccessThrowsNotFoundException(): void
+    {
+        $staticSiteAccessProvider = new StaticSiteAccessProvider(
+            [self::EXISTING_SA_NAME],
+            [self::EXISTING_SA_NAME => [self::SA_GROUP]],
+        );
+        $service = new SiteAccessService(
+            $staticSiteAccessProvider,
+            $this->createMock(ConfigResolverInterface::class)
+        );
+
+        $this->expectException(NotFoundException::class);
+        $service->get(self::UNDEFINED_SA_NAME);
     }
 
     public function testGetCurrentSiteAccessesRelation(): void


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31320](https://jira.ez.no/browse/EZP-31320)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This issue is present in Behat tests when `default` Site Access is present and Site Access is not matched by Matcher. As a bonus, the fix also simplifies SiteAccessService::getCurrent method and correct docblock for `$provider` property of Site Access object.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
