### PR TITLE
EZP-30882: Changed the way new fieldtype thumbnail strategies are injected

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
@@ -11,11 +11,14 @@ namespace eZ\Publish\Core\FieldType\Image;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
-use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field\ThumbnailStrategy;
+use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field\FieldTypeBasedThumbnailStrategy;
 use eZ\Publish\SPI\Variation\VariationHandler;
 
-class ImageThumbnailStrategy implements ThumbnailStrategy
+class ImageThumbnailStrategy implements FieldTypeBasedThumbnailStrategy
 {
+    /** @var string */
+    private $fieldTypeIdentifier;
+
     /** @var \eZ\Publish\SPI\Variation\VariationHandler */
     private $variationHandler;
 
@@ -23,11 +26,18 @@ class ImageThumbnailStrategy implements ThumbnailStrategy
     private $variationName;
 
     public function __construct(
+        string $fieldTypeIdentifier,
         VariationHandler $variationHandler,
         string $variationName
     ) {
+        $this->fieldTypeIdentifier = $fieldTypeIdentifier;
         $this->variationHandler = $variationHandler;
         $this->variationName = $variationName;
+    }
+
+    public function getFieldTypeIdentifier(): string
+    {
+        return $this->fieldTypeIdentifier;
     }
 
     public function getThumbnail(Field $field): ?Thumbnail

--- a/eZ/Publish/Core/FieldType/ImageAsset/ImageAssetThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/ImageAssetThumbnailStrategy.php
@@ -11,21 +11,33 @@ namespace eZ\Publish\Core\FieldType\ImageAsset;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
+use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field\FieldTypeBasedThumbnailStrategy;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy as ContentThumbnailStrategy;
-use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field\ThumbnailStrategy;
 
-class ImageAssetThumbnailStrategy implements ThumbnailStrategy
+class ImageAssetThumbnailStrategy implements FieldTypeBasedThumbnailStrategy
 {
+    /** @var string */
+    private $fieldTypeIdentifier;
+
     /** @var \eZ\Publish\API\Repository\ContentService */
     private $contentService;
 
     /** @var \eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy */
     private $thumbnailStrategy;
 
-    public function __construct(ContentThumbnailStrategy $thumbnailStrategy, ContentService $contentService)
-    {
+    public function __construct(
+        string $fieldTypeIdentifier,
+        ContentThumbnailStrategy $thumbnailStrategy,
+        ContentService $contentService
+    ) {
+        $this->fieldTypeIdentifier = $fieldTypeIdentifier;
         $this->contentService = $contentService;
         $this->thumbnailStrategy = $thumbnailStrategy;
+    }
+
+    public function getFieldTypeIdentifier(): string
+    {
+        return $this->fieldTypeIdentifier;
     }
 
     public function getThumbnail(Field $field): ?Thumbnail

--- a/eZ/Publish/Core/Repository/Tests/ContentThumbnail/ContentFieldStrategyTest.php
+++ b/eZ/Publish/Core/Repository/Tests/ContentThumbnail/ContentFieldStrategyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Repository\Tests\ContentThumbnail;
+
+use ArrayIterator;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\Thumbnail;
+use eZ\Publish\Core\Repository\Strategy\ContentThumbnail\Field\ContentFieldStrategy;
+use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field\FieldTypeBasedThumbnailStrategy;
+use PHPUnit\Framework\TestCase;
+
+class ContentFieldStrategyTest extends TestCase
+{
+    private function getFieldTypeBasedThumbnailStrategy(string $fieldTypeIdentifier): FieldTypeBasedThumbnailStrategy
+    {
+        return new class($fieldTypeIdentifier) implements FieldTypeBasedThumbnailStrategy {
+            /** @var string */
+            private $fieldTypeIdentifier;
+
+            public function __construct(string $fieldTypeIdentifier)
+            {
+                $this->fieldTypeIdentifier = $fieldTypeIdentifier;
+            }
+
+            public function getFieldTypeIdentifier(): string
+            {
+                return $this->fieldTypeIdentifier;
+            }
+
+            public function getThumbnail(Field $field): ?Thumbnail
+            {
+                return new Thumbnail([
+                    'resource' => $field->value,
+                ]);
+            }
+        };
+    }
+
+    public function testHasStrategy(): void
+    {
+        $contentFieldStrategy = new ContentFieldStrategy(new ArrayIterator([
+            $this->getFieldTypeBasedThumbnailStrategy('example'),
+        ]));
+
+        $this->assertTrue($contentFieldStrategy->hasStrategy('example'));
+        $this->assertFalse($contentFieldStrategy->hasStrategy('something_else'));
+    }
+
+    public function testAddStrategy(): void
+    {
+        $contentFieldStrategy = new ContentFieldStrategy(new ArrayIterator());
+
+        $this->assertFalse($contentFieldStrategy->hasStrategy('example'));
+
+        $contentFieldStrategy->addStrategy('example', $this->getFieldTypeBasedThumbnailStrategy('example'));
+
+        $this->assertTrue($contentFieldStrategy->hasStrategy('example'));
+    }
+
+    public function testSetStrategies(): void
+    {
+        $contentFieldStrategy = new ContentFieldStrategy(new ArrayIterator([
+            $this->getFieldTypeBasedThumbnailStrategy('previous'),
+        ]));
+
+        $this->assertTrue($contentFieldStrategy->hasStrategy('previous'));
+
+        $contentFieldStrategy->setStrategies([
+            $this->getFieldTypeBasedThumbnailStrategy('new-example-1'),
+            $this->getFieldTypeBasedThumbnailStrategy('new-example-2'),
+        ]);
+
+        $this->assertFalse($contentFieldStrategy->hasStrategy('previous'));
+        $this->assertTrue($contentFieldStrategy->hasStrategy('new-example-1'));
+        $this->assertTrue($contentFieldStrategy->hasStrategy('new-example-2'));
+    }
+
+    public function testGetThumbnailFound(): void
+    {
+        $contentFieldStrategy = new ContentFieldStrategy(new ArrayIterator([
+            $this->getFieldTypeBasedThumbnailStrategy('example'),
+        ]));
+
+        $field = new Field([
+            'fieldTypeIdentifier' => 'example',
+            'value' => 'example-value',
+        ]);
+
+        $thumbnail = $contentFieldStrategy->getThumbnail($field);
+
+        $this->assertInstanceOf(Thumbnail::class, $thumbnail);
+        $this->assertEquals('example-value', $thumbnail->resource);
+    }
+
+    public function testGetThumbnailNotFound(): void
+    {
+        $contentFieldStrategy = new ContentFieldStrategy(new ArrayIterator([
+            $this->getFieldTypeBasedThumbnailStrategy('something-else'),
+        ]));
+
+        $field = new Field([
+            'fieldTypeIdentifier' => 'example',
+            'value' => 'example-value',
+        ]);
+
+        $this->expectException(NotFoundException::class);
+
+        $contentFieldStrategy->getThumbnail($field);
+    }
+}

--- a/eZ/Publish/Core/settings/thumbnails.yml
+++ b/eZ/Publish/Core/settings/thumbnails.yml
@@ -6,20 +6,24 @@ services:
 
     eZ\Publish\Core\FieldType\Image\ImageThumbnailStrategy:
         arguments:
+            $fieldTypeIdentifier: 'ezimage'
             $variationHandler: '@eZ\Publish\SPI\Variation\VariationHandler'
             $variationName: 'medium'
+        tags:
+            - { name: ezplatform.spi.field.thumbnail_strategy, priority: 0 }
 
     eZ\Publish\Core\FieldType\ImageAsset\ImageAssetThumbnailStrategy:
         lazy: true
         arguments:
+            $fieldTypeIdentifier: 'ezimageasset'
             $thumbnailStrategy: '@eZ\Publish\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'
             $contentService: '@ezpublish.api.service.content'
+        tags:
+            - { name: ezplatform.spi.field.thumbnail_strategy, priority: 0 }
 
     eZ\Publish\Core\Repository\Strategy\ContentThumbnail\Field\ContentFieldStrategy:
         arguments:
-            $strategies:
-                ezimage: '@eZ\Publish\Core\FieldType\Image\ImageThumbnailStrategy'
-                ezimageasset: '@eZ\Publish\Core\FieldType\ImageAsset\ImageAssetThumbnailStrategy'
+            $strategies: !tagged_iterator ezplatform.spi.field.thumbnail_strategy
 
     eZ\Publish\Core\Repository\Strategy\ContentThumbnail\FirstMatchingFieldStrategy:
         arguments:

--- a/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/Field/FieldTypeBasedThumbnailStrategy.php
+++ b/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/Field/FieldTypeBasedThumbnailStrategy.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field;
+
+interface FieldTypeBasedThumbnailStrategy extends ThumbnailStrategy
+{
+    public function getFieldTypeIdentifier(): string;
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30882](https://jira.ez.no/browse/EZP-30882)
| **Improvement**| yes
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

Improved the way how new fieldtype thumbnail strategies are injected. Instead of plain hardcoded hashmap, make strategies tagged services. This will make thumbnails much easier to extend or overwrite new strategies.

Late follow-up to: https://github.com/ezsystems/ezpublish-kernel/pull/2868

Previous:
```yaml
        arguments:
            $strategies:
                ezimage: '@eZ\Publish\Core\FieldType\Image\ImageThumbnailStrategy'
                ezimageasset: '@eZ\Publish\Core\FieldType\ImageAsset\ImageAssetThumbnailStrategy'
```
Now:
```yaml
        arguments:
            $strategies: !tagged_iterator ezplatform.spi.field.thumbnail_strategy
```

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
