### PR TITLE
[Behat] Make Behat SiteAccess aware

### DIFF
--- a/eZ/Bundle/PlatformBehatBundle/Initializer/BehatSiteAccessInitializer.php
+++ b/eZ/Bundle/PlatformBehatBundle/Initializer/BehatSiteAccessInitializer.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\PlatformBehatBundle\Initializer;
+
+use Behat\Behat\EventDispatcher\Event\ExampleTested;
+use Behat\Behat\EventDispatcher\Event\ScenarioTested;
+use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+final class BehatSiteAccessInitializer implements EventSubscriberInterface
+{
+    private const EZPLATFORM_SITEACCESS_ENV_VAR = 'EZPLATFORM_SITEACCESS';
+    private const DEFAULT_SITEACCESS_PARAMETER = 'ezpublish.siteaccess.default';
+    private const EVENT_DISPATCHER_SERVICE_ID = 'event_dispatcher';
+
+    /** @var \Symfony\Component\HttpKernel\KernelInterface */
+    private $kernel;
+
+    public function __construct(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ScenarioTested::BEFORE => ['setSiteAccess'],
+            ExampleTested::BEFORE => ['setSiteAccess'],
+        ];
+    }
+
+    public function setSiteAccess(): void
+    {
+        $siteAccess = $this->getSiteAccess();
+        // We cannot inject EventDispatcher directly because it would be the one used by Behat internally
+        // We need to get the one made available by Symfony2Extension
+        $this->kernel
+            ->getContainer()
+            ->get(self::EVENT_DISPATCHER_SERVICE_ID)
+            ->dispatch(MVCEvents::CONFIG_SCOPE_CHANGE, new ScopeChangeEvent($siteAccess));
+    }
+
+    private function getSiteAccess(): SiteAccess
+    {
+        $siteAccessFromEnvVar = getenv(self::EZPLATFORM_SITEACCESS_ENV_VAR);
+        $defaultSiteAccess = $this->kernel->getContainer()->getParameter(self::DEFAULT_SITEACCESS_PARAMETER);
+
+        $siteAccessName = $siteAccessFromEnvVar !== false ? $siteAccessFromEnvVar : $defaultSiteAccess;
+
+        return new SiteAccess($siteAccessName, 'cli');
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/ServiceContainer/EzBehatExtension.php
+++ b/eZ/Bundle/PlatformBehatBundle/ServiceContainer/EzBehatExtension.php
@@ -1,44 +1,43 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace EzSystems\PlatformBehatBundle\ServiceContainer;
 
+use Behat\Behat\EventDispatcher\ServiceContainer\EventDispatcherExtension;
+use Behat\Symfony2Extension\ServiceContainer\Symfony2Extension;
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
+use eZ\Bundle\PlatformBehatBundle\Initializer\BehatSiteAccessInitializer;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * EzBehatExtension loads extension specific services.
  */
 class EzBehatExtension implements Extension
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getConfigKey()
     {
         return 'ezbehatextension';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(ContainerBuilder $container)
     {
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function initialize(ExtensionManager $extensionManager)
     {
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function configure(ArrayNodeDefinition $builder)
     {
     }
@@ -46,12 +45,24 @@ class EzBehatExtension implements Extension
     /**
      * Loads extension services into temporary container.
      *
-     * @param ContainerBuilder $container
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      * @param array $config
      */
     public function load(ContainerBuilder $container, array $config)
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
+
+        $this->loadSiteAccessInitializer($container);
+    }
+
+    private function loadSiteAccessInitializer(ContainerBuilder $container): void
+    {
+        $definition = new Definition(BehatSiteAccessInitializer::class);
+        $definition->setArguments([
+            new Reference(Symfony2Extension::KERNEL_ID),
+        ]);
+        $definition->addTag(EventDispatcherExtension::SUBSCRIBER_TAG, ['priority' => 0]);
+        $container->setDefinition(BehatSiteAccessInitializer::class, $definition);
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31313](https://jira.ez.no/browse/EZP-31313)
| **Bug/Improvement**| no
| **New feature**    | for Behat
| **Target version** | 7.5, not for master - PlatformBehatBundle has been moved to BehatBundle in master and the solution will be ported there
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | added short doc in https://github.com/ezsystems/BehatBundle/pull/124/commits/4380a8fcff48abd3b406f3ee6252a399303f6ba8

Adding the possibility to set the SiteAccess used by Behat when running tests. If the `EZPLATFORM_SITEACCESS` env variable is not present then the default one will be used.

WIll be used by multirepository suite added in https://github.com/ezsystems/BehatBundle/pull/124

The idea of initializing SiteAccess has ben "taken" from:
https://github.com/ezsystems/ezpublish-kernel/blob/50563cf4472a5b2306709e0148797796142e1849/eZ/Bundle/EzPublishCoreBundle/EventListener/ConsoleCommandListener.php#L60

**Naming:**
Not sure if `EZPLATFORM_SITEACCESS` is the best name, as it could suggest something related to the whole application - I've also considered `BEHAT_EZPLATFORM_SITEACCESS`, which is more specific. WDYT?

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests: this will be tested on Travis by Behat usage, for me it's enough
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
