### PR TITLE
EZP-31088: Refactored Content Type GW to use Doctrine\DBAL

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
@@ -145,7 +145,7 @@ abstract class Gateway
     abstract public function updateType(int $typeId, int $status, Type $type): void;
 
     /**
-     * Loads an array with data about several Types in defined status.
+     * Bulk-load an array with data about the given Content Types.
      *
      * @param array $typeIds
      *
@@ -156,34 +156,19 @@ abstract class Gateway
     /**
      * Loads an array with data about $typeId in $status.
      *
-     * @param mixed $typeId
-     * @param int $status
-     *
      * @return array Data rows.
      */
-    abstract public function loadTypeData($typeId, $status);
+    abstract public function loadTypeData(int $typeId, int $status): array;
 
     /**
-     * Loads an array with data about the type referred to by $identifier in
-     * $status.
-     *
-     * @param string $identifier
-     * @param int $status
-     *
-     * @return array(int=>array(string=>mixed)) Data rows.
+     * Load an array with data about the Content Type of the given identifier and status.
      */
-    abstract public function loadTypeDataByIdentifier($identifier, $status);
+    abstract public function loadTypeDataByIdentifier(string $identifier, int $status): array;
 
     /**
-     * Loads an array with data about the type referred to by $remoteId in
-     * $status.
-     *
-     * @param mixed $remoteId
-     * @param int $status
-     *
-     * @return array(int=>array(string=>mixed)) Data rows.
+     * Load an array with data about the Content Type of a given Remote ID and status.
      */
-    abstract public function loadTypeDataByRemoteId($remoteId, $status);
+    abstract public function loadTypeDataByRemoteId(string $remoteId, int $status): array;
 
     /**
      * Count the number of existing instances a Content Type.
@@ -191,12 +176,9 @@ abstract class Gateway
     abstract public function countInstancesOfType(int $typeId): int;
 
     /**
-     * Deletes a Type completely.
-     *
-     * @param mixed $typeId
-     * @param int $status
+     * Permanently delete a Content Type of the given status.
      */
-    abstract public function delete($typeId, $status);
+    abstract public function delete(int $typeId, int $status): void;
 
     /**
      * Delete all Field Definitions definitions of Content Type.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
@@ -32,48 +32,23 @@ abstract class Gateway
     public const CONTENT_TYPE_SEQ = 'ezcontentclass_id_seq';
     public const FIELD_DEFINITION_SEQ = 'ezcontentclass_attribute_id_seq';
 
-    /**
-     * Insert the given $group.
-     *
-     * @return int Group ID
-     */
     abstract public function insertGroup(Group $group): int;
 
-    /**
-     * Update a group based on the given GroupUpdateStruct.
-     */
     abstract public function updateGroup(GroupUpdateStruct $group): void;
 
-    /**
-     * Return a number of Types in Group.
-     */
     abstract public function countTypesInGroup(int $groupId): int;
 
-    /**
-     * Return the number of Groups the Type is assigned to.
-     */
     abstract public function countGroupsForType(int $typeId, int $status): int;
 
-    /**
-     * Delete the Group with the given $groupId.
-     */
     abstract public function deleteGroup(int $groupId): void;
 
     /**
-     * Return an array with data about the Group(s) with $groupIds.
-     *
      * @param int[] $groupIds
      */
     abstract public function loadGroupData(array $groupIds): array;
 
-    /**
-     * Return an array with data about the Group of the given identifier.
-     */
     abstract public function loadGroupDataByIdentifier(string $identifier): array;
 
-    /**
-     * Return an array with data about all Group objects.
-     */
     abstract public function loadAllGroupsData(): array;
 
     /**
@@ -82,10 +57,6 @@ abstract class Gateway
     abstract public function loadTypesDataForGroup(int $groupId, int $status): array;
 
     /**
-     * Insert a new Content Type.
-     *
-     * @return int Content Type ID
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the given language does not exist
      */
     abstract public function insertType(Type $type, ?int $typeId = null): int;
@@ -103,8 +74,6 @@ abstract class Gateway
     abstract public function deleteGroupAssignment(int $groupId, int $typeId, int $status): void;
 
     /**
-     * Load Field Definition data for the given ID and status.
-     *
      * @param int $id Field Definition ID
      * @param int $status One of Type::STATUS_DEFINED|Type::STATUS_DRAFT|Type::STATUS_MODIFIED
      */
@@ -120,18 +89,12 @@ abstract class Gateway
         StorageFieldDefinition $storageFieldDef
     ): int;
 
-    /**
-     * Delete a Field Definition.
-     */
     abstract public function deleteFieldDefinition(
         int $typeId,
         int $status,
         int $fieldDefinitionId
     ): void;
 
-    /**
-     * Update a Field Definition.
-     */
     abstract public function updateFieldDefinition(
         int $typeId,
         int $status,
@@ -149,32 +112,16 @@ abstract class Gateway
     /**
      * Bulk-load an array with data about the given Content Types.
      *
-     * @param array $typeIds
-     *
-     * @return array Data rows.
+     * @param int[] $typeIds
      */
     abstract public function loadTypesListData(array $typeIds): array;
 
-    /**
-     * Loads an array with data about $typeId in $status.
-     *
-     * @return array Data rows.
-     */
     abstract public function loadTypeData(int $typeId, int $status): array;
 
-    /**
-     * Load an array with data about the Content Type of the given identifier and status.
-     */
     abstract public function loadTypeDataByIdentifier(string $identifier, int $status): array;
 
-    /**
-     * Load an array with data about the Content Type of a given Remote ID and status.
-     */
     abstract public function loadTypeDataByRemoteId(string $remoteId, int $status): array;
 
-    /**
-     * Count the number of existing instances a Content Type.
-     */
     abstract public function countInstancesOfType(int $typeId): int;
 
     /**
@@ -182,9 +129,6 @@ abstract class Gateway
      */
     abstract public function delete(int $typeId, int $status): void;
 
-    /**
-     * Delete all Field Definitions definitions of Content Type.
-     */
     abstract public function deleteFieldDefinitionsForType(int $typeId, int $status): void;
 
     /**
@@ -194,9 +138,6 @@ abstract class Gateway
      */
     abstract public function deleteType(int $typeId, int $status): void;
 
-    /**
-     * Delete all Content Type Group assignments for a Content Type.
-     */
     abstract public function deleteGroupAssignmentsForType(int $typeId, int $status): void;
 
     /**
@@ -208,9 +149,6 @@ abstract class Gateway
         int $targetStatus
     ): void;
 
-    /**
-     * Return searchable Fields mapping data.
-     */
     abstract public function getSearchableFieldMapData(): array;
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the Content Type Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -15,7 +13,9 @@ use eZ\Publish\SPI\Persistence\Content\Type\Group\UpdateStruct as GroupUpdateStr
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 
 /**
- * Base class for content type gateways.
+ * Content Type Gateway.
+ *
+ * @internal For internal use by Persistence Handlers.
  */
 abstract class Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type;
 
 use eZ\Publish\SPI\Persistence\Content\Type;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
@@ -19,170 +19,130 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
  */
 abstract class Gateway
 {
-    /**
-     * Inserts the given $group.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Group $group
-     *
-     * @return mixed Group ID
-     */
-    abstract public function insertGroup(Group $group);
+    public const CONTENT_TYPE_TO_GROUP_ASSIGNMENT_TABLE = 'ezcontentclass_classgroup';
+    public const CONTENT_TYPE_GROUP_TABLE = 'ezcontentclassgroup';
+    public const CONTENT_TYPE_TABLE = 'ezcontentclass';
+    public const CONTENT_TYPE_NAME_TABLE = 'ezcontentclass_name';
+    public const FIELD_DEFINITION_TABLE = 'ezcontentclass_attribute';
+    public const MULTILINGUAL_FIELD_DEFINITION_TABLE = 'ezcontentclass_attribute_ml';
+
+    public const CONTENT_TYPE_GROUP_SEQ = 'ezcontentclassgroup_id_seq';
+    public const CONTENT_TYPE_SEQ = 'ezcontentclass_id_seq';
+    public const FIELD_DEFINITION_SEQ = 'ezcontentclass_attribute_id_seq';
 
     /**
-     * Updates a group with data in $group.
+     * Insert the given $group.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Group\UpdateStruct $group
+     * @return int Group ID
      */
-    abstract public function updateGroup(GroupUpdateStruct $group);
+    abstract public function insertGroup(Group $group): int;
 
     /**
-     * Returns the number of types in a certain group.
-     *
-     * @param int $groupId
-     *
-     * @return int
+     * Update a group based on the given GroupUpdateStruct.
      */
-    abstract public function countTypesInGroup($groupId);
+    abstract public function updateGroup(GroupUpdateStruct $group): void;
 
     /**
-     * Returns the number of Groups the type is assigned to.
-     *
-     * @param int $typeId
-     * @param int $status
-     *
-     * @return int
+     * Return a number of Types in Group.
      */
-    abstract public function countGroupsForType($typeId, $status);
+    abstract public function countTypesInGroup(int $groupId): int;
 
     /**
-     * Deletes the Group with the given $groupId.
-     *
-     * @param int $groupId
+     * Return the number of Groups the Type is assigned to.
      */
-    abstract public function deleteGroup($groupId);
+    abstract public function countGroupsForType(int $typeId, int $status): int;
 
     /**
-     * Returns an array with data about the Group(s) with $groupIds.
+     * Delete the Group with the given $groupId.
+     */
+    abstract public function deleteGroup(int $groupId): void;
+
+    /**
+     * Return an array with data about the Group(s) with $groupIds.
      *
      * @param int[] $groupIds
-     *
-     * @return array
      */
-    abstract public function loadGroupData(array $groupIds);
+    abstract public function loadGroupData(array $groupIds): array;
 
     /**
-     * Returns an array with data about the Group with $identifier.
-     *
-     * @param string $identifier
-     *
-     * @return array
+     * Return an array with data about the Group of the given identifier.
      */
-    abstract public function loadGroupDataByIdentifier($identifier);
+    abstract public function loadGroupDataByIdentifier(string $identifier): array;
 
     /**
-     * Returns an array with data about all Group objects.
-     *
-     * @return array
+     * Return an array with data about all Group objects.
      */
-    abstract public function loadAllGroupsData();
+    abstract public function loadAllGroupsData(): array;
 
     /**
-     * Loads data for all Types in $status in $groupId.
-     *
-     * @param mixed $groupId
-     * @param int $status
-     *
-     * @return string[][]
+     * Load data for all Content Types of the given status, belonging to the given Group.
      */
-    abstract public function loadTypesDataForGroup($groupId, $status);
+    abstract public function loadTypesDataForGroup(int $groupId, int $status): array;
 
     /**
-     * Inserts a new content type.
+     * Insert a new Content Type.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\Type $type
-     * @param mixed|null $typeId
+     * @return int Content Type ID
      *
-     * @return mixed Type ID
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the given language does not exist
      */
-    abstract public function insertType(Type $type, $typeId = null);
+    abstract public function insertType(Type $type, ?int $typeId = null): int;
 
     /**
-     * Insert assignment of $typeId to $groupId.
+     * Assign a Content Type of the given status (published, draft) to Content Type Group.
      *
-     * @param mixed $typeId
-     * @param int $status
-     * @param mixed $groupId
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the given Group does not exist
      */
-    abstract public function insertGroupAssignment($typeId, $status, $groupId);
+    abstract public function insertGroupAssignment(int $groupId, int $typeId, int $status): void;
 
     /**
-     * Deletes a group assignments for a Type.
-     *
-     * @param mixed $groupId
-     * @param mixed $typeId
-     * @param int $status
+     * Delete a Group assignments for Content Type of the given status (published, draft).
      */
-    abstract public function deleteGroupAssignment($groupId, $typeId, $status);
+    abstract public function deleteGroupAssignment(int $groupId, int $typeId, int $status): void;
 
     /**
-     * Loads an array with data about field definition referred $id and $status.
+     * Load Field Definition data for the given ID and status.
      *
-     * @param mixed $id field definition id
-     * @param int $status field definition status
-     *
-     * @return array Data rows.
+     * @param int $id Field Definition ID
+     * @param int $status One of Type::STATUS_DEFINED|Type::STATUS_DRAFT|Type::STATUS_MODIFIED
      */
-    abstract public function loadFieldDefinition($id, $status);
+    abstract public function loadFieldDefinition(int $id, int $status): array;
 
     /**
-     * Inserts a $fieldDefinition for $typeId.
-     *
-     * @param mixed $typeId
-     * @param int $status
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageFieldDef
-     *
-     * @return mixed Field definition ID
+     * Insert a Field Definition into Content Type.
      */
     abstract public function insertFieldDefinition(
-        $typeId,
-        $status,
+        int $typeId,
+        int $status,
         FieldDefinition $fieldDefinition,
         StorageFieldDefinition $storageFieldDef
-    );
+    ): int;
 
     /**
-     * Deletes a field definition.
-     *
-     * @param mixed $typeId
-     * @param int $status
-     * @param mixed $fieldDefinitionId
+     * Delete a Field Definition.
      */
-    abstract public function deleteFieldDefinition($typeId, $status, $fieldDefinitionId);
+    abstract public function deleteFieldDefinition(
+        int $typeId,
+        int $status,
+        int $fieldDefinitionId
+    ): void;
 
     /**
-     * Updates a $fieldDefinition for $typeId.
-     *
-     * @param mixed $typeId
-     * @param int $status
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageFieldDef
+     * Update a Field Definition.
      */
     abstract public function updateFieldDefinition(
-        $typeId,
-        $status,
+        int $typeId,
+        int $status,
         FieldDefinition $fieldDefinition,
         StorageFieldDefinition $storageFieldDef
-    );
+    ): void;
 
     /**
-     * Update a type with $updateStruct.
+     * Update a Content Type based on the given SPI Persistence Type Value Object.
      *
-     * @param mixed $typeId
-     * @param int $status
-     * @param \eZ\Publish\SPI\Persistence\Content\Type $type
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if at least one of the used languages does not exist
      */
-    abstract public function updateType($typeId, $status, Type $type);
+    abstract public function updateType(int $typeId, int $status, Type $type): void;
 
     /**
      * Loads an array with data about several Types in defined status.
@@ -226,13 +186,9 @@ abstract class Gateway
     abstract public function loadTypeDataByRemoteId($remoteId, $status);
 
     /**
-     * Counts the number of instances that exists of the identified type.
-     *
-     * @param int $typeId
-     *
-     * @return int
+     * Count the number of existing instances a Content Type.
      */
-    abstract public function countInstancesOfType($typeId);
+    abstract public function countInstancesOfType(int $typeId): int;
 
     /**
      * Deletes a Type completely.
@@ -243,54 +199,40 @@ abstract class Gateway
     abstract public function delete($typeId, $status);
 
     /**
-     * Deletes all field definitions of a Type.
-     *
-     * @param mixed $typeId
-     * @param int $status
+     * Delete all Field Definitions definitions of Content Type.
      */
-    abstract public function deleteFieldDefinitionsForType($typeId, $status);
+    abstract public function deleteFieldDefinitionsForType(int $typeId, int $status): void;
 
     /**
-     * Deletes a the Type.
+     * Delete a Content Type.
      *
-     * Does no delete the field definitions!
-     *
-     * @param mixed $typeId
-     * @param int $status
+     * Does not delete Field Definitions!
      */
-    abstract public function deleteType($typeId, $status);
+    abstract public function deleteType(int $typeId, int $status): void;
 
     /**
-     * Deletes all group assignments for a Type.
-     *
-     * @param mixed $typeId
-     * @param int $status
+     * Delete all Content Type Group assignments for a Content Type.
      */
-    abstract public function deleteGroupAssignmentsForType($typeId, $status);
+    abstract public function deleteGroupAssignmentsForType(int $typeId, int $status): void;
 
     /**
-     * Publishes the Type with $typeId from $sourceVersion to $targetVersion,
-     * including its fields.
-     *
-     * @param int $typeId
-     * @param int $sourceStatus
-     * @param int $targetStatus
+     * Publish a Content Type including its Field Definitions.
      */
-    abstract public function publishTypeAndFields($typeId, $sourceStatus, $targetStatus);
+    abstract public function publishTypeAndFields(
+        int $typeId,
+        int $sourceStatus,
+        int $targetStatus
+    ): void;
 
     /**
-     * Returns searchable fields mapping data.
-     *
-     * @return array
+     * Return searchable Fields mapping data.
      */
-    abstract public function getSearchableFieldMapData();
+    abstract public function getSearchableFieldMapData(): array;
 
     /**
-     * Removes fieldDefinition data from multilingual table.
+     * Remove Field Definition data from multilingual table.
      *
-     * @param int $fieldDefinitionId
-     * @param string $languageCode
-     * @param int $status
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the given language does not exist
      */
     abstract public function removeFieldDefinitionTranslation(
         int $fieldDefinitionId,
@@ -299,10 +241,7 @@ abstract class Gateway
     ): void;
 
     /**
-     * Removes items created or modified by the user.
-     *
-     * @param int $userId
-     * @param int $version
+     * Remove items created or modified by User.
      */
     abstract public function removeByUserAndVersion(int $userId, int $version): void;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -16,7 +16,6 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Persistence\Legacy\Content\MultilingualStorageFieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator;
 use eZ\Publish\Core\Persistence\Legacy\SharedGateway\Gateway as SharedGateway;
 use eZ\Publish\SPI\Persistence\Content\Type;
@@ -93,14 +92,6 @@ final class DoctrineDatabase extends Gateway
     ];
 
     /**
-     * DoctrineDatabase handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     * @deprecated Start to use DBAL $connection instead.
-     */
-    private $dbHandler;
-
-    /**
      * The native Doctrine connection.
      *
      * Meant to be used to transition from eZ/Zeta interface to Doctrine.
@@ -126,12 +117,10 @@ final class DoctrineDatabase extends Gateway
      * @throws \Doctrine\DBAL\DBALException
      */
     public function __construct(
-        DatabaseHandler $db,
         Connection $connection,
         SharedGateway $sharedGateway,
         MaskGenerator $languageMaskGenerator
     ) {
-        $this->dbHandler = $db;
         $this->connection = $connection;
         $this->dbPlatform = $connection->getDatabasePlatform();
         $this->sharedGateway = $sharedGateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -31,14 +31,14 @@ use PDO;
  *
  * @see \eZ\Publish\SPI\Persistence\Content\Type\Handler
  */
-class DoctrineDatabase extends Gateway
+final class DoctrineDatabase extends Gateway
 {
     /**
      * Columns of database tables.
      *
      * @var array
      */
-    protected $columns = [
+    private $columns = [
         'ezcontentclass' => [
             'id',
             'always_available',
@@ -96,7 +96,7 @@ class DoctrineDatabase extends Gateway
      * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      * @deprecated Start to use DBAL $connection instead.
      */
-    protected $dbHandler;
+    private $dbHandler;
 
     /**
      * The native Doctrine connection.
@@ -105,14 +105,14 @@ class DoctrineDatabase extends Gateway
      *
      * @var \Doctrine\DBAL\Connection
      */
-    protected $connection;
+    private $connection;
 
     /**
      * Language mask generator.
      *
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator
      */
-    protected $languageMaskGenerator;
+    private $languageMaskGenerator;
 
     /**
      * Creates a new gateway based on $db.
@@ -293,7 +293,7 @@ class DoctrineDatabase extends Gateway
      * @param int $typeStatus
      * @param string[] $languages
      */
-    protected function insertTypeNameData($typeId, $typeStatus, array $languages)
+    private function insertTypeNameData($typeId, $typeStatus, array $languages)
     {
         $tmpLanguages = $languages;
         if (isset($tmpLanguages['always-available'])) {
@@ -373,7 +373,7 @@ class DoctrineDatabase extends Gateway
      * @param \eZ\Publish\Core\Persistence\Database\InsertQuery|\eZ\Publish\Core\Persistence\Database\UpdateQuery $q
      * @param \eZ\Publish\SPI\Persistence\ValueObject|\eZ\Publish\SPI\Persistence\Content\Type $type
      */
-    protected function setCommonTypeColumns(Query $q, ValueObject $type)
+    private function setCommonTypeColumns(Query $q, ValueObject $type)
     {
         $q->set(
             $this->dbHandler->quoteColumn('serialized_name_list'),
@@ -548,7 +548,7 @@ class DoctrineDatabase extends Gateway
      *
      * @return \eZ\Publish\Core\Persistence\Database\SelectQuery
      */
-    protected function createGroupLoadQuery()
+    private function createGroupLoadQuery()
     {
         $q = $this->dbHandler->createSelectQuery();
         $q->select(
@@ -671,7 +671,7 @@ class DoctrineDatabase extends Gateway
      * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageFieldDef
      */
-    protected function setCommonFieldColumns(
+    private function setCommonFieldColumns(
         Query $q,
         FieldDefinition $fieldDefinition,
         StorageFieldDefinition $storageFieldDef
@@ -974,7 +974,7 @@ class DoctrineDatabase extends Gateway
      * @param int $typeId
      * @param int $typeStatus
      */
-    protected function deleteTypeNameData($typeId, $typeStatus)
+    private function deleteTypeNameData($typeId, $typeStatus)
     {
         $query = $this->dbHandler->createDeleteQuery();
         $query->deleteFrom('ezcontentclass_name')
@@ -1463,7 +1463,7 @@ class DoctrineDatabase extends Gateway
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $q
      * @param string $tableName
      */
-    protected function selectColumns(SelectQuery $q, $tableName)
+    private function selectColumns(SelectQuery $q, $tableName)
     {
         foreach ($this->columns[$tableName] as $col) {
             $q->select(

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -8,8 +8,10 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Persistence\Legacy\Content\MultilingualStorageFieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
@@ -20,10 +22,7 @@ use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\Type\Group;
 use eZ\Publish\SPI\Persistence\Content\Type\Group\UpdateStruct as GroupUpdateStruct;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\SPI\Persistence\ValueObject;
-use eZ\Publish\Core\Persistence\Database\Query;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
-use PDO;
+use function sprintf;
 
 /**
  * Content Type gateway implementation using the Doctrine database.
@@ -137,172 +136,124 @@ final class DoctrineDatabase extends Gateway
         $this->languageMaskGenerator = $languageMaskGenerator;
     }
 
-    /**
-     * Inserts the given $group.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Group $group
-     *
-     * @return int Group ID
-     */
-    public function insertGroup(Group $group)
+    public function insertGroup(Group $group): int
     {
-        $q = $this->dbHandler->createInsertQuery();
-        $q->insertInto(
-            $this->dbHandler->quoteTable('ezcontentclassgroup')
-        )->set(
-            $this->dbHandler->quoteColumn('id'),
-            $this->dbHandler->getAutoIncrementValue('ezcontentclassgroup', 'id')
-        )->set(
-            $this->dbHandler->quoteColumn('created'),
-            $q->bindValue($group->created, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('creator_id'),
-            $q->bindValue($group->creatorId, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('modified'),
-            $q->bindValue($group->modified, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('modifier_id'),
-            $q->bindValue($group->modifierId, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('name'),
-            $q->bindValue($group->identifier)
-        );
-        $q->prepare()->execute();
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->insert(self::CONTENT_TYPE_GROUP_TABLE)
+            ->values(
+                [
+                    'created' => $query->createPositionalParameter(
+                        $group->created,
+                        ParameterType::INTEGER
+                    ),
+                    'creator_id' => $query->createPositionalParameter(
+                        $group->creatorId,
+                        ParameterType::INTEGER
+                    ),
+                    'modified' => $query->createPositionalParameter(
+                        $group->modified,
+                        ParameterType::INTEGER
+                    ),
+                    'modifier_id' => $query->createPositionalParameter(
+                        $group->modifierId,
+                        ParameterType::INTEGER
+                    ),
+                    'name' => $query->createPositionalParameter(
+                        $group->identifier,
+                        ParameterType::STRING
+                    ),
+                ]
+            );
+        $query->execute();
 
-        return (int)$this->dbHandler->lastInsertId(
-            $this->dbHandler->getSequenceName('ezcontentclassgroup', 'id')
-        );
+        return (int)$this->connection->lastInsertId(self::CONTENT_TYPE_GROUP_SEQ);
     }
 
-    /**
-     * Updates a group with data in $group.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Group\UpdateStruct $group
-     */
-    public function updateGroup(GroupUpdateStruct $group)
+    public function updateGroup(GroupUpdateStruct $group): void
     {
-        $q = $this->dbHandler->createUpdateQuery();
-        $q->update(
-            $this->dbHandler->quoteColumn('ezcontentclassgroup')
-        )->set(
-            $this->dbHandler->quoteColumn('modified'),
-            $q->bindValue($group->modified, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('modifier_id'),
-            $q->bindValue($group->modifierId, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('name'),
-            $q->bindValue($group->identifier)
-        )->where(
-            $q->expr->eq(
-                $this->dbHandler->quoteColumn('id'),
-                $q->bindValue($group->id, null, \PDO::PARAM_INT)
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->update(self::CONTENT_TYPE_GROUP_TABLE)
+            ->set(
+                'modified',
+                $query->createPositionalParameter($group->modified, ParameterType::INTEGER)
             )
-        );
-
-        $q->prepare()->execute();
-    }
-
-    /**
-     * Returns the number of types in a certain group.
-     *
-     * @param int $groupId
-     *
-     * @return int
-     */
-    public function countTypesInGroup($groupId)
-    {
-        $q = $this->dbHandler->createSelectQuery();
-        $q->select(
-            $q->alias(
-                $q->expr->count(
-                    $this->dbHandler->quoteColumn('contentclass_id')
-                ),
-                'count'
+            ->set(
+                'modifier_id',
+                $query->createPositionalParameter($group->modifierId, ParameterType::INTEGER)
             )
-        )->from(
-            $this->dbHandler->quoteTable('ezcontentclass_classgroup')
-        )->where(
-            $q->expr->eq(
-                $this->dbHandler->quoteColumn('group_id'),
-                $q->bindValue($groupId, null, \PDO::PARAM_INT)
-            )
-        );
-
-        $stmt = $q->prepare();
-        $stmt->execute();
-
-        return (int)$stmt->fetchColumn();
-    }
-
-    /**
-     * Returns the number of Groups the type is assigned to.
-     *
-     * @param int $typeId
-     * @param int $status
-     *
-     * @return int
-     */
-    public function countGroupsForType($typeId, $status)
-    {
-        $q = $this->dbHandler->createSelectQuery();
-        $q->select(
-            $q->alias(
-                $q->expr->count(
-                    $this->dbHandler->quoteColumn('group_id')
-                ),
-                'count'
-            )
-        )->from(
-            $this->dbHandler->quoteTable('ezcontentclass_classgroup')
-        )->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_id'),
-                    $q->bindValue($typeId, null, \PDO::PARAM_INT)
-                )
-            ),
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_version'),
-                    $q->bindValue($status, null, \PDO::PARAM_INT)
-                )
-            )
-        );
-
-        $stmt = $q->prepare();
-        $stmt->execute();
-
-        return (int)$stmt->fetchColumn();
-    }
-
-    /**
-     * Deletes the Group with the given $groupId.
-     *
-     * @param int $groupId
-     */
-    public function deleteGroup($groupId)
-    {
-        $q = $this->dbHandler->createDeleteQuery();
-        $q->deleteFrom($this->dbHandler->quoteTable('ezcontentclassgroup'))
-            ->where(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('id'),
-                    $q->bindValue($groupId, null, \PDO::PARAM_INT)
+            ->set(
+                'name',
+                $query->createPositionalParameter($group->identifier, ParameterType::STRING)
+            )->where(
+                $query->expr()->eq(
+                    'id',
+                    $query->createPositionalParameter($group->id, ParameterType::INTEGER)
                 )
             );
-        $q->prepare()->execute();
+
+        $query->execute();
+    }
+
+    public function countTypesInGroup(int $groupId): int
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select($this->dbPlatform->getCountExpression('contentclass_id'))
+            ->from(self::CONTENT_TYPE_TO_GROUP_ASSIGNMENT_TABLE)
+            ->where(
+                $query->expr()->eq(
+                    'group_id',
+                    $query->createPositionalParameter($groupId, ParameterType::INTEGER)
+                )
+            );
+
+        return (int)$query->execute()->fetchColumn();
+    }
+
+    public function countGroupsForType(int $typeId, int $status): int
+    {
+        $query = $this->connection->createQueryBuilder();
+        $expr = $query->expr();
+        $query
+            ->select($this->dbPlatform->getCountExpression('group_id'))
+            ->from(self::CONTENT_TYPE_TO_GROUP_ASSIGNMENT_TABLE)
+            ->where(
+                $expr->eq(
+                    'contentclass_id',
+                    $query->createPositionalParameter($typeId, ParameterType::INTEGER)
+                )
+            )
+            ->andWhere(
+                $expr->eq(
+                    'contentclass_version',
+                    $query->createPositionalParameter($status, ParameterType::INTEGER)
+                )
+            );
+
+        return (int)$query->execute()->fetchColumn();
+    }
+
+    public function deleteGroup(int $groupId): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query->delete(self::CONTENT_TYPE_GROUP_TABLE)
+            ->where(
+                $query->expr()->eq(
+                    'id',
+                    $query->createPositionalParameter($groupId, ParameterType::INTEGER)
+                )
+            );
+        $query->execute();
     }
 
     /**
-     * Inserts data into contentclass_name.
-     *
-     * @param int $typeId
-     * @param int $typeStatus
      * @param string[] $languages
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if at least one of the used languages does not exist
      */
-    private function insertTypeNameData($typeId, $typeStatus, array $languages)
+    private function insertTypeNameData(int $typeId, int $typeStatus, array $languages): void
     {
         $tmpLanguages = $languages;
         if (isset($tmpLanguages['always-available'])) {
@@ -310,64 +261,121 @@ final class DoctrineDatabase extends Gateway
         }
 
         foreach ($tmpLanguages as $language => $name) {
-            $query = $this->dbHandler->createInsertQuery();
+            $query = $this->connection->createQueryBuilder();
             $query
-                ->insertInto($this->dbHandler->quoteTable('ezcontentclass_name'))
-                ->set('contentclass_id', $query->bindValue($typeId, null, \PDO::PARAM_INT))
-                ->set('contentclass_version', $query->bindValue($typeStatus, null, \PDO::PARAM_INT))
-                ->set(
-                    'language_id',
-                    $query->bindValue(
-                        $this->languageMaskGenerator->generateLanguageIndicator(
-                            $language,
-                            $this->languageMaskGenerator->isLanguageAlwaysAvailable(
-                                $language,
-                                $languages
-                            )
+                ->insert(self::CONTENT_TYPE_NAME_TABLE)
+                ->values(
+                    [
+                        'contentclass_id' => $query->createPositionalParameter(
+                            $typeId,
+                            ParameterType::INTEGER
                         ),
-                        null,
-                        \PDO::PARAM_INT
-                    )
-                )
-                ->set('language_locale', $query->bindValue($language))
-                ->set('name', $query->bindValue($name));
-            $query->prepare()->execute();
+                        'contentclass_version' => $query->createPositionalParameter(
+                            $typeStatus,
+                            ParameterType::INTEGER
+                        ),
+                        'language_id' => $query->createPositionalParameter(
+                            $this->languageMaskGenerator->generateLanguageIndicator(
+                                $language,
+                                $this->languageMaskGenerator->isLanguageAlwaysAvailable(
+                                    $language,
+                                    $languages
+                                )
+                            ),
+                            ParameterType::INTEGER
+                        ),
+                        'language_locale' => $query->createPositionalParameter(
+                            $language,
+                            ParameterType::STRING
+                        ),
+                        'name' => $query->createPositionalParameter($name, ParameterType::STRING),
+                    ]
+                );
+            $query->execute();
         }
     }
 
-    /**
-     * Inserts a new content type.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Type $type
-     * @param mixed|null $typeId
-     *
-     * @return mixed Type ID
-     */
-    public function insertType(Type $type, $typeId = null)
-    {
-        $q = $this->dbHandler->createInsertQuery();
-        $q->insertInto($this->dbHandler->quoteTable('ezcontentclass'));
-        $q->set(
-            $this->dbHandler->quoteColumn('id'),
-            isset($typeId) ? $q->bindValue($typeId, null, \PDO::PARAM_INT) : $this->dbHandler->getAutoIncrementValue('ezcontentclass', 'id')
-        )->set(
-            $this->dbHandler->quoteColumn('version'),
-            $q->bindValue($type->status, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('created'),
-            $q->bindValue($type->created, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('creator_id'),
-            $q->bindValue($type->creatorId, null, \PDO::PARAM_INT)
-        );
-        $this->setCommonTypeColumns($q, $type);
+    private function setNextAutoIncrementedValueIfAvailable(
+        QueryBuilder $queryBuilder,
+        string $tableName,
+        string $idColumnName,
+        string $sequenceName,
+        ?int $defaultValue = null
+    ): void {
+        if (null === $defaultValue) {
+            // usually returns null to trigger default column value behavior
+            $defaultValue = $this->sharedGateway->getColumnNextIntegerValue(
+                $tableName,
+                $idColumnName,
+                $sequenceName
+            );
+        }
+        // avoid trying to insert NULL to trigger default column value behavior
+        if (null !== $defaultValue) {
+            $queryBuilder->setValue(
+                $idColumnName,
+                $queryBuilder->createNamedParameter(
+                    $defaultValue,
+                    ParameterType::INTEGER,
+                    ":{$idColumnName}"
+                )
+            );
+        }
+    }
 
-        $q->prepare()->execute();
+    public function insertType(Type $type, ?int $typeId = null): int
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->insert(self::CONTENT_TYPE_TABLE)
+            ->values(
+                [
+                    // Legacy Storage: "version" stores CT status (draft, published)
+                    'version' => $query->createNamedParameter(
+                        $type->status,
+                        ParameterType::INTEGER,
+                        ':status'
+                    ),
+                    'created' => $query->createNamedParameter(
+                        $type->created,
+                        ParameterType::INTEGER,
+                        ':created'
+                    ),
+                    'creator_id' => $query->createNamedParameter(
+                        $type->creatorId,
+                        ParameterType::INTEGER,
+                        ':creator_id'
+                    ),
+                ]
+            );
+        $this->setNextAutoIncrementedValueIfAvailable(
+            $query,
+            self::CONTENT_TYPE_TABLE,
+            'id',
+            self::CONTENT_TYPE_SEQ,
+            $typeId
+        );
+
+        $columnQueryValueAndTypeMap = $this->mapCommonContentTypeColumnsToQueryValuesAndTypes(
+            $type
+        );
+        foreach ($columnQueryValueAndTypeMap as $columnName => $data) {
+            [$value, $parameterType] = $data;
+            $query
+                ->setValue(
+                    $columnName,
+                    $query->createNamedParameter($value, $parameterType, ":{$columnName}")
+                );
+        }
+
+        $query->setParameter('status', $type->status, ParameterType::INTEGER);
+        $query->setParameter('created', $type->created, ParameterType::INTEGER);
+        $query->setParameter('creator_id', $type->creatorId, ParameterType::INTEGER);
+
+        $query->execute();
 
         if (empty($typeId)) {
-            $typeId = (int)$this->dbHandler->lastInsertId(
-                $this->dbHandler->getSequenceName('ezcontentclass', 'id')
-            );
+            $typeId = $this->sharedGateway->getLastInsertedId(self::CONTENT_TYPE_SEQ);
         }
 
         $this->insertTypeNameData($typeId, $type->status, $type->name);
@@ -377,274 +385,220 @@ final class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Set common columns for insert/update of a Type.
+     * Get a map of Content Type storage column name to its value and parameter type.
      *
-     * @param \eZ\Publish\Core\Persistence\Database\InsertQuery|\eZ\Publish\Core\Persistence\Database\UpdateQuery $q
-     * @param \eZ\Publish\SPI\Persistence\ValueObject|\eZ\Publish\SPI\Persistence\Content\Type $type
+     * Key value of the map is represented as a two-elements array with column value and its type.
      */
-    private function setCommonTypeColumns(Query $q, ValueObject $type)
+    private function mapCommonContentTypeColumnsToQueryValuesAndTypes(Type $type): array
     {
-        $q->set(
-            $this->dbHandler->quoteColumn('serialized_name_list'),
-            $q->bindValue(serialize($type->name))
-        )->set(
-            $this->dbHandler->quoteColumn('serialized_description_list'),
-            $q->bindValue(serialize($type->description))
-        )->set(
-            $this->dbHandler->quoteColumn('identifier'),
-            $q->bindValue($type->identifier)
-        )->set(
-            $this->dbHandler->quoteColumn('modified'),
-            $q->bindValue($type->modified, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('modifier_id'),
-            $q->bindValue($type->modifierId, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('remote_id'),
-            $q->bindValue($type->remoteId)
-        )->set(
-            $this->dbHandler->quoteColumn('url_alias_name'),
-            $q->bindValue($type->urlAliasSchema)
-        )->set(
-            $this->dbHandler->quoteColumn('contentobject_name'),
-            $q->bindValue($type->nameSchema)
-        )->set(
-            $this->dbHandler->quoteColumn('is_container'),
-            $q->bindValue($type->isContainer ? 1 : 0, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('language_mask'),
-            $q->bindValue(
-                $this->languageMaskGenerator->generateLanguageMaskFromLanguageCodes($type->languageCodes, array_key_exists('always-available', $type->name)),
-                null,
-                \PDO::PARAM_INT
-            )
-        )->set(
-            $this->dbHandler->quoteColumn('initial_language_id'),
-            $q->bindValue($type->initialLanguageId, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('sort_field'),
-            $q->bindValue($type->sortField, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('sort_order'),
-            $q->bindValue($type->sortOrder, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('always_available'),
-            $q->bindValue((int)$type->defaultAlwaysAvailable, null, \PDO::PARAM_INT)
-        );
+        return [
+            'serialized_name_list' => [serialize($type->name), ParameterType::STRING],
+            'serialized_description_list' => [serialize($type->description), ParameterType::STRING],
+            'identifier' => [$type->identifier, ParameterType::STRING],
+            'modified' => [$type->modified, ParameterType::INTEGER],
+            'modifier_id' => [$type->modifierId, ParameterType::INTEGER],
+            'remote_id' => [$type->remoteId, ParameterType::STRING],
+            'url_alias_name' => [$type->urlAliasSchema, ParameterType::STRING],
+            'contentobject_name' => [$type->nameSchema, ParameterType::STRING],
+            'is_container' => [(int)$type->isContainer, ParameterType::INTEGER],
+            'language_mask' => [
+                $this->languageMaskGenerator->generateLanguageMaskFromLanguageCodes(
+                    $type->languageCodes,
+                    array_key_exists('always-available', $type->name)
+                ),
+                ParameterType::INTEGER,
+            ],
+            'initial_language_id' => [$type->initialLanguageId, ParameterType::INTEGER],
+            'sort_field' => [$type->sortField, ParameterType::INTEGER],
+            'sort_order' => [$type->sortOrder, ParameterType::INTEGER],
+            'always_available' => [(int)$type->defaultAlwaysAvailable, ParameterType::INTEGER],
+        ];
     }
 
-    /**
-     * Insert assignment of $typeId to $groupId.
-     *
-     * @param mixed $groupId
-     * @param mixed $typeId
-     * @param int $status
-     */
-    public function insertGroupAssignment($groupId, $typeId, $status)
+    public function insertGroupAssignment(int $groupId, int $typeId, int $status): void
     {
         $groups = $this->loadGroupData([$groupId]);
+        if (empty($groups)) {
+            throw new NotFoundException('Content Type Group', $groupId);
+        }
         $group = $groups[0];
 
-        $q = $this->dbHandler->createInsertQuery();
-        $q->insertInto(
-            $this->dbHandler->quoteTable('ezcontentclass_classgroup')
-        )->set(
-            $this->dbHandler->quoteColumn('contentclass_id'),
-            $q->bindValue($typeId, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('contentclass_version'),
-            $q->bindValue($status, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('group_id'),
-            $q->bindValue($groupId, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('group_name'),
-            $q->bindValue($group['name'])
-        );
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->insert(self::CONTENT_TYPE_TO_GROUP_ASSIGNMENT_TABLE)
+            ->values(
+                [
+                    'contentclass_id' => $query->createPositionalParameter(
+                        $typeId,
+                        ParameterType::INTEGER
+                    ),
+                    'contentclass_version' => $query->createPositionalParameter(
+                        $status,
+                        ParameterType::INTEGER
+                    ),
+                    'group_id' => $query->createPositionalParameter(
+                        $groupId,
+                        ParameterType::INTEGER
+                    ),
+                    'group_name' => $query->createPositionalParameter(
+                        $group['name'],
+                        ParameterType::STRING
+                    ),
+                ]
+            );
 
-        $q->prepare()->execute();
+        $query->execute();
     }
 
-    /**
-     * Deletes a group assignments for a Type.
-     *
-     * @param mixed $groupId
-     * @param mixed $typeId
-     * @param int $status
-     */
-    public function deleteGroupAssignment($groupId, $typeId, $status)
+    public function deleteGroupAssignment(int $groupId, int $typeId, int $status): void
     {
-        $q = $this->dbHandler->createDeleteQuery();
-        $q->deleteFrom(
-            $this->dbHandler->quoteTable('ezcontentclass_classgroup')
-        )->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_id'),
-                    $q->bindValue($typeId, null, \PDO::PARAM_INT)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_version'),
-                    $q->bindValue($status, null, \PDO::PARAM_INT)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('group_id'),
-                    $q->bindValue($groupId, null, \PDO::PARAM_INT)
+        $query = $this->connection->createQueryBuilder();
+        $expr = $query->expr();
+        $query
+            ->delete(self::CONTENT_TYPE_TO_GROUP_ASSIGNMENT_TABLE)
+            ->where(
+                $expr->eq(
+                    'contentclass_id',
+                    $query->createPositionalParameter($typeId, ParameterType::INTEGER)
                 )
             )
-        );
-        $q->prepare()->execute();
+            ->andWhere(
+                $expr->eq(
+                    'contentclass_version',
+                    $query->createPositionalParameter($status, ParameterType::INTEGER)
+                )
+            )
+            ->andWhere(
+                $expr->eq(
+                    'group_id',
+                    $query->createPositionalParameter($groupId, ParameterType::INTEGER)
+                )
+            );
+        $query->execute();
     }
 
-    /**
-     * Loads data about Groups with $groupIds.
-     *
-     * @param int[] $groupIds
-     *
-     * @return string[][]
-     */
-    public function loadGroupData(array $groupIds)
+    public function loadGroupData(array $groupIds): array
     {
-        $q = $this->connection->createQueryBuilder();
-        $q
+        $query = $this->connection->createQueryBuilder();
+        $query
             ->select('created', 'creator_id', 'id', 'modified', 'modifier_id', 'name')
-            ->from('ezcontentclassgroup')
-            ->where($q->expr()->in('id', ':ids'))
+            ->from(self::CONTENT_TYPE_GROUP_TABLE)
+            ->where($query->expr()->in('id', ':ids'))
             ->setParameter('ids', $groupIds, Connection::PARAM_INT_ARRAY);
 
-        return $q->execute()->fetchAll();
+        return $query->execute()->fetchAll();
     }
 
-    /**
-     * Loads data about Group with $identifier.
-     *
-     * @param mixed $identifier
-     *
-     * @return string[][]
-     */
-    public function loadGroupDataByIdentifier($identifier)
+    public function loadGroupDataByIdentifier(string $identifier): array
     {
-        $q = $this->createGroupLoadQuery();
-        $q->where(
-            $q->expr->eq(
-                $this->dbHandler->quoteColumn('name'),
-                $q->bindValue($identifier, null, \PDO::PARAM_STR)
+        $query = $this->createGroupLoadQuery();
+        $query->where(
+            $query->expr()->eq(
+                'name',
+                $query->createPositionalParameter($identifier, ParameterType::STRING)
             )
         );
-        $stmt = $q->prepare();
-        $stmt->execute();
 
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return $query->execute()->fetchAll(FetchMode::ASSOCIATIVE);
+    }
+
+    public function loadAllGroupsData(): array
+    {
+        $query = $this->createGroupLoadQuery();
+
+        return $query->execute()->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
     /**
-     * Returns an array with data about all Group objects.
-     *
-     * @return string[][]
+     * Create the basic query to load Group data.
      */
-    public function loadAllGroupsData()
+    private function createGroupLoadQuery(): QueryBuilder
     {
-        $q = $this->createGroupLoadQuery();
+        $query = $this->connection->createQueryBuilder();
+        $query->select(
+            'created',
+            'creator_id',
+            'id',
+            'modified',
+            'modifier_id',
+            'name'
+        )->from(self::CONTENT_TYPE_GROUP_TABLE);
 
-        $stmt = $q->prepare();
-        $stmt->execute();
-
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return $query;
     }
 
-    /**
-     * Creates the basic query to load Group data.
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\SelectQuery
-     */
-    private function createGroupLoadQuery()
+    public function loadTypesDataForGroup(int $groupId, int $status): array
     {
-        $q = $this->dbHandler->createSelectQuery();
-        $q->select(
-            $this->dbHandler->quoteColumn('created'),
-            $this->dbHandler->quoteColumn('creator_id'),
-            $this->dbHandler->quoteColumn('id'),
-            $this->dbHandler->quoteColumn('modified'),
-            $this->dbHandler->quoteColumn('modifier_id'),
-            $this->dbHandler->quoteColumn('name')
-        )->from(
-            $this->dbHandler->quoteTable('ezcontentclassgroup')
-        );
-
-        return $q;
-    }
-
-    /**
-     * Loads data for all Types in $status in $groupId.
-     *
-     * @param mixed $groupId
-     * @param int $status
-     *
-     * @return string[][]
-     */
-    public function loadTypesDataForGroup($groupId, $status)
-    {
-        $q = $this->getLoadTypeQueryBuilder();
-        $q
-            ->where($q->expr()->eq('g.group_id', ':gid'))
-            ->andWhere($q->expr()->eq('c.version', ':version'))
+        $query = $this->getLoadTypeQueryBuilder();
+        $expr = $query->expr();
+        $query
+            ->where($expr->eq('g.group_id', ':gid'))
+            ->andWhere($expr->eq('c.version', ':version'))
             ->addOrderBy('c.identifier')
             ->setParameter('gid', $groupId, ParameterType::INTEGER)
             ->setParameter('version', $status, ParameterType::INTEGER);
 
-        return $q->execute()->fetchAll();
+        return $query->execute()->fetchAll();
     }
 
-    /**
-     * Inserts a $fieldDefinition for $typeId.
-     *
-     * @param mixed $typeId
-     * @param int $status
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageFieldDef
-     *
-     * @return mixed Field definition ID
-     */
     public function insertFieldDefinition(
-        $typeId,
-        $status,
+        int $typeId,
+        int $status,
         FieldDefinition $fieldDefinition,
         StorageFieldDefinition $storageFieldDef
-    ) {
-        $q = $this->dbHandler->createInsertQuery();
-        $q->insertInto($this->dbHandler->quoteTable('ezcontentclass_attribute'));
-        $q->set(
-            $this->dbHandler->quoteColumn('id'),
-            isset($fieldDefinition->id) ? $q->bindValue($fieldDefinition->id, null, \PDO::PARAM_INT) : $this->dbHandler->getAutoIncrementValue('ezcontentclass_attribute', 'id')
-        )->set(
-            $this->dbHandler->quoteColumn('contentclass_id'),
-            $q->bindValue($typeId, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('version'),
-            $q->bindValue($status, null, \PDO::PARAM_INT)
+    ): int {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->insert(self::FIELD_DEFINITION_TABLE)
+            ->values(
+                [
+                    'contentclass_id' => $query->createNamedParameter(
+                        $typeId,
+                        ParameterType::INTEGER,
+                        ':content_type_id'
+                    ),
+                    'version' => $query->createNamedParameter(
+                        $status,
+                        ParameterType::INTEGER,
+                        ':status'
+                    ),
+                ]
+            );
+        $this->setNextAutoIncrementedValueIfAvailable(
+            $query,
+            self::FIELD_DEFINITION_TABLE,
+            'id',
+            self::FIELD_DEFINITION_SEQ,
+            $fieldDefinition->id
         );
-        $this->setCommonFieldColumns($q, $fieldDefinition, $storageFieldDef);
+        $columnValueAndTypeMap = $this->mapCommonFieldDefinitionColumnsToQueryValuesAndTypes(
+            $fieldDefinition,
+            $storageFieldDef
+        );
+        foreach ($columnValueAndTypeMap as $columnName => $data) {
+            [$columnValue, $parameterType] = $data;
+            $query
+                ->setValue($columnName, ":{$columnName}")
+                ->setParameter($columnName, $columnValue, $parameterType);
+        }
 
-        $q->prepare()->execute();
+        $query->execute();
 
-        $fieldDefinitionId = (int)($fieldDefinition->id ?? $this->dbHandler->lastInsertId(
-            $this->dbHandler->getSequenceName('ezcontentclass_attribute', 'id')
-        ));
+        $fieldDefinitionId = $fieldDefinition->id ?? $this->sharedGateway->getLastInsertedId(
+            self::FIELD_DEFINITION_SEQ
+        );
 
         foreach ($storageFieldDef->multilingualData as $multilingualData) {
-            $this->insertFieldDefinitionMultilingualData($fieldDefinitionId, $multilingualData, $status);
+            $this->insertFieldDefinitionMultilingualData(
+                $fieldDefinitionId,
+                $multilingualData,
+                $status
+            );
         }
 
         return $fieldDefinitionId;
     }
 
-    /**
-     * @param int $fieldDefinitionId
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\MultilingualStorageFieldDefinition $multilingualData
-     * @param int $status
-     *
-     * @throws \Doctrine\DBAL\DBALException
-     */
     private function insertFieldDefinitionMultilingualData(
         int $fieldDefinitionId,
         MultilingualStorageFieldDefinition $multilingualData,
@@ -652,258 +606,219 @@ final class DoctrineDatabase extends Gateway
     ): void {
         $query = $this->connection->createQueryBuilder();
         $query
-            ->insert('ezcontentclass_attribute_ml')
-            ->values([
-                'data_text' => ':dataText',
-                'data_json' => ':dataJson',
-                'name' => ':name',
-                'description' => ':description',
-                'contentclass_attribute_id' => ':fieldDefinitionId',
-                'version' => ':status',
-                'language_id' => ':languageId',
-            ])
-            ->setParameter('dataText', $multilingualData->dataText)
-            ->setParameter('dataJson', $multilingualData->dataJson)
+            ->insert(self::MULTILINGUAL_FIELD_DEFINITION_TABLE)
+            ->values(
+                [
+                    'data_text' => ':data_text',
+                    'data_json' => ':data_json',
+                    'name' => ':name',
+                    'description' => ':description',
+                    'contentclass_attribute_id' => ':field_definition_id',
+                    'version' => ':status',
+                    'language_id' => ':language_id',
+                ]
+            )
+            ->setParameter('data_text', $multilingualData->dataText)
+            ->setParameter('data_json', $multilingualData->dataJson)
             ->setParameter('name', $multilingualData->name)
             ->setParameter('description', $multilingualData->description)
-            ->setParameter('fieldDefinitionId', $fieldDefinitionId, ParameterType::INTEGER)
+            ->setParameter('field_definition_id', $fieldDefinitionId, ParameterType::INTEGER)
             ->setParameter('status', $status, ParameterType::INTEGER)
-            ->setParameter('languageId', $multilingualData->languageId, ParameterType::INTEGER);
+            ->setParameter('language_id', $multilingualData->languageId, ParameterType::INTEGER);
 
         $query->execute();
     }
 
     /**
-     * Set common columns for insert/update of FieldDefinition.
+     * Get a map of Field Definition storage column name to its value and parameter type.
      *
-     * @param \eZ\Publish\Core\Persistence\Database\InsertQuery|\eZ\Publish\Core\Persistence\Database\UpdateQuery $q
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageFieldDef
+     * Key value of the map is represented as a two-elements array with column value and its type.
      */
-    private function setCommonFieldColumns(
-        Query $q,
+    private function mapCommonFieldDefinitionColumnsToQueryValuesAndTypes(
         FieldDefinition $fieldDefinition,
         StorageFieldDefinition $storageFieldDef
-    ) {
-        $q->set(
-            $this->dbHandler->quoteColumn('serialized_name_list'),
-            $q->bindValue(serialize($fieldDefinition->name))
-        )->set(
-            $this->dbHandler->quoteColumn('serialized_description_list'),
-            $q->bindValue(serialize($fieldDefinition->description))
-        )->set(
-            $this->dbHandler->quoteColumn('identifier'),
-            $q->bindValue($fieldDefinition->identifier)
-        )->set(
-            $this->dbHandler->quoteColumn('category'),
-            $q->bindValue($fieldDefinition->fieldGroup, null, \PDO::PARAM_STR)
-        )->set(
-            $this->dbHandler->quoteColumn('placement'),
-            $q->bindValue($fieldDefinition->position, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('data_type_string'),
-            $q->bindValue($fieldDefinition->fieldType)
-        )->set(
-            $this->dbHandler->quoteColumn('can_translate'),
-            $q->bindValue(($fieldDefinition->isTranslatable ? 1 : 0), null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('is_thumbnail'),
-            $q->bindValue((bool)$fieldDefinition->isThumbnail, null, \PDO::PARAM_BOOL)
-        )->set(
-            $this->dbHandler->quoteColumn('is_required'),
-            $q->bindValue(($fieldDefinition->isRequired ? 1 : 0), null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('is_information_collector'),
-            $q->bindValue(($fieldDefinition->isInfoCollector ? 1 : 0), null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('data_float1'),
-            $q->bindValue($storageFieldDef->dataFloat1)
-        )->set(
-            $this->dbHandler->quoteColumn('data_float2'),
-            $q->bindValue($storageFieldDef->dataFloat2)
-        )->set(
-            $this->dbHandler->quoteColumn('data_float3'),
-            $q->bindValue($storageFieldDef->dataFloat3)
-        )->set(
-            $this->dbHandler->quoteColumn('data_float4'),
-            $q->bindValue($storageFieldDef->dataFloat4)
-        )->set(
-            $this->dbHandler->quoteColumn('data_int1'),
-            $q->bindValue($storageFieldDef->dataInt1, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('data_int2'),
-            $q->bindValue($storageFieldDef->dataInt2, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('data_int3'),
-            $q->bindValue($storageFieldDef->dataInt3, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('data_int4'),
-            $q->bindValue($storageFieldDef->dataInt4, null, \PDO::PARAM_INT)
-        )->set(
-            $this->dbHandler->quoteColumn('data_text1'),
-            $q->bindValue($storageFieldDef->dataText1)
-        )->set(
-            $this->dbHandler->quoteColumn('data_text2'),
-            $q->bindValue($storageFieldDef->dataText2)
-        )->set(
-            $this->dbHandler->quoteColumn('data_text3'),
-            $q->bindValue($storageFieldDef->dataText3)
-        )->set(
-            $this->dbHandler->quoteColumn('data_text4'),
-            $q->bindValue($storageFieldDef->dataText4)
-        )->set(
-            $this->dbHandler->quoteColumn('data_text5'),
-            $q->bindValue($storageFieldDef->dataText5)
-        )->set(
-            $this->dbHandler->quoteColumn('serialized_data_text'),
-            $q->bindValue(serialize($storageFieldDef->serializedDataText))
-        )->set(
-            $this->dbHandler->quoteColumn('is_searchable'),
-            $q->bindValue(($fieldDefinition->isSearchable ? 1 : 0), null, \PDO::PARAM_INT)
-        );
+    ): array {
+        return [
+            'serialized_name_list' => [serialize($fieldDefinition->name), ParameterType::STRING],
+            'serialized_description_list' => [
+                serialize($fieldDefinition->description),
+                ParameterType::STRING,
+            ],
+            'serialized_data_text' => [
+                serialize($storageFieldDef->serializedDataText),
+                ParameterType::STRING,
+            ],
+            'identifier' => [$fieldDefinition->identifier, ParameterType::STRING],
+            'category' => [$fieldDefinition->fieldGroup, ParameterType::STRING],
+            'placement' => [$fieldDefinition->position, ParameterType::INTEGER],
+            'data_type_string' => [$fieldDefinition->fieldType, ParameterType::STRING],
+            'can_translate' => [(int)$fieldDefinition->isTranslatable, ParameterType::INTEGER],
+            'is_thumbnail' => [(bool)$fieldDefinition->isThumbnail, ParameterType::INTEGER],
+            'is_required' => [(int)$fieldDefinition->isRequired, ParameterType::INTEGER],
+            'is_information_collector' => [
+                (int)$fieldDefinition->isInfoCollector,
+                ParameterType::INTEGER,
+            ],
+            'is_searchable' => [(int)$fieldDefinition->isSearchable, ParameterType::INTEGER],
+            'data_float1' => [$storageFieldDef->dataFloat1, null],
+            'data_float2' => [$storageFieldDef->dataFloat2, null],
+            'data_float3' => [$storageFieldDef->dataFloat3, null],
+            'data_float4' => [$storageFieldDef->dataFloat4, null],
+            'data_int1' => [$storageFieldDef->dataInt1, ParameterType::INTEGER],
+            'data_int2' => [$storageFieldDef->dataInt2, ParameterType::INTEGER],
+            'data_int3' => [$storageFieldDef->dataInt3, ParameterType::INTEGER],
+            'data_int4' => [$storageFieldDef->dataInt4, ParameterType::INTEGER],
+            'data_text1' => [$storageFieldDef->dataText1, ParameterType::STRING],
+            'data_text2' => [$storageFieldDef->dataText2, ParameterType::STRING],
+            'data_text3' => [$storageFieldDef->dataText3, ParameterType::STRING],
+            'data_text4' => [$storageFieldDef->dataText4, ParameterType::STRING],
+            'data_text5' => [$storageFieldDef->dataText5, ParameterType::STRING],
+        ];
     }
 
-    /**
-     * Loads an array with data about field definition referred $id and $status.
-     *
-     * @param mixed $id field definition id
-     * @param int $status One of Type::STATUS_DEFINED|Type::STATUS_DRAFT|Type::STATUS_MODIFIED
-     *
-     * @return array Data rows.
-     */
-    public function loadFieldDefinition($id, $status)
+    public function loadFieldDefinition(int $id, int $status): array
     {
-        $q = $this->dbHandler->createSelectQuery();
-        $this->selectColumns($q, 'ezcontentclass_attribute');
-        $q->select([
-                'ezcontentclass.initial_language_id AS ezcontentclass_initial_language_id',
-                'ezcontentclass_attribute_ml.name AS ezcontentclass_attribute_multilingual_name',
-                'ezcontentclass_attribute_ml.description AS ezcontentclass_attribute_multilingual_description',
-                'ezcontentclass_attribute_ml.language_id AS ezcontentclass_attribute_multilingual_language_id',
-                'ezcontentclass_attribute_ml.data_text AS ezcontentclass_attribute_multilingual_data_text',
-                'ezcontentclass_attribute_ml.data_json AS ezcontentclass_attribute_multilingual_data_json',
-            ]);
-        $q->from(
-            $this->dbHandler->quoteTable('ezcontentclass_attribute')
-        )->leftJoin(
-            'ezcontentclass',
-            $q->expr->lAnd(
-                $q->expr->eq('ezcontentclass_attribute.contentclass_id', 'ezcontentclass.id'),
-                $q->expr->eq('ezcontentclass_attribute.version', 'ezcontentclass.version')
+        $query = $this->connection->createQueryBuilder();
+        $expr = $query->expr();
+        $this
+            ->selectColumns($query, self::FIELD_DEFINITION_TABLE, 'f_def')
+            ->addSelect(
+                [
+                    'ct.initial_language_id AS ezcontentclass_initial_language_id',
+                    'transl_f_def.name AS ezcontentclass_attribute_multilingual_name',
+                    'transl_f_def.description AS ezcontentclass_attribute_multilingual_description',
+                    'transl_f_def.language_id AS ezcontentclass_attribute_multilingual_language_id',
+                    'transl_f_def.data_text AS ezcontentclass_attribute_multilingual_data_text',
+                    'transl_f_def.data_json AS ezcontentclass_attribute_multilingual_data_json',
+                ]
             )
-        )->leftJoin(
-            'ezcontentclass_attribute_ml',
-            $q->expr->lAnd(
-                $q->expr->eq('ezcontentclass_attribute.id', 'ezcontentclass_attribute_ml.contentclass_attribute_id'),
-                $q->expr->eq('ezcontentclass_attribute.version', 'ezcontentclass_attribute_ml.version')
-            )
-        )->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('id', 'ezcontentclass_attribute'),
-                    $q->bindValue($id, null, \PDO::PARAM_INT)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('version', 'ezcontentclass_attribute'),
-                    $q->bindValue($status, null, \PDO::PARAM_INT)
+            ->from(self::FIELD_DEFINITION_TABLE, 'f_def')
+            ->leftJoin(
+                'f_def',
+                self::CONTENT_TYPE_TABLE,
+                'ct',
+                $expr->andX(
+                    $expr->eq('f_def.contentclass_id', 'ct.id'),
+                    $expr->eq('f_def.version', 'ct.version')
                 )
             )
-        );
+            ->leftJoin(
+                'f_def',
+                self::MULTILINGUAL_FIELD_DEFINITION_TABLE,
+                'transl_f_def',
+                $expr->andX(
+                    $expr->eq(
+                        'f_def.id',
+                        'transl_f_def.contentclass_attribute_id'
+                    ),
+                    $expr->eq(
+                        'f_def.version',
+                        'transl_f_def.version'
+                    )
+                )
+            )
+            ->where(
+                $expr->eq(
+                    'f_def.id',
+                    $query->createPositionalParameter($id, ParameterType::INTEGER)
+                )
+            )
+            ->andWhere(
+                $expr->eq(
+                    'f_def.version',
+                    $query->createPositionalParameter($status, ParameterType::INTEGER)
+                )
+            );
 
-        $stmt = $q->prepare();
-        $stmt->execute();
+        $stmt = $query->execute();
 
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return $stmt->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    /**
-     * Deletes a field definition.
-     *
-     * @param mixed $typeId
-     * @param int $status
-     * @param mixed $fieldDefinitionId
-     */
-    public function deleteFieldDefinition($typeId, $status, $fieldDefinitionId)
-    {
-        $q = $this->dbHandler->createDeleteQuery();
-        $q->deleteFrom(
-            $this->dbHandler->quoteTable('ezcontentclass_attribute')
-        )->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('id'),
-                    $q->bindValue($fieldDefinitionId, null, \PDO::PARAM_INT)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('version'),
-                    $q->bindValue($status, null, \PDO::PARAM_INT)
-                ),
-                // @todo FIXME: Actually not needed
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_id'),
-                    $q->bindValue($typeId, null, \PDO::PARAM_INT)
-                )
-            )
-        );
-
-        $q->prepare()->execute();
-
+    public function deleteFieldDefinition(
+        int $typeId,
+        int $status,
+        int $fieldDefinitionId
+    ): void {
+        // Delete multilingual data first to keep DB integrity
         $deleteQuery = $this->connection->createQueryBuilder();
         $deleteQuery
-            ->delete('ezcontentclass_attribute_ml')
-            ->where('contentclass_attribute_id = :fieldDefinitionId')
+            ->delete(self::MULTILINGUAL_FIELD_DEFINITION_TABLE)
+            ->where('contentclass_attribute_id = :field_definition_id')
             ->andWhere('version = :status')
-            ->setParameter('fieldDefinitionId', $fieldDefinitionId, ParameterType::INTEGER)
+            ->setParameter('field_definition_id', $fieldDefinitionId, ParameterType::INTEGER)
             ->setParameter('status', $status, ParameterType::INTEGER);
 
         $deleteQuery->execute();
-    }
 
-    /**
-     * Updates a $fieldDefinition for $typeId.
-     *
-     * @param mixed $typeId
-     * @param int $status
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageFieldDef
-     */
-    public function updateFieldDefinition(
-        $typeId,
-        $status,
-        FieldDefinition $fieldDefinition,
-        StorageFieldDefinition $storageFieldDef
-    ) {
-        $q = $this->dbHandler->createUpdateQuery();
-        $q
-            ->update(
-                $this->dbHandler->quoteTable('ezcontentclass_attribute')
-            )->where(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('id'),
-                    $q->bindValue($fieldDefinition->id, null, \PDO::PARAM_INT)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('version'),
-                    $q->bindValue($status, null, \PDO::PARAM_INT)
-                ),
-                // @todo FIXME: Actually not needed
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_id'),
-                    $q->bindValue($typeId, null, \PDO::PARAM_INT)
+        // Delete legacy Field Definition data
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->delete(self::FIELD_DEFINITION_TABLE)
+            ->where(
+                $query->expr()->eq(
+                    'id',
+                    $query->createPositionalParameter($fieldDefinitionId, ParameterType::INTEGER)
+                )
+            )
+            ->andWhere(
+            // in Legacy Storage Field Definition table the "version" column stores status (e.g. draft, published, modified)
+                $query->expr()->eq(
+                    'version',
+                    $query->createPositionalParameter($status, ParameterType::INTEGER)
+                )
+            )
+            ->andWhere(
+            // @todo FIXME: Actually not needed
+                $query->expr()->eq(
+                    'contentclass_id',
+                    $query->createPositionalParameter($typeId, ParameterType::INTEGER)
                 )
             );
-        $this->setCommonFieldColumns($q, $fieldDefinition, $storageFieldDef);
 
-        $q->prepare()->execute();
+        $query->execute();
+    }
 
-        foreach ($storageFieldDef->multilingualData as $languageCode => $data) {
-            $dataExist = $this->fieldDefinitionMultilingualDataExist(
+    public function updateFieldDefinition(
+        int $typeId,
+        int $status,
+        FieldDefinition $fieldDefinition,
+        StorageFieldDefinition $storageFieldDef
+    ): void {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->update(self::FIELD_DEFINITION_TABLE)
+            ->where('id = :field_definition_id')
+            ->andWhere('version = :status')
+            // @todo FIXME: Actually not needed
+            ->andWhere('contentclass_id = :content_type_id')
+            ->setParameter('field_definition_id', $fieldDefinition->id, ParameterType::INTEGER)
+            ->setParameter('status', $status, ParameterType::INTEGER)
+            ->setParameter('content_type_id', $typeId, ParameterType::INTEGER);
+
+        $fieldDefinitionValueAndTypeMap = $this->mapCommonFieldDefinitionColumnsToQueryValuesAndTypes(
+            $fieldDefinition,
+            $storageFieldDef
+        );
+        foreach ($fieldDefinitionValueAndTypeMap as $columnName => $data) {
+            [$value, $parameterType] = $data;
+            $query
+                ->set(
+                    $columnName,
+                    $query->createNamedParameter($value, $parameterType, ":{$columnName}")
+                );
+        }
+
+        $query->execute();
+
+        foreach ($storageFieldDef->multilingualData as $data) {
+            $dataExists = $this->fieldDefinitionMultilingualDataExist(
                 $fieldDefinition,
                 $data->languageId,
                 $status
             );
 
-            if ($dataExist) {
+            if ($dataExists) {
                 $this->updateFieldDefinitionMultilingualData(
                     $fieldDefinition->id,
                     $data,
@@ -978,58 +893,61 @@ final class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Deletes all name data for $typeId in $typeStatus.
-     *
-     * @param int $typeId
-     * @param int $typeStatus
+     * Delete entire name data for the given Content Type of the given status.
      */
-    private function deleteTypeNameData($typeId, $typeStatus)
+    private function deleteTypeNameData(int $typeId, int $typeStatus): void
     {
-        $query = $this->dbHandler->createDeleteQuery();
-        $query->deleteFrom('ezcontentclass_name')
+        $query = $this->connection->createQueryBuilder();
+        $expr = $query->expr();
+        $query
+            ->delete(self::CONTENT_TYPE_NAME_TABLE)
             ->where(
-                $query->expr->lAnd(
-                    $query->expr->eq(
-                        $this->dbHandler->quoteColumn('contentclass_id'),
-                        $query->bindValue($typeId, null, \PDO::PARAM_INT)
-                    ),
-                    $query->expr->eq(
-                        $this->dbHandler->quoteColumn('contentclass_version'),
-                        $query->bindValue($typeStatus, null, \PDO::PARAM_INT)
-                    )
-                )
-            );
-        $query->prepare()->execute();
-    }
-
-    /**
-     * Update a type with $updateStruct.
-     *
-     * @param mixed $typeId
-     * @param int $status
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\UpdateStruct $updateStruct
-     */
-    public function updateType($typeId, $status, Type $type)
-    {
-        $q = $this->dbHandler->createUpdateQuery();
-        $q->update($this->dbHandler->quoteTable('ezcontentclass'));
-
-        $this->setCommonTypeColumns($q, $type);
-
-        $q->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('id'),
-                    $q->bindValue($typeId, null, \PDO::PARAM_INT)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('version'),
-                    $q->bindValue($status, null, \PDO::PARAM_INT)
+                $expr->eq(
+                    'contentclass_id',
+                    $query->createPositionalParameter($typeId, ParameterType::INTEGER)
                 )
             )
-        );
+            ->andWhere(
+                $expr->eq(
+                    'contentclass_version',
+                    $query->createPositionalParameter($typeStatus, ParameterType::INTEGER)
+                )
+            );
+        $query->execute();
+    }
 
-        $q->prepare()->execute();
+    public function updateType(int $typeId, int $status, Type $type): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query->update(self::CONTENT_TYPE_TABLE);
+
+        $columnQueryValueAndTypeMap = $this->mapCommonContentTypeColumnsToQueryValuesAndTypes(
+            $type
+        );
+        foreach ($columnQueryValueAndTypeMap as $columnName => $data) {
+            [$value, $parameterType] = $data;
+            $query
+                ->set(
+                    $columnName,
+                    $query->createNamedParameter($value, $parameterType, ":{$columnName}")
+                );
+        }
+        $expr = $query->expr();
+        $query
+            ->where(
+                $expr->eq(
+                    'id',
+                    $query->createNamedParameter($typeId, ParameterType::INTEGER, ':id')
+                )
+            )
+            ->andWhere(
+                $expr->eq(
+                    'version',
+                    $query->createNamedParameter($status, ParameterType::INTEGER, ':status')
+                )
+            );
+
+        $query->execute();
 
         $this->deleteTypeNameData($typeId, $status);
         $this->insertTypeNameData($typeId, $status, $type->name);
@@ -1110,68 +1028,70 @@ final class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Returns a basic query to retrieve Type data.
+     * Return a basic query to retrieve Type data.
      */
     private function getLoadTypeQueryBuilder(): QueryBuilder
     {
-        $q = $this->connection->createQueryBuilder();
-        $expr = $q->expr();
-        $q
-            ->select([
-                'c.id AS ezcontentclass_id',
-                'c.version AS ezcontentclass_version',
-                'c.serialized_name_list AS ezcontentclass_serialized_name_list',
-                'c.serialized_description_list AS ezcontentclass_serialized_description_list',
-                'c.identifier AS ezcontentclass_identifier',
-                'c.created AS ezcontentclass_created',
-                'c.modified AS ezcontentclass_modified',
-                'c.modifier_id AS ezcontentclass_modifier_id',
-                'c.creator_id AS ezcontentclass_creator_id',
-                'c.remote_id AS ezcontentclass_remote_id',
-                'c.url_alias_name AS ezcontentclass_url_alias_name',
-                'c.contentobject_name AS ezcontentclass_contentobject_name',
-                'c.is_container AS ezcontentclass_is_container',
-                'c.initial_language_id AS ezcontentclass_initial_language_id',
-                'c.always_available AS ezcontentclass_always_available',
-                'c.sort_field AS ezcontentclass_sort_field',
-                'c.sort_order AS ezcontentclass_sort_order',
-                'c.language_mask AS ezcontentclass_language_mask',
+        $query = $this->connection->createQueryBuilder();
+        $expr = $query->expr();
+        $query
+            ->select(
+                [
+                    'c.id AS ezcontentclass_id',
+                    'c.version AS ezcontentclass_version',
+                    'c.serialized_name_list AS ezcontentclass_serialized_name_list',
+                    'c.serialized_description_list AS ezcontentclass_serialized_description_list',
+                    'c.identifier AS ezcontentclass_identifier',
+                    'c.created AS ezcontentclass_created',
+                    'c.modified AS ezcontentclass_modified',
+                    'c.modifier_id AS ezcontentclass_modifier_id',
+                    'c.creator_id AS ezcontentclass_creator_id',
+                    'c.remote_id AS ezcontentclass_remote_id',
+                    'c.url_alias_name AS ezcontentclass_url_alias_name',
+                    'c.contentobject_name AS ezcontentclass_contentobject_name',
+                    'c.is_container AS ezcontentclass_is_container',
+                    'c.initial_language_id AS ezcontentclass_initial_language_id',
+                    'c.always_available AS ezcontentclass_always_available',
+                    'c.sort_field AS ezcontentclass_sort_field',
+                    'c.sort_order AS ezcontentclass_sort_order',
+                    'c.language_mask AS ezcontentclass_language_mask',
 
-                'a.id AS ezcontentclass_attribute_id',
-                'a.serialized_name_list AS ezcontentclass_attribute_serialized_name_list',
-                'a.serialized_description_list AS ezcontentclass_attribute_serialized_description_list',
-                'a.identifier AS ezcontentclass_attribute_identifier',
-                'a.category AS ezcontentclass_attribute_category',
-                'a.data_type_string AS ezcontentclass_attribute_data_type_string',
-                'a.can_translate AS ezcontentclass_attribute_can_translate',
-                'a.is_required AS ezcontentclass_attribute_is_required',
-                'a.is_information_collector AS ezcontentclass_attribute_is_information_collector',
-                'a.is_searchable AS ezcontentclass_attribute_is_searchable',
-                'a.is_thumbnail AS ezcontentclass_attribute_is_thumbnail',
-                'a.placement AS ezcontentclass_attribute_placement',
-                'a.data_float1 AS ezcontentclass_attribute_data_float1',
-                'a.data_float2 AS ezcontentclass_attribute_data_float2',
-                'a.data_float3 AS ezcontentclass_attribute_data_float3',
-                'a.data_float4 AS ezcontentclass_attribute_data_float4',
-                'a.data_int1 AS ezcontentclass_attribute_data_int1',
-                'a.data_int2 AS ezcontentclass_attribute_data_int2',
-                'a.data_int3 AS ezcontentclass_attribute_data_int3',
-                'a.data_int4 AS ezcontentclass_attribute_data_int4',
-                'a.data_text1 AS ezcontentclass_attribute_data_text1',
-                'a.data_text2 AS ezcontentclass_attribute_data_text2',
-                'a.data_text3 AS ezcontentclass_attribute_data_text3',
-                'a.data_text4 AS ezcontentclass_attribute_data_text4',
-                'a.data_text5 AS ezcontentclass_attribute_data_text5',
-                'a.serialized_data_text AS ezcontentclass_attribute_serialized_data_text',
+                    'a.id AS ezcontentclass_attribute_id',
+                    'a.serialized_name_list AS ezcontentclass_attribute_serialized_name_list',
+                    'a.serialized_description_list AS ezcontentclass_attribute_serialized_description_list',
+                    'a.identifier AS ezcontentclass_attribute_identifier',
+                    'a.category AS ezcontentclass_attribute_category',
+                    'a.data_type_string AS ezcontentclass_attribute_data_type_string',
+                    'a.can_translate AS ezcontentclass_attribute_can_translate',
+                    'a.is_required AS ezcontentclass_attribute_is_required',
+                    'a.is_information_collector AS ezcontentclass_attribute_is_information_collector',
+                    'a.is_searchable AS ezcontentclass_attribute_is_searchable',
+                    'a.is_thumbnail AS ezcontentclass_attribute_is_thumbnail',
+                    'a.placement AS ezcontentclass_attribute_placement',
+                    'a.data_float1 AS ezcontentclass_attribute_data_float1',
+                    'a.data_float2 AS ezcontentclass_attribute_data_float2',
+                    'a.data_float3 AS ezcontentclass_attribute_data_float3',
+                    'a.data_float4 AS ezcontentclass_attribute_data_float4',
+                    'a.data_int1 AS ezcontentclass_attribute_data_int1',
+                    'a.data_int2 AS ezcontentclass_attribute_data_int2',
+                    'a.data_int3 AS ezcontentclass_attribute_data_int3',
+                    'a.data_int4 AS ezcontentclass_attribute_data_int4',
+                    'a.data_text1 AS ezcontentclass_attribute_data_text1',
+                    'a.data_text2 AS ezcontentclass_attribute_data_text2',
+                    'a.data_text3 AS ezcontentclass_attribute_data_text3',
+                    'a.data_text4 AS ezcontentclass_attribute_data_text4',
+                    'a.data_text5 AS ezcontentclass_attribute_data_text5',
+                    'a.serialized_data_text AS ezcontentclass_attribute_serialized_data_text',
 
-                'g.group_id AS ezcontentclass_classgroup_group_id',
+                    'g.group_id AS ezcontentclass_classgroup_group_id',
 
-                'ml.name AS ezcontentclass_attribute_multilingual_name',
-                'ml.description AS ezcontentclass_attribute_multilingual_description',
-                'ml.language_id AS ezcontentclass_attribute_multilingual_language_id',
-                'ml.data_text AS ezcontentclass_attribute_multilingual_data_text',
-                'ml.data_json AS ezcontentclass_attribute_multilingual_data_json',
-            ])
+                    'ml.name AS ezcontentclass_attribute_multilingual_name',
+                    'ml.description AS ezcontentclass_attribute_multilingual_description',
+                    'ml.language_id AS ezcontentclass_attribute_multilingual_language_id',
+                    'ml.data_text AS ezcontentclass_attribute_multilingual_data_text',
+                    'ml.data_json AS ezcontentclass_attribute_multilingual_data_json',
+                ]
+            )
             ->from('ezcontentclass', 'c')
             ->leftJoin(
                 'c',
@@ -1202,81 +1122,64 @@ final class DoctrineDatabase extends Gateway
             )
             ->orderBy('a.placement');
 
-        return $q;
+        return $query;
     }
 
-    /**
-     * Counts the number of instances that exists of the identified type.
-     *
-     * @param int $typeId
-     *
-     * @return int
-     */
-    public function countInstancesOfType($typeId)
+    public function countInstancesOfType(int $typeId): int
     {
-        $q = $this->dbHandler->createSelectQuery();
-        $q->select(
-            $q->alias(
-                $q->expr->count(
-                    $this->dbHandler->quoteColumn('id')
-                ),
-                'count'
-            )
-        )->from(
-            $this->dbHandler->quoteTable('ezcontentobject')
-        )->where(
-            $q->expr->eq(
-                $this->dbHandler->quoteColumn('contentclass_id'),
-                $q->bindValue($typeId, null, \PDO::PARAM_INT)
-            )
-        );
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select($this->dbPlatform->getCountExpression('id'))
+            ->from('ezcontentobject')
+            ->where(
+                $query->expr()->eq(
+                    'contentclass_id',
+                    $query->createPositionalParameter($typeId, ParameterType::INTEGER)
+                )
+            );
 
-        $stmt = $q->prepare();
-        $stmt->execute();
+        $stmt = $query->execute();
 
         return (int)$stmt->fetchColumn();
     }
 
-    /**
-     * Deletes all field definitions of a Type.
-     *
-     * @param mixed $typeId
-     * @param int $status
-     */
-    public function deleteFieldDefinitionsForType($typeId, $status)
+    public function deleteFieldDefinitionsForType(int $typeId, int $status): void
     {
-        $q = $this->dbHandler->createDeleteQuery();
-        $q->deleteFrom(
-            $this->dbHandler->quoteTable('ezcontentclass_attribute')
-        )->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_id'),
-                    $q->bindValue($typeId, null, \PDO::PARAM_INT)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('version'),
-                    $q->bindValue($status, null, \PDO::PARAM_INT)
+        $query = $this->connection->createQueryBuilder();
+        $expr = $query->expr();
+        $query
+            ->delete(self::FIELD_DEFINITION_TABLE)
+            ->where(
+                $query->expr()->eq(
+                    'contentclass_id',
+                    $query->createPositionalParameter($typeId, ParameterType::INTEGER)
                 )
             )
-        );
+            ->andWhere(
+                $expr->eq(
+                    'version',
+                    $query->createPositionalParameter($status, ParameterType::INTEGER)
+                )
+            );
 
-        $q->prepare()->execute();
+        $query->execute();
+
         $subQuery = $this->connection->createQueryBuilder();
         $subQuery
-            ->select('attr.id as ezcontentclass_attribute_id')
-            ->from('ezcontentclass_attribute', 'attr')
-            ->where('attr.contentclass_id = :typeId')
-            ->andWhere('attr.id = ezcontentclass_attribute_ml.contentclass_attribute_id');
+            ->select('f_def.id as ezcontentclass_attribute_id')
+            ->from(self::FIELD_DEFINITION_TABLE, 'f_def')
+            ->where('f_def.contentclass_id = :content_type_id')
+            ->andWhere('f_def.id = ezcontentclass_attribute_ml.contentclass_attribute_id');
 
         $deleteQuery = $this->connection->createQueryBuilder();
         $deleteQuery
-            ->delete('ezcontentclass_attribute_ml')
+            ->delete(self::MULTILINGUAL_FIELD_DEFINITION_TABLE)
             ->where(
                 sprintf('EXISTS (%s)', $subQuery->getSQL())
             )
-            ->andWhere('ezcontentclass_attribute_ml.version = :status')
-            ->setParameter('typeId', $typeId, ParameterType::INTEGER)
+            // note: not all drivers support aliasing tables in DELETE query, hence the following:
+            ->andWhere(sprintf('%s.version = :status', self::MULTILINGUAL_FIELD_DEFINITION_TABLE))
+            ->setParameter('content_type_id', $typeId, ParameterType::INTEGER)
             ->setParameter('status', $status, ParameterType::INTEGER);
 
         $deleteQuery->execute();
@@ -1296,238 +1199,193 @@ final class DoctrineDatabase extends Gateway
         $this->deleteType($typeId, $status);
     }
 
-    /**
-     * Deletes a the Type.
-     *
-     * Does no delete the field definitions!
-     *
-     * @param mixed $typeId
-     * @param int $status
-     */
-    public function deleteType($typeId, $status)
+    public function deleteType(int $typeId, int $status): void
     {
-        $q = $this->dbHandler->createDeleteQuery();
-        $q->deleteFrom(
-            $this->dbHandler->quoteTable('ezcontentclass')
-        )->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('id'),
-                    $q->bindValue($typeId, null, \PDO::PARAM_INT)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('version'),
-                    $q->bindValue($status, null, \PDO::PARAM_INT)
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->delete(self::CONTENT_TYPE_TABLE)
+            ->where(
+                $query->expr()->andX(
+                    $query->expr()->eq(
+                        'id',
+                        $query->createPositionalParameter($typeId, ParameterType::INTEGER)
+                    ),
+                    $query->expr()->eq(
+                        'version',
+                        $query->createPositionalParameter($status, ParameterType::INTEGER)
+                    )
                 )
-            )
-        );
-        $q->prepare()->execute();
+            );
+        $query->execute();
+    }
+
+    public function deleteGroupAssignmentsForType(int $typeId, int $status): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->delete(self::CONTENT_TYPE_TO_GROUP_ASSIGNMENT_TABLE)
+            ->where(
+                $query->expr()->eq(
+                    'contentclass_id',
+                    $query->createPositionalParameter($typeId, ParameterType::INTEGER)
+                )
+            )->andWhere(
+                $query->expr()->eq(
+                    'contentclass_version',
+                    $query->createPositionalParameter($status, ParameterType::INTEGER)
+                )
+            );
+        $query->execute();
     }
 
     /**
-     * Deletes all group assignments for a Type.
+     * Append all columns of a given table to the SELECT part of a query.
      *
-     * @param mixed $typeId
-     * @param int $status
+     * Each column is aliased in the form of
+     * <code><column_name> AS <table_name>_<column_name></code>.
      */
-    public function deleteGroupAssignmentsForType($typeId, $status)
-    {
-        $q = $this->dbHandler->createDeleteQuery();
-        $q->deleteFrom(
-            $this->dbHandler->quoteTable('ezcontentclass_classgroup')
-        )->where(
-            $q->expr->lAnd(
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_id'),
-                    $q->bindValue($typeId, null, \PDO::PARAM_INT)
-                ),
-                $q->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_version'),
-                    $q->bindValue($status, null, \PDO::PARAM_INT)
+    private function selectColumns(
+        QueryBuilder $queryBuilder,
+        string $tableName,
+        string $tableAlias = ''
+    ): QueryBuilder {
+        if (empty($tableAlias)) {
+            $tableAlias = $tableName;
+        }
+        $queryBuilder
+            ->addSelect(
+                array_map(
+                    function (string $columnName) use ($tableName, $tableAlias): string {
+                        return sprintf(
+                            '%s.%s as %s_%s',
+                            $tableAlias,
+                            $this->connection->quoteIdentifier($columnName),
+                            $tableName,
+                            $columnName
+                        );
+                    },
+                    $this->columns[$tableName]
                 )
-            )
-        );
-        $q->prepare()->execute();
+            );
+
+        return $queryBuilder;
     }
 
-    /**
-     * Publishes the Type with $typeId from $sourceVersion to $targetVersion,
-     * including its fields.
-     *
-     * @param int $typeId
-     * @param int $sourceVersion
-     * @param int $targetVersion
-     */
-    public function publishTypeAndFields($typeId, $sourceVersion, $targetVersion)
+    public function internalChangeContentTypeStatus(
+        int $typeId,
+        int $sourceStatus,
+        int $targetStatus,
+        string $tableName,
+        string $typeIdColumnName,
+        string $statusColumnName
+    ): void {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->update($tableName)
+            ->set(
+                $statusColumnName,
+                $query->createPositionalParameter($targetStatus, ParameterType::INTEGER)
+            )
+            ->where(
+                $query->expr()->eq(
+                    $typeIdColumnName,
+                    $query->createPositionalParameter($typeId, ParameterType::INTEGER)
+                )
+            )->andWhere(
+                $query->expr()->eq(
+                    $statusColumnName,
+                    $query->createPositionalParameter($sourceStatus, ParameterType::INTEGER)
+                )
+            );
+
+        $query->execute();
+    }
+
+    public function publishTypeAndFields(int $typeId, int $sourceStatus, int $targetStatus): void
     {
-        $query = $this->dbHandler->createUpdateQuery();
-        $query->update(
-            $this->dbHandler->quoteTable('ezcontentclass')
-        )->set(
-            $this->dbHandler->quoteColumn('version'),
-            $query->bindValue($targetVersion, null, \PDO::PARAM_INT)
-        )->where(
-            $query->expr->lAnd(
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('id'),
-                    $query->bindValue($typeId, null, \PDO::PARAM_INT)
-                ),
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('version'),
-                    $query->bindValue($sourceVersion, null, \PDO::PARAM_INT)
-                )
-            )
+        $this->internalChangeContentTypeStatus(
+            $typeId,
+            $sourceStatus,
+            $targetStatus,
+            self::CONTENT_TYPE_TABLE,
+            'id',
+            'version'
         );
 
-        $query->prepare()->execute();
-
-        $query = $this->dbHandler->createUpdateQuery();
-        $query->update(
-            $this->dbHandler->quoteTable('ezcontentclass_classgroup')
-        )->set(
-            $this->dbHandler->quoteColumn('contentclass_version'),
-            $query->bindValue($targetVersion, null, \PDO::PARAM_INT)
-        )->where(
-            $query->expr->lAnd(
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_id'),
-                    $query->bindValue($typeId, null, \PDO::PARAM_INT)
-                ),
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_version'),
-                    $query->bindValue($sourceVersion, null, \PDO::PARAM_INT)
-                )
-            )
+        $this->internalChangeContentTypeStatus(
+            $typeId,
+            $sourceStatus,
+            $targetStatus,
+            self::CONTENT_TYPE_TO_GROUP_ASSIGNMENT_TABLE,
+            'contentclass_id',
+            'contentclass_version'
         );
 
-        $query->prepare()->execute();
-
-        $query = $this->dbHandler->createUpdateQuery();
-        $query->update(
-            $this->dbHandler->quoteTable('ezcontentclass_attribute')
-        )->set(
-            $this->dbHandler->quoteColumn('version'),
-            $query->bindValue($targetVersion, null, \PDO::PARAM_INT)
-        )->where(
-            $query->expr->lAnd(
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_id'),
-                    $query->bindValue($typeId, null, \PDO::PARAM_INT)
-                ),
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('version'),
-                    $query->bindValue($sourceVersion, null, \PDO::PARAM_INT)
-                )
-            )
+        $this->internalChangeContentTypeStatus(
+            $typeId,
+            $sourceStatus,
+            $targetStatus,
+            self::FIELD_DEFINITION_TABLE,
+            'contentclass_id',
+            'version'
         );
 
-        $query->prepare()->execute();
-
-        $query = $this->dbHandler->createUpdateQuery();
-        $query->update(
-            $this->dbHandler->quoteTable('ezcontentclass_name')
-        )->set(
-            $this->dbHandler->quoteColumn('contentclass_version'),
-            $query->bindValue($targetVersion, null, \PDO::PARAM_INT)
-        )->where(
-            $query->expr->lAnd(
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_id'),
-                    $query->bindValue($typeId, null, \PDO::PARAM_INT)
-                ),
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_version'),
-                    $query->bindValue($sourceVersion, null, \PDO::PARAM_INT)
-                )
-            )
+        $this->internalChangeContentTypeStatus(
+            $typeId,
+            $sourceStatus,
+            $targetStatus,
+            self::CONTENT_TYPE_NAME_TABLE,
+            'contentclass_id',
+            'contentclass_version'
         );
-
-        $query->prepare()->execute();
 
         $subQuery = $this->connection->createQueryBuilder();
         $subQuery
-            ->select('attr.id as ezcontentclass_attribute_id')
-            ->from('ezcontentclass_attribute', 'attr')
-            ->where('attr.contentclass_id = :typeId')
-            ->andWhere('attr.id = ezcontentclass_attribute_ml.contentclass_attribute_id');
+            ->select('f_def.id as ezcontentclass_attribute_id')
+            ->from(self::FIELD_DEFINITION_TABLE, 'f_def')
+            ->where('f_def.contentclass_id = :type_id')
+            ->andWhere('f_def.id = ezcontentclass_attribute_ml.contentclass_attribute_id');
 
         $mlDataPublishQuery = $this->connection->createQueryBuilder();
         $mlDataPublishQuery
-            ->update('ezcontentclass_attribute_ml')
-            ->set('version', ':newVersion')
+            ->update(self::MULTILINGUAL_FIELD_DEFINITION_TABLE)
+            ->set('version', ':target_status')
             ->where(
                 sprintf('EXISTS (%s)', $subQuery->getSQL())
             )
-            ->andWhere('ezcontentclass_attribute_ml.version = :sourceVersion')
-            ->setParameter('typeId', $typeId, ParameterType::INTEGER)
-            ->setParameter('newVersion', $targetVersion, ParameterType::INTEGER)
-            ->setParameter('sourceVersion', $sourceVersion, ParameterType::INTEGER);
+            // note: not all drivers support aliasing tables in UPDATE query, hence the following:
+            ->andWhere(
+                sprintf('%s.version = :source_status', self::MULTILINGUAL_FIELD_DEFINITION_TABLE)
+            )
+            ->setParameter('type_id', $typeId, ParameterType::INTEGER)
+            ->setParameter('target_status', $targetStatus, ParameterType::INTEGER)
+            ->setParameter('source_status', $sourceStatus, ParameterType::INTEGER);
 
         $mlDataPublishQuery->execute();
     }
 
-    /**
-     * Creates an array of select columns for $tableName.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $q
-     * @param string $tableName
-     */
-    private function selectColumns(SelectQuery $q, $tableName)
+    public function getSearchableFieldMapData(): array
     {
-        foreach ($this->columns[$tableName] as $col) {
-            $q->select(
-                $this->dbHandler->aliasedColumn($q, $col, $tableName)
-            );
-        }
-    }
-
-    /**
-     * Returns searchable field mapping data.
-     *
-     * @return array
-     */
-    public function getSearchableFieldMapData()
-    {
-        $query = $this->dbHandler->createSelectQuery();
+        $query = $this->connection->createQueryBuilder();
         $query
             ->select(
-                $this->dbHandler->alias(
-                    $this->dbHandler->quoteColumn('identifier', 'ezcontentclass_attribute'),
-                    $this->dbHandler->quoteIdentifier('field_definition_identifier')
-                ),
-                $this->dbHandler->alias(
-                    $this->dbHandler->quoteColumn('identifier', 'ezcontentclass'),
-                    $this->dbHandler->quoteIdentifier('content_type_identifier')
-                ),
-                $this->dbHandler->alias(
-                    $this->dbHandler->quoteColumn('id', 'ezcontentclass_attribute'),
-                    $this->dbHandler->quoteIdentifier('field_definition_id')
-                ),
-                $this->dbHandler->alias(
-                    $this->dbHandler->quoteColumn('data_type_string', 'ezcontentclass_attribute'),
-                    $this->dbHandler->quoteIdentifier('field_type_identifier')
-                )
+                'f_def.identifier AS field_definition_identifier',
+                'ct.identifier AS content_type_identifier',
+                'f_def.id AS field_definition_id',
+                'f_def.data_type_string AS field_type_identifier'
             )
-            ->from(
-                $this->dbHandler->quoteTable('ezcontentclass_attribute')
-            )
-            ->innerJoin(
-                $this->dbHandler->quoteTable('ezcontentclass'),
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('contentclass_id', 'ezcontentclass_attribute'),
-                    $this->dbHandler->quoteColumn('id', 'ezcontentclass')
-                )
-            )->where(
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('is_searchable', 'ezcontentclass_attribute'),
-                    $query->bindValue(1, null, PDO::PARAM_INT)
+            ->from(self::FIELD_DEFINITION_TABLE, 'f_def')
+            ->innerJoin('f_def', self::CONTENT_TYPE_TABLE, 'ct', 'f_def.contentclass_id = ct.id')
+            ->where(
+                $query->expr()->eq(
+                    'f_def.is_searchable',
+                    $query->createPositionalParameter(1, ParameterType::INTEGER)
                 )
             );
 
-        $statement = $query->prepare($query);
-        $statement->execute();
+        $statement = $query->execute($query);
 
-        return $statement->fetchAll(\PDO::FETCH_ASSOC);
+        return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
     /**
@@ -1548,13 +1406,13 @@ final class DoctrineDatabase extends Gateway
 
         $deleteQuery = $this->connection->createQueryBuilder();
         $deleteQuery
-            ->delete('ezcontentclass_attribute_ml')
-            ->where('contentclass_attribute_id = :fieldDefinitionId')
+            ->delete(self::MULTILINGUAL_FIELD_DEFINITION_TABLE)
+            ->where('contentclass_attribute_id = :field_definition_id')
             ->andWhere('version = :status')
-            ->andWhere('language_id = :languageId')
-            ->setParameter('fieldDefinitionId', $fieldDefinitionId, ParameterType::INTEGER)
+            ->andWhere('language_id = :language_id')
+            ->setParameter('field_definition_id', $fieldDefinitionId, ParameterType::INTEGER)
             ->setParameter('status', $status, ParameterType::INTEGER)
-            ->setParameter('languageId', $languageId, ParameterType::INTEGER);
+            ->setParameter('language_id', $languageId, ParameterType::INTEGER);
 
         $deleteQuery->execute();
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway;
 
 use Doctrine\DBAL\Connection;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -752,8 +752,8 @@ final class DoctrineDatabase extends Gateway
                     $query->createPositionalParameter($fieldDefinitionId, ParameterType::INTEGER)
                 )
             )
-            ->andWhere(
             // in Legacy Storage Field Definition table the "version" column stores status (e.g. draft, published, modified)
+            ->andWhere(
                 $query->expr()->eq(
                     'version',
                     $query->createPositionalParameter($status, ParameterType::INTEGER)

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -770,13 +770,7 @@ final class DoctrineDatabase extends Gateway
                     $query->createPositionalParameter($status, ParameterType::INTEGER)
                 )
             )
-            ->andWhere(
-            // @todo FIXME: Actually not needed
-                $query->expr()->eq(
-                    'contentclass_id',
-                    $query->createPositionalParameter($typeId, ParameterType::INTEGER)
-                )
-            );
+        ;
 
         $query->execute();
     }
@@ -792,11 +786,8 @@ final class DoctrineDatabase extends Gateway
             ->update(self::FIELD_DEFINITION_TABLE)
             ->where('id = :field_definition_id')
             ->andWhere('version = :status')
-            // @todo FIXME: Actually not needed
-            ->andWhere('contentclass_id = :content_type_id')
             ->setParameter('field_definition_id', $fieldDefinition->id, ParameterType::INTEGER)
-            ->setParameter('status', $status, ParameterType::INTEGER)
-            ->setParameter('content_type_id', $typeId, ParameterType::INTEGER);
+            ->setParameter('status', $status, ParameterType::INTEGER);
 
         $fieldDefinitionValueAndTypeMap = $this->mapCommonFieldDefinitionColumnsToQueryValuesAndTypes(
             $fieldDefinition,

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\Persistence\Legacy\Content\MultilingualStorageFieldDefinitio
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator;
+use eZ\Publish\Core\Persistence\Legacy\SharedGateway\Gateway as SharedGateway;
 use eZ\Publish\SPI\Persistence\Content\Type;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\Type\Group;
@@ -110,6 +111,9 @@ final class DoctrineDatabase extends Gateway
     /** @var \Doctrine\DBAL\Platforms\AbstractPlatform */
     private $dbPlatform;
 
+    /** @var \eZ\Publish\Core\Persistence\Legacy\SharedGateway\Gateway */
+    private $sharedGateway;
+
     /**
      * Language mask generator.
      *
@@ -123,11 +127,13 @@ final class DoctrineDatabase extends Gateway
     public function __construct(
         DatabaseHandler $db,
         Connection $connection,
+        SharedGateway $sharedGateway,
         MaskGenerator $languageMaskGenerator
     ) {
         $this->dbHandler = $db;
         $this->connection = $connection;
         $this->dbPlatform = $connection->getDatabasePlatform();
+        $this->sharedGateway = $sharedGateway;
         $this->languageMaskGenerator = $languageMaskGenerator;
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase Content Type Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -27,7 +25,11 @@ use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use PDO;
 
 /**
- * Doctrine database based content type gateway.
+ * Content Type gateway implementation using the Doctrine database.
+ *
+ * @internal Gateway implementation is considered internal. Use Persistence Content Type Handler instead.
+ *
+ * @see \eZ\Publish\SPI\Persistence\Content\Type\Handler
  */
 class DoctrineDatabase extends Gateway
 {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -107,6 +107,9 @@ final class DoctrineDatabase extends Gateway
      */
     private $connection;
 
+    /** @var \Doctrine\DBAL\Platforms\AbstractPlatform */
+    private $dbPlatform;
+
     /**
      * Language mask generator.
      *
@@ -115,16 +118,16 @@ final class DoctrineDatabase extends Gateway
     private $languageMaskGenerator;
 
     /**
-     * Creates a new gateway based on $db.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $db
-     * @param \Doctrine\DBAL\Connection $connection
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator $languageMaskGenerator
+     * @throws \Doctrine\DBAL\DBALException
      */
-    public function __construct(DatabaseHandler $db, Connection $connection, MaskGenerator $languageMaskGenerator)
-    {
+    public function __construct(
+        DatabaseHandler $db,
+        Connection $connection,
+        MaskGenerator $languageMaskGenerator
+    ) {
         $this->dbHandler = $db;
         $this->connection = $connection;
+        $this->dbPlatform = $connection->getDatabasePlatform();
         $this->languageMaskGenerator = $languageMaskGenerator;
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway;
 
 use eZ\Publish\Core\Base\Exceptions\DatabaseException;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -29,7 +29,7 @@ final class ExceptionConversion extends Gateway
     private $innerGateway;
 
     /**
-     * Creates a new exception conversion gateway around $innerGateway.
+     * Create a new exception conversion gateway around $innerGateway.
      *
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway $innerGateway
      */
@@ -216,7 +216,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadTypeData($typeId, $status)
+    public function loadTypeData(int $typeId, int $status): array
     {
         try {
             return $this->innerGateway->loadTypeData($typeId, $status);
@@ -234,7 +234,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadTypeDataByRemoteId($remoteId, $status)
+    public function loadTypeDataByRemoteId(string $remoteId, int $status): array
     {
         try {
             return $this->innerGateway->loadTypeDataByRemoteId($remoteId, $status);
@@ -252,10 +252,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function delete($typeId, $status)
+    public function delete(int $typeId, int $status): void
     {
         try {
-            return $this->innerGateway->delete($typeId, $status);
+            $this->innerGateway->delete($typeId, $status);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -16,6 +16,9 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use Doctrine\DBAL\DBALException;
 use PDOException;
 
+/**
+ * @internal Internal exception conversion layer.
+ */
 class ExceptionConversion extends Gateway
 {
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -19,14 +19,14 @@ use PDOException;
 /**
  * @internal Internal exception conversion layer.
  */
-class ExceptionConversion extends Gateway
+final class ExceptionConversion extends Gateway
 {
     /**
      * The wrapped gateway.
      *
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway
      */
-    protected $innerGateway;
+    private $innerGateway;
 
     /**
      * Creates a new exception conversion gateway around $innerGateway.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -38,7 +38,7 @@ final class ExceptionConversion extends Gateway
         $this->innerGateway = $innerGateway;
     }
 
-    public function insertGroup(Group $group)
+    public function insertGroup(Group $group): int
     {
         try {
             return $this->innerGateway->insertGroup($group);
@@ -47,16 +47,16 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function updateGroup(GroupUpdateStruct $group)
+    public function updateGroup(GroupUpdateStruct $group): void
     {
         try {
-            return $this->innerGateway->updateGroup($group);
+            $this->innerGateway->updateGroup($group);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function countTypesInGroup($groupId)
+    public function countTypesInGroup(int $groupId): int
     {
         try {
             return $this->innerGateway->countTypesInGroup($groupId);
@@ -65,7 +65,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function countGroupsForType($typeId, $status)
+    public function countGroupsForType(int $typeId, int $status): int
     {
         try {
             return $this->innerGateway->countGroupsForType($typeId, $status);
@@ -74,16 +74,16 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function deleteGroup($groupId)
+    public function deleteGroup(int $groupId): void
     {
         try {
-            return $this->innerGateway->deleteGroup($groupId);
+            $this->innerGateway->deleteGroup($groupId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function loadGroupData(array $groupIds)
+    public function loadGroupData(array $groupIds): array
     {
         try {
             return $this->innerGateway->loadGroupData($groupIds);
@@ -92,7 +92,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadGroupDataByIdentifier($identifier)
+    public function loadGroupDataByIdentifier(string $identifier): array
     {
         try {
             return $this->innerGateway->loadGroupDataByIdentifier($identifier);
@@ -101,7 +101,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadAllGroupsData()
+    public function loadAllGroupsData(): array
     {
         try {
             return $this->innerGateway->loadAllGroupsData();
@@ -110,7 +110,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadTypesDataForGroup($groupId, $status)
+    public function loadTypesDataForGroup(int $groupId, int $status): array
     {
         try {
             return $this->innerGateway->loadTypesDataForGroup($groupId, $status);
@@ -119,7 +119,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function insertType(Type $type, $typeId = null)
+    public function insertType(Type $type, ?int $typeId = null): int
     {
         try {
             return $this->innerGateway->insertType($type, $typeId);
@@ -128,25 +128,25 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function insertGroupAssignment($typeId, $status, $groupId)
+    public function insertGroupAssignment(int $groupId, int $typeId, int $status): void
     {
         try {
-            return $this->innerGateway->insertGroupAssignment($typeId, $status, $groupId);
+            $this->innerGateway->insertGroupAssignment($groupId, $typeId, $status);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function deleteGroupAssignment($groupId, $typeId, $status)
+    public function deleteGroupAssignment(int $groupId, int $typeId, int $status): void
     {
         try {
-            return $this->innerGateway->deleteGroupAssignment($groupId, $typeId, $status);
+            $this->innerGateway->deleteGroupAssignment($groupId, $typeId, $status);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function loadFieldDefinition($id, $status)
+    public function loadFieldDefinition(int $id, int $status): array
     {
         try {
             return $this->innerGateway->loadFieldDefinition($id, $status);
@@ -156,44 +156,52 @@ final class ExceptionConversion extends Gateway
     }
 
     public function insertFieldDefinition(
-        $typeId,
-        $status,
+        int $typeId,
+        int $status,
         FieldDefinition $fieldDefinition,
         StorageFieldDefinition $storageFieldDef
-    ) {
+    ): int {
         try {
-            return $this->innerGateway->insertFieldDefinition($typeId, $status, $fieldDefinition, $storageFieldDef);
+            return $this->innerGateway->insertFieldDefinition(
+                $typeId,
+                $status,
+                $fieldDefinition,
+                $storageFieldDef
+            );
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function deleteFieldDefinition($typeId, $status, $fieldDefinitionId)
-    {
+    public function deleteFieldDefinition(
+        int $typeId,
+        int $status,
+        int $fieldDefinitionId
+    ): void {
         try {
-            return $this->innerGateway->deleteFieldDefinition($typeId, $status, $fieldDefinitionId);
+            $this->innerGateway->deleteFieldDefinition($typeId, $status, $fieldDefinitionId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
     public function updateFieldDefinition(
-        $typeId,
-        $status,
+        int $typeId,
+        int $status,
         FieldDefinition $fieldDefinition,
         StorageFieldDefinition $storageFieldDef
-    ) {
+    ): void {
         try {
-            return $this->innerGateway->updateFieldDefinition($typeId, $status, $fieldDefinition, $storageFieldDef);
+            $this->innerGateway->updateFieldDefinition($typeId, $status, $fieldDefinition, $storageFieldDef);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function updateType($typeId, $status, Type $type)
+    public function updateType(int $typeId, int $status, Type $type): void
     {
         try {
-            return $this->innerGateway->updateType($typeId, $status, $type);
+            $this->innerGateway->updateType($typeId, $status, $type);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
@@ -217,7 +225,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadTypeDataByIdentifier($identifier, $status)
+    public function loadTypeDataByIdentifier(string $identifier, int $status): array
     {
         try {
             return $this->innerGateway->loadTypeDataByIdentifier($identifier, $status);
@@ -235,7 +243,7 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function countInstancesOfType($typeId)
+    public function countInstancesOfType(int $typeId): int
     {
         try {
             return $this->innerGateway->countInstancesOfType($typeId);
@@ -253,43 +261,43 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function deleteFieldDefinitionsForType($typeId, $status)
+    public function deleteFieldDefinitionsForType(int $typeId, int $status): void
     {
         try {
-            return $this->innerGateway->deleteFieldDefinitionsForType($typeId, $status);
+            $this->innerGateway->deleteFieldDefinitionsForType($typeId, $status);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function deleteType($typeId, $status)
+    public function deleteType(int $typeId, int $status): void
     {
         try {
-            return $this->innerGateway->deleteType($typeId, $status);
+            $this->innerGateway->deleteType($typeId, $status);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function deleteGroupAssignmentsForType($typeId, $status)
+    public function deleteGroupAssignmentsForType(int $typeId, int $status): void
     {
         try {
-            return $this->innerGateway->deleteGroupAssignmentsForType($typeId, $status);
+            $this->innerGateway->deleteGroupAssignmentsForType($typeId, $status);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function publishTypeAndFields($typeId, $sourceStatus, $targetStatus)
+    public function publishTypeAndFields(int $typeId, int $sourceStatus, int $targetStatus): void
     {
         try {
-            return $this->innerGateway->publishTypeAndFields($typeId, $sourceStatus, $targetStatus);
+            $this->innerGateway->publishTypeAndFields($typeId, $sourceStatus, $targetStatus);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
     }
 
-    public function getSearchableFieldMapData()
+    public function getSearchableFieldMapData(): array
     {
         try {
             return $this->innerGateway->getSearchableFieldMapData();

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
@@ -1259,16 +1259,17 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
     }
 
     /**
-     * Returns the DoctrineDatabase gateway to test.
+     * Return the DoctrineDatabase gateway to test.
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase
+     * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getGateway()
+    protected function getGateway(): DoctrineDatabase
     {
         if (!isset($this->gateway)) {
             $this->gateway = new DoctrineDatabase(
                 $this->getDatabaseHandler(),
                 $this->getDatabaseConnection(),
+                $this->getSharedGateway(),
                 $this->getLanguageMaskGenerator()
             );
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
@@ -1260,7 +1260,6 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
     {
         if (!isset($this->gateway)) {
             $this->gateway = new DoctrineDatabase(
-                $this->getDatabaseHandler(),
                 $this->getDatabaseConnection(),
                 $this->getSharedGateway(),
                 $this->getLanguageMaskGenerator()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File contains: eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type\Gateway\DoctrineDatabaseTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
@@ -476,7 +476,6 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
     /**
      * @dataProvider getTypeCreationExpectations
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase::insertType
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase::setCommonTypeColumns
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase::insertTypeNameData
      */
     public function testInsertType($column, $expectation)
@@ -515,7 +514,6 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
     /**
      * @dataProvider getTypeCreationContentClassNameExpectations
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase::insertType
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase::setCommonTypeColumns
      */
     public function testInsertTypeContentClassName($column, $expectation)
     {
@@ -604,7 +602,6 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
                     'can_translate' => '1',
                     'is_required' => '1',
                     'is_information_collector' => '1',
-                    'serialized_data_text' => 'a:2:{i:0;s:0:"";s:16:"always-available";b:0;}',
                     'version' => '1',
 
                     'data_float1' => '0.1',
@@ -636,7 +633,6 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
                     'can_translate',
                     'is_required',
                     'is_information_collector',
-                    'serialized_data_text',
                     'version',
                     'data_float1',
                     'data_float2',
@@ -882,7 +878,6 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
 
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase::updateType
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase::setCommonTypeColumns
      * @dataProvider getTypeUpdateExpectations
      */
     public function testUpdateType($fieldName, $expectedValue)

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -15,6 +13,7 @@ use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper as ContentTypeMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as ContentTypeUpdateHandler;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as SPIContentTypeHandler;
 
 /**
  * Abstract test suite for legacy search.
@@ -75,13 +74,17 @@ class AbstractTestCase extends LanguageAwareTestCase
         return $ids;
     }
 
-    protected function getContentTypeHandler()
+    /**
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    protected function getContentTypeHandler(): SPIContentTypeHandler
     {
         if (!isset($this->contentTypeHandler)) {
             $this->contentTypeHandler = new ContentTypeHandler(
                 new ContentTypeGateway(
                     $this->getDatabaseHandler(),
                     $this->getDatabaseConnection(),
+                    $this->getSharedGateway(),
                     $this->getLanguageMaskGenerator()
                 ),
                 new ContentTypeMapper($this->getConverterRegistry(), $this->getLanguageMaskGenerator()),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
@@ -82,7 +82,6 @@ class AbstractTestCase extends LanguageAwareTestCase
         if (!isset($this->contentTypeHandler)) {
             $this->contentTypeHandler = new ContentTypeHandler(
                 new ContentTypeGateway(
-                    $this->getDatabaseHandler(),
                     $this->getDatabaseConnection(),
                     $this->getSharedGateway(),
                     $this->getLanguageMaskGenerator()

--- a/eZ/Publish/Core/settings/storage_engines/legacy/content_type.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/content_type.yml
@@ -2,10 +2,9 @@ services:
     ezpublish.persistence.legacy.content_type.gateway.inner:
         class: eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.api.storage_engine.legacy.connection"
+            - '@ezpublish.api.storage_engine.legacy.connection'
             - '@eZ\Publish\Core\Persistence\Legacy\SharedGateway\Gateway'
-            - "@ezpublish.persistence.legacy.language.mask_generator"
+            - '@ezpublish.persistence.legacy.language.mask_generator'
 
     ezpublish.persistence.legacy.content_type.gateway.exception_conversion:
         class: eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\ExceptionConversion

--- a/eZ/Publish/Core/settings/storage_engines/legacy/content_type.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/content_type.yml
@@ -4,6 +4,7 @@ services:
         arguments:
             - "@ezpublish.api.storage_engine.legacy.dbhandler"
             - "@ezpublish.api.storage_engine.legacy.connection"
+            - '@eZ\Publish\Core\Persistence\Legacy\SharedGateway\Gateway'
             - "@ezpublish.persistence.legacy.language.mask_generator"
 
     ezpublish.persistence.legacy.content_type.gateway.exception_conversion:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31088](https://jira.ez.no/browse/EZP-31088) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (8.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR refactors the Legacy Storage Content Model **`Content Type`** gateway implementation (`\eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase`) to rely on `\Doctrine\DBAL\Connection` and `QueryBuilder` instead of our custom Database Handler from legacy Zeta Components.

This time, unlike in most of the related refactoring, I've taken a bit different approach. Refactoring of each method contains also PHPDoc and strict types alignment to speed up the process. I hope it's not too much inconvenient.

Please note that I've cherry-picked commit introducing Shared Gateway from #2845. Review of that can be skipped or added to #2845 if there are any comments. Quick reminder: Shared Gateway abstracts work-around for SQLite not supporting composite primary keys with auto-increments.

Another notable point is that given the strategies for building `insert` and `update` queries using QueryBuilder from Doctrine are different, the methods setting common columns were dropped and replaced with a map of column name to its value and QueryBuilder parameter type. So far, in the other gateways (except Content GW AFAIR), the approach was to create queries separately and set parameters in a common way. However for Content Type entities, the list of columns is so long, it makes more sense (it is more readable) to do it the way it is done now.

Strict types for test classes will be covered via #2903.

#### QA

- [ ] Sanities on Content Type manipulation.

**TODO**:
- [x] **Drop Shared Gateway Commit and rebase after merging #2845.**
- [x] Refactor Content Type gateway methods to rely on `\Doctrine\DBAL` and `\Doctrine\DBAL\Query\QueryBuilder`.
- [x] Mark Content Type gateway classes as `@internal`.
- [x] Mark Content Type gateway implementations as `final`.
- [x] Set Doctrine Database Platform in Content Type DoctrineDatabase gateway constructor.
- [x] Inject & reuse Shared Gateway introduced in #2845
- [x] Introduce strict types and align CS of the remaining methods.
- [x] Enforce strict types on Content Type gateway classes
- [x] Dropped unnecessary Content Type ID constraint from the queries generated by `updateFieldDefinition` and `deleteFieldDefinition` methods.
- [x] Drop DatabaseHandler from Content Type DoctrineDatabase gateway
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Wait for Travis.
- [x] Ask for Code Review.
