### PR TITLE
EZP-31080: Created missing search Criterions

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -785,6 +785,14 @@ class SearchServiceTest extends BaseTest
                 ],
                 $fixtureDir . 'ObjectStateIdentifier.php',
             ],
+            [
+                [
+                    'query' => new Criterion\ObjectStateIdentifier(['not_locked'], 'ez_lock'),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'ObjectStateIdentifier.php',
+            ],
         ];
     }
 

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -655,6 +656,134 @@ class SearchServiceTest extends BaseTest
                     'limit' => 50,
                 ],
                 $fixtureDir . 'Visibility.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\IsUserEnabled(true),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 5,
+                ],
+                $fixtureDir . 'IsUserEnabledTrue.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\IsUserEnabled(false),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 5,
+                ],
+                $fixtureDir . 'IsUserEnabledFalse.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\IsUserBased(true),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'IsUserBasedTrue.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\IsUserBased(false),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 1,
+                ],
+                $fixtureDir . 'IsUserBasedFalse.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\UserId(14),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'UserIdEq.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\UserId([14, 10]),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'UserIdIn.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\UserLogin('*adm*', Operator::LIKE),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'UserLogin.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\UserLogin('admin', Operator::EQ),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'UserLogin.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\UserLogin(['admin'], Operator::IN),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'UserLogin.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\UserEmail('*nospam*', Operator::LIKE),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'UserEmail.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\UserEmail('nospam@ez.no', Operator::EQ),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'UserEmail.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\UserEmail(['nospam@ez.no'], Operator::IN),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'UserEmail.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\SectionIdentifier('users'),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'SectionIdentifier.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\SectionIdentifier(['users']),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'SectionIdentifier.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\ObjectStateIdentifier('not_locked'),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'ObjectStateIdentifier.php',
+            ],
+            [
+                [
+                    'query' => new Criterion\ObjectStateIdentifier(['not_locked']),
+                    'sortClauses' => [new SortClause\ContentId()],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'ObjectStateIdentifier.php',
             ],
         ];
     }

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/IsUserBasedFalse.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/IsUserBasedFalse.php
@@ -1,0 +1,24 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state([
+    'facets' => [],
+    'searchHits' =>
+        [
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 4,
+                        'title' => 'Users',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+                'matchedTranslation' => 'eng-US',
+            ]),
+        ],
+    'spellSuggestion' => null,
+    'time' => 1,
+    'timedOut' => null,
+    'maxScore' => null,
+    'totalCount' => 16,
+]);

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/IsUserBasedTrue.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/IsUserBasedTrue.php
@@ -1,0 +1,35 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state([
+    'facets' => [],
+    'searchHits' =>
+        [
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 10,
+                        'title' => 'Anonymous User',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+                'matchedTranslation' => 'eng-US',
+            ]),
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 14,
+                        'title' => 'Administrator User',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+                'matchedTranslation' => 'eng-US',
+            ]),
+        ],
+    'spellSuggestion' => null,
+    'time' => 1,
+    'timedOut' => null,
+    'maxScore' => null,
+    'totalCount' => 2,
+]);

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/IsUserEnabledFalse.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/IsUserEnabledFalse.php
@@ -1,0 +1,11 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state([
+    'facets' => [],
+    'searchHits' => [],
+    'spellSuggestion' => null,
+    'time' => 1,
+    'timedOut' => null,
+    'maxScore' => null,
+    'totalCount' => 0,
+]);

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/IsUserEnabledTrue.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/IsUserEnabledTrue.php
@@ -1,0 +1,35 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state([
+    'facets' => [],
+    'searchHits' =>
+        [
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 10,
+                        'title' => 'Anonymous User',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+                'matchedTranslation' => 'eng-US',
+            ]),
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 14,
+                        'title' => 'Administrator User',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+                'matchedTranslation' => 'eng-US',
+            ]),
+        ],
+    'spellSuggestion' => null,
+    'time' => 1,
+    'timedOut' => null,
+    'maxScore' => null,
+    'totalCount' => 2,
+]);

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/ObjectStateIdentifier.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/ObjectStateIdentifier.php
@@ -1,0 +1,229 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state([
+    'facets' => [],
+    'searchHits' =>
+        [
+            0 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+                    'valueObject' =>
+                        [
+                            'id' => 4,
+                            'title' => 'Users',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                )),
+            1 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 10,
+                            'title' => 'Anonymous User',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            2 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 11,
+                            'title' => 'Members',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            3 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 12,
+                            'title' => 'Administrator users',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            4 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 13,
+                            'title' => 'Editors',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            5 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 14,
+                            'title' => 'Administrator User',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            6 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 41,
+                            'title' => 'Media',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            7 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 42,
+                            'title' => 'Anonymous Users',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            8 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 45,
+                            'title' => 'Setup',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            9 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 49,
+                            'title' => 'Images',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            10 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 50,
+                            'title' => 'Files',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            11 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 51,
+                            'title' => 'Multimedia',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            12 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 52,
+                            'title' => 'Common INI settings',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            13 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 54,
+                            'title' => 'eZ Publish Demo Design (without demo content)',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            14 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 56,
+                            'title' => 'Design',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            15 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 57,
+                            'title' => 'Home',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            16 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 58,
+                            'title' => 'Contact Us',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+            17 =>
+                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                    'valueObject' =>
+                        [
+                            'id' => 59,
+                            'title' => 'Partners',
+                        ],
+                    'score' => 0.0,
+                    'index' => NULL,
+                    'matchedTranslation' => NULL,
+                    'highlight' => NULL,
+                ]),
+        ],
+    'spellSuggestion' => null,
+    'time' => 1,
+    'timedOut' => null,
+    'maxScore' => null,
+    'totalCount' => 18,
+]);

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/SectionIdentifier.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/SectionIdentifier.php
@@ -1,0 +1,93 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state([
+    'facets' => [],
+    'searchHits' =>
+        [
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 4,
+                        'title' => 'Users',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+            ]),
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 10,
+                        'title' => 'Anonymous User',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+            ]),
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 11,
+                        'title' => 'Members',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+            ]),
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 12,
+                        'title' => 'Administrator users',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+            ]),
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 13,
+                        'title' => 'Editors',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+            ]),
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 14,
+                        'title' => 'Administrator User',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+            ]),
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 42,
+                        'title' => 'Anonymous Users',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+            ]),
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 59,
+                        'title' => 'Partners',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+            ]),
+        ],
+    'spellSuggestion' => null,
+    'time' => 1,
+    'timedOut' => null,
+    'maxScore' => null,
+    'totalCount' => 8,
+]);

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/UserEmail.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/UserEmail.php
@@ -1,0 +1,24 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state([
+    'facets' => [],
+    'searchHits' =>
+        [
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 10,
+                        'title' => 'Anonymous User',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+                'matchedTranslation' => 'eng-US',
+            ]),
+        ],
+    'spellSuggestion' => null,
+    'time' => 1,
+    'timedOut' => null,
+    'maxScore' => null,
+    'totalCount' => 1,
+]);

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/UserIdEq.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/UserIdEq.php
@@ -1,0 +1,24 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state([
+    'facets' => [],
+    'searchHits' =>
+        [
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 14,
+                        'title' => 'Administrator User',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+                'matchedTranslation' => 'eng-US',
+            ]),
+        ],
+    'spellSuggestion' => null,
+    'time' => 1,
+    'timedOut' => null,
+    'maxScore' => null,
+    'totalCount' => 1,
+]);

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/UserIdIn.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/UserIdIn.php
@@ -1,0 +1,35 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state([
+    'facets' => [],
+    'searchHits' =>
+        [
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 10,
+                        'title' => 'Anonymous User',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+                'matchedTranslation' => 'eng-US',
+            ]),
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 14,
+                        'title' => 'Administrator User',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+                'matchedTranslation' => 'eng-US',
+            ]),
+        ],
+    'spellSuggestion' => null,
+    'time' => 1,
+    'timedOut' => null,
+    'maxScore' => null,
+    'totalCount' => 2,
+]);

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/UserLogin.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/UserLogin.php
@@ -1,0 +1,24 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state([
+    'facets' => [],
+    'searchHits' =>
+        [
+            eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state([
+                'valueObject' =>
+                    [
+                        'id' => 14,
+                        'title' => 'Administrator User',
+                    ],
+                'score' => null,
+                'index' => null,
+                'highlight' => null,
+                'matchedTranslation' => 'eng-US',
+            ]),
+        ],
+    'spellSuggestion' => null,
+    'time' => 1,
+    'timedOut' => null,
+    'maxScore' => null,
+    'totalCount' => 1,
+]);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsUserBased.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsUserBased.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+class IsUserBased extends Criterion
+{
+    public function __construct(bool $value = true)
+    {
+        parent::__construct(null, null, $value);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications[]
+     */
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(
+                Operator::EQ,
+                Specifications::FORMAT_SINGLE,
+                Specifications::TYPE_BOOLEAN
+            ),
+        ];
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsUserEnabled.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsUserEnabled.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+class IsUserEnabled extends Criterion
+{
+    public function __construct(bool $value = true)
+    {
+        parent::__construct(null, null, $value);
+    }
+
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(
+                Operator::EQ,
+                Specifications::FORMAT_SINGLE,
+                Specifications::TYPE_BOOLEAN
+            ),
+        ];
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateIdentifier.php
@@ -15,10 +15,11 @@ class ObjectStateIdentifier extends Criterion
 {
     /**
      * @param string|string[] $value
+     * @param string|null $target
      */
-    public function __construct($value)
+    public function __construct($value, ?string $target = null)
     {
-        parent::__construct(null, null, $value);
+        parent::__construct($target, null, $value);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateIdentifier.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+class ObjectStateIdentifier extends Criterion
+{
+    /**
+     * @param string|string[] $value
+     */
+    public function __construct($value)
+    {
+        parent::__construct(null, null, $value);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications[]
+     */
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(
+                Operator::IN,
+                Specifications::FORMAT_ARRAY
+            ),
+            new Specifications(
+                Operator::EQ,
+                Specifications::FORMAT_SINGLE
+            ),
+        ];
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/SectionIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/SectionIdentifier.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+class SectionIdentifier extends Criterion
+{
+    /**
+     * @param string|string[] $value
+     */
+    public function __construct($value)
+    {
+        parent::__construct(null, null, $value);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications[]
+     */
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(
+                Operator::IN,
+                Specifications::FORMAT_ARRAY
+            ),
+            new Specifications(
+                Operator::EQ,
+                Specifications::FORMAT_SINGLE
+            ),
+        ];
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserEmail.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserEmail.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+class UserEmail extends Criterion
+{
+    /**
+     * @param string|string[] $value
+     * @param string|null $operator
+     */
+    public function __construct($value, ?string $operator = null)
+    {
+        parent::__construct(null, $operator, $value);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications[]
+     */
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(
+                Operator::EQ,
+                Specifications::FORMAT_SINGLE
+            ),
+            new Specifications(
+                Operator::IN,
+                Specifications::FORMAT_ARRAY
+            ),
+            new Specifications(
+                Operator::LIKE,
+                Specifications::FORMAT_SINGLE
+            ),
+        ];
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserId.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+class UserId extends Criterion
+{
+    /**
+     * @param int|int[] $value
+     */
+    public function __construct($value)
+    {
+        parent::__construct(null, null, $value);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications[]
+     */
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(
+                Operator::EQ,
+                Specifications::FORMAT_SINGLE
+            ),
+            new Specifications(
+                Operator::IN,
+                Specifications::FORMAT_ARRAY
+            ),
+        ];
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserLogin.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserLogin.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+class UserLogin extends Criterion
+{
+    /**
+     * @param string|string[] $value
+     * @param string|null $operator
+     */
+    public function __construct($value, ?string $operator = null)
+    {
+        parent::__construct(null, $operator, $value);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications[]
+     */
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(
+                Operator::EQ,
+                Specifications::FORMAT_SINGLE
+            ),
+            new Specifications(
+                Operator::IN,
+                Specifications::FORMAT_ARRAY
+            ),
+            new Specifications(
+                Operator::LIKE,
+                Specifications::FORMAT_SINGLE
+            ),
+        ];
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/IsUserBased.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/IsUserBased.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+
+class IsUserBased extends CriterionHandler
+{
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof Criterion\IsUserBased;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $isUserBased = (bool) reset($criterion->value);
+
+        $subSelect = $query->subSelect();
+        $subSelect
+            ->select(
+                $this->dbHandler->quoteColumn('contentobject_id')
+            )->from(
+                $this->dbHandler->quoteTable('ezuser')
+            );
+
+        $queryExpression = $query->expr->in(
+            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
+            $subSelect
+        );
+
+        return $isUserBased
+            ? $queryExpression
+            : $query->expr->not($queryExpression);
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/IsUserEnabled.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/IsUserEnabled.php
@@ -47,7 +47,7 @@ class IsUserEnabled extends CriterionHandler
             )->where(
                 $query->expr->eq(
                     $this->dbHandler->quoteColumn('is_enabled', 't2'),
-                    $query->bindValue(reset($criterion->value))
+                    (int) reset($criterion->value)
                 )
             );
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/IsUserEnabled.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/IsUserEnabled.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+
+class IsUserEnabled extends CriterionHandler
+{
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof Criterion\IsUserEnabled;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $subSelect = $query->subSelect();
+        $subSelect
+            ->select(
+                $this->dbHandler->quoteColumn('contentobject_id', 't1')
+            )->from(
+                $query->alias(
+                    $this->dbHandler->quoteTable('ezuser'),
+                    't1'
+                )
+            )->leftJoin(
+                $query->alias(
+                    $this->dbHandler->quoteTable('ezuser_setting'),
+                    't2'
+                ),
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn('contentobject_id', 't1'),
+                    $this->dbHandler->quoteColumn('user_id', 't2')
+                )
+            )->where(
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn('is_enabled', 't2'),
+                    $query->bindValue(reset($criterion->value))
+                )
+            );
+
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
+            $subSelect
+        );
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ObjectStateIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ObjectStateIdentifier.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+
+class ObjectStateIdentifier extends CriterionHandler
+{
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof Criterion\ObjectStateIdentifier;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $subSelect = $query->subSelect();
+        $subSelect
+            ->select(
+                $this->dbHandler->quoteColumn('contentobject_id', 't1')
+            )->from(
+                $query->alias(
+                    $this->dbHandler->quoteTable('ezcobj_state_link'),
+                    't1'
+                )
+            )->leftJoin(
+                $query->alias(
+                    $this->dbHandler->quoteTable('ezcobj_state'),
+                    't2'
+                ),
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn('contentobject_state_id', 't1'),
+                    $this->dbHandler->quoteColumn('id', 't2')
+                )
+            )->where(
+                $query->expr->in(
+                    $this->dbHandler->quoteColumn('identifier', 't2'),
+                    $criterion->value
+                )
+            );
+
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
+            $subSelect
+        );
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionIdentifier.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+
+class SectionIdentifier extends CriterionHandler
+{
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof Criterion\SectionIdentifier;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $subSelect = $query->subSelect();
+        $subSelect
+            ->select(
+                $this->dbHandler->quoteColumn('id', 't1')
+            )->from(
+                $query->alias(
+                    $this->dbHandler->quoteTable('ezcontentobject'),
+                    't1'
+                )
+            )->leftJoin(
+                $query->alias(
+                    $this->dbHandler->quoteTable('ezsection'),
+                    't2'
+                ),
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn('section_id', 't1'),
+                    $this->dbHandler->quoteColumn('id', 't2')
+                )
+            )->where(
+                $query->expr->in(
+                    $this->dbHandler->quoteColumn('identifier', 't2'),
+                    $criterion->value
+                )
+            );
+
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
+            $subSelect
+        );
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserEmail.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserEmail.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\Core\Persistence\TransformationProcessor;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+
+class UserEmail extends CriterionHandler
+{
+    /** @var \eZ\Publish\Core\Persistence\TransformationProcessor */
+    private $transformationProcessor;
+
+    public function __construct(DatabaseHandler $dbHandler, TransformationProcessor $transformationProcessor)
+    {
+        parent::__construct($dbHandler);
+
+        $this->transformationProcessor = $transformationProcessor;
+    }
+
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof Criterion\UserEmail;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        if (Criterion\Operator::LIKE === $criterion->operator) {
+            $expression = $query->expr->like(
+                $this->dbHandler->quoteColumn('email', 't1'),
+                $query->bindValue(
+                    str_replace(
+                        '*',
+                        '%',
+                        addcslashes(
+                            $this->transformationProcessor->transformByGroup(
+                                $criterion->value,
+                                'lowercase'
+                            ),
+                            '%_'
+                        )
+                    )
+                )
+            );
+        } else {
+            $expression = $query->expr->in(
+                $this->dbHandler->quoteColumn('email', 't1'),
+                $criterion->value
+            );
+        }
+
+        $subSelect = $query->subSelect();
+        $subSelect
+            ->select(
+                $this->dbHandler->quoteColumn('contentobject_id', 't1')
+            )->from(
+                $query->alias(
+                    $this->dbHandler->quoteTable('ezuser'),
+                    't1'
+                )
+            )->where(
+                $expression
+            );
+
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
+            $subSelect
+        );
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserId.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+
+class UserId extends CriterionHandler
+{
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof Criterion\UserId;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $subSelect = $query->subSelect();
+        $subSelect
+            ->select(
+                $this->dbHandler->quoteColumn('contentobject_id', 't1')
+            )->from(
+                $query->alias(
+                    $this->dbHandler->quoteTable('ezuser'),
+                    't1'
+                )
+            )->where(
+                $query->expr->in(
+                    $this->dbHandler->quoteColumn('contentobject_id', 't1'),
+                    $criterion->value
+                )
+            );
+
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
+            $subSelect
+        );
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserLogin.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserLogin.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\Core\Persistence\TransformationProcessor;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+
+class UserLogin extends CriterionHandler
+{
+    /** @var \eZ\Publish\Core\Persistence\TransformationProcessor */
+    private $transformationProcessor;
+
+    public function __construct(DatabaseHandler $dbHandler, TransformationProcessor $transformationProcessor)
+    {
+        parent::__construct($dbHandler);
+
+        $this->transformationProcessor = $transformationProcessor;
+    }
+
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof Criterion\UserLogin;
+    }
+
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        if (Criterion\Operator::LIKE === $criterion->operator) {
+            $expression = $query->expr->like(
+                $this->dbHandler->quoteColumn('login', 't1'),
+                $query->bindValue(
+                    str_replace(
+                        '*',
+                        '%',
+                        addcslashes(
+                            $this->transformationProcessor->transformByGroup(
+                                $criterion->value,
+                                'lowercase'
+                            ),
+                            '%_'
+                        )
+                    )
+                )
+            );
+        } else {
+            $expression = $query->expr->in(
+                $this->dbHandler->quoteColumn('login', 't1'),
+                $criterion->value
+            );
+        }
+
+        $subSelect = $query->subSelect();
+        $subSelect
+            ->select(
+                $this->dbHandler->quoteColumn('contentobject_id', 't1')
+            )->from(
+                $query->alias(
+                    $this->dbHandler->quoteTable('ezuser'),
+                    't1'
+                )
+            )->where(
+                $expression
+            );
+
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
+            $subSelect
+        );
+    }
+}

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -186,6 +186,13 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
+    ezpublish.search.legacy.gateway.criterion_handler.common.object_state_identifier:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ObjectStateIdentifier
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
     ezpublish.search.legacy.gateway.criterion_handler.common.field_relation:
         parent: ezpublish.search.legacy.gateway.criterion_handler.field_base
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldRelation
@@ -207,9 +214,55 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
+    ezpublish.search.legacy.gateway.criterion_handler.common.section_identifier:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\SectionIdentifier
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
+    ezpublish.search.legacy.gateway.criterion_handler.common.user_id:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\UserId
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
+    ezpublish.search.legacy.gateway.criterion_handler.common.user_email:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\UserEmail
+        arguments:
+            $transformationProcessor: '@ezpublish.api.storage_engine.transformation_processor'
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
+    ezpublish.search.legacy.gateway.criterion_handler.common.user_login:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\UserLogin
+        arguments:
+            $transformationProcessor: '@ezpublish.api.storage_engine.transformation_processor'
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
+    ezpublish.search.legacy.gateway.criterion_handler.common.is_user_enabled:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\IsUserEnabled
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
     ezpublish.search.legacy.gateway.criterion_handler.common.user_metadata:
         parent: ezpublish.search.legacy.gateway.criterion_handler.base
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\UserMetadata
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
+    ezpublish.search.legacy.gateway.criterion_handler.common.is_user_based:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\IsUserBased
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31080](https://jira.ez.no/browse/EZP-31080)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

# Description
This PR adds new criterions. REST implementation is provided in https://github.com/ezsystems/ezplatform-rest/pull/39

## IsUserBased
Matches content that are also User instances (usually `user` content type but may very on different installations). Supported operators: `EQ`

#### REST example:
`{"IsUserBasedCriterion": false}`

## IsUserEnabled

Matches only enabled/disabled users (via `ezuser` fieldtype attribute). Supported operators: `EQ`

#### REST example:
`{"IsUserEnabledCriterion": true}`

## UserId

Matches only particular User IDs. Supported operators: `EQ`, `IN`

#### REST example:
`{"UserIdCriterion": '10,14'}`

## UserLogin

Matches only particular User logins. Supported operators: `EQ`, `IN`, `LIKE`
 
#### REST example:
* Equal matches: `{"UserLoginCriterion": 'admin,anonymous'}`
* Matched by pattern: `{"UserLoginCriterion": 'adm*'}`

## UserEmail

Matches only particular User e-mails. Supported operators: `EQ`, `IN`, `LIKE`
 
#### REST example:
* Equal matches: `{"UserEmailCriterion": 'nospam@ez.no'}`
* Matched by pattern: `{"UserEmailCriterion": 'nospam*'}`

## SectionIdentifier

Matches only content in particular sections. Supported operators: `EQ`, `IN`
 
#### REST example:
`{"SectionIdentifierCriterion": 'users'}`

## ObjectStateIdentifier

Matches only content in particular object state. It supports passing object state group as a `$target`. Supported operators: `EQ`, `IN`
 
#### REST example:
`{"ObjectStateIdentifierCriterion": {"value": 'not_locked', "target": 'ez_lock'}}`

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
