### PR TITLE
EZP-31348: Dropped deprecated createFromQueryBuilder method from the Criterion classes

### DIFF
--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -81,7 +81,27 @@ Changes affecting version compatibility with former or future versions.
     * `\eZ\Publish\API\Repository\RoleService::loadPoliciesByUserId`
     * `\eZ\Publish\API\Repository\RoleService::unassignRoleFromUser`
     * `\eZ\Publish\API\Repository\RoleService::unassignRoleFromUserGroup`
-
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentId::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeGroupId::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeId::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\FieldRelation::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\FullText::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\LanguageCode::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationId::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationRemoteId::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchAll::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchNone::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\MoreLikeThis::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ObjectStateId::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\RemoteId::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\SectionId::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility::createFromQueryBuilder`
+    
 * The "Setup" folder and Section have been removed from the initial (clean installation) data.
 
 * The "Design" Section has been removed from the initial (clean installation) data.

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
@@ -177,14 +177,4 @@ abstract class Criterion implements CriterionInterface
 
         return $callback;
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new static($target, $operator, $value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
@@ -55,14 +55,4 @@ class Ancestor extends Criterion
             ),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentId.php
@@ -42,14 +42,4 @@ class ContentId extends Criterion
             new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, $types),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeGroupId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeGroupId.php
@@ -52,14 +52,4 @@ class ContentTypeGroupId extends Criterion
             ),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeId.php
@@ -44,14 +44,4 @@ class ContentTypeId extends Criterion
             new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, $types),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeIdentifier.php
@@ -49,14 +49,4 @@ class ContentTypeIdentifier extends Criterion
             ),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FieldRelation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FieldRelation.php
@@ -32,14 +32,4 @@ class FieldRelation extends Criterion
             new Specifications(Operator::IN, Specifications::FORMAT_ARRAY, $types),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($target, $operator, $value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FullText.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FullText.php
@@ -123,16 +123,6 @@ class FullText extends Criterion implements CustomFieldInterface
     }
 
     /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
-
-    /**
      * Set a custom field to query.
      *
      * Set a custom field to query for a defined field in a defined type.

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LanguageCode.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LanguageCode.php
@@ -63,14 +63,4 @@ class LanguageCode extends Criterion
             ),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationId.php
@@ -50,14 +50,4 @@ class LocationId extends Criterion
             ),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationRemoteId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationRemoteId.php
@@ -48,14 +48,4 @@ class LocationRemoteId extends Criterion
             ),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchAll.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchAll.php
@@ -27,14 +27,4 @@ class MatchAll extends Criterion
     {
         return [];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self();
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchNone.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchNone.php
@@ -27,14 +27,4 @@ class MatchNone extends Criterion
     {
         return [];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self();
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MoreLikeThis.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MoreLikeThis.php
@@ -49,14 +49,4 @@ class MoreLikeThis extends Criterion
             new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateId.php
@@ -48,14 +48,4 @@ class ObjectStateId extends Criterion
             ),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ParentLocationId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ParentLocationId.php
@@ -50,14 +50,4 @@ class ParentLocationId extends Criterion
             ),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/RemoteId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/RemoteId.php
@@ -48,14 +48,4 @@ class RemoteId extends Criterion
             ),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/SectionId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/SectionId.php
@@ -48,14 +48,4 @@ class SectionId extends Criterion
             ),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Subtree.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Subtree.php
@@ -53,14 +53,4 @@ class Subtree extends Criterion
             ),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Visibility.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Visibility.php
@@ -57,14 +57,4 @@ class Visibility extends Criterion
             ),
         ];
     }
-
-    /**
-     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
-     */
-    public static function createFromQueryBuilder($target, $operator, $value)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
-
-        return new self($value);
-    }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31348](https://jira.ez.no/browse/EZP-31348)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** |`master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

Methods `ceateFromQueryBuilder` in the criterion classes has been deprecated sine eZ Platform 2.2. See  https://github.com/ezsystems/ezpublish-kernel/pull/2330 for more details

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
