### PR TITLE
[CS][Travis] Fixed Code Style check for branches

### DIFF
--- a/bin/.travis/check_code_style.sh
+++ b/bin/.travis/check_code_style.sh
@@ -11,14 +11,16 @@ then
         exit 0;
     fi
     echo "> Code Style check: checking the following files: ${FILES_LIST}";
+    PATH_MODE=intersection
 else
     # for non-PR builds check entire codebase
     FILES_LIST=""
+    PATH_MODE=override
     echo "> Code Style check: checking the entire codebase";
 fi
 
 php ./vendor/bin/php-cs-fixer fix \
     --config=.php_cs \
-    --path-mode=intersection \
+    --path-mode=${PATH_MODE} \
     --dry-run -v \
     --show-progress=estimating ${FILES_LIST};

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleDownOnlyFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleDownOnlyFilterLoaderTest.php
@@ -9,7 +9,6 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;
 
 use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\ScaleDownOnlyFilterLoader;
-use Imagine\Image\ImageInterface;
 use PHPUnit\Framework\TestCase;
 
 class ScaleDownOnlyFilterLoaderTest extends TestCase

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoaderTest.php
@@ -9,7 +9,6 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;
 
 use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\ScaleHeightDownOnlyFilterLoader;
-use Imagine\Image\ImageInterface;
 use PHPUnit\Framework\TestCase;
 
 class ScaleHeightDownOnlyFilterLoaderTest extends TestCase

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoaderTest.php
@@ -9,7 +9,6 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;
 
 use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\ScaleWidthDownOnlyFilterLoader;
-use Imagine\Image\ImageInterface;
 use PHPUnit\Framework\TestCase;
 
 class ScaleWidthDownOnlyFilterLoaderTest extends TestCase

--- a/eZ/Publish/Core/FieldType/Tests/BinaryBaseTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/BinaryBaseTest.php
@@ -60,7 +60,7 @@ abstract class BinaryBaseTest extends FieldTypeTest
         return $this
             ->getMockBuilder(FileExtensionBlackListValidator::class)
             ->setConstructorArgs([
-                $this->getConfigResolverMock()
+                $this->getConfigResolverMock(),
             ])
             ->setMethods(null)
             ->getMock();

--- a/eZ/Publish/Core/FieldType/Tests/ImageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageTest.php
@@ -65,7 +65,7 @@ class ImageTest extends FieldTypeTest
     {
         $fieldType = new ImageType([
             $this->getBlackListValidatorMock(),
-            $this->getImageValidatorMock()
+            $this->getImageValidatorMock(),
         ]);
         $fieldType->setTransformationProcessor($this->getTransformationProcessorMock());
 
@@ -77,7 +77,7 @@ class ImageTest extends FieldTypeTest
         return $this
             ->getMockBuilder(FileExtensionBlackListValidator::class)
             ->setConstructorArgs([
-                $this->getConfigResolverMock()
+                $this->getConfigResolverMock(),
             ])
             ->setMethods(null)
             ->getMock();

--- a/eZ/Publish/Core/FieldType/Validator/FileExtensionBlackListValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/FileExtensionBlackListValidator.php
@@ -35,7 +35,7 @@ class FileExtensionBlackListValidator extends Validator
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function validateConstraints($constraints)
     {
@@ -43,7 +43,7 @@ class FileExtensionBlackListValidator extends Validator
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function validate(BaseValue $value)
     {

--- a/eZ/Publish/Core/FieldType/Validator/ImageValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/ImageValidator.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\FieldType\Value;
 class ImageValidator extends Validator
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function validateConstraints($constraints)
     {
@@ -21,7 +21,7 @@ class ImageValidator extends Validator
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function validate(Value $value)
     {

--- a/eZ/Publish/Core/settings/containerBuilder.php
+++ b/eZ/Publish/Core/settings/containerBuilder.php
@@ -79,5 +79,4 @@ $containerBuilder->addCompilerPass(new Compiler\Search\Legacy\CriteriaConverterP
 $containerBuilder->addCompilerPass(new Compiler\Search\Legacy\CriterionFieldValueHandlerRegistryPass());
 $containerBuilder->addCompilerPass(new Compiler\Search\Legacy\SortClauseConverterPass());
 
-
 return $containerBuilder;

--- a/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
@@ -68,7 +68,7 @@ class BinaryFileIntegrationTest extends FileBaseIntegrationTest
     public function getCustomHandler()
     {
         $fieldType = new FieldType\BinaryFile\Type([
-            self::$container->get('ezpublish.fieldType.validator.black_list')
+            self::$container->get('ezpublish.fieldType.validator.black_list'),
         ]);
         $fieldType->setTransformationProcessor($this->getTransformationProcessor());
 

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -75,7 +75,7 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
     {
         $fieldType = new FieldType\Image\Type([
             $this->getContainer()->get('ezpublish.fieldType.validator.black_list'),
-            $this->getContainer()->get('ezpublish.fieldType.validator.image')
+            $this->getContainer()->get('ezpublish.fieldType.validator.image'),
         ]);
         $fieldType->setTransformationProcessor($this->getTransformationProcessor());
 

--- a/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
@@ -68,7 +68,7 @@ class MediaIntegrationTest extends FileBaseIntegrationTest
     public function getCustomHandler()
     {
         $fieldType = new FieldType\Media\Type([
-            $this->getContainer()->get('ezpublish.fieldType.validator.black_list')
+            $this->getContainer()->get('ezpublish.fieldType.validator.black_list'),
         ]);
         $fieldType->setTransformationProcessor($this->getTransformationProcessor());
 


### PR DESCRIPTION
|     |     |
| --- | --- |
| **Brief**: | bug in automated CS check |
| **Affects**: | `6.13`, `7.5`, `master` |

#### Summary
Seems when I've introduced CS checking via Travis, I've made a mistake for the case when checking CS for branch (it still can occur that something gets in outside PR workflow, e.g. security fixes). 

The expectation for branches was to run CS check for all PHP files, the result was that no files were checked, because when `--path-mode=intersection` is used with empty list of files, CS fixer doesn't check anything (makes sense). So to solve that, in case of branch CS check, a default option is used.

Failing CS job on branch: https://travis-ci.org/github/ezsystems/ezpublish-kernel/jobs/661158539 (yes, we have CS issues in the codebase because of this bug).

Passing CS job on branch after fixes: https://travis-ci.org/github/ezsystems/ezpublish-kernel/jobs/661500130.

Passing CS job on PR for fixed files: https://travis-ci.org/github/ezsystems/ezpublish-kernel/jobs/661499904

**TODO**:
- [x] **Drop TMP commit testing the change**
- [x] Fix Travis CS checking script.
- [x] Align superfluous CS for the codebase.
- [x] Ask for Code Review.