### PR TITLE
EZP-31411: Added ability to sort Trash items by trashed date

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTrashServiceTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use Doctrine\DBAL\ParameterType;
+
 /**
  * Base class for trash specific tests.
  */
@@ -40,5 +42,21 @@ abstract class BaseTrashServiceTest extends BaseTest
         /* END: Inline */
 
         return $trashItem;
+    }
+
+    /**
+     * @throws \ErrorException
+     */
+    protected function updateTrashedDate(int $locationId, int $newTimestamp): void
+    {
+        $connection = $this->getRawDatabaseConnection();
+        $query = $connection->createQueryBuilder();
+        $query
+            ->update('ezcontentobject_trash')
+            ->set('trashed', ':trashed_timestamp')
+            ->where('node_id = :location_id')
+            ->setParameter('trashed_timestamp', $newTimestamp, ParameterType::INTEGER)
+            ->setParameter('location_id', $locationId, ParameterType::INTEGER);
+        $query->execute();
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/DateTrashed.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/DateTrashed.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Trash;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+
+/**
+ * Sets sort direction on the Trashed Location date for a Location query.
+ */
+class DateTrashed extends SortClause
+{
+    public function __construct(string $sortDirection = Query::SORT_ASC)
+    {
+        parent::__construct('trashed', $sortDirection);
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1340,6 +1340,10 @@ class DoctrineDatabase extends Gateway
                     $query->orderBy('priority', $sortDirection);
                     break;
 
+                case $condition instanceof SortClause\Trash\DateTrashed:
+                    $query->orderBy('trashed', $sortDirection);
+                    break;
+
                 default:
                     // Only handle location related sort clauses. The others
                     // require data aggregation which is not sensible here.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31411](https://jira.ez.no/browse/EZP-31411)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Currently, admin interface has trashed items sorted by priority, which makes it hard to find recently trashed items.
This PR will allow sorting by trashed date, so we can do further improvement of sorting order in admin UI.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
