### PR TITLE
EZP-31383: Implemented API to copy Roles

### DIFF
--- a/eZ/Publish/API/Repository/Events/Role/BeforeCopyRoleEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeCopyRoleEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Events\Role;
+
+use eZ\Publish\API\Repository\Values\User\RoleCopyStruct;
+use eZ\Publish\API\Repository\Values\User\Role;
+use eZ\Publish\SPI\Repository\Event\BeforeEvent;
+use UnexpectedValueException;
+
+final class BeforeCopyRoleEvent extends BeforeEvent
+{
+    /** @var \eZ\Publish\API\Repository\Values\User\Role */
+    private $role;
+
+    /** @var \eZ\Publish\API\Repository\Values\User\RoleCopyStruct */
+    private $roleCopyStruct;
+
+    /** @var \eZ\Publish\API\Repository\Values\User\Role|null */
+    private $copiedRole;
+
+    public function __construct(Role $role, RoleCopyStruct $roleCopyStruct)
+    {
+        $this->role = $role;
+        $this->roleCopyStruct = $roleCopyStruct;
+    }
+
+    public function getRole(): Role
+    {
+        return $this->role;
+    }
+
+    public function getCopiedRole(): Role
+    {
+        if (!$this->hasCopiedRole()) {
+            throw new UnexpectedValueException(sprintf('Return value is not set or not of type %s. Check hasRole() or set it using setRole() before you call the getter.', Role::class));
+        }
+
+        return $this->copiedRole;
+    }
+
+    public function hasCopiedRole(): bool
+    {
+        return $this->copiedRole instanceof Role;
+    }
+}

--- a/eZ/Publish/API/Repository/Events/Role/CopyRoleEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/CopyRoleEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Events\Role;
+
+use eZ\Publish\API\Repository\Values\User\Role;
+use eZ\Publish\API\Repository\Values\User\RoleCopyStruct;
+use eZ\Publish\SPI\Repository\Event\AfterEvent;
+
+final class CopyRoleEvent extends AfterEvent
+{
+    /** @var \eZ\Publish\API\Repository\Values\User\Role */
+    private $copiedRole;
+
+    /** @var \eZ\Publish\API\Repository\Values\User\Role */
+    private $role;
+
+    /** @var \eZ\Publish\API\Repository\Values\User\RoleCopyStruct */
+    private $roleCopyStruct;
+
+    public function __construct(
+        Role $copiedRole,
+        Role $role,
+        RoleCopyStruct $roleCopyStruct
+    ) {
+        $this->copiedRole = $copiedRole;
+        $this->role = $role;
+        $this->roleCopyStruct = $roleCopyStruct;
+    }
+
+    public function getRole(): Role
+    {
+        return $this->role;
+    }
+
+    public function getCopiedRole(): Role
+    {
+        return $this->copiedRole;
+    }
+
+    public function getRoleCopyStruct(): RoleCopyStruct
+    {
+        return $this->roleCopyStruct;
+    }
+}

--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\Values\User\PolicyDraft;
 use eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\Role;
 use eZ\Publish\API\Repository\Values\User\RoleAssignment;
+use eZ\Publish\API\Repository\Values\User\RoleCopyStruct;
 use eZ\Publish\API\Repository\Values\User\RoleCreateStruct;
 use eZ\Publish\API\Repository\Values\User\RoleDraft;
 use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
@@ -56,6 +57,23 @@ interface RoleService
      * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
      */
     public function createRoleDraft(Role $role): RoleDraft;
+
+    /**
+     * Copies an existing Role.
+     *
+     * @since 8.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to copy a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the same type
+     *         is repeated in the policy create struct or if limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCopyStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Role $role
+     * @param \eZ\Publish\API\Repository\Values\User\RoleCopyStruct $roleCopyStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Role
+     */
+    public function copyRole(Role $role, RoleCopyStruct $roleCopyStruct): Role;
 
     /**
      * Loads a RoleDraft for the given id.
@@ -307,6 +325,15 @@ interface RoleService
      * @return \eZ\Publish\API\Repository\Values\User\RoleCreateStruct
      */
     public function newRoleCreateStruct(string $name): RoleCreateStruct;
+
+    /**
+     * Instantiates a role copy class.
+     *
+     * @param string $name
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleCopyStruct
+     */
+    public function newRoleCopyStruct(string $name): RoleCopyStruct;
 
     /**
      * Instantiates a policy create class.

--- a/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\API\Repository\Tests;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
 use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\Role;
@@ -52,6 +53,23 @@ class RoleServiceTest extends BaseTest
         $roleCreate = $roleService->newRoleCreateStruct('roleName');
 
         $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\User\\RoleCreateStruct', $roleCreate);
+    }
+
+    /**
+     * Test for the newRoleCopyStruct() method.
+     *
+     * @see \eZ\Publish\API\Repository\RoleService::newRoleCopyStruct()
+     */
+    public function testNewRoleCopyStruct()
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $roleService = $repository->getRoleService();
+        $roleCopy = $roleService->newRoleCopyStruct('copiedRole');
+        /* END: Use Case */
+
+        $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\User\\RoleCopyStruct', $roleCopy);
     }
 
     /**
@@ -499,6 +517,126 @@ class RoleServiceTest extends BaseTest
         /* END: Use Case */
 
         $this->fail('Role draft object still exists after rollback.');
+    }
+
+    /**
+     * Test for the copyRole() method.
+     *
+     * @see \eZ\Publish\API\Repository\RoleService::copyRole()
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testNewRoleCopyStruct
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testLoadRoleByIdentifier
+     */
+    public function testCopyRole()
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $roleService = $repository->getRoleService();
+        $roleCreate = $roleService->newRoleCreateStruct('newRole');
+
+        $roleDraft = $roleService->createRole($roleCreate);
+
+        $roleService->publishRoleDraft($roleDraft);
+        $role = $roleService->loadRole($roleDraft->id);
+
+        $roleCopy = $roleService->newRoleCopyStruct('copiedRole');
+
+        $copiedRole = $roleService->copyRole($role, $roleCopy);
+        /* END: Use Case */
+
+        // Now verify that our change was saved
+        $role = $roleService->loadRoleByIdentifier('copiedRole');
+
+        $this->assertEquals($role->id, $copiedRole->id);
+    }
+
+    /**
+     * Test for the copyRole() method with added policies.
+     *
+     * @see \eZ\Publish\API\Repository\RoleService::copyRole()
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testNewRoleCopyStruct
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testLoadRoleByIdentifier
+     */
+    public function testCopyRoleWithPolicies()
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $roleService = $repository->getRoleService();
+        $roleCreate = $roleService->newRoleCreateStruct('newRole');
+
+        $policyCreateStruct1 = $roleService->newPolicyCreateStruct('content', 'read');
+        $policyCreateStruct2 = $roleService->newPolicyCreateStruct('content', 'edit');
+
+        $roleCreate->addPolicy($policyCreateStruct1);
+        $roleCreate->addPolicy($policyCreateStruct2);
+
+        $roleDraft = $roleService->createRole($roleCreate);
+
+        $roleService->publishRoleDraft($roleDraft);
+        $role = $roleService->loadRole($roleDraft->id);
+
+        $roleCopy = $roleService->newRoleCopyStruct('copiedRole');
+
+        $copiedRole = $roleService->copyRole($role, $roleCopy);
+        /* END: Use Case */
+
+        // Now verify that our change was saved
+        $role = $roleService->loadRoleByIdentifier('copiedRole');
+
+        $this->assertEquals($role->getPolicies(), $copiedRole->getPolicies());
+    }
+
+    /**
+     * Test for the copyRole() method with added policies and limitations.
+     *
+     * @see \eZ\Publish\API\Repository\RoleService::copyRole()
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testNewRoleCopyStruct
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testLoadRoleByIdentifier
+     */
+    public function testCopyRoleWithPoliciesAndLimitations()
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $roleService = $repository->getRoleService();
+        $roleCreate = $roleService->newRoleCreateStruct('newRole');
+
+        $policyCreateStruct1 = $roleService->newPolicyCreateStruct('content', 'read');
+        $roleLimitations = [
+            new SectionLimitation(['limitationValues' => [2]]),
+            new SubtreeLimitation(['limitationValues' => ['/1/2/']]),
+        ];
+        foreach ($roleLimitations as $roleLimitation) {
+            $policyCreateStruct1->addLimitation($roleLimitation);
+        }
+        $policyCreateStruct2 = $roleService->newPolicyCreateStruct('content', 'edit');
+
+        $roleCreate->addPolicy($policyCreateStruct1);
+        $roleCreate->addPolicy($policyCreateStruct2);
+
+        $roleDraft = $roleService->createRole($roleCreate);
+
+        $roleService->publishRoleDraft($roleDraft);
+        $role = $roleService->loadRole($roleDraft->id);
+
+        $roleCopy = $roleService->newRoleCopyStruct('copiedRole');
+        $copiedRole = $roleService->copyRole($role, $roleCopy);
+        /* END: Use Case */
+
+        // Now verify that our change was saved
+        $role = $roleService->loadRoleByIdentifier('copiedRole');
+
+        $limitations = [];
+        foreach ($role->getPolicies() as $policy) {
+            $limitations[] = $policy->getLimitations();
+        }
+        $limitationsCopied = [];
+        foreach ($copiedRole->getPolicies() as $policy) {
+            $limitationsCopied[] = $policy->getLimitations();
+        }
+
+        $this->assertEquals($limitations, $limitationsCopied);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Values/User/RoleCopyStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleCopyStruct.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * File containing the eZ\Publish\API\Repository\Values\User\RoleCreateStruct class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Values\User;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * This class is used to copy an existing role.
+ */
+abstract class RoleCopyStruct extends ValueObject
+{
+    /**
+     * Readable string identifier of a new role.
+     *
+     * @var string
+     */
+    public $newIdentifier;
+
+    /**
+     * Returns policies associated with the role.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct[]
+     */
+    abstract public function getPolicies();
+
+    /**
+     * Adds a policy to this role.
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct $policyCreateStruct
+     */
+    abstract public function addPolicy(PolicyCreateStruct $policyCreateStruct);
+}

--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -13,6 +13,7 @@ use eZ\Publish\SPI\Persistence\User\Handler as UserHandlerInterface;
 use eZ\Publish\SPI\Persistence\User;
 use eZ\Publish\SPI\Persistence\User\Role;
 use eZ\Publish\SPI\Persistence\User\RoleAssignment;
+use eZ\Publish\SPI\Persistence\User\RoleCopyStruct;
 use eZ\Publish\SPI\Persistence\User\RoleCreateStruct;
 use eZ\Publish\SPI\Persistence\User\RoleUpdateStruct;
 use eZ\Publish\SPI\Persistence\User\Policy;
@@ -247,6 +248,16 @@ class UserHandler extends AbstractInMemoryPersistenceHandler implements UserHand
         $this->logger->logCall(__METHOD__, ['role' => $roleId]);
 
         return $this->persistenceHandler->userHandler()->createRoleDraft($roleId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function copyRole(RoleCopyStruct $copyStruct)
+    {
+        $this->logger->logCall(__METHOD__, ['struct' => $copyStruct]);
+
+        return $this->persistenceHandler->userHandler()->copyRole($copyStruct);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/Role/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/Role/Gateway/DoctrineDatabaseTest.php
@@ -66,6 +66,35 @@ class DoctrineDatabaseTest extends TestCase
     }
 
     /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\DoctrineDatabase::createRole
+     */
+    public function testCopyRole()
+    {
+        $gateway = $this->getDatabaseGateway();
+
+        $spiRole = new Role([
+            'identifier' => 'cloned_role',
+            'status' => Role::STATUS_DRAFT,
+        ]);
+        $gateway->copyRole($spiRole);
+        $query = $this->getDatabaseHandler()->createSelectQuery();
+
+        $this->assertQueryResult(
+            [
+                [
+                    'id' => '6',
+                    'name' => 'cloned_role',
+                    'version' => 0,
+                ],
+            ],
+            $query
+                ->select('id', 'name', 'version')
+                ->from('ezrole')
+                ->where($query->expr->eq('name', $query->bindValue('cloned_role')))
+        );
+    }
+
+    /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\DoctrineDatabase::loadRoleAssignment
      */
     public function testLoadRoleAssignment()

--- a/eZ/Publish/Core/Persistence/Legacy/User/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Handler.php
@@ -272,6 +272,28 @@ class Handler implements BaseUserHandler
     }
 
     /**
+     * Copies an existing role.
+     *
+     * @param \eZ\Publish\SPI\Persistence\User\RoleCopyStruct $copyStruct
+     *
+     * @return \eZ\Publish\SPI\Persistence\User\Role
+     */
+    public function copyRole(User\RoleCopyStruct $copyStruct)
+    {
+        $role = $this->mapper->createRoleFromCopyStruct(
+            $copyStruct
+        );
+
+        $this->roleGateway->copyRole($role);
+
+        foreach ($role->policies as $policy) {
+            $this->addPolicy($role->id, $policy);
+        }
+
+        return $role;
+    }
+
+    /**
      * Loads a specified role (draft) by $roleId and $status.
      *
      * @param mixed $roleId

--- a/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
@@ -242,4 +242,22 @@ class Mapper
 
         return $role;
     }
+
+    /**
+     * Maps properties from $struct to $role.
+     *
+     * @param \eZ\Publish\SPI\Persistence\User\RoleCopyStruct $copyStruct
+     *
+     * @return \eZ\Publish\SPI\Persistence\User\Role
+     */
+    public function createRoleFromCopyStruct(User\RoleCopyStruct $copyStruct)
+    {
+        $role = new Role();
+
+        $role->identifier = $copyStruct->newIdentifier;
+        $role->policies = $copyStruct->policies;
+        $role->status = Role::STATUS_DEFINED;
+
+        return $role;
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
@@ -27,6 +27,15 @@ abstract class Gateway
     abstract public function createRole(Role $role);
 
     /**
+     * Copies an existing Role.
+     *
+     * @param Role $role
+     *
+     * @return Role
+     */
+    abstract public function copyRole(Role $role);
+
+    /**
      * Loads a specified role by $roleId.
      *
      * @param mixed $roleId

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -90,6 +90,41 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
+     * Copies an existing Role.
+     *
+     * @param \eZ\Publish\SPI\Persistence\User\Role $role
+     */
+    public function copyRole(Role $role)
+    {
+        $query = $this->handler->createInsertQuery();
+        $query
+            ->insertInto($this->handler->quoteTable('ezrole'))
+            ->set(
+                $this->handler->quoteColumn('id'),
+                $this->handler->getAutoIncrementValue('ezrole', 'id')
+            )->set(
+                $this->handler->quoteColumn('is_new'),
+                0
+            )->set(
+                $this->handler->quoteColumn('name'),
+                $query->bindValue($role->identifier)
+            )->set(
+                $this->handler->quoteColumn('value'),
+                0
+            )->set(
+                $this->handler->quoteColumn('version'),
+                $query->bindValue(0)
+            );
+        $query->prepare()->execute();
+
+        if (!isset($role->id) || (int)$role->id < 1 || $role->status === Role::STATUS_DRAFT) {
+            $role->id = $this->handler->lastInsertId(
+                $this->handler->getSequenceName('ezrole', 'id')
+            );
+        }
+    }
+
+    /**
      * Loads a specified role by id.
      *
      * @param mixed $roleId

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
@@ -57,6 +57,24 @@ class ExceptionConversion extends Gateway
     }
 
     /**
+     * Copies an existing Role.
+     *
+     * @param Role $role
+     *
+     * @return Role
+     */
+    public function copyRole(Role $role)
+    {
+        try {
+            return $this->innerGateway->copyRole($role);
+        } catch (DBALException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        } catch (PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
+
+    /**
      * Loads a specified role by $roleId.
      *
      * @param mixed $roleId

--- a/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\Repository\Values\User\Role;
 use eZ\Publish\API\Repository\Values\User\Role as APIRole;
 use eZ\Publish\Core\Repository\Values\User\RoleDraft;
 use eZ\Publish\API\Repository\Values\User\RoleCreateStruct as APIRoleCreateStruct;
+use eZ\Publish\API\Repository\Values\User\RoleCopyStruct as APIRoleCopyStruct;
 use eZ\Publish\Core\Repository\Values\User\UserRoleAssignment;
 use eZ\Publish\Core\Repository\Values\User\UserGroupRoleAssignment;
 use eZ\Publish\API\Repository\Values\User\User;
@@ -22,6 +23,7 @@ use eZ\Publish\SPI\Persistence\User\Policy as SPIPolicy;
 use eZ\Publish\SPI\Persistence\User\RoleAssignment as SPIRoleAssignment;
 use eZ\Publish\SPI\Persistence\User\Role as SPIRole;
 use eZ\Publish\SPI\Persistence\User\RoleCreateStruct as SPIRoleCreateStruct;
+use eZ\Publish\SPI\Persistence\User\RoleCopyStruct as SPIRoleCopyStruct;
 
 /**
  * Internal service to map Role objects between API and SPI values.
@@ -196,6 +198,34 @@ class RoleDomainMapper
             [
                 'identifier' => $roleCreateStruct->identifier,
                 'policies' => $policiesToCreate,
+            ]
+        );
+    }
+
+    /**
+     * Creates SPI Role copy struct from provided API role copy struct.
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleCopyStruct $roleCopyStruct
+     * @param mixed $clonedId
+     *
+     * @return \eZ\Publish\SPI\Persistence\User\RoleCopyStruct
+     */
+    public function buildPersistenceRoleCopyStruct(APIRoleCopyStruct $roleCopyStruct, $clonedId)
+    {
+        $policiesToCopy = [];
+        foreach ($roleCopyStruct->getPolicies() as $policyCopyStruct) {
+            $policiesToCopy[] = $this->buildPersistencePolicyObject(
+                $policyCopyStruct->module,
+                $policyCopyStruct->function,
+                $policyCopyStruct->getLimitations()
+            );
+        }
+
+        return new SPIRoleCopyStruct(
+            [
+                'clonedId' => $clonedId,
+                'newIdentifier' => $roleCopyStruct->newIdentifier,
+                'policies' => $policiesToCopy,
             ]
         );
     }

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -19,6 +19,7 @@ use eZ\Publish\API\Repository\Values\User\PolicyDraft;
 use eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct as APIPolicyUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\Role as APIRole;
 use eZ\Publish\API\Repository\Values\User\RoleAssignment;
+use eZ\Publish\API\Repository\Values\User\RoleCopyStruct as APIRoleCopyStruct;
 use eZ\Publish\API\Repository\Values\User\RoleCreateStruct as APIRoleCreateStruct;
 use eZ\Publish\API\Repository\Values\User\RoleDraft as APIRoleDraft;
 use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
@@ -33,6 +34,7 @@ use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\Core\Repository\Values\User\PolicyCreateStruct;
 use eZ\Publish\Core\Repository\Values\User\PolicyUpdateStruct;
 use eZ\Publish\Core\Repository\Values\User\Role;
+use eZ\Publish\Core\Repository\Values\User\RoleCopyStruct;
 use eZ\Publish\Core\Repository\Values\User\RoleCreateStruct;
 use eZ\Publish\SPI\Limitation\Type;
 use eZ\Publish\SPI\Persistence\User\Handler;
@@ -181,6 +183,73 @@ class RoleService implements RoleServiceInterface
         }
 
         return $this->roleDomainMapper->buildDomainRoleDraftObject($spiRole);
+    }
+
+    /**
+     * Copies an existing Role.
+     *
+     * @since 8.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to copy a Role
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the same type
+     *         is repeated in the policy create struct or if limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCopyStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Role $role
+     * @param \eZ\Publish\API\Repository\Values\User\RoleCopyStruct $roleCopyStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Role
+     */
+    public function copyRole(APIRole $role, APIRoleCopyStruct $roleCopyStruct): APIRole
+    {
+        if (!is_string($roleCopyStruct->newIdentifier) || empty($roleCopyStruct->newIdentifier)) {
+            throw new InvalidArgumentValue('newIdentifier', $roleCopyStruct->newIdentifier, 'RoleCopyStruct');
+        }
+
+        if (!$this->permissionResolver->canUser('role', 'create', $roleCopyStruct)) {
+            throw new UnauthorizedException('role', 'create');
+        }
+
+        try {
+            $existingRole = $this->loadRoleByIdentifier($roleCopyStruct->newIdentifier);
+
+            throw new InvalidArgumentException(
+                '$roleCopyStruct',
+                "Role '{$existingRole->id}' with the specified identifier '{$roleCopyStruct->newIdentifier}' " .
+                'already exists'
+            );
+        } catch (APINotFoundException $e) {
+            // Do nothing
+        }
+
+        foreach ($role->getPolicies() as $policy) {
+            $policyCreateStruct = new PolicyCreateStruct([
+                'module' => $policy->module,
+                'function' => $policy->function,
+            ]);
+            foreach ($policy->getLimitations() as $limitation) {
+                $policyCreateStruct->addLimitation($limitation);
+            }
+            $roleCopyStruct->addPolicy($policyCreateStruct);
+        }
+
+        $limitationValidationErrors = $this->validateRoleCopyStruct($roleCopyStruct);
+        if (!empty($limitationValidationErrors)) {
+            throw new LimitationValidationException($limitationValidationErrors);
+        }
+
+        $spiRoleCopyStruct = $this->roleDomainMapper->buildPersistenceRoleCopyStruct($roleCopyStruct, $role->id);
+
+        $this->repository->beginTransaction();
+        try {
+            $spiRole = $this->userHandler->copyRole($spiRoleCopyStruct);
+            $this->repository->commit();
+        } catch (Exception $e) {
+            $this->repository->rollback();
+            throw $e;
+        }
+
+        return $this->loadRole($spiRole->id);
     }
 
     /**
@@ -949,6 +1018,23 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
+     * Instantiates a role copy class.
+     *
+     * @param string $name
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleCopyStruct
+     */
+    public function newRoleCopyStruct($name): APIRoleCopyStruct
+    {
+        return new RoleCopyStruct(
+            [
+                'newIdentifier' => $name,
+                'policies' => [],
+            ]
+        );
+    }
+
+    /**
      * Instantiates a policy create class.
      *
      * @param string $module
@@ -1064,6 +1150,33 @@ class RoleService implements RoleServiceInterface
                 $policyCreateStruct->module,
                 $policyCreateStruct->function,
                 $policyCreateStruct->getLimitations()
+            );
+
+            if (!empty($errors)) {
+                $allErrors[$key] = $errors;
+            }
+        }
+
+        return $allErrors;
+    }
+
+    /**
+     * Validates Policies and Limitations in Role copy struct.
+     *
+     * @uses ::validatePolicy()
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleCopyStruct $roleCopyStruct
+     *
+     * @return \eZ\Publish\Core\FieldType\ValidationError[][][]
+     */
+    protected function validateRoleCopyStruct(APIRoleCopyStruct $roleCopyStruct)
+    {
+        $allErrors = [];
+        foreach ($roleCopyStruct->getPolicies() as $key => $policyCopyStruct) {
+            $errors = $this->validatePolicy(
+                $policyCopyStruct->module,
+                $policyCopyStruct->function,
+                $policyCopyStruct->getLimitations()
             );
 
             if (!empty($errors)) {

--- a/eZ/Publish/Core/Repository/Values/User/RoleCopyStruct.php
+++ b/eZ/Publish/Core/Repository/Values/User/RoleCopyStruct.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * File containing the eZ\Publish\Core\Repository\Values\User\RoleCopyStruct class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\Values\User;
+
+use eZ\Publish\API\Repository\Values\User\PolicyCreateStruct as APIPolicyCreateStruct;
+use eZ\Publish\API\Repository\Values\User\RoleCopyStruct as APIRoleCopyStruct;
+
+/**
+ * This class is used to create a new role.
+ *
+ * @internal Meant for internal use by Repository, type hint against API instead.
+ */
+class RoleCopyStruct extends APIRoleCopyStruct
+{
+    /**
+     * Policies associated with the role.
+     *
+     * @var \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct[]
+     */
+    protected $policies = [];
+
+    /**
+     * Returns policies associated with the role.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct[]
+     */
+    public function getPolicies()
+    {
+        return $this->policies;
+    }
+
+    /**
+     * Adds a policy to this role.
+     */
+    public function addPolicy(APIPolicyCreateStruct $policyCopy)
+    {
+        $this->policies[] = $policyCopy;
+    }
+}

--- a/eZ/Publish/SPI/Persistence/User/RoleCopyStruct.php
+++ b/eZ/Publish/SPI/Persistence/User/RoleCopyStruct.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * File containing the RoleCopyStruct class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\Persistence\User;
+
+use eZ\Publish\SPI\Persistence\ValueObject;
+
+class RoleCopyStruct extends ValueObject
+{
+    /**
+     * ID of user role being cloned.
+     *
+     * @var mixed
+     */
+    public $clonedId;
+
+    /**
+     * Identifier of new role.
+     *
+     * @var string
+     */
+    public $newIdentifier;
+
+    /**
+     * Contains an array of role policies.
+     *
+     * @var mixed[]
+     */
+    public $policies = [];
+}

--- a/eZ/Publish/SPI/Repository/Decorator/RoleServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/RoleServiceDecorator.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\Values\User\PolicyDraft;
 use eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\Role;
 use eZ\Publish\API\Repository\Values\User\RoleAssignment;
+use eZ\Publish\API\Repository\Values\User\RoleCopyStruct;
 use eZ\Publish\API\Repository\Values\User\RoleCreateStruct;
 use eZ\Publish\API\Repository\Values\User\RoleDraft;
 use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
@@ -40,6 +41,13 @@ abstract class RoleServiceDecorator implements RoleService
     public function createRoleDraft(Role $role): RoleDraft
     {
         return $this->innerService->createRoleDraft($role);
+    }
+
+    public function copyRole(
+        Role $role,
+        RoleCopyStruct $roleCopyStruct
+    ): Role {
+        return $this->innerService->copyRole($role, $roleCopyStruct);
     }
 
     public function loadRoleDraft(int $id): RoleDraft
@@ -157,6 +165,11 @@ abstract class RoleServiceDecorator implements RoleService
     public function newRoleCreateStruct(string $name): RoleCreateStruct
     {
         return $this->innerService->newRoleCreateStruct($name);
+    }
+
+    public function newRoleCopyStruct(string $name): RoleCopyStruct
+    {
+        return $this->innerService->newRoleCopyStruct($name);
     }
 
     public function newPolicyCreateStruct(


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31383](https://jira.ez.no/browse/EZP-31383)
| **Improvement**| yes
| **New feature**    | yes
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Prepared `ezpublish-kernel` for `Role` copying functionality.
Added `copyRole` method to `RoleService` API Interface with `Core` and `Event` implementations.
Created related structs and `Database Gateway` and `User\Handler` implementations.
Created `DatabaseHandler` role copying test and tests using `RoleService` API with double-check on`Policies` and `Limitations` respectively.

**TODO**:
- [x] Implement feature.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
