### PR TITLE
EZP-31088: Refactored Section GW methods to use Doctrine\DBAL

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Section;
 
 /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
@@ -23,7 +23,7 @@ abstract class Gateway
      *
      * @return int The ID of the new section
      */
-    abstract public function insertSection($name, $identifier);
+    abstract public function insertSection(string $name, string $identifier): int;
 
     /**
      * Updates section with $id to have $name and $identifier.
@@ -32,7 +32,7 @@ abstract class Gateway
      * @param string $name
      * @param string $identifier
      */
-    abstract public function updateSection($id, $name, $identifier);
+    abstract public function updateSection(int $id, string $name, string $identifier): void;
 
     /**
      * Loads data for section with $id.
@@ -41,14 +41,14 @@ abstract class Gateway
      *
      * @return string[][]
      */
-    abstract public function loadSectionData($id);
+    abstract public function loadSectionData(int $id): array;
 
     /**
      * Loads data for all sections.
      *
      * @return string[][]
      */
-    abstract public function loadAllSectionData();
+    abstract public function loadAllSectionData(): array;
 
     /**
      * Loads data for section with $identifier.
@@ -57,7 +57,7 @@ abstract class Gateway
      *
      * @return string[][]
      */
-    abstract public function loadSectionDataByIdentifier($identifier);
+    abstract public function loadSectionDataByIdentifier(string $identifier): array;
 
     /**
      * Counts the number of content objects assigned to section with $id.
@@ -66,7 +66,7 @@ abstract class Gateway
      *
      * @return int
      */
-    abstract public function countContentObjectsInSection($id);
+    abstract public function countContentObjectsInSection(int $id): int;
 
     /**
      * Counts the number of role policies using section with $id in their limitations.
@@ -75,7 +75,7 @@ abstract class Gateway
      *
      * @return int
      */
-    abstract public function countPoliciesUsingSection($id);
+    abstract public function countPoliciesUsingSection(int $id): int;
 
     /**
      * Counts the number of role assignments using section with $id in their limitations.
@@ -84,14 +84,14 @@ abstract class Gateway
      *
      * @return int
      */
-    abstract public function countRoleAssignmentsUsingSection($id);
+    abstract public function countRoleAssignmentsUsingSection(int $id): int;
 
     /**
      * Deletes the Section with $id.
      *
      * @param int $id
      */
-    abstract public function deleteSection($id);
+    abstract public function deleteSection(int $id): void;
 
     /**
      * Inserts the assignment of $contentId to $sectionId.
@@ -99,5 +99,5 @@ abstract class Gateway
      * @param int $sectionId
      * @param int $contentId
      */
-    abstract public function assignSectionToContent($sectionId, $contentId);
+    abstract public function assignSectionToContent(int $sectionId, int $contentId): void;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
@@ -7,7 +7,9 @@
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Section;
 
 /**
- * Section Handler.
+ * Base class for Section gateways.
+ *
+ * @internal For internal use by Persistence Handlers.
  */
 abstract class Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the Section Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
@@ -14,6 +14,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\Section;
 abstract class Gateway
 {
     public const CONTENT_SECTION_SEQ = 'ezsection_id_seq';
+    public const CONTENT_SECTION_TABLE = 'ezsection';
 
     /**
      * Inserts a new section with $name and $identifier.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
@@ -13,6 +13,8 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\Section;
  */
 abstract class Gateway
 {
+    public const CONTENT_SECTION_SEQ = 'ezsection_id_seq';
+
     /**
      * Inserts a new section with $name and $identifier.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
@@ -18,86 +18,52 @@ abstract class Gateway
     /**
      * Inserts a new section with $name and $identifier.
      *
-     * @param string $name
-     * @param string $identifier
-     *
      * @return int The ID of the new section
      */
     abstract public function insertSection(string $name, string $identifier): int;
 
     /**
      * Updates section with $id to have $name and $identifier.
-     *
-     * @param int $id
-     * @param string $name
-     * @param string $identifier
      */
     abstract public function updateSection(int $id, string $name, string $identifier): void;
 
     /**
      * Loads data for section with $id.
-     *
-     * @param int $id
-     *
-     * @return string[][]
      */
     abstract public function loadSectionData(int $id): array;
 
     /**
      * Loads data for all sections.
-     *
-     * @return string[][]
      */
     abstract public function loadAllSectionData(): array;
 
     /**
      * Loads data for section with $identifier.
-     *
-     * @param string $identifier
-     *
-     * @return string[][]
      */
     abstract public function loadSectionDataByIdentifier(string $identifier): array;
 
     /**
      * Counts the number of content objects assigned to section with $id.
-     *
-     * @param int $id
-     *
-     * @return int
      */
     abstract public function countContentObjectsInSection(int $id): int;
 
     /**
      * Counts the number of role policies using section with $id in their limitations.
-     *
-     * @param int $id
-     *
-     * @return int
      */
     abstract public function countPoliciesUsingSection(int $id): int;
 
     /**
      * Counts the number of role assignments using section with $id in their limitations.
-     *
-     * @param int $id
-     *
-     * @return int
      */
     abstract public function countRoleAssignmentsUsingSection(int $id): int;
 
     /**
      * Deletes the Section with $id.
-     *
-     * @param int $id
      */
     abstract public function deleteSection(int $id): void;
 
     /**
      * Inserts the assignment of $contentId to $sectionId.
-     *
-     * @param int $sectionId
-     * @param int $contentId
      */
     abstract public function assignSectionToContent(int $sectionId, int $contentId): void;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
@@ -24,6 +24,9 @@ final class DoctrineDatabase extends Gateway
      */
     private $dbHandler;
 
+    /** @var \Doctrine\DBAL\Connection */
+    private $connection;
+
     /**
      * Creates a new DoctrineDatabase Section Gateway.
      *
@@ -32,6 +35,7 @@ final class DoctrineDatabase extends Gateway
     public function __construct(DatabaseHandler $dbHandler)
     {
         $this->dbHandler = $dbHandler;
+        $this->connection = $dbHandler->getConnection();
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway;
 
 use Doctrine\DBAL\Connection;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
@@ -35,14 +35,6 @@ final class DoctrineDatabase extends Gateway
         $this->dbPlatform = $this->connection->getDatabasePlatform();
     }
 
-    /**
-     * Inserts a new section with $name and $identifier.
-     *
-     * @param string $name
-     * @param string $identifier
-     *
-     * @return int The ID of the new section
-     */
     public function insertSection(string $name, string $identifier): int
     {
         $query = $this->connection->createQueryBuilder();
@@ -60,13 +52,6 @@ final class DoctrineDatabase extends Gateway
         return (int)$this->connection->lastInsertId(Gateway::CONTENT_SECTION_SEQ);
     }
 
-    /**
-     * Updates section with $id to have $name and $identifier.
-     *
-     * @param int $id
-     * @param string $name
-     * @param string $identifier
-     */
     public function updateSection(int $id, string $name, string $identifier): void
     {
         $query = $this->connection->createQueryBuilder();
@@ -84,13 +69,6 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Loads data for section with $id.
-     *
-     * @param int $id
-     *
-     * @return string[][]
-     */
     public function loadSectionData(int $id): array
     {
         $query = $this->connection->createQueryBuilder();
@@ -109,11 +87,6 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads data for all sections.
-     *
-     * @return string[][]
-     */
     public function loadAllSectionData(): array
     {
         $query = $this->connection->createQueryBuilder();
@@ -126,13 +99,6 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads data for section with $identifier.
-     *
-     * @param string $identifier
-     *
-     * @return string[][]
-     */
     public function loadSectionDataByIdentifier(string $identifier): array
     {
         $query = $this->connection->createQueryBuilder();
@@ -154,13 +120,6 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Counts the number of content objects assigned to section with $id.
-     *
-     * @param int $id
-     *
-     * @return int
-     */
     public function countContentObjectsInSection(int $id): int
     {
         $query = $this->connection->createQueryBuilder();
@@ -180,13 +139,6 @@ final class DoctrineDatabase extends Gateway
         return (int)$statement->fetchColumn();
     }
 
-    /**
-     * Counts the number of role policies using section with $id in their limitations.
-     *
-     * @param int $id
-     *
-     * @return int
-     */
     public function countPoliciesUsingSection(int $id): int
     {
         $query = $this->connection->createQueryBuilder();
@@ -220,13 +172,6 @@ final class DoctrineDatabase extends Gateway
         return (int)$query->execute()->fetchColumn();
     }
 
-    /**
-     * Counts the number of role assignments using section with $id in their limitations.
-     *
-     * @param int $id
-     *
-     * @return int
-     */
     public function countRoleAssignmentsUsingSection(int $id): int
     {
         $query = $this->connection->createQueryBuilder();
@@ -251,11 +196,6 @@ final class DoctrineDatabase extends Gateway
         return (int)$query->execute()->fetchColumn();
     }
 
-    /**
-     * Deletes the Section with $id.
-     *
-     * @param int $id
-     */
     public function deleteSection(int $id): void
     {
         $query = $this->connection->createQueryBuilder();
@@ -271,12 +211,6 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Inserts the assignment of $contentId to $sectionId.
-     *
-     * @param int $sectionId
-     * @param int $contentId
-     */
     public function assignSectionToContent(int $sectionId, int $contentId): void
     {
         $query = $this->connection->createQueryBuilder();

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase Section Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
@@ -39,7 +39,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->insert('ezsection')
+            ->insert(self::CONTENT_SECTION_TABLE)
             ->values(
                 [
                     'name' => $query->createPositionalParameter($name),
@@ -56,7 +56,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->update('ezsection')
+            ->update(self::CONTENT_SECTION_TABLE)
             ->set('name', $query->createPositionalParameter($name))
             ->set('identifier', $query->createPositionalParameter($identifier))
             ->where(
@@ -74,7 +74,7 @@ final class DoctrineDatabase extends Gateway
         $query = $this->connection->createQueryBuilder();
         $query
             ->select(['id', 'identifier', 'name'])
-            ->from('ezsection')
+            ->from(self::CONTENT_SECTION_TABLE)
             ->where(
                 $query->expr()->eq(
                     'id',
@@ -92,7 +92,7 @@ final class DoctrineDatabase extends Gateway
         $query = $this->connection->createQueryBuilder();
         $query
             ->select(['id', 'identifier', 'name'])
-            ->from('ezsection');
+            ->from(self::CONTENT_SECTION_TABLE);
 
         $statement = $query->execute();
 
@@ -107,7 +107,7 @@ final class DoctrineDatabase extends Gateway
             'identifier',
             'name'
         )->from(
-            'ezsection'
+            self::CONTENT_SECTION_TABLE
         )->where(
             $query->expr()->eq(
                 'identifier',
@@ -200,7 +200,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->delete('ezsection')
+            ->delete(self::CONTENT_SECTION_TABLE)
             ->where(
                 $query->expr()->eq(
                     'id',

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
@@ -10,9 +10,11 @@ use eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 
 /**
- * Section Handler.
+ * @internal Gateway implementation is considered internal. Use Persistence Section Handler instead.
+ *
+ * @see \eZ\Publish\SPI\Persistence\Content\Section\Handler
  */
-class DoctrineDatabase extends Gateway
+final class DoctrineDatabase extends Gateway
 {
     /**
      * Database handler.
@@ -20,7 +22,7 @@ class DoctrineDatabase extends Gateway
      * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      * @deprecated Start to use DBAL $connection instead.
      */
-    protected $dbHandler;
+    private $dbHandler;
 
     /**
      * Creates a new DoctrineDatabase Section Gateway.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
@@ -6,10 +6,10 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 
 /**
  * @internal Gateway implementation is considered internal. Use Persistence Section Handler instead.
@@ -18,14 +18,6 @@ use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
  */
 final class DoctrineDatabase extends Gateway
 {
-    /**
-     * Database handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     * @deprecated Start to use DBAL $connection instead.
-     */
-    private $dbHandler;
-
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
@@ -35,13 +27,11 @@ final class DoctrineDatabase extends Gateway
     /**
      * Creates a new DoctrineDatabase Section Gateway.
      *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function __construct(DatabaseHandler $dbHandler)
+    public function __construct(Connection $connection)
     {
-        $this->dbHandler = $dbHandler;
-        $this->connection = $dbHandler->getConnection();
+        $this->connection = $connection;
         $this->dbPlatform = $this->connection->getDatabasePlatform();
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
@@ -43,7 +43,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return int The ID of the new section
      */
-    public function insertSection($name, $identifier)
+    public function insertSection(string $name, string $identifier): int
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -67,7 +67,7 @@ final class DoctrineDatabase extends Gateway
      * @param string $name
      * @param string $identifier
      */
-    public function updateSection($id, $name, $identifier)
+    public function updateSection(int $id, string $name, string $identifier): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -91,7 +91,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return string[][]
      */
-    public function loadSectionData($id)
+    public function loadSectionData(int $id): array
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -114,7 +114,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return string[][]
      */
-    public function loadAllSectionData()
+    public function loadAllSectionData(): array
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -129,11 +129,11 @@ final class DoctrineDatabase extends Gateway
     /**
      * Loads data for section with $identifier.
      *
-     * @param int $identifier
+     * @param string $identifier
      *
      * @return string[][]
      */
-    public function loadSectionDataByIdentifier($identifier)
+    public function loadSectionDataByIdentifier(string $identifier): array
     {
         $query = $this->connection->createQueryBuilder();
         $query->select(
@@ -161,7 +161,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return int
      */
-    public function countContentObjectsInSection($id)
+    public function countContentObjectsInSection(int $id): int
     {
         $query = $this->connection->createQueryBuilder();
         $query->select(
@@ -187,7 +187,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return int
      */
-    public function countPoliciesUsingSection($id)
+    public function countPoliciesUsingSection(int $id): int
     {
         $query = $this->connection->createQueryBuilder();
         $expr = $query->expr();
@@ -227,7 +227,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return int
      */
-    public function countRoleAssignmentsUsingSection($id)
+    public function countRoleAssignmentsUsingSection(int $id): int
     {
         $query = $this->connection->createQueryBuilder();
         $expr = $query->expr();
@@ -256,7 +256,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @param int $id
      */
-    public function deleteSection($id)
+    public function deleteSection(int $id): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -277,7 +277,7 @@ final class DoctrineDatabase extends Gateway
      * @param int $sectionId
      * @param int $contentId
      */
-    public function assignSectionToContent($sectionId, $contentId)
+    public function assignSectionToContent(int $sectionId, int $contentId): void
     {
         $query = $this->connection->createQueryBuilder();
         $query

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/ExceptionConversion.php
@@ -33,7 +33,7 @@ final class ExceptionConversion extends Gateway
         $this->innerGateway = $innerGateway;
     }
 
-    public function insertSection($name, $identifier)
+    public function insertSection(string $name, string $identifier): int
     {
         try {
             return $this->innerGateway->insertSection($name, $identifier);
@@ -42,16 +42,16 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function updateSection($id, $name, $identifier)
+    public function updateSection(int $id, string $name, string $identifier): void
     {
         try {
-            return $this->innerGateway->updateSection($id, $name, $identifier);
+            $this->innerGateway->updateSection($id, $name, $identifier);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function loadSectionData($id)
+    public function loadSectionData(int $id): array
     {
         try {
             return $this->innerGateway->loadSectionData($id);
@@ -60,7 +60,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadAllSectionData()
+    public function loadAllSectionData(): array
     {
         try {
             return $this->innerGateway->loadAllSectionData();
@@ -69,7 +69,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadSectionDataByIdentifier($identifier)
+    public function loadSectionDataByIdentifier(string $identifier): array
     {
         try {
             return $this->innerGateway->loadSectionDataByIdentifier($identifier);
@@ -78,7 +78,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function countContentObjectsInSection($id)
+    public function countContentObjectsInSection(int $id): int
     {
         try {
             return $this->innerGateway->countContentObjectsInSection($id);
@@ -87,7 +87,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function countPoliciesUsingSection($id)
+    public function countPoliciesUsingSection(int $id): int
     {
         try {
             return $this->innerGateway->countPoliciesUsingSection($id);
@@ -96,7 +96,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function countRoleAssignmentsUsingSection($id)
+    public function countRoleAssignmentsUsingSection(int $id): int
     {
         try {
             return $this->innerGateway->countRoleAssignmentsUsingSection($id);
@@ -105,19 +105,19 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function deleteSection($id)
+    public function deleteSection(int $id): void
     {
         try {
-            return $this->innerGateway->deleteSection($id);
+            $this->innerGateway->deleteSection($id);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function assignSectionToContent($sectionId, $contentId)
+    public function assignSectionToContent(int $sectionId, int $contentId): void
     {
         try {
-            return $this->innerGateway->assignSectionToContent($sectionId, $contentId);
+            $this->innerGateway->assignSectionToContent($sectionId, $contentId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/ExceptionConversion.php
@@ -11,14 +11,17 @@ use eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway;
 use Doctrine\DBAL\DBALException;
 use PDOException;
 
-class ExceptionConversion extends Gateway
+/**
+ * @internal Internal exception conversion layer.
+ */
+final class ExceptionConversion extends Gateway
 {
     /**
      * The wrapped gateway.
      *
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway
      */
-    protected $innerGateway;
+    private $innerGateway;
 
     /**
      * Creates a new exception conversion gateway around $innerGateway.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/ExceptionConversion.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway;
 
 use eZ\Publish\Core\Base\Exceptions\DatabaseException;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Handler.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the Section Handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Section/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Section/Gateway/DoctrineDatabaseTest.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Section\Gateway;
 
+use eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway\DoctrineDatabase;
 
@@ -275,13 +276,13 @@ class DoctrineDatabaseTest extends TestCase
      * Returns a ready to test DoctrineDatabase gateway.
      *
      * @return \eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway\DoctrineDatabase
+     *
+     * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getDatabaseGateway()
+    protected function getDatabaseGateway(): Gateway
     {
         if (!isset($this->databaseGateway)) {
-            $this->databaseGateway = new DoctrineDatabase(
-                $this->getDatabaseHandler()
-            );
+            $this->databaseGateway = new DoctrineDatabase($this->getDatabaseConnection());
         }
 
         return $this->databaseGateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Section/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Section/Gateway/DoctrineDatabaseTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File contains: eZ\Publish\Core\Persistence\Legacy\Tests\Content\Section\Gateway\DoctrineDatabaseTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/settings/storage_engines/legacy/section.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/section.yml
@@ -2,7 +2,7 @@ services:
     ezpublish.persistence.legacy.section.gateway.inner:
         class: eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway\DoctrineDatabase
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - "@ezpublish.api.storage_engine.legacy.connection"
 
     ezpublish.persistence.legacy.section.gateway.exception_conversion:
         class: eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway\ExceptionConversion


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31088](https://jira.ez.no/browse/EZP-31088) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR refactors the Legacy (Content) Section Gateway implementation (`\eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway\DoctrineDatabase`) to rely on `\Doctrine\DBAL\Connection` instead of our custom Database Handler.

**TODO**:
- [x]  Set Content Section Doctrine GW connection.
- [x]  Refactor Content Section gateway methods to use Doctrine\DBAL.
- [x]  Drop DatabaseHandler from Section GW DoctrineDatabase constructor.
- [x]  Add strict types to Content Section GW method signatures.
- [x]  Force strict types for Content Section GW classes.
- [x]  Extract "ezsection" table reference to the Gateway constant..
- [x]  Mark Content Section gateways as final and internal.
- [x]  [CS] Align Persistence\Legacy\Content\Section classes file headers.
- [x]  [CS] Remove redundant PHPDoc blocks from Content Section gateways.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Wait for Travis.
- [x] Ask for Code Review.