### PR TITLE
Changed assertEquals to assertEqualsCanonicalizing in tests

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/URLChecker/URLCheckerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/URLChecker/URLCheckerTest.php
@@ -63,7 +63,7 @@ class URLCheckerTest extends TestCase
                 ->expects($this->once())
                 ->method('validate')
                 ->willReturnCallback(function (array $urls) use ($scheme, $groups) {
-                    $this->assertEqualsArrays($groups[$scheme], $urls);
+                    $this->assertEqualsCanonicalizing($groups[$scheme], $urls);
                 });
         }
 
@@ -98,7 +98,7 @@ class URLCheckerTest extends TestCase
                 ->expects($this->once())
                 ->method('validate')
                 ->willReturnCallback(function (array $urls) use ($scheme, $groups) {
-                    $this->assertEqualsArrays($groups[$scheme], $urls);
+                    $this->assertEqualsCanonicalizing($groups[$scheme], $urls);
                 });
         }
 
@@ -106,14 +106,6 @@ class URLCheckerTest extends TestCase
 
         $urlChecker = $this->createUrlChecker();
         $urlChecker->check($query);
-    }
-
-    protected function assertEqualsArrays(array $expected, array $actual, $message = '')
-    {
-        sort($expected);
-        sort($actual);
-
-        $this->assertEquals($expected, $actual, $message);
     }
 
     private function configureUrlHandlerRegistry(array $schemes)

--- a/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
@@ -750,9 +750,7 @@ class RoleServiceTest extends BaseTest
         }
         /* END: Use Case */
 
-        sort($roleNames);
-
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             [
                 'Administrator',
                 'Anonymous',

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
@@ -169,10 +169,8 @@ class ViewManagerTest extends TestCase
             ->method('render');
 
         $templateResult = unserialize($this->viewManager->renderContent($content, 'full', $params));
-        sort($expectedTemplateResult);
-        sort($templateResult);
 
-        self::assertEquals($expectedTemplateResult, $templateResult);
+        self::assertEqualsCanonicalizing($expectedTemplateResult, $templateResult);
     }
 
     public function testRenderLocation()

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
@@ -180,8 +180,7 @@ class HandlerContentSortTest extends AbstractTestCase
             },
             $result->searchHits
         );
-        sort($ids);
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             [4, 10, 11, 12, 13, 14, 42, 226],
             $ids
         );
@@ -281,8 +280,7 @@ class HandlerContentSortTest extends AbstractTestCase
         foreach ($idMapSet as $idSet) {
             $contentIdsSubset = array_slice($contentIds, $index, $count = count($idSet));
             $index += $count;
-            sort($contentIdsSubset);
-            $this->assertEquals(
+            $this->assertEqualsCanonicalizing(
                 $idSet,
                 $contentIdsSubset
             );
@@ -335,8 +333,7 @@ class HandlerContentSortTest extends AbstractTestCase
         foreach ($idMapSet as $idSet) {
             $contentIdsSubset = array_slice($contentIds, $index, $count = count($idSet));
             $index += $count;
-            sort($contentIdsSubset);
-            $this->assertEquals(
+            $this->assertEqualsCanonicalizing(
                 $idSet,
                 $contentIdsSubset
             );
@@ -433,8 +430,7 @@ class HandlerContentSortTest extends AbstractTestCase
         foreach ($idMapSet as $idSet) {
             $contentIdsSubset = array_slice($contentIds, $index, $count = count($idSet));
             $index += $count;
-            sort($contentIdsSubset);
-            $this->assertEquals(
+            $this->assertEqualsCanonicalizing(
                 $idSet,
                 $contentIdsSubset
             );

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
@@ -153,8 +153,7 @@ class HandlerLocationSortTest extends AbstractTestCase
         );
 
         $ids = $this->getIds($locations);
-        sort($ids);
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             [179, 180, 181, 182, 183],
             $ids
         );
@@ -330,8 +329,7 @@ class HandlerLocationSortTest extends AbstractTestCase
         foreach ($idMapSet as $idSet) {
             $locationIdsSubset = array_slice($locationIds, $index, $count = count($idSet));
             $index += $count;
-            sort($locationIdsSubset);
-            $this->assertEquals(
+            $this->assertEqualsCanonicalizing(
                 $idSet,
                 $locationIdsSubset
             );
@@ -499,8 +497,7 @@ class HandlerLocationSortTest extends AbstractTestCase
         foreach ($idMapSet as $idSet) {
             $locationIdsSubset = array_slice($locationIds, $index, $count = count($idSet));
             $index += $count;
-            sort($locationIdsSubset);
-            $this->assertEquals(
+            $this->assertEqualsCanonicalizing(
                 $idSet,
                 $locationIdsSubset
             );
@@ -569,8 +566,7 @@ class HandlerLocationSortTest extends AbstractTestCase
         foreach ($idMapSet as $idSet) {
             $locationIdsSubset = array_slice($locationIds, $index, $count = count($idSet));
             $index += $count;
-            sort($locationIdsSubset);
-            $this->assertEquals(
+            $this->assertEqualsCanonicalizing(
                 $idSet,
                 $locationIdsSubset
             );


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     |no

Because PHPUnit has dedicated assertion which sorts both arrays before the actual comparison we can improve the code in several places. This assertion can be only used to replace sorting with the `SORT_REGULAR` flag.

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
