### PR TITLE
[Tests] EZP-31226: Enabled testFulltextContentSearchSolr6

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceFulltextTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceFulltextTest.php
@@ -266,10 +266,6 @@ class SearchServiceFulltextTest extends BaseTest
      */
     public function testFulltextContentSearchSolr6(string $searchString, array $expectedKeys, array $idMap): void
     {
-        self::markTestIncomplete(
-            'Scoring changed due to EZP-31226. Test results need to be revisited.'
-        );
-
         if (($solrVersion = getenv('SOLR_VERSION')) >= 7) {
             $this->markTestSkipped('This test is only relevant for Solr 6');
         }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31226](https://jira.ez.no/browse/EZP-31226)
| **Alternative to** | #2935
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform 3.0
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | no

Re-enabled test for Solr 6 FullText Content search.

**TODO**:
- [x] Wait for Travis.