### PR TITLE
EZP-31088: Refactored ObjectState GW methods to use Doctrine\DBAL

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
@@ -12,7 +12,9 @@ use eZ\Publish\SPI\Persistence\Content\ObjectState;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
 
 /**
- * ObjectState Gateway.
+ * Base class for Object State gateways.
+ *
+ * @internal For internal use by Persistence Handlers.
  */
 abstract class Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
@@ -16,6 +16,15 @@ use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
  */
 abstract class Gateway
 {
+    public const OBJECT_STATE_TABLE = 'ezcobj_state';
+    public const OBJECT_STATE_LANGUAGE_TABLE = 'ezcobj_state_language';
+    public const OBJECT_STATE_GROUP_TABLE = 'ezcobj_state_group';
+    public const OBJECT_STATE_GROUP_LANGUAGE_TABLE = 'ezcobj_state_group_language';
+    public const OBJECT_STATE_LINK_TABLE = 'ezcobj_state_link';
+
+    public const OBJECT_STATE_TABLE_SEQ = 'ezcobj_state_id_seq';
+    public const OBJECT_STATE_GROUP_TABLE_SEQ = 'ezcobj_state_group_id_seq';
+
     /**
      * Loads data for an object state.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
@@ -6,6 +6,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\ObjectState;
 
 use eZ\Publish\SPI\Persistence\Content\ObjectState;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
@@ -34,7 +34,7 @@ abstract class Gateway
      *
      * @return array
      */
-    abstract public function loadObjectStateData($stateId);
+    abstract public function loadObjectStateData(int $stateId): array;
 
     /**
      * Loads data for an object state by identifier.
@@ -44,7 +44,10 @@ abstract class Gateway
      *
      * @return array
      */
-    abstract public function loadObjectStateDataByIdentifier($identifier, $groupId);
+    abstract public function loadObjectStateDataByIdentifier(
+        string $identifier,
+        int $groupId
+    ): array;
 
     /**
      * Loads data for all object states belonging to group with $groupId ID.
@@ -53,7 +56,7 @@ abstract class Gateway
      *
      * @return array
      */
-    abstract public function loadObjectStateListData($groupId);
+    abstract public function loadObjectStateListData(int $groupId): array;
 
     /**
      * Loads data for an object state group.
@@ -62,7 +65,7 @@ abstract class Gateway
      *
      * @return array
      */
-    abstract public function loadObjectStateGroupData($groupId);
+    abstract public function loadObjectStateGroupData(int $groupId): array;
 
     /**
      * Loads data for an object state group by identifier.
@@ -71,7 +74,7 @@ abstract class Gateway
      *
      * @return array
      */
-    abstract public function loadObjectStateGroupDataByIdentifier($identifier);
+    abstract public function loadObjectStateGroupDataByIdentifier(string $identifier): array;
 
     /**
      * Loads data for all object state groups, filtered by $offset and $limit.
@@ -81,7 +84,7 @@ abstract class Gateway
      *
      * @return array
      */
-    abstract public function loadObjectStateGroupListData($offset, $limit);
+    abstract public function loadObjectStateGroupListData(int $offset, int $limit): array;
 
     /**
      * Inserts a new object state into database.
@@ -89,21 +92,21 @@ abstract class Gateway
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState $objectState
      * @param int $groupId
      */
-    abstract public function insertObjectState(ObjectState $objectState, $groupId);
+    abstract public function insertObjectState(ObjectState $objectState, int $groupId): void;
 
     /**
      * Updates the stored object state with provided data.
      *
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState $objectState
      */
-    abstract public function updateObjectState(ObjectState $objectState);
+    abstract public function updateObjectState(ObjectState $objectState): void;
 
     /**
      * Deletes object state identified by $stateId.
      *
      * @param int $stateId
      */
-    abstract public function deleteObjectState($stateId);
+    abstract public function deleteObjectState(int $stateId): void;
 
     /**
      * Update object state links from $oldStateId to $newStateId.
@@ -111,35 +114,35 @@ abstract class Gateway
      * @param int $oldStateId
      * @param int $newStateId
      */
-    abstract public function updateObjectStateLinks($oldStateId, $newStateId);
+    abstract public function updateObjectStateLinks(int $oldStateId, int $newStateId): void;
 
     /**
      * Deletes object state links identified by $stateId.
      *
      * @param int $stateId
      */
-    abstract public function deleteObjectStateLinks($stateId);
+    abstract public function deleteObjectStateLinks(int $stateId): void;
 
     /**
      * Inserts a new object state group into database.
      *
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Group $objectStateGroup
      */
-    abstract public function insertObjectStateGroup(Group $objectStateGroup);
+    abstract public function insertObjectStateGroup(Group $objectStateGroup): void;
 
     /**
      * Updates the stored object state group with provided data.
      *
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Group $objectStateGroup
      */
-    abstract public function updateObjectStateGroup(Group $objectStateGroup);
+    abstract public function updateObjectStateGroup(Group $objectStateGroup): void;
 
     /**
      * Deletes the object state group identified by $groupId.
      *
      * @param mixed $groupId
      */
-    abstract public function deleteObjectStateGroup($groupId);
+    abstract public function deleteObjectStateGroup(int $groupId): void;
 
     /**
      * Sets the object state $stateId to content with $contentId ID.
@@ -148,7 +151,7 @@ abstract class Gateway
      * @param mixed $groupId
      * @param mixed $stateId
      */
-    abstract public function setContentState($contentId, $groupId, $stateId);
+    abstract public function setContentState(int $contentId, int $groupId, int $stateId): void;
 
     /**
      * Loads object state data for $contentId content from $stateGroupId state group.
@@ -158,7 +161,10 @@ abstract class Gateway
      *
      * @return array
      */
-    abstract public function loadObjectStateDataForContent($contentId, $stateGroupId);
+    abstract public function loadObjectStateDataForContent(
+        int $contentId,
+        int $stateGroupId
+    ): array;
 
     /**
      * Returns the number of objects which are in this state.
@@ -167,7 +173,7 @@ abstract class Gateway
      *
      * @return int
      */
-    abstract public function getContentCount($stateId);
+    abstract public function getContentCount(int $stateId): int;
 
     /**
      * Updates the object state priority to provided value.
@@ -175,5 +181,5 @@ abstract class Gateway
      * @param mixed $stateId
      * @param int $priority
      */
-    abstract public function updateObjectStatePriority($stateId, $priority);
+    abstract public function updateObjectStatePriority(int $stateId, int $priority): void;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the ObjectState Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -30,21 +28,12 @@ abstract class Gateway
     public const OBJECT_STATE_GROUP_TABLE_SEQ = 'ezcobj_state_group_id_seq';
 
     /**
-     * Loads data for an object state.
-     *
-     * @param mixed $stateId
-     *
-     * @return array
+     * Load data for an object state.
      */
     abstract public function loadObjectStateData(int $stateId): array;
 
     /**
-     * Loads data for an object state by identifier.
-     *
-     * @param string $identifier
-     * @param mixed $groupId
-     *
-     * @return array
+     * Load data for an object state by identifier.
      */
     abstract public function loadObjectStateDataByIdentifier(
         string $identifier,
@@ -52,116 +41,80 @@ abstract class Gateway
     ): array;
 
     /**
-     * Loads data for all object states belonging to group with $groupId ID.
-     *
-     * @param mixed $groupId
-     *
-     * @return array
+     * Load data for all object states belonging to group with $groupId ID.
      */
     abstract public function loadObjectStateListData(int $groupId): array;
 
     /**
-     * Loads data for an object state group.
-     *
-     * @param mixed $groupId
-     *
-     * @return array
+     * Load data for an object state group.
      */
     abstract public function loadObjectStateGroupData(int $groupId): array;
 
     /**
-     * Loads data for an object state group by identifier.
-     *
-     * @param string $identifier
-     *
-     * @return array
+     * Load data for an object state group by identifier.
      */
     abstract public function loadObjectStateGroupDataByIdentifier(string $identifier): array;
 
     /**
-     * Loads data for all object state groups, filtered by $offset and $limit.
-     *
-     * @param int $offset
-     * @param int $limit
-     *
-     * @return array
+     * Load data for all object state groups, filtered by $offset and $limit.
      */
     abstract public function loadObjectStateGroupListData(int $offset, int $limit): array;
 
     /**
-     * Inserts a new object state into database.
+     * Insert a new object state into database.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState $objectState
-     * @param int $groupId
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     abstract public function insertObjectState(ObjectState $objectState, int $groupId): void;
 
     /**
-     * Updates the stored object state with provided data.
+     * Update the stored object state with provided data.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState $objectState
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     abstract public function updateObjectState(ObjectState $objectState): void;
 
     /**
-     * Deletes object state identified by $stateId.
-     *
-     * @param int $stateId
+     * Delete object state identified by $stateId.
      */
     abstract public function deleteObjectState(int $stateId): void;
 
     /**
      * Update object state links from $oldStateId to $newStateId.
-     *
-     * @param int $oldStateId
-     * @param int $newStateId
      */
     abstract public function updateObjectStateLinks(int $oldStateId, int $newStateId): void;
 
     /**
-     * Deletes object state links identified by $stateId.
-     *
-     * @param int $stateId
+     * Delete object state links identified by $stateId.
      */
     abstract public function deleteObjectStateLinks(int $stateId): void;
 
     /**
-     * Inserts a new object state group into database.
+     * Insert a new object state group into database.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Group $objectStateGroup
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if Object State Group language does not exist
      */
     abstract public function insertObjectStateGroup(Group $objectStateGroup): void;
 
     /**
-     * Updates the stored object state group with provided data.
+     * Update the stored object state group with provided data.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Group $objectStateGroup
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     abstract public function updateObjectStateGroup(Group $objectStateGroup): void;
 
     /**
-     * Deletes the object state group identified by $groupId.
-     *
-     * @param mixed $groupId
+     * Delete the object state group identified by $groupId.
      */
     abstract public function deleteObjectStateGroup(int $groupId): void;
 
     /**
-     * Sets the object state $stateId to content with $contentId ID.
-     *
-     * @param mixed $contentId
-     * @param mixed $groupId
-     * @param mixed $stateId
+     * Set the object state $stateId to content with $contentId ID.
      */
     abstract public function setContentState(int $contentId, int $groupId, int $stateId): void;
 
     /**
-     * Loads object state data for $contentId content from $stateGroupId state group.
-     *
-     * @param int $contentId
-     * @param int $stateGroupId
-     *
-     * @return array
+     * Load object state data for $contentId content from $stateGroupId state group.
      */
     abstract public function loadObjectStateDataForContent(
         int $contentId,
@@ -169,19 +122,12 @@ abstract class Gateway
     ): array;
 
     /**
-     * Returns the number of objects which are in this state.
-     *
-     * @param mixed $stateId
-     *
-     * @return int
+     * Return the number of objects which are in this state.
      */
     abstract public function getContentCount(int $stateId): int;
 
     /**
-     * Updates the object state priority to provided value.
-     *
-     * @param mixed $stateId
-     * @param int $priority
+     * Update the object state priority to provided value.
      */
     abstract public function updateObjectStatePriority(int $stateId, int $priority): void;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
@@ -38,16 +38,22 @@ class DoctrineDatabase extends Gateway
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
+    /** @var \Doctrine\DBAL\Platforms\AbstractPlatform */
+    private $dbPlatform;
+
     /**
      * Creates a new Doctrine database ObjectState Gateway.
      *
      * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator $maskGenerator
+     *
+     * @throws \Doctrine\DBAL\DBALException
      */
     public function __construct(DatabaseHandler $dbHandler, MaskGenerator $maskGenerator)
     {
         $this->dbHandler = $dbHandler;
         $this->connection = $dbHandler->getConnection();
+        $this->dbPlatform = $this->connection->getDatabasePlatform();
         $this->maskGenerator = $maskGenerator;
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
@@ -8,12 +8,12 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\ObjectState;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
 
@@ -22,14 +22,6 @@ use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
  */
 class DoctrineDatabase extends Gateway
 {
-    /**
-     * Database handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     * @deprecated Start to use DBAL $connection instead.
-     */
-    protected $dbHandler;
-
     /**
      * Language mask generator.
      *
@@ -44,17 +36,11 @@ class DoctrineDatabase extends Gateway
     private $dbPlatform;
 
     /**
-     * Creates a new Doctrine database ObjectState Gateway.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator $maskGenerator
-     *
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function __construct(DatabaseHandler $dbHandler, MaskGenerator $maskGenerator)
+    public function __construct(Connection $connection, MaskGenerator $maskGenerator)
     {
-        $this->dbHandler = $dbHandler;
-        $this->connection = $dbHandler->getConnection();
+        $this->connection = $connection;
         $this->dbPlatform = $this->connection->getDatabasePlatform();
         $this->maskGenerator = $maskGenerator;
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
@@ -18,7 +18,11 @@ use eZ\Publish\SPI\Persistence\Content\ObjectState;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
 
 /**
- * ObjectState Doctrine database Gateway.
+ * Object State gateway implementation using the Doctrine database.
+ *
+ * @internal Gateway implementation is considered internal. Use Persistence Location Handler instead.
+ *
+ * @see \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler
  */
 final class DoctrineDatabase extends Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase ObjectState Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -51,13 +49,6 @@ final class DoctrineDatabase extends Gateway
         $this->maskGenerator = $maskGenerator;
     }
 
-    /**
-     * Loads data for an object state.
-     *
-     * @param mixed $stateId
-     *
-     * @return array
-     */
     public function loadObjectStateData(int $stateId): array
     {
         $query = $this->createObjectStateFindQuery();
@@ -73,14 +64,6 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads data for an object state by identifier.
-     *
-     * @param string $identifier
-     * @param mixed $groupId
-     *
-     * @return array
-     */
     public function loadObjectStateDataByIdentifier(string $identifier, int $groupId): array
     {
         $query = $this->createObjectStateFindQuery();
@@ -102,13 +85,6 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads data for all object states belonging to group with $groupId ID.
-     *
-     * @param mixed $groupId
-     *
-     * @return array
-     */
     public function loadObjectStateListData(int $groupId): array
     {
         $query = $this->createObjectStateFindQuery();
@@ -129,13 +105,6 @@ final class DoctrineDatabase extends Gateway
         return array_values($rows);
     }
 
-    /**
-     * Loads data for an object state group.
-     *
-     * @param mixed $groupId
-     *
-     * @return array
-     */
     public function loadObjectStateGroupData(int $groupId): array
     {
         $query = $this->createObjectStateGroupFindQuery();
@@ -151,13 +120,6 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads data for an object state group by identifier.
-     *
-     * @param string $identifier
-     *
-     * @return array
-     */
     public function loadObjectStateGroupDataByIdentifier(string $identifier): array
     {
         $query = $this->createObjectStateGroupFindQuery();
@@ -173,14 +135,6 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads data for all object state groups, filtered by $offset and $limit.
-     *
-     * @param int $offset
-     * @param int $limit
-     *
-     * @return array
-     */
     public function loadObjectStateGroupListData(int $offset, int $limit): array
     {
         $query = $this->createObjectStateGroupFindQuery();
@@ -200,10 +154,8 @@ final class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Inserts a new object state into database.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState $objectState
-     * @param int $groupId
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function insertObjectState(ObjectState $objectState, int $groupId): void
     {
@@ -262,10 +214,6 @@ final class DoctrineDatabase extends Gateway
     }
 
     /**
-     * @param string $tableName
-     * @param int $id
-     * @param string $identifier
-     * @param string $defaultLanguageCode
      * @param string[] $languageCodes
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
@@ -317,11 +265,6 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Updates the stored object state with provided data.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState $objectState
-     */
     public function updateObjectState(ObjectState $objectState): void
     {
         // First update the state
@@ -339,11 +282,6 @@ final class DoctrineDatabase extends Gateway
         $this->insertObjectStateTranslations($objectState);
     }
 
-    /**
-     * Deletes object state identified by $stateId.
-     *
-     * @param int $stateId
-     */
     public function deleteObjectState(int $stateId): void
     {
         $this->deleteObjectStateTranslations($stateId);
@@ -361,12 +299,6 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Update object state links to $newStateId.
-     *
-     * @param int $oldStateId
-     * @param int $newStateId
-     */
     public function updateObjectStateLinks(int $oldStateId, int $newStateId): void
     {
         $query = $this->connection->createQueryBuilder();
@@ -424,11 +356,6 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Deletes object state links identified by $stateId.
-     *
-     * @param int $stateId
-     */
     public function deleteObjectStateLinks(int $stateId): void
     {
         $query = $this->connection->createQueryBuilder();
@@ -444,11 +371,6 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Inserts a new object state group into database.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Group $objectStateGroup
-     */
     public function insertObjectStateGroup(Group $objectStateGroup): void
     {
         $query = $this->connection->createQueryBuilder();
@@ -487,11 +409,6 @@ final class DoctrineDatabase extends Gateway
         $this->insertObjectStateGroupTranslations($objectStateGroup);
     }
 
-    /**
-     * Updates the stored object state group with provided data.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Group $objectStateGroup
-     */
     public function updateObjectStateGroup(Group $objectStateGroup): void
     {
         // First update the group
@@ -509,11 +426,6 @@ final class DoctrineDatabase extends Gateway
         $this->insertObjectStateGroupTranslations($objectStateGroup);
     }
 
-    /**
-     * Deletes the object state group identified by $groupId.
-     *
-     * @param mixed $groupId
-     */
     public function deleteObjectStateGroup(int $groupId): void
     {
         $this->deleteObjectStateGroupTranslations($groupId);
@@ -532,13 +444,6 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Sets the object state $stateId to content with $contentId ID.
-     *
-     * @param mixed $contentId
-     * @param mixed $groupId
-     * @param mixed $stateId
-     */
     public function setContentState(int $contentId, int $groupId, int $stateId): void
     {
         // First find out if $contentId is related to existing states in $groupId
@@ -553,14 +458,6 @@ final class DoctrineDatabase extends Gateway
         }
     }
 
-    /**
-     * Loads object state data for $contentId content from $stateGroupId state group.
-     *
-     * @param int $contentId
-     * @param int $stateGroupId
-     *
-     * @return array
-     */
     public function loadObjectStateDataForContent(int $contentId, int $stateGroupId): array
     {
         $query = $this->createObjectStateFindQuery();
@@ -590,13 +487,6 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Returns the number of objects which are in this state.
-     *
-     * @param mixed $stateId
-     *
-     * @return int
-     */
     public function getContentCount(int $stateId): int
     {
         $query = $this->connection->createQueryBuilder();
@@ -615,12 +505,6 @@ final class DoctrineDatabase extends Gateway
         return (int)$query->execute()->fetchColumn();
     }
 
-    /**
-     * Updates the object state priority to provided value.
-     *
-     * @param mixed $stateId
-     * @param int $priority
-     */
     public function updateObjectStatePriority(int $stateId, int $priority): void
     {
         $query = $this->connection->createQueryBuilder();
@@ -700,9 +584,9 @@ final class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Inserts object state group translations into database.
+     * Insert object state group translations into database.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState $objectState
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if Object State language does not exist
      */
     private function insertObjectStateTranslations(ObjectState $objectState): void
     {
@@ -759,9 +643,9 @@ final class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Inserts object state group translations into database.
+     * Insert object state group translations into database.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Group $objectStateGroup
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if Object State Group language does not exist
      */
     private function insertObjectStateGroupTranslations(Group $objectStateGroup): void
     {
@@ -795,9 +679,7 @@ final class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Deletes all translations of the $groupId state group.
-     *
-     * @param mixed $groupId
+     * Delete all translations of the $groupId state group.
      */
     private function deleteObjectStateGroupTranslations(int $groupId): void
     {
@@ -864,10 +746,6 @@ final class DoctrineDatabase extends Gateway
         return false !== $stateId ? (int)$stateId : null;
     }
 
-    /**
-     * @param int $contentId
-     * @param int $stateId
-     */
     private function insertContentStateAssignment(int $contentId, int $stateId): void
     {
         $query = $this->connection->createQueryBuilder();

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
@@ -56,7 +56,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return array
      */
-    public function loadObjectStateData($stateId)
+    public function loadObjectStateData(int $stateId): array
     {
         $query = $this->createObjectStateFindQuery();
         $query->where(
@@ -79,7 +79,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return array
      */
-    public function loadObjectStateDataByIdentifier($identifier, $groupId)
+    public function loadObjectStateDataByIdentifier(string $identifier, int $groupId): array
     {
         $query = $this->createObjectStateFindQuery();
         $query->where(
@@ -107,7 +107,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return array
      */
-    public function loadObjectStateListData($groupId)
+    public function loadObjectStateListData(int $groupId): array
     {
         $query = $this->createObjectStateFindQuery();
         $query->where(
@@ -134,7 +134,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return array
      */
-    public function loadObjectStateGroupData($groupId)
+    public function loadObjectStateGroupData(int $groupId): array
     {
         $query = $this->createObjectStateGroupFindQuery();
         $query->where(
@@ -156,7 +156,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return array
      */
-    public function loadObjectStateGroupDataByIdentifier($identifier)
+    public function loadObjectStateGroupDataByIdentifier(string $identifier): array
     {
         $query = $this->createObjectStateGroupFindQuery();
         $query->where(
@@ -179,7 +179,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return array
      */
-    public function loadObjectStateGroupListData($offset, $limit)
+    public function loadObjectStateGroupListData(int $offset, int $limit): array
     {
         $query = $this->createObjectStateGroupFindQuery();
         if ($limit > 0) {
@@ -203,7 +203,7 @@ final class DoctrineDatabase extends Gateway
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState $objectState
      * @param int $groupId
      */
-    public function insertObjectState(ObjectState $objectState, $groupId)
+    public function insertObjectState(ObjectState $objectState, int $groupId): void
     {
         $maxPriority = $this->getMaxPriorityForObjectStatesInGroup($groupId);
 
@@ -320,7 +320,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState $objectState
      */
-    public function updateObjectState(ObjectState $objectState)
+    public function updateObjectState(ObjectState $objectState): void
     {
         // First update the state
         $this->updateObjectStateCommonFields(
@@ -342,7 +342,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @param int $stateId
      */
-    public function deleteObjectState($stateId)
+    public function deleteObjectState(int $stateId): void
     {
         $this->deleteObjectStateTranslations($stateId);
 
@@ -365,7 +365,7 @@ final class DoctrineDatabase extends Gateway
      * @param int $oldStateId
      * @param int $newStateId
      */
-    public function updateObjectStateLinks($oldStateId, $newStateId)
+    public function updateObjectStateLinks(int $oldStateId, int $newStateId): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -388,8 +388,11 @@ final class DoctrineDatabase extends Gateway
     /**
      * Change Content to object state assignment.
      */
-    private function updateContentStateAssignment(int $contentId, int $stateId, int $assignedStateId): void
-    {
+    private function updateContentStateAssignment(
+        int $contentId,
+        int $stateId,
+        int $assignedStateId
+    ): void {
         // no action required if there's no change
         if ($stateId === $assignedStateId) {
             return;
@@ -424,7 +427,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @param int $stateId
      */
-    public function deleteObjectStateLinks($stateId)
+    public function deleteObjectStateLinks(int $stateId): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -444,7 +447,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Group $objectStateGroup
      */
-    public function insertObjectStateGroup(Group $objectStateGroup)
+    public function insertObjectStateGroup(Group $objectStateGroup): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -487,7 +490,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Group $objectStateGroup
      */
-    public function updateObjectStateGroup(Group $objectStateGroup)
+    public function updateObjectStateGroup(Group $objectStateGroup): void
     {
         // First update the group
         $this->updateObjectStateCommonFields(
@@ -509,7 +512,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @param mixed $groupId
      */
-    public function deleteObjectStateGroup($groupId)
+    public function deleteObjectStateGroup(int $groupId): void
     {
         $this->deleteObjectStateGroupTranslations($groupId);
 
@@ -534,7 +537,7 @@ final class DoctrineDatabase extends Gateway
      * @param mixed $groupId
      * @param mixed $stateId
      */
-    public function setContentState($contentId, $groupId, $stateId)
+    public function setContentState(int $contentId, int $groupId, int $stateId): void
     {
         // First find out if $contentId is related to existing states in $groupId
         $assignedStateId = $this->getContentStateId($contentId, $groupId);
@@ -556,7 +559,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return array
      */
-    public function loadObjectStateDataForContent($contentId, $stateGroupId)
+    public function loadObjectStateDataForContent(int $contentId, int $stateGroupId): array
     {
         $query = $this->createObjectStateFindQuery();
         $expr = $query->expr();
@@ -592,7 +595,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return int
      */
-    public function getContentCount($stateId)
+    public function getContentCount(int $stateId): int
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -616,7 +619,7 @@ final class DoctrineDatabase extends Gateway
      * @param mixed $stateId
      * @param int $priority
      */
-    public function updateObjectStatePriority($stateId, $priority)
+    public function updateObjectStatePriority(int $stateId, int $priority): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -699,7 +702,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState $objectState
      */
-    private function insertObjectStateTranslations(ObjectState $objectState)
+    private function insertObjectStateTranslations(ObjectState $objectState): void
     {
         foreach ($objectState->languageCodes as $languageCode) {
             $query = $this->connection->createQueryBuilder();
@@ -738,7 +741,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @param mixed $stateId
      */
-    private function deleteObjectStateTranslations($stateId)
+    private function deleteObjectStateTranslations(int $stateId): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -758,7 +761,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Group $objectStateGroup
      */
-    private function insertObjectStateGroupTranslations(Group $objectStateGroup)
+    private function insertObjectStateGroupTranslations(Group $objectStateGroup): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -794,7 +797,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @param mixed $groupId
      */
-    private function deleteObjectStateGroupTranslations($groupId)
+    private function deleteObjectStateGroupTranslations(int $groupId): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -809,7 +812,7 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    private function getMaxPriorityForObjectStatesInGroup($groupId): ?int
+    private function getMaxPriorityForObjectStatesInGroup(int $groupId): ?int
     {
         $query = $this->connection->createQueryBuilder();
         $query

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
@@ -20,14 +20,14 @@ use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
 /**
  * ObjectState Doctrine database Gateway.
  */
-class DoctrineDatabase extends Gateway
+final class DoctrineDatabase extends Gateway
 {
     /**
      * Language mask generator.
      *
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator
      */
-    protected $maskGenerator;
+    private $maskGenerator;
 
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
@@ -632,7 +632,7 @@ class DoctrineDatabase extends Gateway
     /**
      * Create a generic query for fetching object state(s).
      */
-    protected function createObjectStateFindQuery(): QueryBuilder
+    private function createObjectStateFindQuery(): QueryBuilder
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -663,7 +663,7 @@ class DoctrineDatabase extends Gateway
     /**
      * Create a generic query for fetching object state group(s).
      */
-    protected function createObjectStateGroupFindQuery(): QueryBuilder
+    private function createObjectStateGroupFindQuery(): QueryBuilder
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -695,7 +695,7 @@ class DoctrineDatabase extends Gateway
      *
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState $objectState
      */
-    protected function insertObjectStateTranslations(ObjectState $objectState)
+    private function insertObjectStateTranslations(ObjectState $objectState)
     {
         foreach ($objectState->languageCodes as $languageCode) {
             $query = $this->connection->createQueryBuilder();
@@ -734,7 +734,7 @@ class DoctrineDatabase extends Gateway
      *
      * @param mixed $stateId
      */
-    protected function deleteObjectStateTranslations($stateId)
+    private function deleteObjectStateTranslations($stateId)
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -754,7 +754,7 @@ class DoctrineDatabase extends Gateway
      *
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Group $objectStateGroup
      */
-    protected function insertObjectStateGroupTranslations(Group $objectStateGroup)
+    private function insertObjectStateGroupTranslations(Group $objectStateGroup)
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -790,7 +790,7 @@ class DoctrineDatabase extends Gateway
      *
      * @param mixed $groupId
      */
-    protected function deleteObjectStateGroupTranslations($groupId)
+    private function deleteObjectStateGroupTranslations($groupId)
     {
         $query = $this->connection->createQueryBuilder();
         $query

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
@@ -6,6 +6,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway;
 
 use Doctrine\DBAL\Connection;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
@@ -35,6 +35,9 @@ class DoctrineDatabase extends Gateway
      */
     protected $maskGenerator;
 
+    /** @var \Doctrine\DBAL\Connection */
+    private $connection;
+
     /**
      * Creates a new Doctrine database ObjectState Gateway.
      *
@@ -44,6 +47,7 @@ class DoctrineDatabase extends Gateway
     public function __construct(DatabaseHandler $dbHandler, MaskGenerator $maskGenerator)
     {
         $this->dbHandler = $dbHandler;
+        $this->connection = $dbHandler->getConnection();
         $this->maskGenerator = $maskGenerator;
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
@@ -37,7 +37,7 @@ final class ExceptionConversion extends Gateway
         $this->innerGateway = $innerGateway;
     }
 
-    public function loadObjectStateData($stateId)
+    public function loadObjectStateData(int $stateId): array
     {
         try {
             return $this->innerGateway->loadObjectStateData($stateId);
@@ -46,7 +46,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadObjectStateDataByIdentifier($identifier, $groupId)
+    public function loadObjectStateDataByIdentifier(string $identifier, int $groupId): array
     {
         try {
             return $this->innerGateway->loadObjectStateDataByIdentifier($identifier, $groupId);
@@ -55,7 +55,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadObjectStateListData($groupId)
+    public function loadObjectStateListData(int $groupId): array
     {
         try {
             return $this->innerGateway->loadObjectStateListData($groupId);
@@ -64,7 +64,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadObjectStateGroupData($groupId)
+    public function loadObjectStateGroupData(int $groupId): array
     {
         try {
             return $this->innerGateway->loadObjectStateGroupData($groupId);
@@ -73,7 +73,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadObjectStateGroupDataByIdentifier($identifier)
+    public function loadObjectStateGroupDataByIdentifier(string $identifier): array
     {
         try {
             return $this->innerGateway->loadObjectStateGroupDataByIdentifier($identifier);
@@ -82,7 +82,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadObjectStateGroupListData($offset, $limit)
+    public function loadObjectStateGroupListData(int $offset, int $limit): array
     {
         try {
             return $this->innerGateway->loadObjectStateGroupListData($offset, $limit);
@@ -91,88 +91,88 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function insertObjectState(ObjectState $objectState, $groupId)
+    public function insertObjectState(ObjectState $objectState, int $groupId): void
     {
         try {
-            return $this->innerGateway->insertObjectState($objectState, $groupId);
+            $this->innerGateway->insertObjectState($objectState, $groupId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function updateObjectState(ObjectState $objectState)
+    public function updateObjectState(ObjectState $objectState): void
     {
         try {
-            return $this->innerGateway->updateObjectState($objectState);
+            $this->innerGateway->updateObjectState($objectState);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function deleteObjectState($stateId)
+    public function deleteObjectState(int $stateId): void
     {
         try {
-            return $this->innerGateway->deleteObjectState($stateId);
+            $this->innerGateway->deleteObjectState($stateId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function updateObjectStateLinks($oldStateId, $newStateId)
+    public function updateObjectStateLinks(int $oldStateId, int $newStateId): void
     {
         try {
-            return $this->innerGateway->updateObjectStateLinks($oldStateId, $newStateId);
+            $this->innerGateway->updateObjectStateLinks($oldStateId, $newStateId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function deleteObjectStateLinks($stateId)
+    public function deleteObjectStateLinks(int $stateId): void
     {
         try {
-            return $this->innerGateway->deleteObjectStateLinks($stateId);
+            $this->innerGateway->deleteObjectStateLinks($stateId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function insertObjectStateGroup(Group $objectStateGroup)
+    public function insertObjectStateGroup(Group $objectStateGroup): void
     {
         try {
-            return $this->innerGateway->insertObjectStateGroup($objectStateGroup);
+            $this->innerGateway->insertObjectStateGroup($objectStateGroup);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function updateObjectStateGroup(Group $objectStateGroup)
+    public function updateObjectStateGroup(Group $objectStateGroup): void
     {
         try {
-            return $this->innerGateway->updateObjectStateGroup($objectStateGroup);
+            $this->innerGateway->updateObjectStateGroup($objectStateGroup);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function deleteObjectStateGroup($groupId)
+    public function deleteObjectStateGroup(int $groupId): void
     {
         try {
-            return $this->innerGateway->deleteObjectStateGroup($groupId);
+            $this->innerGateway->deleteObjectStateGroup($groupId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function setContentState($contentId, $groupId, $stateId)
+    public function setContentState(int $contentId, int $groupId, int $stateId): void
     {
         try {
-            return $this->innerGateway->setContentState($contentId, $groupId, $stateId);
+            $this->innerGateway->setContentState($contentId, $groupId, $stateId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function loadObjectStateDataForContent($contentId, $stateGroupId)
+    public function loadObjectStateDataForContent(int $contentId, int $stateGroupId): array
     {
         try {
             return $this->innerGateway->loadObjectStateDataForContent($contentId, $stateGroupId);
@@ -181,7 +181,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function getContentCount($stateId)
+    public function getContentCount(int $stateId): int
     {
         try {
             return $this->innerGateway->getContentCount($stateId);
@@ -190,10 +190,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function updateObjectStatePriority($stateId, $priority)
+    public function updateObjectStatePriority(int $stateId, int $priority): void
     {
         try {
-            return $this->innerGateway->updateObjectStatePriority($stateId, $priority);
+            $this->innerGateway->updateObjectStatePriority($stateId, $priority);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
@@ -6,6 +6,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway;
 
 use eZ\Publish\Core\Base\Exceptions\DatabaseException;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
@@ -15,14 +15,14 @@ use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
 use Doctrine\DBAL\DBALException;
 use PDOException;
 
-class ExceptionConversion extends Gateway
+final class ExceptionConversion extends Gateway
 {
     /**
      * The wrapped gateway.
      *
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway
      */
-    protected $innerGateway;
+    private $innerGateway;
 
     /**
      * Creates a new exception conversion gateway around $innerGateway.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the ObjectState Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
@@ -15,6 +15,9 @@ use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
 use Doctrine\DBAL\DBALException;
 use PDOException;
 
+/**
+ * @internal Internal exception conversion layer.
+ */
 final class ExceptionConversion extends Gateway
 {
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/Gateway/DoctrineDatabaseTest.php
@@ -601,13 +601,13 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
     /**
      * Returns a ready to test DoctrineDatabase gateway.
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway\DoctrineDatabase
+     * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getDatabaseGateway()
+    protected function getDatabaseGateway(): DoctrineDatabase
     {
         if (!isset($this->databaseGateway)) {
             $this->databaseGateway = new DoctrineDatabase(
-                $this->getDatabaseHandler(),
+                $this->getDatabaseConnection(),
                 $this->getLanguageMaskGenerator()
             );
         }

--- a/eZ/Publish/Core/settings/storage_engines/legacy/object_state.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/object_state.yml
@@ -2,7 +2,7 @@ services:
     ezpublish.persistence.legacy.object_state.gateway.inner:
         class: eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway\DoctrineDatabase
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - "@ezpublish.api.storage_engine.legacy.connection"
             - "@ezpublish.persistence.legacy.language.mask_generator"
 
     ezpublish.persistence.legacy.object_state.gateway.exception_conversion:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31088](https://jira.ez.no/browse/EZP-31088) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR refactors the Legacy (Content) ObjectState Gateway implementation (`\eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway\DoctrineDatabase`) to rely on `\Doctrine\DBAL\Connection` instead of our custom Database Handler. Some CS alignment, optimizations, strict types enforcement (as it proved to be safe) has been done along the way.

The full list of tasks done for the `ObjectState` gateway:
- [x] Added `$connection` property to the gateway.
- [x] Set `DatabasePlatform` instance in tje gateway constructor.
- [x] Refactored the gateway to rely on `Doctrine\DBAL\Connection`.
- [x] Replaced `DatabaseHandler` with `Connection` in the gateway constructor.
- [x] Marked the gateway classes as `final` and `@internal`.
- [x] Introduced strict types to the gateway classes methods.
- [x] Enforced strict types.
- [x] [CS] Aligned the gateway classes CS with eZ Platform Code Style.

**TODO**:
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Wait for Travis.
- [x] Ask for Code Review.