### PR TITLE
EZP-31088: Refactored User GW to use Doctrine\DBAL

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/Gateway/DoctrineDatabaseTest.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\User\Gateway;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
@@ -36,7 +38,7 @@ class DoctrineDatabaseTest extends TestCase
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\User\Gateway\DoctrineDatabase::removeRoleAssignmentById
      */
-    public function testRemoveRoleByAssignmentId()
+    public function testRemoveRoleByAssignmentId(): void
     {
         $gateway = $this->getDatabaseGateway();
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/Gateway/DoctrineDatabaseTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File contains: eZ\Publish\Core\Persistence\Legacy\Tests\User\Gateway\DoctrineDatabaseTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -79,13 +77,13 @@ class DoctrineDatabaseTest extends TestCase
     /**
      * Returns a ready to test DoctrineDatabase gateway.
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\User\Gateway\DoctrineDatabase
+     * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getDatabaseGateway()
+    protected function getDatabaseGateway(): DoctrineDatabase
     {
         if (!isset($this->databaseGateway)) {
             $this->databaseGateway = new DoctrineDatabase(
-                $this->getDatabaseHandler()
+                $this->getDatabaseConnection()
             );
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -8,6 +8,9 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\User;
 
+use DateInterval;
+use DateTime;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Values\User\Role as APIRole;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
@@ -56,7 +59,7 @@ class UserHandlerTest extends TestCase
         $userToken = new Persistence\User\UserTokenUpdateStruct();
         $userToken->userId = self::TEST_USER_ID;
         $userToken->hashKey = md5('hash');
-        $userToken->time = $time ?? (new \DateTime())->add(new \DateInterval('P1D'))->getTimestamp();
+        $userToken->time = $time ?? (new DateTime())->add(new DateInterval('P1D'))->getTimestamp();
 
         return $userToken;
     }
@@ -107,7 +110,7 @@ class UserHandlerTest extends TestCase
 
     public function testLoadUnknownUser()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
+        $this->expectException(NotFoundException::class);
         $gatewayMock = $this
             ->createMock(User\Gateway::class);
 
@@ -143,7 +146,7 @@ class UserHandlerTest extends TestCase
 
     public function testLoadUserByEmailNotFound()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
+        $this->expectException(NotFoundException::class);
 
         $handler = $this->getUserHandler();
         $user = $this->getValidUser();
@@ -173,7 +176,7 @@ class UserHandlerTest extends TestCase
 
     public function testLoadUserByTokenNotFound()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
+        $this->expectException(NotFoundException::class);
 
         $handler = $this->getUserHandler();
         $handler->updateUserToken($this->getValidUserToken());

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -88,7 +88,7 @@ class UserHandlerTest extends TestCase
     public function testLoadUser()
     {
         $gatewayMock = $this
-            ->createMock(User\Gateway\DoctrineDatabase::class);
+            ->createMock(User\Gateway::class);
 
         $gatewayMock
             ->method('load')
@@ -109,7 +109,7 @@ class UserHandlerTest extends TestCase
     {
         $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
         $gatewayMock = $this
-            ->createMock(User\Gateway\DoctrineDatabase::class);
+            ->createMock(User\Gateway::class);
 
         $gatewayMock
             ->method('load')
@@ -124,7 +124,7 @@ class UserHandlerTest extends TestCase
     public function testLoadUserByLogin()
     {
         $gatewayMock = $this
-            ->createMock(User\Gateway\DoctrineDatabase::class);
+            ->createMock(User\Gateway::class);
 
         $gatewayMock
             ->method('loadByLogin')
@@ -154,7 +154,7 @@ class UserHandlerTest extends TestCase
     public function testLoadUserByEmail()
     {
         $gatewayMock = $this
-            ->createMock(User\Gateway\DoctrineDatabase::class);
+            ->createMock(User\Gateway::class);
 
         $gatewayMock
             ->method('loadByEmail')
@@ -184,7 +184,7 @@ class UserHandlerTest extends TestCase
     public function testLoadUserByToken()
     {
         $gatewayMock = $this
-            ->createMock(User\Gateway\DoctrineDatabase::class);
+            ->createMock(User\Gateway::class);
 
         $userToken = $this->getValidUserToken();
         $gatewayMock

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -16,6 +16,7 @@ use eZ\Publish\Core\Persistence\Legacy\User;
 use eZ\Publish\Core\Persistence\Legacy\User\Role\LimitationConverter;
 use eZ\Publish\Core\Persistence\Legacy\User\Role\LimitationHandler\ObjectStateHandler as ObjectStateLimitationHandler;
 use eZ\Publish\SPI\Persistence;
+use eZ\Publish\SPI\Persistence\User\Handler as SPIHandler;
 use eZ\Publish\SPI\Persistence\User\Role;
 
 /**
@@ -25,12 +26,15 @@ class UserHandlerTest extends TestCase
 {
     private const TEST_USER_ID = 42;
 
-    protected function getUserHandler(User\Gateway $userGateway = null)
+    /**
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    protected function getUserHandler(User\Gateway $userGateway = null): SPIHandler
     {
         $dbHandler = $this->getDatabaseHandler();
 
         return new User\Handler(
-            $userGateway ?? new User\Gateway\DoctrineDatabase($dbHandler),
+            $userGateway ?? new User\Gateway\DoctrineDatabase($this->getDatabaseConnection()),
             new User\Role\Gateway\DoctrineDatabase($dbHandler),
             new User\Mapper(),
             new LimitationConverter([new ObjectStateLimitationHandler($dbHandler)])

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File contains: eZ\Publish\Core\Persistence\Legacy\Tests\User\UserHandlerTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the User Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway.php
@@ -16,76 +16,51 @@ use eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct;
 abstract class Gateway
 {
     /**
-     * Loads user with user ID.
-     *
-     * @param mixed $userId
-     *
-     * @return array
+     * Load a User by User ID.
      */
-    abstract public function load($userId);
+    abstract public function load(int $userId): array;
 
     /**
-     * Loads user with user login.
-     *
-     * @param string $login
-     *
-     * @return array
+     * Load a User by User login.
      */
-    abstract public function loadByLogin($login);
+    abstract public function loadByLogin(string $login): array;
 
     /**
-     * Loads user with user email.
-     *
-     * @param string $email
-     *
-     * @return array
+     * Load a User by User e-mail.
      */
-    abstract public function loadByEmail($email);
+    abstract public function loadByEmail(string $email): array;
 
     /**
-     * Loads user with user hash.
-     *
-     * @param string $hash
-     *
-     * @return array
+     * Load a User by User token.
      */
-    abstract public function loadUserByToken($hash);
+    abstract public function loadUserByToken(string $hash): array;
 
     /**
-     * Update the user acoount key specified by the user account key struct.
+     * Update a User token specified by UserTokenUpdateStruct.
      *
-     * @param \eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct $userTokenUpdateStruct
+     * @see \eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct
      */
-    abstract public function updateUserToken(UserTokenUpdateStruct $userTokenUpdateStruct);
+    abstract public function updateUserToken(UserTokenUpdateStruct $userTokenUpdateStruct): void;
 
     /**
-     * Expires user account key with user hash.
-     *
-     * @param string $hash
+     * Expire the given User token.
      */
-    abstract public function expireUserToken($hash);
+    abstract public function expireUserToken(string $hash): void;
 
     /**
-     * Assigns role to user with given limitation.
+     * Assign, with the given Limitation, a Role to a User.
      *
-     * @param mixed $contentId
-     * @param mixed $roleId
-     * @param array $limitation
+     * @param array $limitation a map of the Limitation identifiers to raw Limitation values.
      */
-    abstract public function assignRole($contentId, $roleId, array $limitation);
+    abstract public function assignRole(int $contentId, int $roleId, array $limitation): void;
 
     /**
-     * Remove role from user or user group.
-     *
-     * @param mixed $contentId
-     * @param mixed $roleId
+     * Remove a Role from User or User group.
      */
-    abstract public function removeRole($contentId, $roleId);
+    abstract public function removeRole(int $contentId, int $roleId): void;
 
     /**
-     * Remove role from user or user group, by assignment ID.
-     *
-     * @param mixed $roleAssignmentId
+     * Remove a Role from User or User group, by assignment ID.
      */
-    abstract public function removeRoleAssignmentById($roleAssignmentId);
+    abstract public function removeRoleAssignmentById(int $roleAssignmentId): void;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway.php
@@ -9,7 +9,9 @@ namespace eZ\Publish\Core\Persistence\Legacy\User;
 use eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct;
 
 /**
- * Base class for user gateways.
+ * User Gateway.
+ *
+ * @internal For internal use by Persistence Handlers.
  */
 abstract class Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\User;
 
 use eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct;

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway.php
@@ -6,7 +6,6 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\User;
 
-use eZ\Publish\SPI\Persistence\User;
 use eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct;
 
 /**

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
@@ -12,6 +12,10 @@ use eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct;
 
 /**
  * User gateway implementation using the Doctrine database.
+ *
+ * @internal Gateway implementation is considered internal. Use Persistence User Handler instead.
+ *
+ * @see \eZ\Publish\SPI\Persistence\User\Handler
  */
 final class DoctrineDatabase extends Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
@@ -6,9 +6,13 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\User\Gateway;
 
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Persistence\Legacy\User\Gateway;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct;
+use function time;
 
 /**
  * User gateway implementation using the Doctrine database.
@@ -55,35 +59,18 @@ final class DoctrineDatabase extends Gateway
      */
     public function load($userId)
     {
-        $query = $this->handler->createSelectQuery();
-        $query->select(
-            $this->handler->quoteColumn('contentobject_id', 'ezuser'),
-            $this->handler->quoteColumn('login', 'ezuser'),
-            $this->handler->quoteColumn('email', 'ezuser'),
-            $this->handler->quoteColumn('password_hash', 'ezuser'),
-            $this->handler->quoteColumn('password_hash_type', 'ezuser'),
-            $this->handler->quoteColumn('password_updated_at', 'ezuser'),
-            $this->handler->quoteColumn('is_enabled', 'ezuser_setting'),
-            $this->handler->quoteColumn('max_login', 'ezuser_setting')
-        )->from(
-            $this->handler->quoteTable('ezuser')
-        )->leftJoin(
-            $this->handler->quoteTable('ezuser_setting'),
-            $query->expr->eq(
-                $this->handler->quoteColumn('user_id', 'ezuser_setting'),
-                $this->handler->quoteColumn('contentobject_id', 'ezuser')
-            )
-        )->where(
-            $query->expr->eq(
-                $this->handler->quoteColumn('contentobject_id', 'ezuser'),
-                $query->bindValue($userId, null, \PDO::PARAM_INT)
-            )
-        );
+        $query = $this->getLoadUserQueryBuilder();
+        $query
+            ->where(
+                $query->expr()->eq(
+                    'u.contentobject_id',
+                    $query->createPositionalParameter($userId, ParameterType::INTEGER)
+                )
+            );
 
-        $statement = $query->prepare();
-        $statement->execute();
+        $statement = $query->execute();
 
-        return $statement->fetchAll(\PDO::FETCH_ASSOC);
+        return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
     /**
@@ -95,36 +82,21 @@ final class DoctrineDatabase extends Gateway
      */
     public function loadByLogin($login)
     {
-        $query = $this->handler->createSelectQuery();
-        $query->select(
-            $this->handler->quoteColumn('contentobject_id', 'ezuser'),
-            $this->handler->quoteColumn('login', 'ezuser'),
-            $this->handler->quoteColumn('email', 'ezuser'),
-            $this->handler->quoteColumn('password_hash', 'ezuser'),
-            $this->handler->quoteColumn('password_hash_type', 'ezuser'),
-            $this->handler->quoteColumn('password_updated_at', 'ezuser'),
-            $this->handler->quoteColumn('is_enabled', 'ezuser_setting'),
-            $this->handler->quoteColumn('max_login', 'ezuser_setting')
-        )->from(
-            $this->handler->quoteTable('ezuser')
-        )->leftJoin(
-            $this->handler->quoteTable('ezuser_setting'),
-            $query->expr->eq(
-                $this->handler->quoteColumn('user_id', 'ezuser_setting'),
-                $this->handler->quoteColumn('contentobject_id', 'ezuser')
-            )
-        )->where(
-            $query->expr->eq(
-                $query->expr->lower($this->handler->quoteColumn('login', 'ezuser')),
-                // Index is case in-sensitive, on some db's lowercase, so we lowercase $login
-                $query->bindValue(mb_strtolower($login, 'UTF-8'), null, \PDO::PARAM_STR)
-            )
-        );
+        $query = $this->getLoadUserQueryBuilder();
+        $expr = $query->expr();
+        $query
+            ->where(
+                $expr->eq(
+                    $this->dbPlatform->getLowerExpression('u.login'),
+                    // Index is case in-sensitive, on some db's lowercase, so we lowercase $login
+                    $query->createPositionalParameter(
+                        mb_strtolower($login, 'UTF-8'),
+                        ParameterType::STRING
+                    )
+                )
+            );
 
-        $statement = $query->prepare();
-        $statement->execute();
-
-        return $statement->fetchAll(\PDO::FETCH_ASSOC);
+        return $query->execute()->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
     /**
@@ -136,35 +108,17 @@ final class DoctrineDatabase extends Gateway
      */
     public function loadByEmail($email)
     {
-        $query = $this->handler->createSelectQuery();
-        $query->select(
-            $this->handler->quoteColumn('contentobject_id', 'ezuser'),
-            $this->handler->quoteColumn('login', 'ezuser'),
-            $this->handler->quoteColumn('email', 'ezuser'),
-            $this->handler->quoteColumn('password_hash', 'ezuser'),
-            $this->handler->quoteColumn('password_hash_type', 'ezuser'),
-            $this->handler->quoteColumn('password_updated_at', 'ezuser'),
-            $this->handler->quoteColumn('is_enabled', 'ezuser_setting'),
-            $this->handler->quoteColumn('max_login', 'ezuser_setting')
-        )->from(
-            $this->handler->quoteTable('ezuser')
-        )->leftJoin(
-            $this->handler->quoteTable('ezuser_setting'),
-            $query->expr->eq(
-                $this->handler->quoteColumn('user_id', 'ezuser_setting'),
-                $this->handler->quoteColumn('contentobject_id', 'ezuser')
-            )
-        )->where(
-            $query->expr->eq(
-                $this->handler->quoteColumn('email', 'ezuser'),
-                $query->bindValue($email, null, \PDO::PARAM_STR)
+        $query = $this->getLoadUserQueryBuilder();
+        $query->where(
+            $query->expr()->eq(
+                'u.email',
+                $query->createPositionalParameter($email, ParameterType::STRING)
             )
         );
 
-        $statement = $query->prepare();
-        $statement->execute();
+        $statement = $query->execute();
 
-        return $statement->fetchAll(\PDO::FETCH_ASSOC);
+        return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
     /**
@@ -176,47 +130,33 @@ final class DoctrineDatabase extends Gateway
      */
     public function loadUserByToken($hash)
     {
-        $query = $this->handler->createSelectQuery();
-        $query->select(
-            $this->handler->quoteColumn('contentobject_id', 'ezuser'),
-            $this->handler->quoteColumn('login', 'ezuser'),
-            $this->handler->quoteColumn('email', 'ezuser'),
-            $this->handler->quoteColumn('password_hash', 'ezuser'),
-            $this->handler->quoteColumn('password_hash_type', 'ezuser'),
-            $this->handler->quoteColumn('password_updated_at', 'ezuser'),
-            $this->handler->quoteColumn('is_enabled', 'ezuser_setting'),
-            $this->handler->quoteColumn('max_login', 'ezuser_setting')
-        )->from(
-            $this->handler->quoteTable('ezuser')
-        )->leftJoin(
-            $this->handler->quoteTable('ezuser_setting'),
-            $query->expr->eq(
-                $this->handler->quoteColumn('user_id', 'ezuser_setting'),
-                $this->handler->quoteColumn('contentobject_id', 'ezuser')
-            )
-        )->leftJoin(
-            $this->handler->quoteTable('ezuser_accountkey'),
-            $query->expr->eq(
-                $this->handler->quoteColumn('user_id', 'ezuser_accountkey'),
-                $this->handler->quoteColumn('contentobject_id', 'ezuser')
-            )
-        )->where(
-            $query->expr->lAnd(
-                $query->expr->eq(
-                    $this->handler->quoteColumn('hash_key', 'ezuser_accountkey'),
-                    $query->bindValue($hash, null, \PDO::PARAM_STR)
-                ),
-                $query->expr->gte(
-                    $this->handler->quoteColumn('time', 'ezuser_accountkey'),
-                    $query->bindValue(time(), null, \PDO::PARAM_INT)
+        $query = $this->getLoadUserQueryBuilder();
+        $query
+            ->leftJoin(
+                'u',
+                'ezuser_accountkey',
+                'token',
+                $query->expr()->eq(
+                    'token.user_id',
+                    'u.contentobject_id'
                 )
             )
-        );
+            ->where(
+                $query->expr()->eq(
+                    'token.hash_key',
+                    $query->createPositionalParameter($hash, ParameterType::STRING)
+                )
+            )
+            ->andWhere(
+                $query->expr()->gte(
+                    'token.time',
+                    $query->createPositionalParameter(time(), ParameterType::INTEGER)
+                )
+            );
 
-        $statement = $query->prepare();
-        $statement->execute();
+        $statement = $query->execute();
 
-        return $statement->fetchAll(\PDO::FETCH_ASSOC);
+        return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
     /**
@@ -226,54 +166,72 @@ final class DoctrineDatabase extends Gateway
      */
     public function updateUserToken(UserTokenUpdateStruct $userTokenUpdateStruct)
     {
-        $query = $this->handler->createSelectQuery();
+        $query = $this->connection->createQueryBuilder();
+        $expr = $query->expr();
         $query->select(
-            $this->handler->quoteColumn('id', 'ezuser_accountkey')
+            'token.id'
         )->from(
-            $this->handler->quoteTable('ezuser_accountkey')
+            'ezuser_accountkey', 'token'
         )->where(
-            $query->expr->eq(
-                $this->handler->quoteColumn('user_id', 'ezuser_accountkey'),
-                $query->bindValue($userTokenUpdateStruct->userId, null, \PDO::PARAM_INT)
+            $expr->eq(
+                'token.user_id',
+                $query->createPositionalParameter(
+                    $userTokenUpdateStruct->userId,
+                    ParameterType::INTEGER
+                )
             )
         );
 
-        $statement = $query->prepare();
-        $statement->execute();
+        $statement = $query->execute();
 
-        if (empty($statement->fetchAll(\PDO::FETCH_ASSOC))) {
-            $query = $this->handler->createInsertQuery();
+        if (empty($statement->fetchAll(FetchMode::ASSOCIATIVE))) {
+            $query = $this->connection->createQueryBuilder();
             $query
-                ->insertInto($this->handler->quoteTable('ezuser_accountkey'))
-                ->set(
-                    $this->handler->quoteColumn('hash_key'),
-                    $query->bindValue($userTokenUpdateStruct->hashKey)
-                )->set(
-                    $this->handler->quoteColumn('time'),
-                    $query->bindValue($userTokenUpdateStruct->time)
-                )->set(
-                    $this->handler->quoteColumn('user_id'),
-                    $query->bindValue($userTokenUpdateStruct->userId)
+                ->insert('ezuser_accountkey')
+                ->values(
+                    [
+                        'hash_key' => $query->createPositionalParameter(
+                            $userTokenUpdateStruct->hashKey,
+                            ParameterType::STRING
+                        ),
+                        'time' => $query->createPositionalParameter(
+                            $userTokenUpdateStruct->time,
+                            ParameterType::INTEGER
+                        ),
+                        'user_id' => $query->createPositionalParameter(
+                            $userTokenUpdateStruct->userId,
+                            ParameterType::INTEGER
+                        ),
+                    ]
                 );
 
-            $query->prepare()->execute();
+            $query->execute();
         } else {
-            $query = $this->handler->createUpdateQuery();
+            $query = $this->connection->createQueryBuilder();
             $query
-                ->update($this->handler->quoteTable('ezuser_accountkey'))
+                ->update('ezuser_accountkey')
                 ->set(
-                    $this->handler->quoteColumn('hash_key'),
-                    $query->bindValue($userTokenUpdateStruct->hashKey)
+                    'hash_key',
+                    $query->createPositionalParameter(
+                        $userTokenUpdateStruct->hashKey,
+                        ParameterType::STRING
+                    )
                 )->set(
-                    $this->handler->quoteColumn('time'),
-                    $query->bindValue($userTokenUpdateStruct->time)
+                    'time',
+                    $query->createPositionalParameter(
+                        $userTokenUpdateStruct->time,
+                        ParameterType::INTEGER
+                    )
                 )->where(
-                    $query->expr->eq(
-                        $this->handler->quoteColumn('user_id'),
-                        $query->bindValue($userTokenUpdateStruct->userId, null, \PDO::PARAM_INT)
+                    $expr->eq(
+                        'user_id',
+                        $query->createPositionalParameter(
+                            $userTokenUpdateStruct->userId,
+                            ParameterType::INTEGER
+                        )
                     )
                 );
-            $query->prepare()->execute();
+            $query->execute();
         }
     }
 
@@ -284,19 +242,19 @@ final class DoctrineDatabase extends Gateway
      */
     public function expireUserToken($hash)
     {
-        $query = $this->handler->createUpdateQuery();
+        $query = $this->connection->createQueryBuilder();
         $query
-            ->update($this->handler->quoteTable('ezuser_accountkey'))
+            ->update('ezuser_accountkey')
             ->set(
-                $this->handler->quoteColumn('time'),
-                $query->bindValue(0)
+                'time',
+                $query->createPositionalParameter(0, ParameterType::INTEGER)
             )->where(
-                $query->expr->eq(
-                    $this->handler->quoteColumn('hash_key'),
-                    $query->bindValue($hash, null, \PDO::PARAM_STR)
+                $query->expr()->eq(
+                    'hash_key',
+                    $query->createPositionalParameter($hash, ParameterType::STRING)
                 )
             );
-        $query->prepare()->execute();
+        $query->execute();
     }
 
     /**
@@ -310,23 +268,30 @@ final class DoctrineDatabase extends Gateway
     {
         foreach ($limitation as $identifier => $values) {
             foreach ($values as $value) {
-                $query = $this->handler->createInsertQuery();
+                $query = $this->connection->createQueryBuilder();
                 $query
-                    ->insertInto($this->handler->quoteTable('ezuser_role'))
-                    ->set(
-                        $this->handler->quoteColumn('contentobject_id'),
-                        $query->bindValue($contentId, null, \PDO::PARAM_INT)
-                    )->set(
-                        $this->handler->quoteColumn('role_id'),
-                        $query->bindValue($roleId, null, \PDO::PARAM_INT)
-                    )->set(
-                        $this->handler->quoteColumn('limit_identifier'),
-                        $query->bindValue($identifier)
-                    )->set(
-                        $this->handler->quoteColumn('limit_value'),
-                        $query->bindValue($value)
+                    ->insert('ezuser_role')
+                    ->values(
+                        [
+                            'contentobject_id' => $query->createPositionalParameter(
+                                $contentId,
+                                ParameterType::INTEGER
+                            ),
+                            'role_id' => $query->createPositionalParameter(
+                                $roleId,
+                                ParameterType::INTEGER
+                            ),
+                            'limit_identifier' => $query->createPositionalParameter(
+                                $identifier,
+                                ParameterType::STRING
+                            ),
+                            'limit_value' => $query->createPositionalParameter(
+                                $value,
+                                ParameterType::STRING
+                            ),
+                        ]
                     );
-                $query->prepare()->execute();
+                $query->execute();
             }
         }
     }
@@ -339,22 +304,23 @@ final class DoctrineDatabase extends Gateway
      */
     public function removeRole($contentId, $roleId)
     {
-        $query = $this->handler->createDeleteQuery();
+        $query = $this->connection->createQueryBuilder();
+        $expr = $query->expr();
         $query
-            ->deleteFrom($this->handler->quoteTable('ezuser_role'))
+            ->delete('ezuser_role')
             ->where(
-                $query->expr->lAnd(
-                    $query->expr->eq(
-                        $this->handler->quoteColumn('contentobject_id'),
-                        $query->bindValue($contentId, null, \PDO::PARAM_INT)
-                    ),
-                    $query->expr->eq(
-                        $this->handler->quoteColumn('role_id'),
-                        $query->bindValue($roleId, null, \PDO::PARAM_INT)
-                    )
+                $expr->eq(
+                    'contentobject_id',
+                    $query->createPositionalParameter($contentId, ParameterType::INTEGER)
+                )
+            )
+            ->andWhere(
+                $expr->eq(
+                    'role_id',
+                    $query->createPositionalParameter($roleId, ParameterType::INTEGER)
                 )
             );
-        $query->prepare()->execute();
+        $query->execute();
     }
 
     /**
@@ -364,15 +330,44 @@ final class DoctrineDatabase extends Gateway
      */
     public function removeRoleAssignmentById($roleAssignmentId)
     {
-        $query = $this->handler->createDeleteQuery();
+        $query = $this->connection->createQueryBuilder();
         $query
-            ->deleteFrom($this->handler->quoteTable('ezuser_role'))
+            ->delete('ezuser_role')
             ->where(
-                $query->expr->eq(
-                    $this->handler->quoteColumn('id'),
-                    $query->bindValue($roleAssignmentId, null, \PDO::PARAM_INT)
+                $query->expr()->eq(
+                    'id',
+                    $query->createPositionalParameter($roleAssignmentId, ParameterType::INTEGER)
                 )
             );
-        $query->prepare()->execute();
+        $query->execute();
+    }
+
+    private function getLoadUserQueryBuilder(): QueryBuilder
+    {
+        $query = $this->connection->createQueryBuilder();
+        $expr = $query->expr();
+        $query
+            ->select(
+                'u.contentobject_id',
+                'u.login',
+                'u.email',
+                'u.password_hash',
+                'u.password_hash_type',
+                'u.password_updated_at',
+                's.is_enabled',
+                's.max_login'
+            )
+            ->from('ezuser', 'u')
+            ->leftJoin(
+                'u',
+                'ezuser_setting',
+                's',
+                $expr->eq(
+                    's.user_id',
+                    'u.contentobject_id'
+                )
+            );
+
+        return $query;
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
@@ -38,14 +38,7 @@ final class DoctrineDatabase extends Gateway
         $this->dbPlatform = $this->connection->getDatabasePlatform();
     }
 
-    /**
-     * Loads user with user ID.
-     *
-     * @param mixed $userId
-     *
-     * @return array
-     */
-    public function load($userId)
+    public function load(int $userId): array
     {
         $query = $this->getLoadUserQueryBuilder();
         $query
@@ -61,14 +54,7 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads user with user login.
-     *
-     * @param string $login
-     *
-     * @return array
-     */
-    public function loadByLogin($login)
+    public function loadByLogin(string $login): array
     {
         $query = $this->getLoadUserQueryBuilder();
         $expr = $query->expr();
@@ -87,14 +73,7 @@ final class DoctrineDatabase extends Gateway
         return $query->execute()->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads user with user email.
-     *
-     * @param string $email
-     *
-     * @return array
-     */
-    public function loadByEmail($email)
+    public function loadByEmail(string $email): array
     {
         $query = $this->getLoadUserQueryBuilder();
         $query->where(
@@ -109,14 +88,7 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads a user with user hash key.
-     *
-     * @param string $hash
-     *
-     * @return array
-     */
-    public function loadUserByToken($hash)
+    public function loadUserByToken(string $hash): array
     {
         $query = $this->getLoadUserQueryBuilder();
         $query
@@ -147,12 +119,7 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Update or insert the user token information specified by the user token struct.
-     *
-     * @param \eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct $userTokenUpdateStruct
-     */
-    public function updateUserToken(UserTokenUpdateStruct $userTokenUpdateStruct)
+    public function updateUserToken(UserTokenUpdateStruct $userTokenUpdateStruct): void
     {
         $query = $this->connection->createQueryBuilder();
         if (false === $this->userHasToken($userTokenUpdateStruct->userId)) {
@@ -180,12 +147,7 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Expires user token with user hash.
-     *
-     * @param string $hash
-     */
-    public function expireUserToken($hash)
+    public function expireUserToken(string $hash): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -202,14 +164,7 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Assigns role to user with given limitation.
-     *
-     * @param mixed $contentId
-     * @param mixed $roleId
-     * @param array $limitation
-     */
-    public function assignRole($contentId, $roleId, array $limitation)
+    public function assignRole(int $contentId, int $roleId, array $limitation): void
     {
         foreach ($limitation as $identifier => $values) {
             foreach ($values as $value) {
@@ -241,13 +196,7 @@ final class DoctrineDatabase extends Gateway
         }
     }
 
-    /**
-     * Remove role from user or user group.
-     *
-     * @param mixed $contentId
-     * @param mixed $roleId
-     */
-    public function removeRole($contentId, $roleId)
+    public function removeRole(int $contentId, int $roleId): void
     {
         $query = $this->connection->createQueryBuilder();
         $expr = $query->expr();
@@ -268,12 +217,7 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Remove role from user or user group, by assignment ID.
-     *
-     * @param mixed $roleAssignmentId
-     */
-    public function removeRoleAssignmentById($roleAssignmentId)
+    public function removeRoleAssignmentById(int $roleAssignmentId): void
     {
         $query = $this->connection->createQueryBuilder();
         $query

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
@@ -6,11 +6,11 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\User\Gateway;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Persistence\Legacy\User\Gateway;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct;
 use function time;
 
@@ -23,13 +23,6 @@ use function time;
  */
 final class DoctrineDatabase extends Gateway
 {
-    /**
-     * Database handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     */
-    private $handler;
-
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
@@ -37,16 +30,11 @@ final class DoctrineDatabase extends Gateway
     private $dbPlatform;
 
     /**
-     * Construct from database handler.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $handler
-     *
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function __construct(DatabaseHandler $handler)
+    public function __construct(Connection $connection)
     {
-        $this->handler = $handler;
-        $this->connection = $handler->getConnection();
+        $this->connection = $connection;
         $this->dbPlatform = $this->connection->getDatabasePlatform();
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
@@ -8,7 +8,6 @@ namespace eZ\Publish\Core\Persistence\Legacy\User\Gateway;
 
 use eZ\Publish\Core\Persistence\Legacy\User\Gateway;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
-use eZ\Publish\SPI\Persistence\User;
 use eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct;
 
 /**

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
@@ -26,14 +26,24 @@ final class DoctrineDatabase extends Gateway
      */
     private $handler;
 
+    /** @var \Doctrine\DBAL\Connection */
+    private $connection;
+
+    /** @var \Doctrine\DBAL\Platforms\AbstractPlatform */
+    private $dbPlatform;
+
     /**
      * Construct from database handler.
      *
      * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $handler
+     *
+     * @throws \Doctrine\DBAL\DBALException
      */
     public function __construct(DatabaseHandler $handler)
     {
         $this->handler = $handler;
+        $this->connection = $handler->getConnection();
+        $this->dbPlatform = $this->connection->getDatabasePlatform();
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
@@ -13,14 +13,14 @@ use eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct;
 /**
  * User gateway implementation using the Doctrine database.
  */
-class DoctrineDatabase extends Gateway
+final class DoctrineDatabase extends Gateway
 {
     /**
      * Database handler.
      *
      * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
-    protected $handler;
+    private $handler;
 
     /**
      * Construct from database handler.

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase Location Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\User\Gateway;
 
 use Doctrine\DBAL\Connection;

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the User Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
@@ -6,11 +6,11 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\User\Gateway;
 
+use eZ\Publish\Core\Base\Exceptions\DatabaseException;
 use eZ\Publish\Core\Persistence\Legacy\User\Gateway;
 use Doctrine\DBAL\DBALException;
 use eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct;
 use PDOException;
-use RuntimeException;
 
 /**
  * @internal Internal exception conversion layer.
@@ -45,10 +45,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->load($userId);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -63,10 +61,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->loadByLogin($login);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -81,10 +77,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->loadByEmail($email);
-        } catch (\DBALException $e) {
-            throw new \RuntimeException('Database error', 0, $e);
-        } catch (\PDOException $e) {
-            throw new \RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -99,10 +93,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->loadUserByToken($hash);
-        } catch (DBALException $e) {
-            throw new \RuntimeException('Database error', 0, $e);
-        } catch (\PDOException $e) {
-            throw new \RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -115,10 +107,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->updateUserToken($userTokenUpdateStruct);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -131,10 +121,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->expireUserToken($hash);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -149,10 +137,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->assignRole($contentId, $roleId, $limitation);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -166,10 +152,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->removeRole($contentId, $roleId);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -182,10 +166,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->removeRoleAssignmentById($roleAssignmentId);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
@@ -13,7 +13,7 @@ use PDOException;
 use RuntimeException;
 
 /**
- * Base class for user gateways.
+ * @internal Internal exception conversion layer.
  */
 final class ExceptionConversion extends Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
@@ -15,14 +15,14 @@ use RuntimeException;
 /**
  * Base class for user gateways.
  */
-class ExceptionConversion extends Gateway
+final class ExceptionConversion extends Gateway
 {
     /**
      * The wrapped gateway.
      *
      * @var Gateway
      */
-    protected $innerGateway;
+    private $innerGateway;
 
     /**
      * Creates a new exception conversion gateway around $innerGateway.

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
@@ -7,7 +7,6 @@
 namespace eZ\Publish\Core\Persistence\Legacy\User\Gateway;
 
 use eZ\Publish\Core\Persistence\Legacy\User\Gateway;
-use eZ\Publish\SPI\Persistence\User;
 use Doctrine\DBAL\DBALException;
 use eZ\Publish\SPI\Persistence\User\UserTokenUpdateStruct;
 use PDOException;

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\User\Gateway;
 
 use eZ\Publish\Core\Base\Exceptions\DatabaseException;

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
@@ -20,12 +20,12 @@ final class ExceptionConversion extends Gateway
     /**
      * The wrapped gateway.
      *
-     * @var Gateway
+     * @var \eZ\Publish\Core\Persistence\Legacy\User\Gateway
      */
     private $innerGateway;
 
     /**
-     * Creates a new exception conversion gateway around $innerGateway.
+     * Create a new exception conversion gateway around $innerGateway.
      *
      * @param Gateway $innerGateway
      */
@@ -34,14 +34,7 @@ final class ExceptionConversion extends Gateway
         $this->innerGateway = $innerGateway;
     }
 
-    /**
-     * Loads user with user ID.
-     *
-     * @param mixed $userId
-     *
-     * @return array
-     */
-    public function load($userId)
+    public function load(int $userId): array
     {
         try {
             return $this->innerGateway->load($userId);
@@ -50,14 +43,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Loads user with user login.
-     *
-     * @param string $login
-     *
-     * @return array
-     */
-    public function loadByLogin($login)
+    public function loadByLogin(string $login): array
     {
         try {
             return $this->innerGateway->loadByLogin($login);
@@ -66,14 +52,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Loads user with user email.
-     *
-     * @param string $email
-     *
-     * @return array
-     */
-    public function loadByEmail($email)
+    public function loadByEmail(string $email): array
     {
         try {
             return $this->innerGateway->loadByEmail($email);
@@ -82,14 +61,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Loads a user with user hash key.
-     *
-     * @param string $hash
-     *
-     * @return array
-     */
-    public function loadUserByToken($hash)
+    public function loadUserByToken(string $hash): array
     {
         try {
             return $this->innerGateway->loadUserByToken($hash);
@@ -98,74 +70,46 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Update the user token information specified by the user token struct.
-     *
-     * @param UserTokenUpdateStruct $userTokenUpdateStruct
-     */
-    public function updateUserToken(UserTokenUpdateStruct $userTokenUpdateStruct)
+    public function updateUserToken(UserTokenUpdateStruct $userTokenUpdateStruct): void
     {
         try {
-            return $this->innerGateway->updateUserToken($userTokenUpdateStruct);
+            $this->innerGateway->updateUserToken($userTokenUpdateStruct);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    /**
-     * Expires user token with user hash.
-     *
-     * @param string $hash
-     */
-    public function expireUserToken($hash)
+    public function expireUserToken(string $hash): void
     {
         try {
-            return $this->innerGateway->expireUserToken($hash);
+            $this->innerGateway->expireUserToken($hash);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    /**
-     * Assigns role to user with given limitation.
-     *
-     * @param mixed $contentId
-     * @param mixed $roleId
-     * @param array $limitation
-     */
-    public function assignRole($contentId, $roleId, array $limitation)
+    public function assignRole(int $contentId, int $roleId, array $limitation): void
     {
         try {
-            return $this->innerGateway->assignRole($contentId, $roleId, $limitation);
+            $this->innerGateway->assignRole($contentId, $roleId, $limitation);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    /**
-     * Remove role from user or user group.
-     *
-     * @param mixed $contentId
-     * @param mixed $roleId
-     */
-    public function removeRole($contentId, $roleId)
+    public function removeRole(int $contentId, int $roleId): void
     {
         try {
-            return $this->innerGateway->removeRole($contentId, $roleId);
+            $this->innerGateway->removeRole($contentId, $roleId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    /**
-     * Remove role from user or user group, by assignment ID.
-     *
-     * @param mixed $roleAssignmentId
-     */
-    public function removeRoleAssignmentById($roleAssignmentId)
+    public function removeRoleAssignmentById(int $roleAssignmentId): void
     {
         try {
-            return $this->innerGateway->removeRoleAssignmentById($roleAssignmentId);
+            $this->innerGateway->removeRoleAssignmentById($roleAssignmentId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }

--- a/eZ/Publish/Core/settings/storage_engines/legacy/user.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/user.yml
@@ -2,7 +2,7 @@ services:
     ezpublish.persistence.legacy.user.gateway.inner:
         class: eZ\Publish\Core\Persistence\Legacy\User\Gateway\DoctrineDatabase
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - '@ezpublish.api.storage_engine.legacy.connection'
 
     ezpublish.persistence.legacy.user.gateway.exception_conversion:
         class: eZ\Publish\Core\Persistence\Legacy\User\Gateway\ExceptionConversion


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31088](https://jira.ez.no/browse/EZP-31088) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR refactors the Legacy Storage Content Model **`User`** gateway implementation (`\eZ\Publish\Core\Persistence\Legacy\User\Gateway\DoctrineDatabase`) to rely on `\Doctrine\DBAL\Connection` and `QueryBuilder` instead of our custom Database Handler from legacy Zeta Components.

**TODO**:
- [x] Refactor Legacy Storage Content Model User gateway to rely on `\Doctrine\DBAL` `Connection` and `QueryBuilder`.
- [x] Refactor gateway implementation for better readability
- [x] Drop DatabaseHandler from gateway implementation constructor.
- [x] Align tests.
- [x] Align CS
- [x] Introduce strict types
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Enforce strict types.
- [x] Wait for Travis.
- [x] Ask for Code Review.
