### PR TITLE
EZP-31048: Allowed empty Site Access groups

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -213,7 +213,6 @@ class Configuration extends SiteAccessConfiguration
                             ->info('SiteAccess groups. Useful to share settings between Siteaccess')
                             ->example(['ezdemo_group' => ['ezdemo_site', 'ezdemo_site_admin']])
                             ->prototype('array')
-                                ->requiresAtLeastOneElement()
                                 ->prototype('scalar')->end()
                             ->end()
                         ->end()

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
@@ -65,6 +65,7 @@ abstract class AbstractParserTestCase extends AbstractExtensionTestCase
                 ['fre', true],
                 ['fre2', true],
                 ['ezdemo_site_admin', true],
+                ['empty_group', false],
             ]);
         $siteAccessProvider
             ->method('getSiteAccess')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
@@ -15,6 +15,8 @@ use Symfony\Component\Yaml\Yaml;
 
 class CommonTest extends AbstractParserTestCase
 {
+    private const EMPTY_SA_GROUP = 'empty_group';
+
     private $minimalConfig;
 
     /** @var \PHPUnit\Framework\MockObject\MockObject */
@@ -46,6 +48,7 @@ class CommonTest extends AbstractParserTestCase
 
         $this->assertConfigResolverParameterValue('index_page', $indexPage1, 'ezdemo_site');
         $this->assertConfigResolverParameterValue('index_page', $indexPage2, 'ezdemo_site_admin');
+        $this->assertConfigResolverParameterValue('index_page', null, self::EMPTY_SA_GROUP);
     }
 
     public function testDefaultPage()
@@ -62,6 +65,7 @@ class CommonTest extends AbstractParserTestCase
 
         $this->assertConfigResolverParameterValue('default_page', $defaultPage1, 'ezdemo_site');
         $this->assertConfigResolverParameterValue('default_page', $defaultPage2, 'ezdemo_site_admin');
+        $this->assertConfigResolverParameterValue('index_page', null, self::EMPTY_SA_GROUP);
     }
 
     public function testDatabaseSingleSiteaccess()

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/IOTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/IOTest.php
@@ -13,6 +13,8 @@ use Symfony\Component\Yaml\Yaml;
 
 class IOTest extends AbstractParserTestCase
 {
+    private const EMPTY_SA_GROUP = 'empty_group';
+
     private $minimalConfig;
 
     protected function setUp(): void
@@ -52,5 +54,6 @@ class IOTest extends AbstractParserTestCase
 
         $this->assertConfigResolverParameterValue('io.metadata_handler', 'cluster', 'ezdemo_site');
         $this->assertConfigResolverParameterValue('io.binarydata_handler', 'cluster', 'ezdemo_site');
+        $this->assertConfigResolverParameterValue('io.binarydata_handler', 'default', self::EMPTY_SA_GROUP);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/LanguagesTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/LanguagesTest.php
@@ -14,6 +14,8 @@ use Symfony\Component\Yaml\Yaml;
 
 class LanguagesTest extends AbstractParserTestCase
 {
+    private const EMPTY_SA_GROUP = 'empty_group';
+
     protected function getContainerExtensions(): array
     {
         return [new EzPublishCoreExtension([new Languages()])];
@@ -43,6 +45,7 @@ class LanguagesTest extends AbstractParserTestCase
         $this->assertConfigResolverParameterValue('languages', $langDemoSite, 'ezdemo_site');
         $this->assertConfigResolverParameterValue('languages', $langFre, 'fre');
         $this->assertConfigResolverParameterValue('languages', $langFre, 'fre2');
+        $this->assertConfigResolverParameterValue('languages', [], self::EMPTY_SA_GROUP);
         $this->assertSame(
             [
                 'eng-GB' => ['ezdemo_site'],
@@ -68,6 +71,7 @@ class LanguagesTest extends AbstractParserTestCase
 
         $this->assertConfigResolverParameterValue('languages', $langDemoSite, 'ezdemo_site');
         $this->assertConfigResolverParameterValue('languages', $langDemoSite, 'fre');
+        $this->assertConfigResolverParameterValue('languages', [], self::EMPTY_SA_GROUP);
         $this->assertSame(
             [
                 'eng-US' => ['ezdemo_site', 'fre'],
@@ -93,6 +97,7 @@ class LanguagesTest extends AbstractParserTestCase
         $this->assertConfigResolverParameterValue('translation_siteaccesses', $translationSAsDemoSite, 'ezdemo_site');
         $this->assertConfigResolverParameterValue('translation_siteaccesses', $translationSAsFre, 'fre');
         $this->assertConfigResolverParameterValue('translation_siteaccesses', [], 'ezdemo_site_admin');
+        $this->assertConfigResolverParameterValue('translation_siteaccesses', [], self::EMPTY_SA_GROUP);
     }
 
     public function testTranslationSiteAccessesWithGroup()
@@ -110,5 +115,6 @@ class LanguagesTest extends AbstractParserTestCase
         $this->assertConfigResolverParameterValue('translation_siteaccesses', $translationSAsDemoSite, 'ezdemo_site');
         $this->assertConfigResolverParameterValue('translation_siteaccesses', $translationSAsDemoSite, 'fre');
         $this->assertConfigResolverParameterValue('translation_siteaccesses', [], 'ezdemo_site_admin');
+        $this->assertConfigResolverParameterValue('translation_siteaccesses', [], self::EMPTY_SA_GROUP);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -40,6 +40,7 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                 'groups' => [
                     'ezdemo_group' => ['ezdemo_site', 'eng', 'fre', 'ezdemo_site_admin'],
                     'ezdemo_frontend_group' => ['ezdemo_site', 'eng', 'fre'],
+                    'empty_group' => [],
                 ],
                 'match' => [
                     'URILElement' => 1,
@@ -51,6 +52,7 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                 'eng' => [],
                 'fre' => [],
                 'ezdemo_site_admin' => [],
+                'empty_group' => ['var_dir' => 'foo'],
             ],
         ];
 
@@ -97,6 +99,7 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
             $expectedMatchingConfig[$key] = is_array($val) ? $val : ['value' => $val];
         }
         $this->assertContainerBuilderHasParameter('ezpublish.siteaccess.match_config', $expectedMatchingConfig);
+        $this->assertContainerBuilderHasParameter('ezsettings.empty_group.var_dir', 'foo');
 
         $groupsBySiteaccess = [];
         foreach ($this->siteaccessConfig['siteaccess']['groups'] as $groupName => $groupMembers) {

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Fixtures/ezpublish_minimal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Fixtures/ezpublish_minimal.yml
@@ -12,6 +12,7 @@ siteaccess:
         ezdemo_frontend_group:
             - ezdemo_site
             - fre
+        empty_group: []
     match:
         URIElement: 1
         Map\URI:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31048](https://jira.ez.no/browse/EZP-31048)
| **Bug/Improvement**|no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     | yes

There is a possibility that SiteAccessProvider will return Site Accesses dynamically. This is why the Site Access group must be initially allowed to be empty.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
