### PR TITLE
EZP-31088: Refactored User Role GW to use Doctrine\DBAL 

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/Role/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/Role/Gateway/DoctrineDatabaseTest.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\User\Role\Gateway;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
@@ -24,6 +26,8 @@ class DoctrineDatabaseTest extends TestCase
 
     /**
      * Inserts DB fixture.
+     *
+     * @throws \Exception
      */
     protected function setUp(): void
     {
@@ -36,8 +40,10 @@ class DoctrineDatabaseTest extends TestCase
 
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\DoctrineDatabase::createRole
+     *
+     * @throws \Doctrine\DBAL\DBALException
      */
-    public function testCreateRole()
+    public function testCreateRole(): void
     {
         $gateway = $this->getDatabaseGateway();
 
@@ -65,8 +71,10 @@ class DoctrineDatabaseTest extends TestCase
 
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\DoctrineDatabase::loadRoleAssignment
+     *
+     * @throws \Doctrine\DBAL\DBALException
      */
-    public function testLoadRoleAssignment()
+    public function testLoadRoleAssignment(): void
     {
         $gateway = $this->getDatabaseGateway();
 
@@ -86,8 +94,10 @@ class DoctrineDatabaseTest extends TestCase
 
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\DoctrineDatabase::loadRoleAssignmentsByGroupId
+     *
+     * @throws \Doctrine\DBAL\DBALException
      */
-    public function testLoadRoleAssignmentsByGroupId()
+    public function testLoadRoleAssignmentsByGroupId(): void
     {
         $gateway = $this->getDatabaseGateway();
 
@@ -121,8 +131,10 @@ class DoctrineDatabaseTest extends TestCase
 
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\DoctrineDatabase::loadRoleAssignmentsByRoleId
+     *
+     * @throws \Doctrine\DBAL\DBALException
      */
-    public function testLoadRoleAssignmentsByRoleId()
+    public function testLoadRoleAssignmentsByRoleId(): void
     {
         $gateway = $this->getDatabaseGateway();
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/Role/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/Role/Gateway/DoctrineDatabaseTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File contains: eZ\Publish\Core\Persistence\Legacy\Tests\User\Role\Gateway\DoctrineDatabaseTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -160,12 +158,14 @@ class DoctrineDatabaseTest extends TestCase
      * Returns a ready to test DoctrineDatabase gateway.
      *
      * @return \eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\DoctrineDatabase
+     *
+     * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getDatabaseGateway()
+    protected function getDatabaseGateway(): DoctrineDatabase
     {
         if (!isset($this->databaseGateway)) {
             $this->databaseGateway = new DoctrineDatabase(
-                $this->getDatabaseHandler()
+                $this->getDatabaseConnection()
             );
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -334,7 +334,7 @@ class UserHandlerTest extends TestCase
 
         $roleDraft = $handler->createRole($createStruct);
 
-        $this->assertSame('1', $roleDraft->id);
+        $this->assertSame(1, $roleDraft->id);
     }
 
     public function testLoadRole()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -16,7 +16,7 @@ use eZ\Publish\Core\Persistence\Legacy\User;
 use eZ\Publish\Core\Persistence\Legacy\User\Role\LimitationConverter;
 use eZ\Publish\Core\Persistence\Legacy\User\Role\LimitationHandler\ObjectStateHandler as ObjectStateLimitationHandler;
 use eZ\Publish\SPI\Persistence;
-use eZ\Publish\SPI\Persistence\User\Handler as SPIHandler;
+use eZ\Publish\SPI\Persistence\User\Handler;
 use eZ\Publish\SPI\Persistence\User\Role;
 
 /**
@@ -29,13 +29,13 @@ class UserHandlerTest extends TestCase
     /**
      * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getUserHandler(User\Gateway $userGateway = null): SPIHandler
+    protected function getUserHandler(User\Gateway $userGateway = null): Handler
     {
         $dbHandler = $this->getDatabaseHandler();
 
         return new User\Handler(
             $userGateway ?? new User\Gateway\DoctrineDatabase($this->getDatabaseConnection()),
-            new User\Role\Gateway\DoctrineDatabase($dbHandler),
+            new User\Role\Gateway\DoctrineDatabase($this->getDatabaseConnection()),
             new User\Mapper(),
             new LimitationConverter([new ObjectStateLimitationHandler($dbHandler)])
         );

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
@@ -17,6 +17,10 @@ use eZ\Publish\SPI\Persistence\User\Role;
  */
 abstract class Gateway
 {
+    public const ROLE_SEQ = 'ezrole_id_seq';
+    public const POLICY_SEQ = 'ezpolicy_id_seq';
+    public const POLICY_LIMITATION_SEQ = 'ezpolicy_limitation_id_seq';
+
     /**
      * Create new role.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
@@ -22,153 +22,122 @@ abstract class Gateway
     public const POLICY_LIMITATION_SEQ = 'ezpolicy_limitation_id_seq';
 
     /**
-     * Create new role.
-     *
-     * @param Role $role
-     *
-     * @return Role
+     * Create a new role.
      */
-    abstract public function createRole(Role $role);
+    abstract public function createRole(Role $role): Role;
 
     /**
-     * Loads a specified role by $roleId.
-     *
-     * @param mixed $roleId
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     *
-     * @return array
-     */
-    abstract public function loadRole($roleId, $status = Role::STATUS_DEFINED);
-
-    /**
-     * Loads a specified role by $identifier.
-     *
-     * @param string $identifier
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     *
-     * @return array
-     */
-    abstract public function loadRoleByIdentifier($identifier, $status = Role::STATUS_DEFINED);
-
-    /**
-     * Loads a role draft by the original role ID.
-     *
-     * @param mixed $roleId ID of the role the draft was created from.
-     *
-     * @return array
-     */
-    abstract public function loadRoleDraftByRoleId($roleId);
-
-    /**
-     * Loads all roles.
+     * Load a specified role by $roleId.
      *
      * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      *
      * @return array
      */
-    abstract public function loadRoles($status = Role::STATUS_DEFINED);
+    abstract public function loadRole(int $roleId, int $status = Role::STATUS_DEFINED): array;
 
     /**
-     * Loads all roles associated with the given content objects.
+     * Load a specified role by $identifier.
      *
-     * @param array $contentIds
      * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     */
+    abstract public function loadRoleByIdentifier(
+        string $identifier,
+        int $status = Role::STATUS_DEFINED
+    ): array;
+
+    /**
+     * Load a role draft by the original role ID.
+     *
+     * @param int $roleId ID of the role the draft was created from.
+     */
+    abstract public function loadRoleDraftByRoleId(int $roleId): array;
+
+    /**
+     * Load all roles.
+     *
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     */
+    abstract public function loadRoles(int $status = Role::STATUS_DEFINED): array;
+
+    /**
+     * Load all roles associated with the given Content items.
+     *
+     * @param int[] $contentIds
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     */
+    abstract public function loadRolesForContentObjects(
+        array $contentIds,
+        int $status = Role::STATUS_DEFINED
+    ): array;
+
+    /**
+     * Load a role assignment for specified assignment ID.
+     */
+    abstract public function loadRoleAssignment(int $roleAssignmentId): array;
+
+    /**
+     * Load role assignment for specified User Group Content ID.
+     */
+    abstract public function loadRoleAssignmentsByGroupId(
+        int $groupId,
+        bool $inherited = false
+    ): array;
+
+    /**
+     * Load a Role assignments for given Role ID.
+     */
+    abstract public function loadRoleAssignmentsByRoleId(int $roleId): array;
+
+    /**
+     * Return User Policies data associated with User.
      *
      * @return array
      */
-    abstract public function loadRolesForContentObjects($contentIds, $status = Role::STATUS_DEFINED);
-
-    /**
-     * Loads role assignment for specified assignment ID.
-     *
-     * @param mixed $roleAssignmentId
-     *
-     * @return array
-     */
-    abstract public function loadRoleAssignment($roleAssignmentId);
-
-    /**
-     * Loads role assignments for specified content ID.
-     *
-     * @param mixed $groupId
-     * @param bool $inherited
-     *
-     * @return array
-     */
-    abstract public function loadRoleAssignmentsByGroupId($groupId, $inherited = false);
-
-    /**
-     * Loads role assignments for given role ID.
-     *
-     * @param mixed $roleId
-     *
-     * @return array
-     */
-    abstract public function loadRoleAssignmentsByRoleId($roleId);
-
-    /**
-     * Returns the user policies associated with the user.
-     *
-     * @param mixed $userId
-     *
-     * @return UserPolicy[]
-     */
-    abstract public function loadPoliciesByUserId($userId);
+    abstract public function loadPoliciesByUserId(int $userId): array;
 
     /**
      * Update role (draft).
      *
      * Will not throw anything if location id is invalid.
-     *
-     * @param RoleUpdateStruct $role
      */
-    abstract public function updateRole(RoleUpdateStruct $role);
+    abstract public function updateRole(RoleUpdateStruct $role): void;
 
     /**
      * Delete the specified role (draft).
      * If it's not a draft, the role assignments will also be deleted.
      *
-     * @param mixed $roleId
      * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    abstract public function deleteRole($roleId, $status = Role::STATUS_DEFINED);
+    abstract public function deleteRole(int $roleId, int $status = Role::STATUS_DEFINED): void;
 
     /**
      * Publish the specified role draft.
      * If the draft was created from an existing role, published version will take the original role ID.
      *
-     * @param mixed $roleDraftId
-     * @param mixed|null $originalRoleId ID of role the draft was created from. Will be null if the role draft was completely new.
+     * @param int|null $originalRoleId ID of role the draft was created from. Will be null
+     *                                 if the role draft was completely new.
      */
-    abstract public function publishRoleDraft($roleDraftId, $originalRoleId = null);
+    abstract public function publishRoleDraft(int $roleDraftId, ?int $originalRoleId = null): void;
 
     /**
-     * Adds a policy to a role.
-     *
-     * @param mixed $roleId
-     * @param Policy $policy
+     * Add a Policy to Role.
      */
-    abstract public function addPolicy($roleId, Policy $policy);
+    abstract public function addPolicy(int $roleId, Policy $policy): Policy;
 
     /**
-     * Adds limitations to an existing policy.
+     * Add Limitations to an existing Policy.
      *
-     * @param int $policyId
-     * @param array $limitations
+     * @param array $limitations a map of Limitation identifiers to their raw values
      */
-    abstract public function addPolicyLimitations($policyId, array $limitations);
+    abstract public function addPolicyLimitations(int $policyId, array $limitations): void;
 
     /**
-     * Removes a policy from a role.
-     *
-     * @param mixed $policyId
+     * Remove a Policy from Role.
      */
-    abstract public function removePolicy($policyId);
+    abstract public function removePolicy(int $policyId): void;
 
     /**
-     * Removes a policy from a role.
-     *
-     * @param mixed $policyId
+     * Remove a Policy from Role.
      */
-    abstract public function removePolicyLimitations($policyId);
+    abstract public function removePolicyLimitations(int $policyId): void;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
@@ -11,7 +11,9 @@ use eZ\Publish\SPI\Persistence\User\Policy;
 use eZ\Publish\SPI\Persistence\User\Role;
 
 /**
- * Base class for content type gateways.
+ * User Role Gateway.
+ *
+ * @internal For internal use by Persistence Handlers.
  */
 abstract class Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\User\Role;
 
 use eZ\Publish\SPI\Persistence\User\RoleUpdateStruct;

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
@@ -19,6 +19,12 @@ use eZ\Publish\SPI\Persistence\User\Role;
  */
 abstract class Gateway
 {
+    public const ROLE_TABLE = 'ezrole';
+    public const POLICY_TABLE = 'ezpolicy';
+    public const POLICY_LIMITATION_TABLE = 'ezpolicy_limitation';
+    public const POLICY_LIMITATION_VALUE_TABLE = 'ezpolicy_limitation_value';
+    public const USER_ROLE_TABLE = 'ezuser_role';
+
     public const ROLE_SEQ = 'ezrole_id_seq';
     public const POLICY_SEQ = 'ezpolicy_id_seq';
     public const POLICY_LIMITATION_SEQ = 'ezpolicy_limitation_id_seq';

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the ContentTypeGateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -28,14 +28,22 @@ final class DoctrineDatabase extends Gateway
      */
     private $handler;
 
+    /** @var \Doctrine\DBAL\Connection */
+    private $connection;
+
+    /** @var \Doctrine\DBAL\Platforms\AbstractPlatform */
+    private $dbPlatform;
+
     /**
      * Construct from database handler.
      *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $handler
+     * @throws \Doctrine\DBAL\DBALException
      */
     public function __construct(DatabaseHandler $handler)
     {
         $this->handler = $handler;
+        $this->connection = $handler->getConnection();
+        $this->dbPlatform = $this->connection->getDatabasePlatform();
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -68,9 +68,8 @@ final class DoctrineDatabase extends Gateway
                         ParameterType::STRING
                     ),
                     'value' => $query->createPositionalParameter(0, ParameterType::INTEGER),
+                    // BC: "version" stores originalId when creating a draft from an existing role
                     'version' => $query->createPositionalParameter(
-                    // Column name "version" is misleading here as it stores originalId when creating a draft from an existing role.
-                    // But hey, this is legacy! :-)
                         $roleOriginalId,
                         ParameterType::STRING
                     ),
@@ -151,11 +150,10 @@ final class DoctrineDatabase extends Gateway
     public function loadRoleDraftByRoleId(int $roleId): array
     {
         $query = $this->getLoadRoleQueryBuilder();
+        // BC: "version" stores originalId when creating a draft from an existing role
         $query
             ->where(
                 $query->expr()->eq(
-                // Column name "version" is misleading as it stores originalId when creating a draft from an existing role.
-                // But hey, this is legacy! :-)
                     'r.version',
                     $query->createPositionalParameter($roleId, ParameterType::STRING)
                 )
@@ -202,8 +200,8 @@ final class DoctrineDatabase extends Gateway
                 'urs',
                 self::ROLE_TABLE,
                 'r',
+                // BC: for drafts the "version" column contains the original role ID
                 $expr->eq(
-                // for drafts the "version" column contains the original role ID...
                     $status === Role::STATUS_DEFINED ? 'r.id' : 'r.version',
                     'urs.role_id'
                 )

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase User Role Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -59,7 +59,7 @@ final class DoctrineDatabase extends Gateway
 
         $query = $this->connection->createQueryBuilder();
         $query
-            ->insert('ezrole')
+            ->insert(self::ROLE_TABLE)
             ->values(
                 [
                     'is_new' => $query->createPositionalParameter(0, ParameterType::INTEGER),
@@ -102,10 +102,10 @@ final class DoctrineDatabase extends Gateway
                 'l.identifier AS ezpolicy_limitation_identifier',
                 'v.value AS ezpolicy_limitation_value_value'
             )
-            ->from('ezrole', 'r')
-            ->leftJoin('r', 'ezpolicy', 'p', 'p.role_id = r.id')
-            ->leftJoin('p', 'ezpolicy_limitation', 'l', 'l.policy_id = p.id')
-            ->leftJoin('l', 'ezpolicy_limitation_value', 'v', 'v.limitation_id = l.id');
+            ->from(self::ROLE_TABLE, 'r')
+            ->leftJoin('r', self::POLICY_TABLE, 'p', 'p.role_id = r.id')
+            ->leftJoin('p', self::POLICY_LIMITATION_TABLE, 'l', 'l.policy_id = p.id')
+            ->leftJoin('l', self::POLICY_LIMITATION_VALUE_TABLE, 'v', 'v.limitation_id = l.id');
 
         return $query;
     }
@@ -197,10 +197,10 @@ final class DoctrineDatabase extends Gateway
                 'l.identifier AS ezpolicy_limitation_identifier',
                 'v.value AS ezpolicy_limitation_value_value'
             )
-            ->from('ezuser_role', 'urs')
+            ->from(self::USER_ROLE_TABLE, 'urs')
             ->leftJoin(
                 'urs',
-                'ezrole',
+                self::ROLE_TABLE,
                 'r',
                 $expr->eq(
                 // for drafts the "version" column contains the original role ID...
@@ -208,10 +208,10 @@ final class DoctrineDatabase extends Gateway
                     'urs.role_id'
                 )
             )
-            ->leftJoin('r', 'ezuser_role', 'ur', 'ur.role_id = r.id')
-            ->leftJoin('r', 'ezpolicy', 'p', 'p.role_id = r.id')
-            ->leftJoin('p', 'ezpolicy_limitation', 'l', 'l.policy_id = p.id')
-            ->leftJoin('l', 'ezpolicy_limitation_value', 'v', 'v.limitation_id = l.id')
+            ->leftJoin('r', self::USER_ROLE_TABLE, 'ur', 'ur.role_id = r.id')
+            ->leftJoin('r', self::POLICY_TABLE, 'p', 'p.role_id = r.id')
+            ->leftJoin('p', self::POLICY_LIMITATION_TABLE, 'l', 'l.policy_id = p.id')
+            ->leftJoin('l', self::POLICY_LIMITATION_VALUE_TABLE, 'v', 'v.limitation_id = l.id')
             ->where(
                 $expr->in(
                     'urs.contentobject_id',
@@ -232,7 +232,7 @@ final class DoctrineDatabase extends Gateway
             'limit_value',
             'role_id'
         )->from(
-            'ezuser_role'
+            self::USER_ROLE_TABLE
         )->where(
             $query->expr()->eq(
                 'id',
@@ -255,7 +255,7 @@ final class DoctrineDatabase extends Gateway
             'limit_value',
             'role_id'
         )->from(
-            'ezuser_role'
+            self::USER_ROLE_TABLE
         );
 
         if ($inherited) {
@@ -291,7 +291,7 @@ final class DoctrineDatabase extends Gateway
             'limit_value',
             'role_id'
         )->from(
-            'ezuser_role'
+            self::USER_ROLE_TABLE
         )->where(
             $query->expr()->eq(
                 'role_id',
@@ -352,7 +352,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->update('ezrole')
+            ->update(self::ROLE_TABLE)
             ->set(
                 'name',
                 $query->createPositionalParameter($role->identifier, ParameterType::STRING)
@@ -371,7 +371,7 @@ final class DoctrineDatabase extends Gateway
         $query = $this->connection->createQueryBuilder();
         $expr = $query->expr();
         $query
-            ->delete('ezrole')
+            ->delete(self::ROLE_TABLE)
             ->where(
                 $expr->eq(
                     'id',
@@ -379,7 +379,7 @@ final class DoctrineDatabase extends Gateway
                 )
             )
             ->andWhere(
-                $this->buildRoleDraftQueryConstraint($status, $query, 'ezrole')
+                $this->buildRoleDraftQueryConstraint($status, $query, self::ROLE_TABLE)
             );
 
         if ($status !== Role::STATUS_DRAFT) {
@@ -398,7 +398,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->insert('ezpolicy')
+            ->insert(self::POLICY_TABLE)
             ->values(
                 [
                     'function_name' => $query->createPositionalParameter(
@@ -436,7 +436,7 @@ final class DoctrineDatabase extends Gateway
         foreach ($limitations as $identifier => $values) {
             $query = $this->connection->createQueryBuilder();
             $query
-                ->insert('ezpolicy_limitation')
+                ->insert(self::POLICY_LIMITATION_TABLE)
                 ->values(
                     [
                         'identifier' => $query->createPositionalParameter(
@@ -456,7 +456,7 @@ final class DoctrineDatabase extends Gateway
             foreach ($values as $value) {
                 $query = $this->connection->createQueryBuilder();
                 $query
-                    ->insert('ezpolicy_limitation_value')
+                    ->insert(self::POLICY_LIMITATION_VALUE_TABLE)
                     ->values(
                         [
                             'value' => $query->createPositionalParameter(
@@ -480,7 +480,7 @@ final class DoctrineDatabase extends Gateway
 
         $query = $this->connection->createQueryBuilder();
         $query
-            ->delete('ezpolicy')
+            ->delete(self::POLICY_TABLE)
             ->where(
                 $query->expr()->eq(
                     'id',
@@ -497,7 +497,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->delete('ezpolicy_limitation')
+            ->delete(self::POLICY_LIMITATION_TABLE)
             ->where(
                 $query->expr()->in(
                     'id',
@@ -517,7 +517,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->delete('ezpolicy_limitation_value')
+            ->delete(self::POLICY_LIMITATION_VALUE_TABLE)
             ->where(
                 $query->expr()->in(
                     'id',
@@ -538,9 +538,9 @@ final class DoctrineDatabase extends Gateway
                 'l.id AS ezpolicy_limitation_id',
                 'v.id AS ezpolicy_limitation_value_id'
             )
-            ->from('ezpolicy', 'p')
-            ->leftJoin('p', 'ezpolicy_limitation', 'l', 'l.policy_id = p.id')
-            ->leftJoin('l', 'ezpolicy_limitation_value', 'v', 'v.limitation_id = l.id')
+            ->from(self::POLICY_TABLE, 'p')
+            ->leftJoin('p', self::POLICY_LIMITATION_TABLE, 'l', 'l.policy_id = p.id')
+            ->leftJoin('l', self::POLICY_LIMITATION_VALUE_TABLE, 'v', 'v.limitation_id = l.id')
             ->where(
                 $query->expr()->eq(
                     'p.id',
@@ -580,7 +580,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->delete('ezuser_role')
+            ->delete(self::USER_ROLE_TABLE)
             ->where(
                 $query->expr()->eq(
                     'role_id',
@@ -652,7 +652,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->update('ezrole')
+            ->update(self::ROLE_TABLE)
             ->set(
                 'version',
                 $query->createPositionalParameter(Role::STATUS_DEFINED, ParameterType::INTEGER)
@@ -678,7 +678,7 @@ final class DoctrineDatabase extends Gateway
     {
         $policyQuery = $this->connection->createQueryBuilder();
         $policyQuery
-            ->update('ezpolicy')
+            ->update(self::POLICY_TABLE)
             ->set(
                 'original_id',
                 $policyQuery->createPositionalParameter(0, ParameterType::INTEGER)

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -14,6 +14,10 @@ use eZ\Publish\SPI\Persistence\User\Role;
 
 /**
  * User Role gateway implementation using the Doctrine database.
+ *
+ * @internal Gateway implementation is considered internal. Use Persistence User Handler instead.
+ *
+ * @see \eZ\Publish\SPI\Persistence\User\Handler
  */
 class DoctrineDatabase extends Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway;
 
 use Doctrine\DBAL\Connection;

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\User\Policy;
 use eZ\Publish\SPI\Persistence\User\RoleUpdateStruct;
 use eZ\Publish\SPI\Persistence\User\Role;
@@ -25,13 +24,6 @@ use eZ\Publish\SPI\Persistence\User\Role;
  */
 final class DoctrineDatabase extends Gateway
 {
-    /**
-     * Database handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     */
-    private $handler;
-
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
@@ -43,10 +35,9 @@ final class DoctrineDatabase extends Gateway
      *
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function __construct(DatabaseHandler $handler)
+    public function __construct(Connection $connection)
     {
-        $this->handler = $handler;
-        $this->connection = $handler->getConnection();
+        $this->connection = $connection;
         $this->dbPlatform = $this->connection->getDatabasePlatform();
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -41,14 +41,7 @@ final class DoctrineDatabase extends Gateway
         $this->dbPlatform = $this->connection->getDatabasePlatform();
     }
 
-    /**
-     * Create new role.
-     *
-     * @param \eZ\Publish\SPI\Persistence\User\Role $role
-     *
-     * @return Role
-     */
-    public function createRole(Role $role)
+    public function createRole(Role $role): Role
     {
         // Role original ID is set when creating a draft from an existing role
         if ($role->status === Role::STATUS_DRAFT && $role->id) {
@@ -115,15 +108,7 @@ final class DoctrineDatabase extends Gateway
         return $query;
     }
 
-    /**
-     * Loads a specified role by id.
-     *
-     * @param mixed $roleId
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     *
-     * @return array
-     */
-    public function loadRole($roleId, $status = Role::STATUS_DEFINED)
+    public function loadRole(int $roleId, int $status = Role::STATUS_DEFINED): array
     {
         $query = $this->getLoadRoleQueryBuilder();
         $query
@@ -140,16 +125,10 @@ final class DoctrineDatabase extends Gateway
         return $query->execute()->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads a specified role by $identifier.
-     *
-     * @param string $identifier
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     *
-     * @return array
-     */
-    public function loadRoleByIdentifier($identifier, $status = Role::STATUS_DEFINED)
-    {
+    public function loadRoleByIdentifier(
+        string $identifier,
+        int $status = Role::STATUS_DEFINED
+    ): array {
         $query = $this->getLoadRoleQueryBuilder();
         $query
             ->where(
@@ -167,14 +146,7 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads a role draft by the original role ID.
-     *
-     * @param mixed $roleId ID of the role the draft was created from.
-     *
-     * @return array
-     */
-    public function loadRoleDraftByRoleId($roleId)
+    public function loadRoleDraftByRoleId(int $roleId): array
     {
         $query = $this->getLoadRoleQueryBuilder();
         $query
@@ -192,14 +164,7 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads all roles.
-     *
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     *
-     * @return array
-     */
-    public function loadRoles($status = Role::STATUS_DEFINED)
+    public function loadRoles(int $status = Role::STATUS_DEFINED): array
     {
         $query = $this->getLoadRoleQueryBuilder();
         $query->where(
@@ -211,16 +176,10 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads all roles associated with the given content objects.
-     *
-     * @param array $contentIds
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     *
-     * @return array
-     */
-    public function loadRolesForContentObjects($contentIds, $status = Role::STATUS_DEFINED)
-    {
+    public function loadRolesForContentObjects(
+        array $contentIds,
+        int $status = Role::STATUS_DEFINED
+    ): array {
         $query = $this->connection->createQueryBuilder();
         $expr = $query->expr();
         $query
@@ -261,14 +220,7 @@ final class DoctrineDatabase extends Gateway
         return $query->execute()->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads role assignment for specified assignment ID.
-     *
-     * @param mixed $roleAssignmentId
-     *
-     * @return array
-     */
-    public function loadRoleAssignment($roleAssignmentId)
+    public function loadRoleAssignment(int $roleAssignmentId): array
     {
         $query = $this->connection->createQueryBuilder();
         $query->select(
@@ -291,15 +243,7 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads role assignments for specified content ID.
-     *
-     * @param mixed $groupId
-     * @param bool $inherited
-     *
-     * @return array
-     */
-    public function loadRoleAssignmentsByGroupId($groupId, $inherited = false)
+    public function loadRoleAssignmentsByGroupId(int $groupId, bool $inherited = false): array
     {
         $query = $this->connection->createQueryBuilder();
         $query->select(
@@ -335,14 +279,7 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads role assignments for given role ID.
-     *
-     * @param mixed $roleId
-     *
-     * @return array
-     */
-    public function loadRoleAssignmentsByRoleId($roleId)
+    public function loadRoleAssignmentsByRoleId(int $roleId): array
     {
         $query = $this->connection->createQueryBuilder();
         $query->select(
@@ -365,14 +302,7 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Returns the user policies associated with the user.
-     *
-     * @param mixed $userId
-     *
-     * @return UserPolicy[]
-     */
-    public function loadPoliciesByUserId($userId)
+    public function loadPoliciesByUserId(int $userId): array
     {
         $groupIds = $this->fetchUserGroups($userId);
         $groupIds[] = $userId;
@@ -391,7 +321,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return array
      */
-    private function fetchUserGroups($userId)
+    private function fetchUserGroups(int $userId): array
     {
         $nodeIDs = $this->getAncestorLocationIdsForUser($userId);
 
@@ -416,16 +346,7 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchAll(FetchMode::COLUMN);
     }
 
-    /**
-     * Update role (draft).
-     *
-     * Will not throw anything if location id is invalid.
-     *
-     * @param \eZ\Publish\SPI\Persistence\User\RoleUpdateStruct $role
-     *
-     * @return array
-     */
-    public function updateRole(RoleUpdateStruct $role)
+    public function updateRole(RoleUpdateStruct $role): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -443,14 +364,7 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Delete the specified role (draft).
-     * If it's not a draft, the role assignments will also be deleted.
-     *
-     * @param mixed $roleId
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     */
-    public function deleteRole($roleId, $status = Role::STATUS_DEFINED)
+    public function deleteRole(int $roleId, int $status = Role::STATUS_DEFINED): void
     {
         $query = $this->connection->createQueryBuilder();
         $expr = $query->expr();
@@ -472,28 +386,13 @@ final class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * Publish the specified role draft.
-     * If the draft was created from an existing role, published version will take the original role ID.
-     *
-     * @param mixed $roleDraftId
-     * @param mixed|null $originalRoleId ID of role the draft was created from. Will be null if the role draft was completely new.
-     */
-    public function publishRoleDraft($roleDraftId, $originalRoleId = null)
+    public function publishRoleDraft(int $roleDraftId, ?int $originalRoleId = null): void
     {
         $this->markRoleAsPublished($roleDraftId, $originalRoleId);
         $this->publishRolePolicies($roleDraftId, $originalRoleId);
     }
 
-    /**
-     * Adds a policy to a role.
-     *
-     * @param mixed $roleId
-     * @param \eZ\Publish\SPI\Persistence\User\Policy $policy
-     *
-     * @return Policy
-     */
-    public function addPolicy($roleId, Policy $policy)
+    public function addPolicy(int $roleId, Policy $policy): Policy
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -530,13 +429,7 @@ final class DoctrineDatabase extends Gateway
         return $policy;
     }
 
-    /**
-     * Adds limitations to an existing policy.
-     *
-     * @param int $policyId
-     * @param array $limitations
-     */
-    public function addPolicyLimitations($policyId, array $limitations)
+    public function addPolicyLimitations(int $policyId, array $limitations): void
     {
         foreach ($limitations as $identifier => $values) {
             $query = $this->connection->createQueryBuilder();
@@ -579,12 +472,7 @@ final class DoctrineDatabase extends Gateway
         }
     }
 
-    /**
-     * Removes a policy from a role.
-     *
-     * @param mixed $policyId
-     */
-    public function removePolicy($policyId)
+    public function removePolicy(int $policyId): void
     {
         $this->removePolicyLimitations($policyId);
 
@@ -661,12 +549,7 @@ final class DoctrineDatabase extends Gateway
         return $query->execute()->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Remove all limitations for a policy.
-     *
-     * @param mixed $policyId
-     */
-    public function removePolicyLimitations($policyId)
+    public function removePolicyLimitations(int $policyId): void
     {
         $limitationValues = $this->loadPolicyLimitationValues($policyId);
 

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -19,14 +19,14 @@ use eZ\Publish\SPI\Persistence\User\Role;
  *
  * @see \eZ\Publish\SPI\Persistence\User\Handler
  */
-class DoctrineDatabase extends Gateway
+final class DoctrineDatabase extends Gateway
 {
     /**
      * Database handler.
      *
      * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
-    protected $handler;
+    private $handler;
 
     /**
      * Construct from database handler.
@@ -563,7 +563,7 @@ class DoctrineDatabase extends Gateway
      *
      * @return array
      */
-    protected function fetchUserGroups($userId)
+    private function fetchUserGroups($userId)
     {
         $query = $this->handler->createSelectQuery();
         $query->select(

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway;
 
 use eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway;
 
+use eZ\Publish\Core\Base\Exceptions\DatabaseException;
 use eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway;
 use eZ\Publish\SPI\Persistence\User\Policy;
 use eZ\Publish\SPI\Persistence\User\RoleUpdateStruct;
 use eZ\Publish\SPI\Persistence\User\Role;
 use Doctrine\DBAL\DBALException;
 use PDOException;
-use RuntimeException;
 
 /**
  * @internal Internal exception conversion layer.
@@ -42,10 +42,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->createRole($role);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -53,10 +51,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->loadRole($roleId, $status);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -66,10 +62,8 @@ final class ExceptionConversion extends Gateway
     ): array {
         try {
             return $this->innerGateway->loadRoleByIdentifier($identifier, $status);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -77,10 +71,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->loadRoleDraftByRoleId($roleId);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -88,10 +80,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->loadRoles();
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -101,10 +91,8 @@ final class ExceptionConversion extends Gateway
     ): array {
         try {
             return $this->innerGateway->loadRolesForContentObjects($contentIds);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -112,10 +100,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->loadRoleAssignment($roleAssignmentId);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -123,10 +109,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->loadRoleAssignmentsByGroupId($groupId, $inherited);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -134,10 +118,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->loadRoleAssignmentsByRoleId($roleId);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -145,10 +127,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->loadPoliciesByUserId($userId);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -156,10 +136,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             $this->innerGateway->updateRole($role);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -167,10 +145,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             $this->innerGateway->deleteRole($roleId, $status);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -178,10 +154,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             $this->innerGateway->publishRoleDraft($roleDraftId, $originalRoleId);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -189,10 +163,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             return $this->innerGateway->addPolicy($roleId, $policy);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -200,10 +172,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             $this->innerGateway->addPolicyLimitations($policyId, $limitations);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -211,10 +181,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             $this->innerGateway->removePolicy($policyId);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 
@@ -222,10 +190,8 @@ final class ExceptionConversion extends Gateway
     {
         try {
             $this->innerGateway->removePolicyLimitations($policyId);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
@@ -15,7 +15,7 @@ use PDOException;
 use RuntimeException;
 
 /**
- * Base class for content type gateways.
+ * @internal Internal exception conversion layer.
  */
 class ExceptionConversion extends Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
@@ -17,14 +17,14 @@ use RuntimeException;
 /**
  * @internal Internal exception conversion layer.
  */
-class ExceptionConversion extends Gateway
+final class ExceptionConversion extends Gateway
 {
     /**
      * The wrapped gateway.
      *
      * @var Gateway
      */
-    protected $innerGateway;
+    private $innerGateway;
 
     /**
      * Creates a new exception conversion gateway around $innerGateway.

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the ContentTypeGateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
@@ -36,14 +36,7 @@ final class ExceptionConversion extends Gateway
         $this->innerGateway = $innerGateway;
     }
 
-    /**
-     * Create new role.
-     *
-     * @param Role $role
-     *
-     * @return Role
-     */
-    public function createRole(Role $role)
+    public function createRole(Role $role): Role
     {
         try {
             return $this->innerGateway->createRole($role);
@@ -54,15 +47,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Loads a specified role by $roleId.
-     *
-     * @param mixed $roleId
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     *
-     * @return array
-     */
-    public function loadRole($roleId, $status = Role::STATUS_DEFINED)
+    public function loadRole(int $roleId, int $status = Role::STATUS_DEFINED): array
     {
         try {
             return $this->innerGateway->loadRole($roleId, $status);
@@ -73,16 +58,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Loads a specified role by $identifier.
-     *
-     * @param string $identifier
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     *
-     * @return array
-     */
-    public function loadRoleByIdentifier($identifier, $status = Role::STATUS_DEFINED)
-    {
+    public function loadRoleByIdentifier(
+        string $identifier,
+        int $status = Role::STATUS_DEFINED
+    ): array {
         try {
             return $this->innerGateway->loadRoleByIdentifier($identifier, $status);
         } catch (DBALException $e) {
@@ -92,14 +71,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Loads a role draft by the original role ID.
-     *
-     * @param mixed $roleId ID of the role the draft was created from.
-     *
-     * @return array
-     */
-    public function loadRoleDraftByRoleId($roleId)
+    public function loadRoleDraftByRoleId(int $roleId): array
     {
         try {
             return $this->innerGateway->loadRoleDraftByRoleId($roleId);
@@ -110,14 +82,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Loads all roles.
-     *
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     *
-     * @return array
-     */
-    public function loadRoles($status = Role::STATUS_DEFINED)
+    public function loadRoles(int $status = Role::STATUS_DEFINED): array
     {
         try {
             return $this->innerGateway->loadRoles();
@@ -128,16 +93,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Loads all roles associated with the given content objects.
-     *
-     * @param array $contentIds
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     *
-     * @return array
-     */
-    public function loadRolesForContentObjects($contentIds, $status = Role::STATUS_DEFINED)
-    {
+    public function loadRolesForContentObjects(
+        array $contentIds,
+        int $status = Role::STATUS_DEFINED
+    ): array {
         try {
             return $this->innerGateway->loadRolesForContentObjects($contentIds);
         } catch (DBALException $e) {
@@ -147,14 +106,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Loads role assignment for specified assignment ID.
-     *
-     * @param mixed $roleAssignmentId
-     *
-     * @return array
-     */
-    public function loadRoleAssignment($roleAssignmentId)
+    public function loadRoleAssignment(int $roleAssignmentId): array
     {
         try {
             return $this->innerGateway->loadRoleAssignment($roleAssignmentId);
@@ -165,15 +117,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Loads role assignments for specified content ID.
-     *
-     * @param mixed $groupId
-     * @param bool $inherited
-     *
-     * @return array
-     */
-    public function loadRoleAssignmentsByGroupId($groupId, $inherited = false)
+    public function loadRoleAssignmentsByGroupId(int $groupId, bool $inherited = false): array
     {
         try {
             return $this->innerGateway->loadRoleAssignmentsByGroupId($groupId, $inherited);
@@ -184,14 +128,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Loads role assignments for given role ID.
-     *
-     * @param mixed $roleId
-     *
-     * @return array
-     */
-    public function loadRoleAssignmentsByRoleId($roleId)
+    public function loadRoleAssignmentsByRoleId(int $roleId): array
     {
         try {
             return $this->innerGateway->loadRoleAssignmentsByRoleId($roleId);
@@ -202,14 +139,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Returns the user policies associated with the user.
-     *
-     * @param mixed $userId
-     *
-     * @return UserPolicy[]
-     */
-    public function loadPoliciesByUserId($userId)
+    public function loadPoliciesByUserId(int $userId): array
     {
         try {
             return $this->innerGateway->loadPoliciesByUserId($userId);
@@ -220,17 +150,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Update role (draft).
-     *
-     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException
-     *
-     * @param RoleUpdateStruct $role
-     */
-    public function updateRole(RoleUpdateStruct $role)
+    public function updateRole(RoleUpdateStruct $role): void
     {
         try {
-            return $this->innerGateway->updateRole($role);
+            $this->innerGateway->updateRole($role);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -238,17 +161,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Delete the specified role (draft).
-     * If it's not a draft, the role assignments will also be deleted.
-     *
-     * @param mixed $roleId
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     */
-    public function deleteRole($roleId, $status = Role::STATUS_DEFINED)
+    public function deleteRole(int $roleId, int $status = Role::STATUS_DEFINED): void
     {
         try {
-            return $this->innerGateway->deleteRole($roleId, $status);
+            $this->innerGateway->deleteRole($roleId, $status);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -256,17 +172,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Publish the specified role draft.
-     * If the draft was created from an existing role, published version will take the original role ID.
-     *
-     * @param mixed $roleDraftId
-     * @param mixed|null $originalRoleId ID of role the draft was created from. Will be null if the role draft was completely new.
-     */
-    public function publishRoleDraft($roleDraftId, $originalRoleId = null)
+    public function publishRoleDraft(int $roleDraftId, ?int $originalRoleId = null): void
     {
         try {
-            return $this->innerGateway->publishRoleDraft($roleDraftId, $originalRoleId);
+            $this->innerGateway->publishRoleDraft($roleDraftId, $originalRoleId);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -274,13 +183,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Adds a policy to a role.
-     *
-     * @param mixed $roleId
-     * @param Policy $policy
-     */
-    public function addPolicy($roleId, Policy $policy)
+    public function addPolicy(int $roleId, Policy $policy): Policy
     {
         try {
             return $this->innerGateway->addPolicy($roleId, $policy);
@@ -291,16 +194,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Adds limitations to an existing policy.
-     *
-     * @param int $policyId
-     * @param array $limitations
-     */
-    public function addPolicyLimitations($policyId, array $limitations)
+    public function addPolicyLimitations(int $policyId, array $limitations): void
     {
         try {
-            return $this->innerGateway->addPolicyLimitations($policyId, $limitations);
+            $this->innerGateway->addPolicyLimitations($policyId, $limitations);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -308,15 +205,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Removes a policy from a role.
-     *
-     * @param mixed $policyId
-     */
-    public function removePolicy($policyId)
+    public function removePolicy(int $policyId): void
     {
         try {
-            return $this->innerGateway->removePolicy($policyId);
+            $this->innerGateway->removePolicy($policyId);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -324,15 +216,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Removes a policy from a role.
-     *
-     * @param mixed $policyId
-     */
-    public function removePolicyLimitations($policyId)
+    public function removePolicyLimitations(int $policyId): void
     {
         try {
-            return $this->innerGateway->removePolicyLimitations($policyId);
+            $this->innerGateway->removePolicyLimitations($policyId);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {

--- a/eZ/Publish/Core/settings/storage_engines/legacy/user.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/user.yml
@@ -16,7 +16,7 @@ services:
     ezpublish.persistence.legacy.role.gateway.inner:
         class: eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\DoctrineDatabase
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - '@ezpublish.api.storage_engine.legacy.connection'
 
     ezpublish.persistence.legacy.role.gateway.exception_conversion:
         class: eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\ExceptionConversion


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31088](https://jira.ez.no/browse/EZP-31088) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR refactors the Legacy Storage Content Model `User` **`Role`** gateway implementation (`\eZ\Publish\Core\Persistence\Legacy\User\Role\Gateway\DoctrineDatabase`) to rely on `\Doctrine\DBAL\Connection` and `QueryBuilder` instead of our custom Database Handler from legacy Zeta Components.

**TODO**:
- [x] Align `Role` gateway class files headers with eZ Platform Code Style.
- [x] Mark `Role` gateway classes as `@internal`.
- [x] Mark Role gateway implementations as `final`.
- [x] Set Doctrine Connection and Database Platform in `Role` `DoctrineDatabase` implementation.
- [x] Refactor Role GW to rely on Doctrine\DBAL Connection and QueryBuilder
- [x] Refactor removePolicyLimitations method for better readability
- [x] Replace DatabaseHandler with Doctrine Connection in User Role GW impl.
- [x] Introduce strict types and align CS of Role gateway classes methods and `DoctrineDatabaseTest`
- [x] Enforce strict types on the above classes.
- [x] Align exception conversion layer with the latest convention (`throw DatabaseException::wrap`).
- [x] Replace Role `DoctrineDatabase` literal table references with `Gateway` constants.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Wait for Travis.
- [x] Ask for Code Review.
