### PR TITLE
Fixed index name assertion for Solr Cloud 6.X in SearchServiceTranslationLanguageFallbackTest

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\API\Repository\Tests;
 
 use eZ\Publish\API\Repository\Tests\SetupFactory\LegacyElasticsearch;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -221,7 +222,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core0',
                             self::SETUP_SHARED => 'localhost:8983/solr/core3',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -231,7 +232,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -241,7 +242,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -263,7 +264,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core0',
                             self::SETUP_SHARED => 'localhost:8983/solr/core3',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -273,7 +274,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -283,7 +284,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -305,7 +306,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -315,7 +316,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -325,7 +326,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -347,7 +348,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -357,7 +358,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -367,7 +368,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -389,7 +390,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -399,7 +400,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -409,7 +410,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -431,7 +432,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -441,7 +442,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -451,7 +452,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -472,7 +473,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core0',
                             self::SETUP_SHARED => 'localhost:8983/solr/core3',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -482,7 +483,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -503,7 +504,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -513,7 +514,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -534,7 +535,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core0',
                             self::SETUP_SHARED => 'localhost:8983/solr/core3',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -544,7 +545,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -554,7 +555,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -575,7 +576,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -585,7 +586,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -595,7 +596,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -616,7 +617,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -626,7 +627,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -636,7 +637,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -657,7 +658,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -667,7 +668,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -677,7 +678,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -717,7 +718,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -727,7 +728,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -747,7 +748,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -757,7 +758,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -767,7 +768,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -798,7 +799,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core0',
                             self::SETUP_SHARED => 'localhost:8983/solr/core3',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -808,7 +809,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -818,7 +819,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -840,7 +841,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core0',
                             self::SETUP_SHARED => 'localhost:8983/solr/core3',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -850,7 +851,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -860,7 +861,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -882,7 +883,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -892,7 +893,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -902,7 +903,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -924,7 +925,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -934,7 +935,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -944,7 +945,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -966,7 +967,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -976,7 +977,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -986,7 +987,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1008,7 +1009,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1018,7 +1019,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1028,7 +1029,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1049,7 +1050,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core0',
                             self::SETUP_SHARED => 'localhost:8983/solr/core3',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1059,7 +1060,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1080,7 +1081,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1090,7 +1091,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1111,7 +1112,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core0',
                             self::SETUP_SHARED => 'localhost:8983/solr/core3',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1121,7 +1122,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1131,7 +1132,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1152,7 +1153,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1162,7 +1163,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1172,7 +1173,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1193,7 +1194,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1203,7 +1204,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1213,7 +1214,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1234,7 +1235,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1244,7 +1245,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1254,7 +1255,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1274,7 +1275,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core0',
                             self::SETUP_SHARED => 'localhost:8983/solr/core3',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core0_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1284,7 +1285,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core0',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core3_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core3_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1304,7 +1305,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1314,7 +1315,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core3',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core1_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1334,7 +1335,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1344,7 +1345,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1354,7 +1355,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core2',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core2_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1374,7 +1375,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core0',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core3_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core3_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1392,7 +1393,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core0',
                             self::SETUP_SHARED => 'localhost:8983/solr/core0',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core3_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core3_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1402,7 +1403,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core0',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core3_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core3_shard1_replica(_n)?1/',
                         ],
                     ],
                     [
@@ -1412,7 +1413,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core0',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core3_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core3_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1470,7 +1471,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                             self::SETUP_DEDICATED => 'localhost:8983/solr/core2',
                             self::SETUP_SHARED => 'localhost:8983/solr/core0',
                             self::SETUP_SINGLE => 'localhost:8983/solr/collection1',
-                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core3_shard1_replica_n1/',
+                            self::SETUP_CLOUD => 'http://localhost:8983/solr/core3_shard1_replica(_n)?1/',
                         ],
                     ],
                 ],
@@ -1549,10 +1550,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                 $data[$contentNo]['content']->id,
                 $content->id
             );
-            $this->assertEquals(
-                $this->getIndexName($indexMap),
-                $searchResult->searchHits[$index]->index
-            );
+            $this->assertIndexName($indexMap, $searchResult->searchHits[$index]);
             $this->assertEquals(
                 $translationLanguageCode,
                 $searchResult->searchHits[$index]->matchedTranslation
@@ -1604,10 +1602,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                 $data[$contentNo]['locations'][0]->id,
                 $location->id
             );
-            $this->assertEquals(
-                $this->getIndexName($indexMap),
-                $searchResult->searchHits[$index]->index
-            );
+            $this->assertIndexName($indexMap, $searchResult->searchHits[$index]);
             $this->assertEquals(
                 $translationLanguageCode,
                 $searchResult->searchHits[$index]->matchedTranslation
@@ -1655,10 +1650,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                 $data[$contentNo]['locations'][0]->id,
                 $location->id
             );
-            $this->assertEquals(
-                $this->getIndexName($indexMap),
-                $searchResult->searchHits[$index]->index
-            );
+            $this->assertIndexName($indexMap, $searchResult->searchHits[$index]);
             $this->assertEquals(
                 $translationLanguageCode,
                 $searchResult->searchHits[$index]->matchedTranslation
@@ -1675,14 +1667,22 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                 $data[$contentNo]['locations'][1]->id,
                 $location->id
             );
-            $this->assertEquals(
-                $this->getIndexName($indexMap),
-                $searchResult->searchHits[$realIndex]->index
-            );
+            $this->assertIndexName($indexMap, $searchResult->searchHits[$realIndex]);
             $this->assertEquals(
                 $translationLanguageCode,
                 $searchResult->searchHits[$realIndex]->matchedTranslation
             );
+        }
+    }
+
+    private function assertIndexName(array $indexMap, SearchHit $searchHit)
+    {
+        $indexName = $this->getIndexName($indexMap);
+
+        if ($indexName === null) {
+            $this->assertNull($searchHit->index);
+        } else {
+            $this->assertRegExp('~^' . $indexName . '$~', $searchHit->index);
         }
     }
 }

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
@@ -1675,7 +1675,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
         }
     }
 
-    private function assertIndexName(array $indexMap, SearchHit $searchHit)
+    private function assertIndexName(array $indexMap, SearchHit $searchHit): void
     {
         $indexName = $this->getIndexName($indexMap);
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | -
| **Bug/Improvement**| yes
| **New feature**    | -
| **Target version** | `7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Integration tests in ezplatform-solr-search-engine@1.7 and 2.0 are using ezpublish-kernel@7.5  so SearchServiceTranslationLanguageFallbackTest should take into account index naming convention for both: Solr Clound 6.X and 7.X (which slightly differs)

Example failed build: 
https://travis-ci.org/ezsystems/ezplatform-solr-search-engine/jobs/642365371?utm_medium=notification&utm_source=github_status

Example successful builds:
* https://travis-ci.org/ezsystems/ezplatform-solr-search-engine/jobs/643324123
* https://travis-ci.org/ezsystems/ezplatform-solr-search-engine/jobs/643354800

**TODO**:
- [ ] ~Implement feature / fix a bug.~
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
