### PR TITLE
Added totalCount attribute to REST ContentList response

### DIFF
--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ContentList.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ContentList.php
@@ -37,6 +37,11 @@ class ContentList extends ValueObjectVisitor
         );
         $generator->endAttribute('href');
 
+        if (isset($data->totalCount)) {
+            $generator->startAttribute('totalCount', $data->totalCount);
+            $generator->endAttribute('totalCount');
+        }
+
         $generator->startList('ContentInfo');
         foreach ($data->contents as $content) {
             $visitor->visitValueObject($content);

--- a/eZ/Publish/Core/REST/Server/Values/ContentList.php
+++ b/eZ/Publish/Core/REST/Server/Values/ContentList.php
@@ -23,12 +23,20 @@ class ContentList extends RestValue
     public $contents;
 
     /**
+     * Total items list count.
+     * @var int|null
+     */
+    public $totalCount;
+
+    /**
      * Construct.
      *
      * @param \eZ\Publish\Core\REST\Server\Values\RestContent[] $contents
+     * @param int|null $totalCount
      */
-    public function __construct(array $contents)
+    public function __construct(array $contents, ?int $totalCount = null)
     {
         $this->contents = $contents;
+        $this->totalCount = $totalCount;
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Used in [EZP-31316](https://jira.ez.no/browse/EZP-31316) for https://github.com/ezsystems/ezplatform-query-fieldtype/pull/20
| **Bug/Improvement**| improvement
| **New feature**    | yes
| **Target version** | `7.x` & `8.x`
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | yes

Adds a `totalCount` attribute to the REST response for `ContentList`. Used for pagination.

### TODO
- [ ] Implement tests.
