### PR TITLE
EZP-31088: Refactored Location gateway methods to use Doctrine\DBAL

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -319,14 +319,13 @@ abstract class Gateway
     abstract public function cleanupTrash();
 
     /**
-     * Lists trashed items.
-     * Returns entries from ezcontentobject_trash.
+     * List trashed items.
      *
      * @param int $offset
      * @param int $limit
-     * @param array $sort
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
      *
-     * @return array
+     * @return array entries from ezcontentobject_trash.
      */
     abstract public function listTrashed($offset, $limit, array $sort = null);
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -168,10 +168,16 @@ abstract class Gateway
 
     abstract public function setNodeWithChildrenInvisible(string $pathString): void;
 
+    /**
+     * Mark a Location and its children as visible unless a parent is hiding the tree.
+     */
     abstract public function setNodeWithChildrenVisible(string $pathString): void;
 
     abstract public function setNodeHidden(string $pathString): void;
 
+    /**
+     * Mark a Location as not hidden.
+     */
     abstract public function setNodeUnhidden(string $pathString): void;
 
     /**
@@ -200,6 +206,8 @@ abstract class Gateway
 
     /**
      * Deletes node assignment for given $contentId and $versionNo.
+     *
+     * If $versionNo is not passed all node assignments for given $contentId are deleted
      */
     abstract public function deleteNodeAssignment(int $contentId, ?int $versionNo = null): void;
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -58,6 +58,8 @@ abstract class Gateway
      * @param bool $useAlwaysAvailable Respect always available flag on content when filtering on $translations.
      *
      * @return array
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     abstract public function getNodeDataList(
         array $locationIds,
@@ -140,6 +142,8 @@ abstract class Gateway
      * Create locations from node assignments.
      *
      * Convert existing node assignments into real locations.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if parent Location does not exist
      */
     abstract public function createLocationsFromNodeAssignments(
         int $contentId,
@@ -254,6 +258,8 @@ abstract class Gateway
 
     /**
      * Loads trash data specified by location ID.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     abstract public function loadTrashByLocation(int $locationId): array;
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -11,6 +11,8 @@ use eZ\Publish\SPI\Persistence\Content\Location\CreateStruct;
 
 /**
  * Base class for location gateways.
+ *
+ * @internal For internal use by Persistence Handlers.
  */
 abstract class Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -30,6 +30,9 @@ abstract class Gateway
     const NODE_ASSIGNMENT_OP_CODE_SET_NOP = 8;
     const NODE_ASSIGNMENT_OP_CODE_SET = 9;
 
+    public const CONTENT_TREE_TABLE = 'ezcontentobject_tree';
+    public const CONTENT_TREE_SEQ = 'ezcontentobject_tree_node_id_seq';
+
     /**
      * Returns an array with basic node data.
      *
@@ -259,7 +262,7 @@ abstract class Gateway
     abstract public function removeLocation($locationId);
 
     /**
-     * Returns id of the next in line node to be set as a new main node.
+     * Return data of the next in line node to be set as a new main node.
      *
      * This returns lowest node id for content identified by $contentId, and not of
      * the node identified by given $locationId (current main node).

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Location;
 
+use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Location\CreateStruct;
 
@@ -38,76 +39,69 @@ abstract class Gateway
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      *
-     * @param mixed $nodeId
      * @param string[]|null $translations
      * @param bool $useAlwaysAvailable Respect always available flag on content when filtering on $translations.
      *
      * @return array
      */
-    abstract public function getBasicNodeData($nodeId, array $translations = null, bool $useAlwaysAvailable = true);
+    abstract public function getBasicNodeData(
+        int $nodeId,
+        array $translations = null,
+        bool $useAlwaysAvailable = true
+    ): array;
 
     /**
      * Returns an array with node data for several locations.
      *
-     * @param array $locationIds
+     * @param int[] $locationIds
      * @param string[]|null $translations
      * @param bool $useAlwaysAvailable Respect always available flag on content when filtering on $translations.
      *
      * @return array
      */
-    abstract public function getNodeDataList(array $locationIds, array $translations = null, bool $useAlwaysAvailable = true): iterable;
+    abstract public function getNodeDataList(
+        array $locationIds,
+        array $translations = null,
+        bool $useAlwaysAvailable = true
+    ): iterable;
 
     /**
      * Returns an array with basic node data for the node with $remoteId.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      *
-     * @param mixed $remoteId
      * @param string[]|null $translations
      * @param bool $useAlwaysAvailable Respect always available flag on content when filtering on $translations.
-     *
-     * @return array
      */
-    abstract public function getBasicNodeDataByRemoteId($remoteId, array $translations = null, bool $useAlwaysAvailable = true);
+    abstract public function getBasicNodeDataByRemoteId(
+        string $remoteId,
+        array $translations = null,
+        bool $useAlwaysAvailable = true
+    ): array;
 
     /**
      * Loads data for all Locations for $contentId, optionally only in the
      * subtree starting at $rootLocationId.
-     *
-     * @param int $contentId
-     * @param int $rootLocationId
-     *
-     * @return array
      */
-    abstract public function loadLocationDataByContent($contentId, $rootLocationId = null);
+    abstract public function loadLocationDataByContent(
+        int $contentId,
+        ?int $rootLocationId = null
+    ): array;
 
     /**
      * Loads data for all parent Locations for unpublished Content by given $contentId.
-     *
-     * @param mixed $contentId
-     *
-     * @return array
      */
-    abstract public function loadParentLocationsDataForDraftContent($contentId);
+    abstract public function loadParentLocationsDataForDraftContent(int $contentId): array;
 
     /**
      * Find all content in the given subtree.
-     *
-     * @param mixed $sourceId
-     * @param bool $onlyIds
-     *
-     * @return array
      */
-    abstract public function getSubtreeContent($sourceId, $onlyIds = false);
+    abstract public function getSubtreeContent(int $sourceId, bool $onlyIds = false): array;
 
     /**
      * Returns data for the first level children of the location identified by given $locationId.
-     *
-     * @param mixed $locationId
-     *
-     * @return array
      */
-    abstract public function getChildren($locationId);
+    abstract public function getChildren(int $locationId): array;
 
     /**
      * Update path strings to move nodes in the ezcontentobject_tree table.
@@ -120,79 +114,60 @@ abstract class Gateway
      * @param array $fromPathString
      * @param array $toPathString
      */
-    abstract public function moveSubtreeNodes(array $fromPathString, array $toPathString);
+    abstract public function moveSubtreeNodes(array $fromPathString, array $toPathString): void;
 
     /**
      * Updated subtree modification time for all nodes on path.
      *
      * @deprecated Not supposed to be in use anymore.
-     *
-     * @param string $pathString
-     * @param int|null $timestamp
      */
-    abstract public function updateSubtreeModificationTime($pathString, $timestamp = null);
+    abstract public function updateSubtreeModificationTime(
+        string $pathString,
+        ?int $timestamp = null
+    ): void;
 
     /**
      * Update node assignment table.
-     *
-     * @param int $contentObjectId
-     * @param int $oldParent
-     * @param int $newParent
-     * @param int $opcode
      */
-    abstract public function updateNodeAssignment($contentObjectId, $oldParent, $newParent, $opcode);
+    abstract public function updateNodeAssignment(
+        int $contentObjectId,
+        int $oldParent,
+        int $newParent,
+        int $opcode
+    ): void;
 
     /**
      * Create locations from node assignments.
      *
      * Convert existing node assignments into real locations.
-     *
-     * @param mixed $contentId
-     * @param mixed $versionNo
      */
-    abstract public function createLocationsFromNodeAssignments($contentId, $versionNo);
+    abstract public function createLocationsFromNodeAssignments(
+        int $contentId,
+        int $versionNo
+    ): void;
 
     /**
      * Updates all Locations of content identified with $contentId with $versionNo.
-     *
-     * @param mixed $contentId
-     * @param mixed $versionNo
      */
-    abstract public function updateLocationsContentVersionNo($contentId, $versionNo);
+    abstract public function updateLocationsContentVersionNo(int $contentId, int $versionNo): void;
 
     /**
      * Sets a location to be hidden, and it self + all children to invisible.
-     *
-     * @param string $pathString
      */
-    abstract public function hideSubtree($pathString);
+    abstract public function hideSubtree(string $pathString): void;
 
     /**
      * Sets a location to be unhidden, and self + children to visible unless a parent is hiding the tree.
      * If not make sure only children down to first hidden node is marked visible.
-     *
-     * @param string $pathString
      */
-    abstract public function unHideSubtree($pathString);
+    abstract public function unHideSubtree(string $pathString): void;
 
-    /**
-     * @param string $pathString
-     **/
     abstract public function setNodeWithChildrenInvisible(string $pathString): void;
 
-    /**
-     * @param string $pathString
-     **/
     abstract public function setNodeWithChildrenVisible(string $pathString): void;
 
-    /**
-     * @param string $pathString
-     **/
     abstract public function setNodeHidden(string $pathString): void;
 
-    /**
-     * @param string $pathString
-     **/
     abstract public function setNodeUnhidden(string $pathString): void;
 
     /**
@@ -200,66 +175,52 @@ abstract class Gateway
      *
      * Make the location identified by $locationId1 refer to the Content
      * referred to by $locationId2 and vice versa.
-     *
-     * @param int $locationId1
-     * @param int $locationId2
-     *
-     * @return bool
      */
     abstract public function swap(int $locationId1, int $locationId2): bool;
 
     /**
      * Creates a new location in given $parentNode.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\Location\CreateStruct $createStruct
-     * @param array $parentNode
-     *
-     * @return \eZ\Publish\SPI\Persistence\Content\Location
+     * @param array $parentNode parent node raw data
      */
-    abstract public function create(CreateStruct $createStruct, array $parentNode);
+    abstract public function create(CreateStruct $createStruct, array $parentNode): Location;
 
     /**
      * Create an entry in the node assignment table.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Location\CreateStruct $createStruct
-     * @param mixed $parentNodeId
-     * @param int $type
      */
-    abstract public function createNodeAssignment(CreateStruct $createStruct, $parentNodeId, $type = self::NODE_ASSIGNMENT_OP_CODE_CREATE_NOP);
+    abstract public function createNodeAssignment(
+        CreateStruct $createStruct,
+        int $parentNodeId,
+        int $type = self::NODE_ASSIGNMENT_OP_CODE_CREATE_NOP
+    ): void;
 
     /**
      * Deletes node assignment for given $contentId and $versionNo.
-     *
-     * @param int $contentId
-     * @param int $versionNo
      */
-    abstract public function deleteNodeAssignment($contentId, $versionNo = null);
+    abstract public function deleteNodeAssignment(int $contentId, ?int $versionNo = null): void;
 
     /**
      * Updates an existing location.
      *
      * Will not throw anything if location id is invalid or no entries are affected.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct $location
-     * @param int $locationId
      */
-    abstract public function update(UpdateStruct $location, $locationId);
+    abstract public function update(UpdateStruct $location, int $locationId): void;
 
     /**
      * Updates path identification string for given $locationId.
      *
-     * @param mixed $locationId
-     * @param mixed $parentLocationId
-     * @param string $text
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    abstract public function updatePathIdentificationString($locationId, $parentLocationId, $text);
+    abstract public function updatePathIdentificationString(
+        int $locationId,
+        int $parentLocationId,
+        string $text
+    ): void;
 
     /**
      * Deletes ezcontentobject_tree row for given $locationId (node_id).
-     *
-     * @param mixed $locationId
      */
-    abstract public function removeLocation($locationId);
+    abstract public function removeLocation(int $locationId): void;
 
     /**
      * Return data of the next in line node to be set as a new main node.
@@ -267,24 +228,17 @@ abstract class Gateway
      * This returns lowest node id for content identified by $contentId, and not of
      * the node identified by given $locationId (current main node).
      * Assumes that content has more than one location.
-     *
-     * @param mixed $contentId
-     * @param mixed $locationId
-     *
-     * @return array
      */
-    abstract public function getFallbackMainNodeData($contentId, $locationId);
+    abstract public function getFallbackMainNodeData(int $contentId, int $locationId): array;
 
     /**
      * Sends a single location identified by given $locationId to the trash.
      *
      * The associated content object is left untouched.
      *
-     * @param mixed $locationId
-     *
-     * @return bool
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    abstract public function trashLocation($locationId);
+    abstract public function trashLocation(int $locationId): void;
 
     /**
      * Returns a trashed location to normal state.
@@ -294,21 +248,14 @@ abstract class Gateway
      * at the old position. If this is not possible ( because the old location
      * does not exist any more) and exception is thrown.
      *
-     * @param mixed $locationId
-     * @param mixed $newParentId
-     *
-     * @return \eZ\Publish\SPI\Persistence\Content\Location
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    abstract public function untrashLocation($locationId, $newParentId = null);
+    abstract public function untrashLocation(int $locationId, ?int $newParentId = null): Location;
 
     /**
      * Loads trash data specified by location ID.
-     *
-     * @param mixed $locationId
-     *
-     * @return array
      */
-    abstract public function loadTrashByLocation($locationId);
+    abstract public function loadTrashByLocation(int $locationId): array;
 
     /**
      * Removes every entries in the trash.
@@ -316,18 +263,16 @@ abstract class Gateway
      *
      * Basically truncates ezcontentobject_trash table.
      */
-    abstract public function cleanupTrash();
+    abstract public function cleanupTrash(): void;
 
     /**
      * List trashed items.
      *
-     * @param int $offset
-     * @param int $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
      *
      * @return array entries from ezcontentobject_trash.
      */
-    abstract public function listTrashed($offset, $limit, array $sort = null);
+    abstract public function listTrashed(int $offset, ?int $limit, array $sort = null): array;
 
     /**
      * Count trashed items.
@@ -340,26 +285,17 @@ abstract class Gateway
      *
      * @param int $id The trashed location Id
      */
-    abstract public function removeElementFromTrash($id);
+    abstract public function removeElementFromTrash(int $id): void;
 
     /**
      * Set section on all content objects in the subtree.
-     *
-     * @param mixed $pathString
-     * @param mixed $sectionId
-     *
-     * @return bool
      */
-    abstract public function setSectionForSubtree($pathString, $sectionId);
+    abstract public function setSectionForSubtree(string $pathString, int $sectionId): bool;
 
     /**
      * Returns how many locations given content object identified by $contentId has.
-     *
-     * @param int $contentId
-     *
-     * @return int
      */
-    abstract public function countLocationsByContentId($contentId);
+    abstract public function countLocationsByContentId(int $contentId): int;
 
     /**
      * Changes main location of content identified by given $contentId to location identified by given $locationId.
@@ -367,13 +303,16 @@ abstract class Gateway
      * Updates ezcontentobject_tree table for the given $contentId and eznode_assignment table for the given
      * $contentId, $parentLocationId and $versionNo
      *
-     * @param mixed $contentId
-     * @param mixed $locationId
-     * @param mixed $versionNo version number, needed to update eznode_assignment table
-     * @param mixed $parentLocationId parent location of location identified by $locationId, needed to update
+     * @param int $versionNo version number, needed to update eznode_assignment table
+     * @param int $parentLocationId parent location of location identified by $locationId, needed to update
      *        eznode_assignment table
      */
-    abstract public function changeMainLocation($contentId, $locationId, $versionNo, $parentLocationId);
+    abstract public function changeMainLocation(
+        int $contentId,
+        int $locationId,
+        int $versionNo,
+        int $parentLocationId
+    ): void;
 
     /**
      * Get the total number of all Locations, except the Root node.
@@ -382,7 +321,7 @@ abstract class Gateway
      *
      * @return int
      */
-    abstract public function countAllLocations();
+    abstract public function countAllLocations(): int;
 
     /**
      * Load data of every Location, except the Root node.
@@ -392,5 +331,5 @@ abstract class Gateway
      *
      * @return array
      */
-    abstract public function loadAllLocationsData($offset, $limit);
+    abstract public function loadAllLocationsData(int $offset, int $limit): array;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the Location Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct;
@@ -44,13 +43,6 @@ final class DoctrineDatabase extends Gateway
         'location_path' => 'path_string',
     ];
 
-    /**
-     * Database handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     */
-    protected $handler;
-
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
@@ -67,15 +59,11 @@ final class DoctrineDatabase extends Gateway
     /**
      * Construct from database handler.
      *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $handler
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator $languageMaskGenerator
-     *
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function __construct(DatabaseHandler $handler, MaskGenerator $languageMaskGenerator)
+    public function __construct(Connection $connection, MaskGenerator $languageMaskGenerator)
     {
-        $this->handler = $handler;
-        $this->connection = $handler->getConnection();
+        $this->connection = $connection;
         $this->dbPlatform = $this->connection->getDatabasePlatform();
         $this->languageMaskGenerator = $languageMaskGenerator;
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -144,7 +144,7 @@ final class DoctrineDatabase extends Gateway
         $query = $this->connection->createQueryBuilder();
         $query
             ->select('*')
-            ->from('ezcontentobject_tree', 't')
+            ->from(self::CONTENT_TREE_TABLE, 't')
             ->where(
                 $query->expr()->eq(
                     't.contentobject_id',
@@ -174,7 +174,7 @@ final class DoctrineDatabase extends Gateway
         $expr = $query->expr();
         $query
             ->select('DISTINCT t.*')
-            ->from('ezcontentobject_tree', 't')
+            ->from(self::CONTENT_TREE_TABLE, 't')
             ->innerJoin(
                 't',
                 'eznode_assignment',
@@ -234,7 +234,7 @@ final class DoctrineDatabase extends Gateway
         $query = $this->connection->createQueryBuilder();
         $query
             ->select($onlyIds ? 'node_id, contentobject_id, depth' : '*')
-            ->from('ezcontentobject_tree', 't')
+            ->from(self::CONTENT_TREE_TABLE, 't')
             ->where($this->getSubtreeLimitationExpression($query, $sourceId))
             ->orderBy('t.depth')
             ->addOrderBy('t.node_id');
@@ -272,7 +272,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query->select('*')->from(
-            'ezcontentobject_tree'
+            self::CONTENT_TREE_TABLE
         )->where(
             $query->expr()->eq(
                 'ezcontentobject_tree.parent_node_id',
@@ -308,7 +308,7 @@ final class DoctrineDatabase extends Gateway
                 'path_identification_string',
                 'is_hidden'
             )
-            ->from('ezcontentobject_tree')
+            ->from(self::CONTENT_TREE_TABLE)
             ->where(
                 $query->expr()->like(
                     'path_string',
@@ -347,7 +347,7 @@ final class DoctrineDatabase extends Gateway
 
             $query = $this->connection->createQueryBuilder();
             $query
-                ->update('ezcontentobject_tree')
+                ->update(self::CONTENT_TREE_TABLE)
                 ->set(
                     'path_string',
                     $query->createPositionalParameter($newPathString, ParameterType::STRING)
@@ -415,7 +415,7 @@ final class DoctrineDatabase extends Gateway
         $nodes = array_filter(explode('/', $pathString));
         $query = $this->connection->createQueryBuilder();
         $query
-            ->update('ezcontentobject_tree')
+            ->update(self::CONTENT_TREE_TABLE)
             ->set(
                 'modified_subnode',
                 $query->createPositionalParameter(
@@ -449,7 +449,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->update('ezcontentobject_tree')
+            ->update(self::CONTENT_TREE_TABLE)
             ->set(
                 'is_invisible',
                 $query->createPositionalParameter(1, ParameterType::INTEGER)
@@ -484,7 +484,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->update('ezcontentobject_tree')
+            ->update(self::CONTENT_TREE_TABLE)
             ->set(
                 'is_hidden',
                 $query->createPositionalParameter((int) $isHidden, ParameterType::INTEGER)
@@ -532,7 +532,7 @@ final class DoctrineDatabase extends Gateway
         $query = $this->connection->createQueryBuilder();
         $expr = $query->expr();
         $query
-            ->update('ezcontentobject_tree')
+            ->update(self::CONTENT_TREE_TABLE)
             ->set(
                 'is_invisible',
                 $query->createPositionalParameter(0, ParameterType::INTEGER)
@@ -617,7 +617,7 @@ final class DoctrineDatabase extends Gateway
         $expr = $query->expr();
         $query
             ->select($selectExpr)
-            ->from('ezcontentobject_tree', 't')
+            ->from(self::CONTENT_TREE_TABLE, 't')
             ->leftJoin('t', 'ezcontentobject', 'c', 't.contentobject_id = c.id')
             ->where(
                 $expr->orX(
@@ -662,7 +662,7 @@ final class DoctrineDatabase extends Gateway
         $expr = $queryBuilder->expr();
         $queryBuilder
             ->select('node_id', 'main_node_id', 'contentobject_id', 'contentobject_version')
-            ->from('ezcontentobject_tree')
+            ->from(self::CONTENT_TREE_TABLE)
             ->where(
                 $expr->in(
                     'node_id',
@@ -693,7 +693,7 @@ final class DoctrineDatabase extends Gateway
 
         $queryBuilder = $this->connection->createQueryBuilder();
         $queryBuilder
-            ->update('ezcontentobject_tree')
+            ->update(self::CONTENT_TREE_TABLE)
             ->set('contentobject_id', ':contentId')
             ->set('contentobject_version', ':versionNo')
             ->set('main_node_id', ':mainNodeId')
@@ -750,7 +750,7 @@ final class DoctrineDatabase extends Gateway
         $location->pathString = $parentNode['path_string'] . $location->id . '/';
         $query = $this->connection->createQueryBuilder();
         $query
-            ->update('ezcontentobject_tree')
+            ->update(self::CONTENT_TREE_TABLE)
             ->set(
                 'path_string',
                 $query->createPositionalParameter($location->pathString, ParameterType::STRING)
@@ -998,7 +998,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query->update(
-            'ezcontentobject_tree'
+            self::CONTENT_TREE_TABLE
         )->set(
             'contentobject_version',
             $query->createPositionalParameter($versionNo, ParameterType::INTEGER)
@@ -1023,7 +1023,7 @@ final class DoctrineDatabase extends Gateway
         $query = $this->connection->createQueryBuilder();
         $query
             ->select('node_id')
-            ->from('ezcontentobject_tree')
+            ->from(self::CONTENT_TREE_TABLE)
             ->where(
                 $query->expr()->andX(
                     $query->expr()->eq(
@@ -1059,7 +1059,7 @@ final class DoctrineDatabase extends Gateway
         $query = $this->connection->createQueryBuilder();
 
         $query
-            ->update('ezcontentobject_tree')
+            ->update(self::CONTENT_TREE_TABLE)
             ->set(
                 'priority',
                 $query->createPositionalParameter($location->priority, ParameterType::INTEGER)
@@ -1102,7 +1102,7 @@ final class DoctrineDatabase extends Gateway
 
         $query = $this->connection->createQueryBuilder();
         $query->update(
-            'ezcontentobject_tree'
+            self::CONTENT_TREE_TABLE
         )->set(
             'path_identification_string',
             $query->createPositionalParameter($newPathIdentificationString, ParameterType::STRING)
@@ -1124,7 +1124,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query->delete(
-            'ezcontentobject_tree'
+            self::CONTENT_TREE_TABLE
         )->where(
             $query->expr()->eq(
                 'node_id',
@@ -1156,7 +1156,7 @@ final class DoctrineDatabase extends Gateway
                 'contentobject_version',
                 'parent_node_id'
             )
-            ->from('ezcontentobject_tree')
+            ->from(self::CONTENT_TREE_TABLE)
             ->where(
                 $expr->eq(
                     'contentobject_id',
@@ -1387,7 +1387,7 @@ final class DoctrineDatabase extends Gateway
         $selectContentIdsQuery = $this->connection->createQueryBuilder();
         $selectContentIdsQuery
             ->select('t.contentobject_id')
-            ->from('ezcontentobject_tree', 't')
+            ->from(self::CONTENT_TREE_TABLE, 't')
             ->where(
                 $selectContentIdsQuery->expr()->like(
                     't.path_string',
@@ -1436,7 +1436,7 @@ final class DoctrineDatabase extends Gateway
             ->select(
                 $this->dbPlatform->getCountExpression('*')
             )
-            ->from('ezcontentobject_tree')
+            ->from(self::CONTENT_TREE_TABLE)
             ->where(
                 $query->expr()->eq(
                     'contentobject_id',
@@ -1465,7 +1465,7 @@ final class DoctrineDatabase extends Gateway
         // Update ezcontentobject_tree table
         $query = $this->connection->createQueryBuilder();
         $query
-            ->update('ezcontentobject_tree')
+            ->update(self::CONTENT_TREE_TABLE)
             ->set(
                 'main_node_id',
                 $query->createPositionalParameter($locationId, ParameterType::INTEGER)
@@ -1555,7 +1555,7 @@ final class DoctrineDatabase extends Gateway
         $query = $this->connection->createQueryBuilder();
         $query
             ->select($columns)
-            ->from('ezcontentobject_tree')
+            ->from(self::CONTENT_TREE_TABLE)
             ->where($query->expr()->neq('node_id', 'parent_node_id'))
         ;
 
@@ -1575,7 +1575,7 @@ final class DoctrineDatabase extends Gateway
         $queryBuilder = $this->connection->createQueryBuilder();
         $queryBuilder
             ->select('t.*')
-            ->from('ezcontentobject_tree', 't');
+            ->from(self::CONTENT_TREE_TABLE, 't');
 
         if (!empty($translations)) {
             $expr = $queryBuilder->expr();
@@ -1646,7 +1646,7 @@ final class DoctrineDatabase extends Gateway
         $location = new Location();
         $query = $this->connection->createQueryBuilder();
         $query
-            ->insert('ezcontentobject_tree')
+            ->insert(self::CONTENT_TREE_TABLE)
             ->values(
                 [
                     'contentobject_id' => ':content_id',

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -26,8 +26,12 @@ use PDO;
 
 /**
  * Location gateway implementation using the Doctrine database.
+ *
+ * @internal Gateway implementation is considered internal. Use Persistence Location Handler instead.
+ *
+ * @see \eZ\Publish\SPI\Persistence\Content\Location\Handler
  */
-class DoctrineDatabase extends Gateway
+final class DoctrineDatabase extends Gateway
 {
     /**
      * 2^30, since PHP_INT_MAX can cause overflows in DB systems, if PHP is run
@@ -43,14 +47,14 @@ class DoctrineDatabase extends Gateway
     protected $handler;
 
     /** @var \Doctrine\DBAL\Connection */
-    protected $connection;
+    private $connection;
 
     /**
      * Language mask generator.
      *
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator
      */
-    protected $languageMaskGenerator;
+    private $languageMaskGenerator;
 
     /**
      * Construct from database handler.
@@ -230,7 +234,7 @@ class DoctrineDatabase extends Gateway
      * @param \eZ\Publish\Core\Persistence\Database\Query $query
      * @param string $rootLocationId
      */
-    protected function applySubtreeLimitation(DatabaseQuery $query, $rootLocationId)
+    private function applySubtreeLimitation(DatabaseQuery $query, $rootLocationId)
     {
         $query->where(
             $query->expr->like(
@@ -1259,7 +1263,7 @@ class DoctrineDatabase extends Gateway
      * @param mixed $contentId
      * @param int $status
      */
-    protected function setContentStatus($contentId, $status)
+    private function setContentStatus($contentId, $status)
     {
         /** @var $query \eZ\Publish\Core\Persistence\Database\UpdateQuery */
         $query = $this->handler->createUpdateQuery();

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -46,19 +46,13 @@ final class DoctrineDatabase extends Gateway
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
-    /**
-     * Language mask generator.
-     *
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator
-     */
+    /** @var \eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator */
     private $languageMaskGenerator;
 
     /** @var \Doctrine\DBAL\Platforms\AbstractPlatform */
     private $dbPlatform;
 
     /**
-     * Construct from database handler.
-     *
      * @throws \Doctrine\DBAL\DBALException
      */
     public function __construct(Connection $connection, MaskGenerator $languageMaskGenerator)
@@ -85,9 +79,6 @@ final class DoctrineDatabase extends Gateway
         throw new NotFound('location', $nodeId);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getNodeDataList(array $locationIds, array $translations = null, bool $useAlwaysAvailable = true): iterable
     {
         $query = $this->createNodeQueryBuilder($translations, $useAlwaysAvailable);
@@ -381,9 +372,6 @@ final class DoctrineDatabase extends Gateway
         $this->setNodeHidden($pathString);
     }
 
-    /**
-     * @param string $pathString
-     **/
     public function setNodeWithChildrenInvisible(string $pathString): void
     {
         $query = $this->connection->createQueryBuilder();
@@ -407,18 +395,11 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * @param string $pathString
-     **/
     public function setNodeHidden(string $pathString): void
     {
         $this->setNodeHiddenStatus($pathString, true);
     }
 
-    /**
-     * @param string $pathString
-     * @param bool $isHidden
-     */
     private function setNodeHiddenStatus(string $pathString, bool $isHidden): void
     {
         $query = $this->connection->createQueryBuilder();
@@ -444,11 +425,6 @@ final class DoctrineDatabase extends Gateway
         $this->setNodeWithChildrenVisible($pathString);
     }
 
-    /**
-     * Sets a location + children to visible unless a parent is hiding the tree.
-     *
-     * @param string $pathString
-     **/
     public function setNodeWithChildrenVisible(string $pathString): void
     {
         // Check if any parent nodes are explicitly hidden
@@ -568,27 +544,11 @@ final class DoctrineDatabase extends Gateway
         return $query;
     }
 
-    /**
-     * Sets location to be unhidden.
-     *
-     * @param string $pathString
-     **/
     public function setNodeUnhidden(string $pathString): void
     {
         $this->setNodeHiddenStatus($pathString, false);
     }
 
-    /**
-     * Swaps the content object being pointed to by a location object.
-     *
-     * Make the location identified by $locationId1 refer to the Content
-     * referred to by $locationId2 and vice versa.
-     *
-     * @param int $locationId1
-     * @param int $locationId2
-     *
-     * @return bool
-     */
     public function swap(int $locationId1, int $locationId2): bool
     {
         $queryBuilder = $this->connection->createQueryBuilder();
@@ -667,14 +627,6 @@ final class DoctrineDatabase extends Gateway
         return true;
     }
 
-    /**
-     * Creates a new location in given $parentNode.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Location\CreateStruct $createStruct
-     * @param array $parentNode
-     *
-     * @return \eZ\Publish\SPI\Persistence\Content\Location
-     */
     public function create(CreateStruct $createStruct, array $parentNode): Location
     {
         $location = $this->insertLocationIntoContentTree($createStruct, $parentNode);
@@ -769,14 +721,6 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Deletes node assignment for given $contentId and $versionNo.
-     *
-     * If $versionNo is not passed all node assignments for given $contentId are deleted
-     *
-     * @param int $contentId
-     * @param int|null $versionNo
-     */
     public function deleteNodeAssignment(int $contentId, ?int $versionNo = null): void
     {
         $query = $this->connection->createQueryBuilder();
@@ -1398,8 +1342,10 @@ final class DoctrineDatabase extends Gateway
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    private function createNodeQueryBuilder(array $translations = null, bool $useAlwaysAvailable = true): QueryBuilder
-    {
+    private function createNodeQueryBuilder(
+        array $translations = null,
+        bool $useAlwaysAvailable = true
+    ): QueryBuilder {
         $queryBuilder = $this->connection->createQueryBuilder();
         $queryBuilder
             ->select('t.*')

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -31,12 +31,6 @@ use function time;
  */
 final class DoctrineDatabase extends Gateway
 {
-    /**
-     * 2^30, since PHP_INT_MAX can cause overflows in DB systems, if PHP is run
-     * on 64 bit systems.
-     */
-    const MAX_LIMIT = 1073741824;
-
     private const SORT_CLAUSE_TARGET_MAP = [
         'location_depth' => 'depth',
         'location_priority' => 'priority',

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase Location Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1395,6 +1395,8 @@ final class DoctrineDatabase extends Gateway
      * @param bool $useAlwaysAvailable Respect always available flag on content when filtering on $translations.
      *
      * @return \Doctrine\DBAL\Query\QueryBuilder
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     private function createNodeQueryBuilder(array $translations = null, bool $useAlwaysAvailable = true): QueryBuilder
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -14,16 +14,16 @@ use Doctrine\DBAL\DBALException;
 use PDOException;
 
 /**
- * Base class for location gateways.
+ * @internal Internal exception conversion layer.
  */
-class ExceptionConversion extends Gateway
+final class ExceptionConversion extends Gateway
 {
     /**
      * The wrapped gateway.
      *
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway
      */
-    protected $innerGateway;
+    private $innerGateway;
 
     /**
      * Creates a new exception conversion gateway around $innerGateway.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -8,6 +8,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway;
 
 use eZ\Publish\Core\Base\Exceptions\DatabaseException;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway;
+use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Location\CreateStruct;
 use Doctrine\DBAL\DBALException;
@@ -35,8 +36,11 @@ final class ExceptionConversion extends Gateway
         $this->innerGateway = $innerGateway;
     }
 
-    public function getBasicNodeData($nodeId, array $translations = null, bool $useAlwaysAvailable = true)
-    {
+    public function getBasicNodeData(
+        int $nodeId,
+        array $translations = null,
+        bool $useAlwaysAvailable = true
+    ): array {
         try {
             return $this->innerGateway->getBasicNodeData($nodeId, $translations, $useAlwaysAvailable);
         } catch (DBALException | PDOException $e) {
@@ -53,8 +57,11 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function getBasicNodeDataByRemoteId($remoteId, array $translations = null, bool $useAlwaysAvailable = true)
-    {
+    public function getBasicNodeDataByRemoteId(
+        string $remoteId,
+        array $translations = null,
+        bool $useAlwaysAvailable = true
+    ): array {
         try {
             return $this->innerGateway->getBasicNodeDataByRemoteId($remoteId, $translations, $useAlwaysAvailable);
         } catch (DBALException | PDOException $e) {
@@ -62,7 +69,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadLocationDataByContent($contentId, $rootLocationId = null)
+    public function loadLocationDataByContent(int $contentId, ?int $rootLocationId = null): array
     {
         try {
             return $this->innerGateway->loadLocationDataByContent($contentId, $rootLocationId);
@@ -71,7 +78,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadParentLocationsDataForDraftContent($contentId)
+    public function loadParentLocationsDataForDraftContent(int $contentId): array
     {
         try {
             return $this->innerGateway->loadParentLocationsDataForDraftContent($contentId);
@@ -80,7 +87,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function getSubtreeContent($sourceId, $onlyIds = false)
+    public function getSubtreeContent(int $sourceId, bool $onlyIds = false): array
     {
         try {
             return $this->innerGateway->getSubtreeContent($sourceId, $onlyIds);
@@ -89,7 +96,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function getChildren($locationId)
+    public function getChildren(int $locationId): array
     {
         try {
             return $this->innerGateway->getChildren($locationId);
@@ -98,64 +105,68 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function moveSubtreeNodes(array $fromPathString, array $toPathString)
+    public function moveSubtreeNodes(array $fromPathString, array $toPathString): void
     {
         try {
-            return $this->innerGateway->moveSubtreeNodes($fromPathString, $toPathString);
+            $this->innerGateway->moveSubtreeNodes($fromPathString, $toPathString);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function updateSubtreeModificationTime($pathString, $timestamp = null)
+    public function updateSubtreeModificationTime(string $pathString, ?int $timestamp = null): void
     {
         try {
-            return $this->innerGateway->updateSubtreeModificationTime($pathString, $timestamp);
+            $this->innerGateway->updateSubtreeModificationTime($pathString, $timestamp);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function updateNodeAssignment($contentObjectId, $oldParent, $newParent, $opcode)
-    {
+    public function updateNodeAssignment(
+        int $contentObjectId,
+        int $oldParent,
+        int $newParent,
+        int $opcode
+    ): void {
         try {
-            return $this->innerGateway->updateNodeAssignment($contentObjectId, $oldParent, $newParent, $opcode);
+            $this->innerGateway->updateNodeAssignment($contentObjectId, $oldParent, $newParent, $opcode);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function createLocationsFromNodeAssignments($contentId, $versionNo)
+    public function createLocationsFromNodeAssignments(int $contentId, int $versionNo): void
     {
         try {
-            return $this->innerGateway->createLocationsFromNodeAssignments($contentId, $versionNo);
+            $this->innerGateway->createLocationsFromNodeAssignments($contentId, $versionNo);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function updateLocationsContentVersionNo($contentId, $versionNo)
+    public function updateLocationsContentVersionNo(int $contentId, int $versionNo): void
     {
         try {
-            return $this->innerGateway->updateLocationsContentVersionNo($contentId, $versionNo);
+            $this->innerGateway->updateLocationsContentVersionNo($contentId, $versionNo);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function hideSubtree($pathString)
+    public function hideSubtree(string $pathString): void
     {
         try {
-            return $this->innerGateway->hideSubtree($pathString);
+            $this->innerGateway->hideSubtree($pathString);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function unHideSubtree($pathString)
+    public function unHideSubtree(string $pathString): void
     {
         try {
-            return $this->innerGateway->unHideSubtree($pathString);
+            $this->innerGateway->unHideSubtree($pathString);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
@@ -206,7 +217,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function create(CreateStruct $createStruct, array $parentNode)
+    public function create(CreateStruct $createStruct, array $parentNode): Location
     {
         try {
             return $this->innerGateway->create($createStruct, $parentNode);
@@ -215,52 +226,58 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function createNodeAssignment(CreateStruct $createStruct, $parentNodeId, $type = self::NODE_ASSIGNMENT_OP_CODE_CREATE_NOP)
-    {
+    public function createNodeAssignment(
+        CreateStruct $createStruct,
+        int $parentNodeId,
+        int $type = self::NODE_ASSIGNMENT_OP_CODE_CREATE_NOP
+    ): void {
         try {
-            return $this->innerGateway->createNodeAssignment($createStruct, $parentNodeId, $type);
+            $this->innerGateway->createNodeAssignment($createStruct, $parentNodeId, $type);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function deleteNodeAssignment($contentId, $versionNo = null)
+    public function deleteNodeAssignment(int $contentId, ?int $versionNo = null): void
     {
         try {
-            return $this->innerGateway->deleteNodeAssignment($contentId, $versionNo);
+            $this->innerGateway->deleteNodeAssignment($contentId, $versionNo);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function update(UpdateStruct $location, $locationId)
+    public function update(UpdateStruct $location, int $locationId): void
     {
         try {
-            return $this->innerGateway->update($location, $locationId);
+            $this->innerGateway->update($location, $locationId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function updatePathIdentificationString($locationId, $parentLocationId, $text)
-    {
+    public function updatePathIdentificationString(
+        int $locationId,
+        int $parentLocationId,
+        string $text
+    ): void {
         try {
-            return $this->innerGateway->updatePathIdentificationString($locationId, $parentLocationId, $text);
+            $this->innerGateway->updatePathIdentificationString($locationId, $parentLocationId, $text);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function removeLocation($locationId)
+    public function removeLocation(int $locationId): void
     {
         try {
-            return $this->innerGateway->removeLocation($locationId);
+            $this->innerGateway->removeLocation($locationId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function getFallbackMainNodeData($contentId, $locationId)
+    public function getFallbackMainNodeData(int $contentId, int $locationId): array
     {
         try {
             return $this->innerGateway->getFallbackMainNodeData($contentId, $locationId);
@@ -269,16 +286,16 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function trashLocation($locationId)
+    public function trashLocation(int $locationId): void
     {
         try {
-            return $this->innerGateway->trashLocation($locationId);
+            $this->innerGateway->trashLocation($locationId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function untrashLocation($locationId, $newParentId = null)
+    public function untrashLocation(int $locationId, ?int $newParentId = null): Location
     {
         try {
             return $this->innerGateway->untrashLocation($locationId, $newParentId);
@@ -287,7 +304,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadTrashByLocation($locationId)
+    public function loadTrashByLocation(int $locationId): array
     {
         try {
             return $this->innerGateway->loadTrashByLocation($locationId);
@@ -296,16 +313,16 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function cleanupTrash()
+    public function cleanupTrash(): void
     {
         try {
-            return $this->innerGateway->cleanupTrash();
+            $this->innerGateway->cleanupTrash();
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function listTrashed($offset, $limit, array $sort = null)
+    public function listTrashed(int $offset, ?int $limit, array $sort = null): array
     {
         try {
             return $this->innerGateway->listTrashed($offset, $limit, $sort);
@@ -323,16 +340,16 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function removeElementFromTrash($id)
+    public function removeElementFromTrash(int $id): void
     {
         try {
-            return $this->innerGateway->removeElementFromTrash($id);
+            $this->innerGateway->removeElementFromTrash($id);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function setSectionForSubtree($pathString, $sectionId)
+    public function setSectionForSubtree(string $pathString, int $sectionId): bool
     {
         try {
             return $this->innerGateway->setSectionForSubtree($pathString, $sectionId);
@@ -341,7 +358,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function countLocationsByContentId($contentId)
+    public function countLocationsByContentId(int $contentId): int
     {
         try {
             return $this->innerGateway->countLocationsByContentId($contentId);
@@ -350,16 +367,20 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function changeMainLocation($contentId, $locationId, $versionNo, $parentLocationId)
-    {
+    public function changeMainLocation(
+        int $contentId,
+        int $locationId,
+        int $versionNo,
+        int $parentLocationId
+    ): void {
         try {
-            return $this->innerGateway->changeMainLocation($contentId, $locationId, $versionNo, $parentLocationId);
+            $this->innerGateway->changeMainLocation($contentId, $locationId, $versionNo, $parentLocationId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function countAllLocations()
+    public function countAllLocations(): int
     {
         try {
             return $this->innerGateway->countAllLocations();
@@ -368,7 +389,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadAllLocationsData($offset, $limit)
+    public function loadAllLocationsData(int $offset, int $limit): array
     {
         try {
             return $this->innerGateway->loadAllLocationsData($offset, $limit);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the Location Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -498,14 +498,14 @@ class Handler implements BaseLocationHandler
     public function create(CreateStruct $createStruct)
     {
         $parentNodeData = $this->locationGateway->getBasicNodeData($createStruct->parentId);
-        $locationStruct = $this->locationGateway->create($createStruct, $parentNodeData);
+        $spiLocation = $this->locationGateway->create($createStruct, $parentNodeData);
         $this->locationGateway->createNodeAssignment(
             $createStruct,
             $parentNodeData['node_id'],
             LocationGateway::NODE_ASSIGNMENT_OP_CODE_CREATE_NOP
         );
 
-        return $locationStruct;
+        return $spiLocation;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -495,13 +495,6 @@ class Handler implements BaseLocationHandler
         $this->locationGateway->update($location, $locationId);
     }
 
-    /**
-     * Creates a new location rooted at $location->parentId.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Location\CreateStruct $createStruct
-     *
-     * @return \eZ\Publish\SPI\Persistence\Content\Location
-     */
     public function create(CreateStruct $createStruct)
     {
         $parentNodeData = $this->locationGateway->getBasicNodeData($createStruct->parentId);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
@@ -95,6 +95,8 @@ class TreeHandler
      * Deletes raw content data.
      *
      * @param int $contentId
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function removeRawContent($contentId)
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
@@ -98,9 +98,11 @@ class TreeHandler
      */
     public function removeRawContent($contentId)
     {
-        $this->locationGateway->removeElementFromTrash(
-            $this->loadContentInfo($contentId)->mainLocationId
-        );
+        $mainLocationId = $this->loadContentInfo($contentId)->mainLocationId;
+        // there can be no Locations for Draft Content items
+        if (null !== $mainLocationId) {
+            $this->locationGateway->removeElementFromTrash($mainLocationId);
+        }
 
         foreach ($this->listVersions($contentId) as $versionInfo) {
             $this->fieldHandler->deleteFields($contentId, $versionInfo);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
@@ -21,10 +21,8 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
 {
     protected function getLocationGateway()
     {
-        $dbHandler = $this->getDatabaseHandler();
-
         return new DoctrineDatabase(
-            $dbHandler,
+            $this->getDatabaseConnection(),
             $this->getLanguageMaskGenerator()
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTrashTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTrashTest.php
@@ -20,10 +20,8 @@ class DoctrineDatabaseTrashTest extends LanguageAwareTestCase
 {
     protected function getLocationGateway()
     {
-        $dbHandler = $this->getDatabaseHandler();
-
         return new DoctrineDatabase(
-            $dbHandler,
+            $this->getDatabaseConnection(),
             $this->getLanguageMaskGenerator()
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
@@ -347,6 +347,10 @@ class LocationHandlerTest extends TestCase
 
         $createStruct = new CreateStruct();
         $createStruct->parentId = 77;
+        $spiLocation = new Location();
+        $spiLocation->id = 78;
+        $spiLocation->parentId = 77;
+        $spiLocation->pathString = '/1/2/77/78/';
 
         $this->locationGateway
             ->expects($this->once())
@@ -365,7 +369,7 @@ class LocationHandlerTest extends TestCase
             ->expects($this->once())
             ->method('create')
             ->with($createStruct, $parentInfo)
-            ->will($this->returnValue($createStruct));
+            ->will($this->returnValue($spiLocation));
 
         $this->locationGateway
             ->expects($this->once())

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
@@ -5439,7 +5439,7 @@ class UrlAliasHandlerTest extends TestCase
     {
         if (!isset($this->locationGateway)) {
             $this->locationGateway = new DoctrineDatabaseLocation(
-                $this->getDatabaseHandler(),
+                $this->getDatabaseConnection(),
                 $this->getLanguageMaskGenerator()
             );
         }

--- a/eZ/Publish/Core/settings/storage_engines/legacy/location.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/location.yml
@@ -2,7 +2,7 @@ services:
     ezpublish.persistence.legacy.location.gateway.inner:
         class: eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\DoctrineDatabase
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - "@ezpublish.api.storage_engine.legacy.connection"
             - "@ezpublish.persistence.legacy.language.mask_generator"
 
     ezpublish.persistence.legacy.location.gateway.exception_conversion:

--- a/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
@@ -187,6 +187,8 @@ interface Handler
      * @param \eZ\Publish\SPI\Persistence\Content\Location\CreateStruct $location
      *
      * @return \eZ\Publish\SPI\Persistence\Content\Location
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if parent Location does not exist
      */
     public function create(CreateStruct $location);
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31088](https://jira.ez.no/browse/EZP-31088) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR refactors the Legacy (Content) Location Gateway implementation (`\eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\DoctrineDatabase`) to rely on `\Doctrine\DBAL\Connection` instead of our custom Database Handler.

**TODO**:
- [x] Refactor Content Location gateway methods to use Doctrine\DBAL.
- [x] Drop DatabaseHandler from Location GW DoctrineDatabase constructor.
- [x] Introduce strict types to Content Location GW method signatures.
- [x] Align other services which use now strictly-typed Location GW.
- [x] Replace `ezcontentobject_tree` literals with `Location\Gateway::CONTENT_TREE_TABLE` constant.
- [x] Mark Content Location gateway classes as final and internal.
- [x] Set database platform in Location GW constructor.
- [x] Simplify Location GW `DoctrineDatabase::listTrashed` method.
- [x] [PHPDoc] Add missing `@throws` attribute to various methods.
- [x] Drop obsolete `MAX_LIMIT` constant from Location GW `DoctrineDatabase`
- [x] Fix incorrect return variable name in `Location\Handler::create` method
- [x] [Tests] Fix mocking error in `LocationHandlerTest::testCreateLocation`
- [x] Align `Location\Gateway\DoctrineDatabase::getAllLocationsQueryBuilder` with `createNodeQueryBuilder`, remove one.
- [x] Optimize `Content\Location\Gateway\DoctrineDatabase::moveSubtreeNodes` method (time and cognitive complexity reduced, query optimization is too complex for this scope).
- [x] [CS] Align Content Location gateway class files headers.
- [x] [CS] Align Code Style with eZ Platform Code Style
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Wait for Travis.
- [x] Ask for Code Review.