### PR TITLE
EZP-31047: Made Site Access group configuration available in DIC

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessor.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessor.php
@@ -57,6 +57,8 @@ class ConfigurationProcessor
      *
      * Important: Available SiteAccesses need to be set before ConfigurationProcessor to be constructed by a bundle
      * to set its configuration up.
+     *
+     * @param string[] $availableSiteAccesses
      */
     public static function setAvailableSiteAccesses(array $availableSiteAccesses)
     {
@@ -68,6 +70,8 @@ class ConfigurationProcessor
      *
      * Important: Groups need to be set before ConfigurationProcessor to be constructed by a bundle
      * to set its configuration up.
+     *
+     * @param array $groupsBySiteAccess Registered scope groups names, indexed by scope.
      */
     public static function setGroupsBySiteAccess(array $groupsBySiteAccess)
     {

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessor.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessor.php
@@ -1,15 +1,13 @@
 <?php
 
 /**
- * File containing the ScopeConfigurationProcessor class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use InvalidArgumentException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Processor for SiteAccess aware configuration processing.
@@ -33,13 +31,20 @@ class ConfigurationProcessor
     protected static $groupsBySiteAccess = [];
 
     /**
+     * Keys are Site Access group names and values are an array of Site Access name which belongs to this group.
+     *
+     * @var array
+     */
+    protected static $availableSiteAccessGroups = [];
+
+    /**
      * Name of the node under which scope based (semantic) configuration takes place.
      *
      * @var string
      */
     protected $scopeNodeName;
 
-    /** @var ContextualizerInterface */
+    /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface */
     protected $contextualizer;
 
     public function __construct(ContainerInterface $containerBuilder, $namespace, $siteAcccessNodeName = 'system')
@@ -52,8 +57,6 @@ class ConfigurationProcessor
      *
      * Important: Available SiteAccesses need to be set before ConfigurationProcessor to be constructed by a bundle
      * to set its configuration up.
-     *
-     * @param array $availableSiteAccesses
      */
     public static function setAvailableSiteAccesses(array $availableSiteAccesses)
     {
@@ -65,12 +68,19 @@ class ConfigurationProcessor
      *
      * Important: Groups need to be set before ConfigurationProcessor to be constructed by a bundle
      * to set its configuration up.
-     *
-     * @param array $groupsBySiteAccess
      */
     public static function setGroupsBySiteAccess(array $groupsBySiteAccess)
     {
         static::$groupsBySiteAccess = $groupsBySiteAccess;
+    }
+
+    /**
+     * @param array<string, array<string>> $availableSiteAccessGroups keys are Site Access group names and values are
+     * an array of Site Access name which belongs to this group
+     */
+    public static function setAvailableSiteAccessGroups(array $availableSiteAccessGroups)
+    {
+        static::$availableSiteAccessGroups = $availableSiteAccessGroups;
     }
 
     /**
@@ -145,7 +155,6 @@ class ConfigurationProcessor
      *
      * static::$scopes and static::$groupsByScope must be injected first.
      *
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface $containerBuilder
      * @param string $namespace
      * @param string $siteAccessNodeName
      *
@@ -153,7 +162,14 @@ class ConfigurationProcessor
      */
     protected function buildContextualizer(ContainerInterface $containerBuilder, $namespace, $siteAccessNodeName)
     {
-        return new Contextualizer($containerBuilder, $namespace, $siteAccessNodeName, static::$availableSiteAccesses, static::$groupsBySiteAccess);
+        return new Contextualizer(
+            $containerBuilder,
+            $namespace,
+            $siteAccessNodeName,
+            static::$availableSiteAccesses,
+            static::$availableSiteAccessGroups,
+            static::$groupsBySiteAccess
+        );
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -230,6 +230,7 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
 
         // Register siteaccess groups + reverse
         $container->setParameter('ezpublish.siteaccess.groups', $config['siteaccess']['groups']);
+        ConfigurationProcessor::setAvailableSiteAccessGroups($config['siteaccess']['groups']);
         $groupsBySiteaccess = [];
         foreach ($config['siteaccess']['groups'] as $groupName => $groupMembers) {
             foreach ($groupMembers as $member) {

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/LanguagesTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/LanguagesTest.php
@@ -74,7 +74,7 @@ class LanguagesTest extends AbstractParserTestCase
         $this->assertConfigResolverParameterValue('languages', [], self::EMPTY_SA_GROUP);
         $this->assertSame(
             [
-                'eng-US' => ['ezdemo_site', 'fre'],
+                'eng-US' => ['ezdemo_frontend_group', 'ezdemo_site', 'fre'],
             ],
             $this->container->getParameter('ezpublish.siteaccesses_by_language')
         );

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessorTest.php
@@ -25,8 +25,14 @@ class ConfigurationProcessorTest extends TestCase
         $container = $this->getContainerMock();
         $siteAccessList = ['test', 'bar'];
         $groupsBySa = ['test' => ['group1', 'group2'], 'bar' => ['group1', 'group3']];
+        $siteAccessGroups = [
+            'group1' => ['test', 'bar'],
+            'group2' => ['test'],
+            'group3' => ['bar'],
+        ];
         ConfigurationProcessor::setAvailableSiteAccesses($siteAccessList);
         ConfigurationProcessor::setGroupsBySiteAccess($groupsBySa);
+        ConfigurationProcessor::setAvailableSiteAccessGroups($siteAccessGroups);
         $processor = new ConfigurationProcessor($container, $namespace, $siteAccessNodeName);
 
         $contextualizer = $processor->getContextualizer();


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31047](https://jira.ez.no/browse/EZP-31047)
| **Bug/Improvement**|no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     | yes

Before this PR when we have a Site Access group with some configuration and Site Access group has no assigned Site Access than this configuration is not available in DIC. This is because Site Access group configuration is accessible by `ezsettings.{SA_NAME}.param_name`. Now parameter will be available by `ezsettings.{SA_GROUP_NAME}.param_name`


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
