### PR TITLE
EZP-31436: Fixed fetching configuration for SiteAccess group

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessConfigResolver.php
@@ -35,7 +35,7 @@ abstract class SiteAccessConfigResolver implements VersatileScopeInterface, Site
         $this->defaultNamespace = $defaultNamespace;
     }
 
-    final public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
+    public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
     {
         [$namespace, $scope] = $this->resolveNamespaceAndScope($namespace, $scope);
         if (!$this->isSiteAccessScope($scope)) {
@@ -50,7 +50,7 @@ abstract class SiteAccessConfigResolver implements VersatileScopeInterface, Site
         return $this->resolverHasParameter($siteAccess, $paramName, $namespace);
     }
 
-    final public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)
+    public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)
     {
         [$namespace, $scope] = $this->resolveNamespaceAndScope($namespace, $scope);
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
@@ -10,6 +10,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Config
 
 use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccessGroup;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
@@ -21,6 +22,58 @@ class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
 {
     use ContainerAwareTrait;
 
+    /** @var array */
+    protected $siteAccessGroups;
+
+    public function __construct(
+        SiteAccess\SiteAccessProviderInterface $siteAccessProvider,
+        string $defaultNamespace,
+        array $siteAccessGroups
+    ) {
+        parent::__construct($siteAccessProvider, $defaultNamespace);
+        $this->siteAccessGroups = $siteAccessGroups;
+    }
+
+    public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
+    {
+        [$namespace, $scope] = $this->resolveNamespaceAndScope($namespace, $scope);
+
+        if ($this->isSiteAccessGroupScope($scope)) {
+            return $this->resolverHasParameterForGroup(new SiteAccessGroup($scope), $paramName, $namespace);
+        }
+
+        if (!$this->isSiteAccessScope($scope)) {
+            return false;
+        }
+
+        $siteAccess = $this->siteAccessProvider->getSiteAccess($scope);
+        if (!$this->isSiteAccessSupported($siteAccess)) {
+            return false;
+        }
+
+        return $this->resolverHasParameter($siteAccess, $paramName, $namespace);
+    }
+
+    final public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)
+    {
+        [$namespace, $scope] = $this->resolveNamespaceAndScope($namespace, $scope);
+
+        if ($this->isSiteAccessGroupScope($scope)) {
+            return $this->getParameterFromResolverForGroup(new SiteAccessGroup($scope), $paramName, $namespace);
+        }
+
+        if (!$this->isSiteAccessScope($scope)) {
+            throw new ParameterNotFoundException($paramName, $namespace, [$scope]);
+        }
+
+        $siteAccess = $this->siteAccessProvider->getSiteAccess($scope);
+        if (!$this->isSiteAccessSupported($siteAccess)) {
+            throw new ParameterNotFoundException($paramName, $namespace, [$scope]);
+        }
+
+        return $this->getParameterFromResolver($siteAccess, $paramName, $namespace);
+    }
+
     protected function resolverHasParameter(SiteAccess $siteAccess, string $paramName, string $namespace): bool
     {
         foreach ($siteAccess->groups as $group) {
@@ -28,6 +81,16 @@ class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
             if ($this->container->hasParameter($groupScopeParamName)) {
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    protected function resolverHasParameterForGroup(SiteAccessGroup $siteAccessGroup, string $paramName, string $namespace): bool
+    {
+        $groupScopeParamName = $this->resolveScopeRelativeParamName($paramName, $namespace, $siteAccessGroup->getName());
+        if ($this->container->hasParameter($groupScopeParamName)) {
+            return true;
         }
 
         return false;
@@ -47,5 +110,20 @@ class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
         }
 
         throw new ParameterNotFoundException($paramName, $namespace, $triedScopes);
+    }
+
+    protected function getParameterFromResolverForGroup(SiteAccessGroup $siteAccessGroup, string $paramName, string $namespace)
+    {
+        $groupScopeParamName = $this->resolveScopeRelativeParamName($paramName, $namespace, $siteAccessGroup->getName());
+        if ($this->container->hasParameter($groupScopeParamName)) {
+            return $this->container->getParameter($groupScopeParamName);
+        }
+
+        throw new ParameterNotFoundException($paramName, $namespace, [$siteAccessGroup]);
+    }
+
+    private function isSiteAccessGroupScope($scope): bool
+    {
+        return array_key_exists($scope, $this->siteAccessGroups);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
@@ -22,7 +22,7 @@ class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
 {
     use ContainerAwareTrait;
 
-    /** @var array */
+    /** @var string[][] */
     protected $siteAccessGroups;
 
     public function __construct(
@@ -34,7 +34,7 @@ class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
         $this->siteAccessGroups = $siteAccessGroups;
     }
 
-    public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
+    final public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool
     {
         [$namespace, $scope] = $this->resolveNamespaceAndScope($namespace, $scope);
 
@@ -89,11 +89,8 @@ class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
     protected function resolverHasParameterForGroup(SiteAccessGroup $siteAccessGroup, string $paramName, string $namespace): bool
     {
         $groupScopeParamName = $this->resolveScopeRelativeParamName($paramName, $namespace, $siteAccessGroup->getName());
-        if ($this->container->hasParameter($groupScopeParamName)) {
-            return true;
-        }
 
-        return false;
+        return $this->container->hasParameter($groupScopeParamName);
     }
 
     protected function getParameterFromResolver(SiteAccess $siteAccess, string $paramName, string $namespace)
@@ -115,11 +112,12 @@ class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
     protected function getParameterFromResolverForGroup(SiteAccessGroup $siteAccessGroup, string $paramName, string $namespace)
     {
         $groupScopeParamName = $this->resolveScopeRelativeParamName($paramName, $namespace, $siteAccessGroup->getName());
-        if ($this->container->hasParameter($groupScopeParamName)) {
-            return $this->container->getParameter($groupScopeParamName);
+
+        if (!$this->container->hasParameter($groupScopeParamName)) {
+            throw new ParameterNotFoundException($paramName, $namespace, [$siteAccessGroup]);
         }
 
-        throw new ParameterNotFoundException($paramName, $namespace, [$siteAccessGroup]);
+        return $this->container->getParameter($groupScopeParamName);
     }
 
     private function isSiteAccessGroupScope($scope): bool

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
@@ -42,16 +42,7 @@ class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
             return $this->resolverHasParameterForGroup(new SiteAccessGroup($scope), $paramName, $namespace);
         }
 
-        if (!$this->isSiteAccessScope($scope)) {
-            return false;
-        }
-
-        $siteAccess = $this->siteAccessProvider->getSiteAccess($scope);
-        if (!$this->isSiteAccessSupported($siteAccess)) {
-            return false;
-        }
-
-        return $this->resolverHasParameter($siteAccess, $paramName, $namespace);
+        return parent::hasParameter($paramName, $namespace, $scope);
     }
 
     final public function getParameter(string $paramName, ?string $namespace = null, ?string $scope = null)
@@ -62,16 +53,7 @@ class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
             return $this->getParameterFromResolverForGroup(new SiteAccessGroup($scope), $paramName, $namespace);
         }
 
-        if (!$this->isSiteAccessScope($scope)) {
-            throw new ParameterNotFoundException($paramName, $namespace, [$scope]);
-        }
-
-        $siteAccess = $this->siteAccessProvider->getSiteAccess($scope);
-        if (!$this->isSiteAccessSupported($siteAccess)) {
-            throw new ParameterNotFoundException($paramName, $namespace, [$scope]);
-        }
-
-        return $this->getParameterFromResolver($siteAccess, $paramName, $namespace);
+        return parent::getParameter($paramName, $namespace, $scope);
     }
 
     protected function resolverHasParameter(SiteAccess $siteAccess, string $paramName, string $namespace): bool

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -28,6 +28,7 @@ services:
         arguments:
             - '@ezpublish.siteaccess.provider'
             - '%ezpublish.config.default_scope%'
+            - '%ezpublish.siteaccess.groups%'
         calls:
             - [setSiteAccess, ['@ezpublish.siteaccess']]
             - [setContainer, ['@service_container']]

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/ChainConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/ChainConfigResolverTest.php
@@ -240,7 +240,8 @@ class ChainConfigResolverTest extends TestCase
          );
         $configResolver = new SiteAccessGroupConfigResolver(
              $this->getStaticSiteAccessProvider(),
-             $defaultNamespace
+             $defaultNamespace,
+             []
          );
         $configResolver->setContainer($this->containerMock);
         $configResolver->setSiteAccess($siteAccess);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolverTest.php
@@ -29,7 +29,8 @@ class SiteAccessGroupConfigResolverTest extends ConfigResolverTest
         );
         $configResolver = new SiteAccessGroupConfigResolver(
             $staticSiteAccessProvider,
-            $defaultNamespace
+            $defaultNamespace,
+            []
         );
         $configResolver->setContainer($this->containerMock);
         $configResolver->setSiteAccess($siteAccess);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
@@ -20,6 +20,8 @@ use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 
 abstract class AbstractParserTestCase extends AbstractExtensionTestCase
 {
+    protected const EMPTY_SA_GROUP = 'empty_group';
+
     /**
      * Asserts a parameter from ConfigResolver has expected value for given scope.
      *
@@ -42,7 +44,7 @@ abstract class AbstractParserTestCase extends AbstractExtensionTestCase
 
         $configResolvers = [
             new DefaultScopeConfigResolver('default'),
-            new SiteAccessGroupConfigResolver($siteAccessProvider, 'default'),
+            new SiteAccessGroupConfigResolver($siteAccessProvider, 'default', [self::EMPTY_SA_GROUP => []]),
             new StaticSiteAccessConfigResolver($siteAccessProvider, 'default'),
             new GlobalScopeConfigResolver('default'),
         ];

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
@@ -15,8 +15,6 @@ use Symfony\Component\Yaml\Yaml;
 
 class CommonTest extends AbstractParserTestCase
 {
-    private const EMPTY_SA_GROUP = 'empty_group';
-
     private $minimalConfig;
 
     /** @var \PHPUnit\Framework\MockObject\MockObject */

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/IOTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/IOTest.php
@@ -13,8 +13,6 @@ use Symfony\Component\Yaml\Yaml;
 
 class IOTest extends AbstractParserTestCase
 {
-    private const EMPTY_SA_GROUP = 'empty_group';
-
     private $minimalConfig;
 
     protected function setUp(): void
@@ -47,6 +45,12 @@ class IOTest extends AbstractParserTestCase
                         'metadata_handler' => 'cluster',
                     ],
                 ],
+                self::EMPTY_SA_GROUP => [
+                    'io' => [
+                        'binarydata_handler' => 'group_cluster',
+                        'metadata_handler' => 'group_cluster',
+                    ],
+                ],
             ],
         ];
 
@@ -54,6 +58,7 @@ class IOTest extends AbstractParserTestCase
 
         $this->assertConfigResolverParameterValue('io.metadata_handler', 'cluster', 'ezdemo_site');
         $this->assertConfigResolverParameterValue('io.binarydata_handler', 'cluster', 'ezdemo_site');
-        $this->assertConfigResolverParameterValue('io.binarydata_handler', 'default', self::EMPTY_SA_GROUP);
+        $this->assertConfigResolverParameterValue('io.metadata_handler', 'group_cluster', self::EMPTY_SA_GROUP);
+        $this->assertConfigResolverParameterValue('io.binarydata_handler', 'group_cluster', self::EMPTY_SA_GROUP);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/LanguagesTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/LanguagesTest.php
@@ -14,8 +14,6 @@ use Symfony\Component\Yaml\Yaml;
 
 class LanguagesTest extends AbstractParserTestCase
 {
-    private const EMPTY_SA_GROUP = 'empty_group';
-
     protected function getContainerExtensions(): array
     {
         return [new EzPublishCoreExtension([new Languages()])];
@@ -30,14 +28,17 @@ class LanguagesTest extends AbstractParserTestCase
     {
         $langDemoSite = ['eng-GB'];
         $langFre = ['fre-FR', 'eng-GB'];
+        $langEmptyGroup = ['pol-PL'];
         $config = [
             'siteaccess' => [
                 'list' => ['fre2'],
+                'groups' => [self::EMPTY_SA_GROUP => []],
             ],
             'system' => [
                 'ezdemo_site' => ['languages' => $langDemoSite],
                 'fre' => ['languages' => $langFre],
                 'fre2' => ['languages' => $langFre],
+                self::EMPTY_SA_GROUP => ['languages' => $langEmptyGroup],
             ],
         ];
         $this->load($config);
@@ -45,11 +46,12 @@ class LanguagesTest extends AbstractParserTestCase
         $this->assertConfigResolverParameterValue('languages', $langDemoSite, 'ezdemo_site');
         $this->assertConfigResolverParameterValue('languages', $langFre, 'fre');
         $this->assertConfigResolverParameterValue('languages', $langFre, 'fre2');
-        $this->assertConfigResolverParameterValue('languages', [], self::EMPTY_SA_GROUP);
+        $this->assertConfigResolverParameterValue('languages', $langEmptyGroup, self::EMPTY_SA_GROUP);
         $this->assertSame(
             [
                 'eng-GB' => ['ezdemo_site'],
                 'fre-FR' => ['fre', 'fre2'],
+                'pol-PL' => [self::EMPTY_SA_GROUP],
             ],
             $this->container->getParameter('ezpublish.siteaccesses_by_language')
         );


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31436](https://jira.ez.no/browse/EZP-31436)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

When the configuration for SiteAccess group was fetch and group was empty then an exception was thrown. The fix is based on the fact that now we check if the scope is a SiteAccess group and proper fetch is done.  


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
