### PR TITLE
EZP-31463: Handled fetching of non existing type field type

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -489,7 +489,7 @@ class Handler implements BaseContentTypeHandler
     {
         $rows = $this->contentTypeGateway->loadFieldDefinition($id, $status);
 
-        if ($rows === false) {
+        if ($rows === false || (is_array($rows) && count($rows) === 0)) {
             throw new NotFoundException(
                 'FieldDefinition',
                 [

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -489,7 +489,7 @@ class Handler implements BaseContentTypeHandler
     {
         $rows = $this->contentTypeGateway->loadFieldDefinition($id, $status);
 
-        if ($rows === false || (is_array($rows) && count($rows) === 0)) {
+        if (count($rows) === 0) {
             throw new NotFoundException(
                 'FieldDefinition',
                 [

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -18,6 +18,7 @@ use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway as LocationGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldHandler;
+use eZ\Publish\SPI\Persistence\Content\Type;
 
 /**
  * Content Search test case for ContentSearchHandler.
@@ -1441,5 +1442,12 @@ class HandlerContentTest extends AbstractTestCase
                 )
             )
         );
+    }
+
+    public function testGetNonExistingFieldDefinition()
+    {
+        $this->expectException(\eZ\Publish\Core\Base\Exceptions\NotFoundException::class);
+
+        $this->getContentTypeHandler()->getFieldDefinition(0, Type::STATUS_DEFINED);
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -19,6 +19,7 @@ use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldHandler;
 use eZ\Publish\SPI\Persistence\Content\Type;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 
 /**
  * Content Search test case for ContentSearchHandler.
@@ -399,6 +400,8 @@ class HandlerContentTest extends AbstractTestCase
      */
     public function testFindSingleZero()
     {
+        $this->expectException(NotFoundException::class);
+
         $locator = $this->getContentSearchHandler();
         $locator->findSingle(new Criterion\ContentId(0));
     }
@@ -1444,9 +1447,9 @@ class HandlerContentTest extends AbstractTestCase
         );
     }
 
-    public function testGetNonExistingFieldDefinition()
+    public function testGetNonExistingFieldDefinition(): void
     {
-        $this->expectException(\eZ\Publish\Core\Base\Exceptions\NotFoundException::class);
+        $this->expectException(NotFoundException::class);
 
         $this->getContentTypeHandler()->getFieldDefinition(0, Type::STATUS_DEFINED);
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31463](https://jira.ez.no/browse/EZP-31463)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

```
$contentTypeHandler->getFieldDefinition(0, Type::STATUS_DEFINED);
```
throws an error:
```
TypeError: Argument 1 passed to eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper::extractFieldFromRow() must be of the type array, bool given, called in /Users/sd/Projects/ez/bundles/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php on line 504
```

Instead of throwing ` \eZ\Publish\Core\Base\Exceptions\NotFoundException`

#### QA
- [ ] Sanities on Content Type Field Definition adding, removal.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
