### PR TITLE
EZP-31002: Skipped Location check for ContentCreateStruct in ObjectStateLimitation

### DIFF
--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -122,14 +122,12 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
             $object = $object->getVersionInfo()->getContentInfo();
         } elseif ($object instanceof VersionInfo) {
             $object = $object->getContentInfo();
-        } elseif ($object instanceof ContentCreateStruct) {
-            return true;
-        } elseif (!$object instanceof ContentInfo) {
+        } elseif (!$object instanceof ContentInfo && !$object instanceof ContentCreateStruct) {
             throw new InvalidArgumentException('$object', 'Must be of type: Content, VersionInfo, ContentInfo or ContentCreateStruct');
         }
 
         // Skip evaluating for RootLocation
-        if (1 === $object->mainLocationId) {
+        if (isset($object->mainLocationId) && 1 === $object->mainLocationId) {
             return true;
         }
 

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -123,11 +123,11 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
         } elseif ($object instanceof VersionInfo) {
             $object = $object->getContentInfo();
         } elseif (!$object instanceof ContentInfo && !$object instanceof ContentCreateStruct) {
-            throw new InvalidArgumentException('$object', 'Must be of type: Content, VersionInfo, ContentInfo or ContentCreateStruct');
+            throw new InvalidArgumentException('$object', 'Must be of type: Content, VersionInfo, ContentInfo, or ContentCreateStruct');
         }
 
         // Skip evaluating for RootLocation
-        if (isset($object->mainLocationId) && 1 === $object->mainLocationId) {
+        if ($object instanceof ContentInfo && 1 === $object->mainLocationId) {
             return true;
         }
 

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -122,8 +122,10 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
             $object = $object->getVersionInfo()->getContentInfo();
         } elseif ($object instanceof VersionInfo) {
             $object = $object->getContentInfo();
-        } elseif (!$object instanceof ContentInfo && !$object instanceof ContentCreateStruct) {
-            throw new InvalidArgumentException('$object', 'Must be of type: Content, VersionInfo or ContentInfo');
+        } elseif ($object instanceof ContentCreateStruct) {
+            return true;
+        } elseif (!$object instanceof ContentInfo) {
+            throw new InvalidArgumentException('$object', 'Must be of type: Content, VersionInfo, ContentInfo or ContentCreateStruct');
         }
 
         // Skip evaluating for RootLocation

--- a/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\Core\Limitation\ObjectStateLimitationType;
+use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\SPI\Persistence\Content\ObjectState;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as SPIHandler;
@@ -141,6 +142,12 @@ class ObjectStateLimitationTypeTest extends Base
             [
                 'limitation' => new ObjectStateLimitation(['limitationValues' => [1, 3]]),
                 'object' => new ContentInfo(['id' => 0, 'mainLocationId' => 1, 'published' => true]),
+                'expected' => true,
+            ],
+            // ContentCreateStruct, with access
+            [
+                'limitation' => new ObjectStateLimitation(['limitationValues' => [1, 3]]),
+                'object' => new ContentCreateStruct(),
                 'expected' => true,
             ],
         ];


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31002](https://jira.ez.no/browse/EZP-31002)
| **Bug**| yes
| **New feature**    |no
| **Target version** | 7.x
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     |no

ContentCreateStructs do not possess location id, evaluating for RootLocation is not necessary in their case, so the additional check has been added.

**TODO**:
- [x] Fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
