### PR TITLE
EZP-31088: Refactored UrlWildcard GW to use Doctrine\DBAL

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
@@ -17,6 +17,7 @@ use eZ\Publish\SPI\Persistence\Content\UrlWildcard;
  */
 abstract class Gateway
 {
+    public const URL_WILDCARD_TABLE = 'ezurlwildcard';
     public const URL_WILDCARD_SEQ = 'ezurlwildcard_id_seq';
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
@@ -12,6 +12,8 @@ use eZ\Publish\SPI\Persistence\Content\UrlWildcard;
 
 /**
  * UrlWildcard Gateway.
+ *
+ * @internal For internal use by Persistence Handlers.
  */
 abstract class Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
@@ -17,6 +17,8 @@ use eZ\Publish\SPI\Persistence\Content\UrlWildcard;
  */
 abstract class Gateway
 {
+    public const URL_WILDCARD_SEQ = 'ezurlwildcard_id_seq';
+
     /**
      * Inserts the given UrlWildcard.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
@@ -6,6 +6,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard;
 
 use eZ\Publish\SPI\Persistence\Content\UrlWildcard;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the UrlWildcard Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -23,46 +21,27 @@ abstract class Gateway
     public const URL_WILDCARD_SEQ = 'ezurlwildcard_id_seq';
 
     /**
-     * Inserts the given UrlWildcard.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\UrlWildcard $urlWildcard
-     *
-     * @return mixed UrlWildcard id
+     * Insert the given UrlWildcard.
      */
     abstract public function insertUrlWildcard(UrlWildcard $urlWildcard): int;
 
     /**
-     * Deletes the UrlWildcard with given $id.
-     *
-     * @param mixed $id
+     * Delete the UrlWildcard with given $id.
      */
     abstract public function deleteUrlWildcard(int $id): void;
 
     /**
-     * Loads an array with data about UrlWildcard with $id.
-     *
-     * @param mixed $id
-     *
-     * @return array
+     * Load an array with data about UrlWildcard with $id.
      */
     abstract public function loadUrlWildcardData(int $id): array;
 
     /**
-     * Loads an array with data about UrlWildcards (paged).
-     *
-     * @param mixed $offset
-     * @param mixed $limit
-     *
-     * @return array
+     * Load an array with data about UrlWildcards (paged).
      */
     abstract public function loadUrlWildcardsData(int $offset = 0, int $limit = -1): array;
 
     /**
-     * Loads the UrlWildcard by source url $sourceUrl.
-     *
-     * @param string $sourceUrl
-     *
-     * @return array
+     * Load the UrlWildcard by source url $sourceUrl.
      */
     abstract public function loadUrlWildcardBySourceUrl(string $sourceUrl): array;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
@@ -27,14 +27,14 @@ abstract class Gateway
      *
      * @return mixed UrlWildcard id
      */
-    abstract public function insertUrlWildcard(UrlWildcard $urlWildcard);
+    abstract public function insertUrlWildcard(UrlWildcard $urlWildcard): int;
 
     /**
      * Deletes the UrlWildcard with given $id.
      *
      * @param mixed $id
      */
-    abstract public function deleteUrlWildcard($id);
+    abstract public function deleteUrlWildcard(int $id): void;
 
     /**
      * Loads an array with data about UrlWildcard with $id.
@@ -43,7 +43,7 @@ abstract class Gateway
      *
      * @return array
      */
-    abstract public function loadUrlWildcardData($id);
+    abstract public function loadUrlWildcardData(int $id): array;
 
     /**
      * Loads an array with data about UrlWildcards (paged).
@@ -53,7 +53,7 @@ abstract class Gateway
      *
      * @return array
      */
-    abstract public function loadUrlWildcardsData($offset = 0, $limit = -1);
+    abstract public function loadUrlWildcardsData(int $offset = 0, int $limit = -1): array;
 
     /**
      * Loads the UrlWildcard by source url $sourceUrl.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
@@ -9,6 +9,8 @@
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway;
 
 use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\UrlWildcard;
@@ -59,41 +61,29 @@ final class DoctrineDatabase extends Gateway
      */
     public function insertUrlWildcard(UrlWildcard $urlWildcard)
     {
-        /** @var $query \eZ\Publish\Core\Persistence\Database\InsertQuery */
-        $query = $this->dbHandler->createInsertQuery();
-        $query->insertInto(
-            $this->dbHandler->quoteTable('ezurlwildcard')
-        )->set(
-            $this->dbHandler->quoteColumn('destination_url'),
-            $query->bindValue(
-                trim($urlWildcard->destinationUrl, '/ '),
-                null,
-                \PDO::PARAM_STR
-            )
-        )->set(
-            $this->dbHandler->quoteColumn('id'),
-            $this->dbHandler->getAutoIncrementValue('ezurlwildcard', 'id')
-        )->set(
-            $this->dbHandler->quoteColumn('source_url'),
-            $query->bindValue(
-                trim($urlWildcard->sourceUrl, '/ '),
-                null,
-                \PDO::PARAM_STR
-            )
-        )->set(
-            $this->dbHandler->quoteColumn('type'),
-            $query->bindValue(
-                $urlWildcard->forward ? 1 : 2,
-                null,
-                \PDO::PARAM_INT
-            )
-        );
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->insert('ezurlwildcard')
+            ->values(
+                [
+                    'destination_url' => $query->createPositionalParameter(
+                        trim($urlWildcard->destinationUrl, '/ '),
+                        ParameterType::STRING
+                    ),
+                    'source_url' => $query->createPositionalParameter(
+                        trim($urlWildcard->sourceUrl, '/ '),
+                        ParameterType::STRING
+                    ),
+                    'type' => $query->createPositionalParameter(
+                        $urlWildcard->forward ? 1 : 2,
+                        ParameterType::INTEGER
+                    ),
+                ]
+            );
 
-        $query->prepare()->execute();
+        $query->execute();
 
-        return (int)$this->dbHandler->lastInsertId(
-            $this->dbHandler->getSequenceName('ezurlwildcard', 'id')
-        );
+        return (int)$this->connection->lastInsertId(self::URL_WILDCARD_SEQ);
     }
 
     /**
@@ -103,17 +93,26 @@ final class DoctrineDatabase extends Gateway
      */
     public function deleteUrlWildcard($id)
     {
-        /** @var $query \eZ\Publish\Core\Persistence\Database\DeleteQuery */
-        $query = $this->dbHandler->createDeleteQuery();
-        $query->deleteFrom(
-            $this->dbHandler->quoteTable('ezurlwildcard')
-        )->where(
-            $query->expr->eq(
-                $this->dbHandler->quoteColumn('id'),
-                $query->bindValue($id, null, \PDO::PARAM_INT)
-            )
-        );
-        $query->prepare()->execute();
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->delete('ezurlwildcard')
+            ->where(
+                $query->expr()->eq(
+                    'id',
+                    $query->createPositionalParameter($id, ParameterType::INTEGER)
+                )
+            );
+        $query->execute();
+    }
+
+    private function buildLoadUrlWildcardDataQuery(): QueryBuilder
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select('id', 'destination_url', 'source_url', 'type')
+            ->from('ezurlwildcard');
+
+        return $query;
     }
 
     /**
@@ -125,22 +124,17 @@ final class DoctrineDatabase extends Gateway
      */
     public function loadUrlWildcardData($id)
     {
-        /** @var $query \eZ\Publish\Core\Persistence\Database\SelectQuery */
-        $query = $this->dbHandler->createSelectQuery();
-        $query->select(
-            '*'
-        )->from(
-            $this->dbHandler->quoteTable('ezurlwildcard')
-        )->where(
-            $query->expr->eq(
-                $this->dbHandler->quoteColumn('id'),
-                $query->bindValue($id, null, \PDO::PARAM_INT)
-            )
-        );
-        $stmt = $query->prepare();
-        $stmt->execute();
+        $query = $this->buildLoadUrlWildcardDataQuery();
+        $query
+            ->where(
+                $query->expr()->eq(
+                    'id',
+                    $query->createPositionalParameter($id, ParameterType::INTEGER)
+                )
+            );
+        $result = $query->execute()->fetch(FetchMode::ASSOCIATIVE);
 
-        return $stmt->fetch(\PDO::FETCH_ASSOC);
+        return false !== $result ? $result : [];
     }
 
     /**
@@ -153,23 +147,14 @@ final class DoctrineDatabase extends Gateway
      */
     public function loadUrlWildcardsData($offset = 0, $limit = -1)
     {
-        $limit = $limit === -1 ? self::MAX_LIMIT : $limit;
+        $query = $this->buildLoadUrlWildcardDataQuery();
+        $query
+            ->setMaxResults($limit > 0 ? $limit : self::MAX_LIMIT)
+            ->setFirstResult($offset);
 
-        /** @var $query \eZ\Publish\Core\Persistence\Database\SelectQuery */
-        $query = $this->dbHandler->createSelectQuery();
-        $query->select(
-            '*'
-        )->from(
-            $this->dbHandler->quoteTable('ezurlwildcard')
-        )->limit(
-            $limit > 0 ? $limit : self::MAX_LIMIT,
-            $offset
-        );
+        $stmt = $query->execute();
 
-        $stmt = $query->prepare();
-        $stmt->execute();
-
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return $stmt->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
     /**
@@ -181,26 +166,18 @@ final class DoctrineDatabase extends Gateway
      */
     public function loadUrlWildcardBySourceUrl(string $sourceUrl): array
     {
-        /** @var \Doctrine\DBAL\Connection $connection */
-        $connection = $this->dbHandler->getConnection();
-        $queryBuilder = $connection->createQueryBuilder();
-        $expr = $queryBuilder->expr();
-        $queryBuilder->select(
-            'id',
-            'destination_url',
-            'source_url',
-            'type'
-        )
-        ->from('ezurlwildcard')
-        ->where(
-            $expr->eq(
-                'source_url',
-                $queryBuilder->createNamedParameter($sourceUrl)
-            )
-        );
+        $query = $this->buildLoadUrlWildcardDataQuery();
+        $expr = $query->expr();
+        $query
+            ->where(
+                $expr->eq(
+                    'source_url',
+                    $query->createPositionalParameter($sourceUrl)
+                )
+            );
 
-        $result = $queryBuilder->execute()->fetch(FetchMode::ASSOCIATIVE);
+        $result = $query->execute()->fetch(FetchMode::ASSOCIATIVE);
 
-        return $result ?: [];
+        return false !== $result ? $result : [];
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase UrlWildcard Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -40,13 +38,6 @@ final class DoctrineDatabase extends Gateway
         $this->connection = $connection;
     }
 
-    /**
-     * Inserts the given UrlWildcard.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\UrlWildcard $urlWildcard
-     *
-     * @return mixed
-     */
     public function insertUrlWildcard(UrlWildcard $urlWildcard): int
     {
         $query = $this->connection->createQueryBuilder();
@@ -74,11 +65,6 @@ final class DoctrineDatabase extends Gateway
         return (int)$this->connection->lastInsertId(self::URL_WILDCARD_SEQ);
     }
 
-    /**
-     * Deletes the UrlWildcard with given $id.
-     *
-     * @param mixed $id
-     */
     public function deleteUrlWildcard(int $id): void
     {
         $query = $this->connection->createQueryBuilder();
@@ -103,13 +89,6 @@ final class DoctrineDatabase extends Gateway
         return $query;
     }
 
-    /**
-     * Loads an array with data about UrlWildcard with $id.
-     *
-     * @param mixed $id
-     *
-     * @return array
-     */
     public function loadUrlWildcardData(int $id): array
     {
         $query = $this->buildLoadUrlWildcardDataQuery();
@@ -125,14 +104,6 @@ final class DoctrineDatabase extends Gateway
         return false !== $result ? $result : [];
     }
 
-    /**
-     * Loads an array with data about UrlWildcards (paged).
-     *
-     * @param mixed $offset
-     * @param mixed $limit
-     *
-     * @return array
-     */
     public function loadUrlWildcardsData(int $offset = 0, int $limit = -1): array
     {
         $query = $this->buildLoadUrlWildcardDataQuery();
@@ -145,13 +116,6 @@ final class DoctrineDatabase extends Gateway
         return $stmt->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Loads the UrlWildcard with given $sourceUrl.
-     *
-     * @param string $sourceUrl
-     *
-     * @return array
-     */
     public function loadUrlWildcardBySourceUrl(string $sourceUrl): array
     {
         $query = $this->buildLoadUrlWildcardDataQuery();

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
@@ -63,7 +63,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->insert('ezurlwildcard')
+            ->insert(self::URL_WILDCARD_TABLE)
             ->values(
                 [
                     'destination_url' => $query->createPositionalParameter(
@@ -95,7 +95,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->delete('ezurlwildcard')
+            ->delete(self::URL_WILDCARD_TABLE)
             ->where(
                 $query->expr()->eq(
                     'id',
@@ -110,7 +110,7 @@ final class DoctrineDatabase extends Gateway
         $query = $this->connection->createQueryBuilder();
         $query
             ->select('id', 'destination_url', 'source_url', 'type')
-            ->from('ezurlwildcard');
+            ->from(self::URL_WILDCARD_TABLE);
 
         return $query;
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
@@ -14,7 +14,11 @@ use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\UrlWildcard;
 
 /**
- * UrlWildcard Gateway.
+ * URL wildcard gateway implementation using the Doctrine database.
+ *
+ * @internal Gateway implementation is considered internal. Use Persistence UrlWildcard Handler instead.
+ *
+ * @see \eZ\Publish\SPI\Persistence\Content\UrlWildcard\Handler
  */
 class DoctrineDatabase extends Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
@@ -26,7 +26,7 @@ final class DoctrineDatabase extends Gateway
      * 2^30, since PHP_INT_MAX can cause overflows in DB systems, if PHP is run
      * on 64 bit systems.
      */
-    const MAX_LIMIT = 1073741824;
+    private const MAX_LIMIT = 1073741824;
 
     /**
      * Database handler.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
@@ -20,7 +20,7 @@ use eZ\Publish\SPI\Persistence\Content\UrlWildcard;
  *
  * @see \eZ\Publish\SPI\Persistence\Content\UrlWildcard\Handler
  */
-class DoctrineDatabase extends Gateway
+final class DoctrineDatabase extends Gateway
 {
     /**
      * 2^30, since PHP_INT_MAX can cause overflows in DB systems, if PHP is run
@@ -34,7 +34,7 @@ class DoctrineDatabase extends Gateway
      * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      * @deprecated Start to use DBAL $connection instead.
      */
-    protected $dbHandler;
+    private $dbHandler;
 
     /**
      * Creates a new DoctrineDatabase Section Gateway.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
@@ -36,6 +36,9 @@ final class DoctrineDatabase extends Gateway
      */
     private $dbHandler;
 
+    /** @var \Doctrine\DBAL\Connection */
+    private $connection;
+
     /**
      * Creates a new DoctrineDatabase Section Gateway.
      *
@@ -44,6 +47,7 @@ final class DoctrineDatabase extends Gateway
     public function __construct(DatabaseHandler $dbHandler)
     {
         $this->dbHandler = $dbHandler;
+        $this->connection = $dbHandler->getConnection();
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
@@ -45,7 +45,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return mixed
      */
-    public function insertUrlWildcard(UrlWildcard $urlWildcard)
+    public function insertUrlWildcard(UrlWildcard $urlWildcard): int
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -77,7 +77,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @param mixed $id
      */
-    public function deleteUrlWildcard($id)
+    public function deleteUrlWildcard(int $id): void
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -108,7 +108,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return array
      */
-    public function loadUrlWildcardData($id)
+    public function loadUrlWildcardData(int $id): array
     {
         $query = $this->buildLoadUrlWildcardDataQuery();
         $query
@@ -131,7 +131,7 @@ final class DoctrineDatabase extends Gateway
      *
      * @return array
      */
-    public function loadUrlWildcardsData($offset = 0, $limit = -1)
+    public function loadUrlWildcardsData(int $offset = 0, int $limit = -1): array
     {
         $query = $this->buildLoadUrlWildcardDataQuery();
         $query

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
@@ -6,6 +6,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway;
 
 use Doctrine\DBAL\Connection;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
@@ -8,11 +8,11 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\UrlWildcard;
 
 /**
@@ -30,26 +30,12 @@ final class DoctrineDatabase extends Gateway
      */
     private const MAX_LIMIT = 1073741824;
 
-    /**
-     * Database handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     * @deprecated Start to use DBAL $connection instead.
-     */
-    private $dbHandler;
-
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
-    /**
-     * Creates a new DoctrineDatabase Section Gateway.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
-     */
-    public function __construct(DatabaseHandler $dbHandler)
+    public function __construct(Connection $connection)
     {
-        $this->dbHandler = $dbHandler;
-        $this->connection = $dbHandler->getConnection();
+        $this->connection = $connection;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/ExceptionConversion.php
@@ -12,6 +12,9 @@ use eZ\Publish\SPI\Persistence\Content\UrlWildcard;
 use Doctrine\DBAL\DBALException;
 use PDOException;
 
+/**
+ * @internal Internal exception conversion layer.
+ */
 class ExceptionConversion extends Gateway
 {
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/ExceptionConversion.php
@@ -27,7 +27,7 @@ final class ExceptionConversion extends Gateway
     private $innerGateway;
 
     /**
-     * Creates a new exception conversion gateway around $innerGateway.
+     * Create a new exception conversion gateway around $innerGateway.
      *
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway $innerGateway
      */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/ExceptionConversion.php
@@ -34,7 +34,7 @@ final class ExceptionConversion extends Gateway
         $this->innerGateway = $innerGateway;
     }
 
-    public function insertUrlWildcard(UrlWildcard $urlWildcard)
+    public function insertUrlWildcard(UrlWildcard $urlWildcard): int
     {
         try {
             return $this->innerGateway->insertUrlWildcard($urlWildcard);
@@ -43,25 +43,25 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function deleteUrlWildcard($id)
+    public function deleteUrlWildcard(int $id): void
     {
         try {
-            return $this->innerGateway->deleteUrlWildcard($id);
+            $this->innerGateway->deleteUrlWildcard($id);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function loadUrlWildcardData($parentId)
+    public function loadUrlWildcardData(int $id): array
     {
         try {
-            return $this->innerGateway->loadUrlWildcardData($parentId);
+            return $this->innerGateway->loadUrlWildcardData($id);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function loadUrlWildcardsData($offset = 0, $limit = -1)
+    public function loadUrlWildcardsData(int $offset = 0, int $limit = -1): array
     {
         try {
             return $this->innerGateway->loadUrlWildcardsData($offset, $limit);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/ExceptionConversion.php
@@ -15,14 +15,14 @@ use PDOException;
 /**
  * @internal Internal exception conversion layer.
  */
-class ExceptionConversion extends Gateway
+final class ExceptionConversion extends Gateway
 {
     /**
      * The wrapped gateway.
      *
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway
      */
-    protected $innerGateway;
+    private $innerGateway;
 
     /**
      * Creates a new exception conversion gateway around $innerGateway.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/ExceptionConversion.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway;
 
 use eZ\Publish\Core\Base\Exceptions\DatabaseException;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/Gateway/DoctrineDatabaseTest.php
@@ -6,6 +6,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlWildcard\Gateway;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/Gateway/DoctrineDatabaseTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File contains: eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlWildcard\Gateway\DoctrineDatabaseTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/Gateway/DoctrineDatabaseTest.php
@@ -171,14 +171,14 @@ class DoctrineDatabaseTest extends TestCase
     }
 
     /**
-     * Returns the DoctrineDatabase gateway to test.
+     * Return the DoctrineDatabase gateway to test.
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway\DoctrineDatabase
+     * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getGateway()
+    protected function getGateway(): DoctrineDatabase
     {
         if (!isset($this->gateway)) {
-            $this->gateway = new DoctrineDatabase($this->getDatabaseHandler());
+            $this->gateway = new DoctrineDatabase($this->getDatabaseConnection());
         }
 
         return $this->gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/UrlWildcardHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/UrlWildcardHandlerTest.php
@@ -6,6 +6,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlWildcard;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/UrlWildcardHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/UrlWildcardHandlerTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File contains: eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlWildcardHandlerTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/UrlWildcardHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/UrlWildcardHandlerTest.php
@@ -200,16 +200,16 @@ class UrlWildcardHandlerTest extends TestCase
     /** @var \eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Mapper */
     protected $mapper;
 
-    /** @var \eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Handler */
+    /** @var \eZ\Publish\SPI\Persistence\Content\UrlWildcard\Handler */
     protected $urlWildcardHandler;
 
     /**
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Handler
+     * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getHandler()
+    protected function getHandler(): UrlWildcard\Handler
     {
         if (!isset($this->urlWildcardHandler)) {
-            $this->gateway = new DoctrineDatabase($this->getDatabaseHandler());
+            $this->gateway = new DoctrineDatabase($this->getDatabaseConnection());
             $this->mapper = new Mapper();
 
             $this->urlWildcardHandler = new Handler(

--- a/eZ/Publish/Core/settings/storage_engines/legacy/url_wildcard.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/url_wildcard.yml
@@ -2,7 +2,7 @@ services:
     ezpublish.persistence.legacy.url_wildcard.gateway.inner:
         class: eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway\DoctrineDatabase
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - '@ezpublish.api.storage_engine.legacy.connection'
 
     ezpublish.persistence.legacy.url_wildcard.gateway.exception_conversion:
         class: eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway\ExceptionConversion


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31088](https://jira.ez.no/browse/EZP-31088) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR refactors the Legacy Storage Content Model **`UrlWildcard`** gateway implementation (`\eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard\Gateway\DoctrineDatabase`) to rely on `\Doctrine\DBAL\Connection` and `QueryBuilder` instead of our custom Database Handler from legacy Zeta Components.

#### QA

- [ ] Sanities on UrlWildcard Router (optional feature, requires enabling).

**TODO**:
- [x] **Refactor `UrlWildcard` gateway to rely on `Doctrine\DBAL`**
- [x] Mark `UrlWildcard` gateway classes as `@internal`
- [x] Mark `UrlWildcard` gateway implementations as `final`.
- [x] Set `\Doctrine\DBAL\Connection` in `UrlWildcard` `DoctrineDatabase` constructor.
- [x] Replace literal `UrlWildcard` table reference with `Gateway` class constant.
- [x] Replace `DatabaseHandler` with `\Doctrine\DBAL\Connection` in `UrlWildcard` gateway.
- [x] Introduce strict types to `UrlWildcard` gateway classes methods.
- [x] Enforce strict types on `UrlWildcard` gateway and test classes.
- [x] [CS] Mark `UrlWildcard` `DoctrineDatabase::MAX_LIMIT` const as `private`.
- [x] [CS] Align CS of modified files with eZ Platform Code Style.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Wait for Travis.
- [x] Ask for Code Review.
