### PR TITLE
Missing semicolon in dbupdate-7.5.6-to-7.5.7.sql

### DIFF
--- a/data/update/mysql/dbupdate-7.5.6-to-7.5.7.sql
+++ b/data/update/mysql/dbupdate-7.5.6-to-7.5.7.sql
@@ -7,7 +7,7 @@ ALTER TABLE `ezsearch_object_word_link`
 ADD COLUMN `language_mask` BIGINT NOT NULL DEFAULT 0;
 
 -- SET DEFAULT MASK VALUE SINCE REINDEX
-UPDATE `ezsearch_object_word_link` SET `language_mask` = 9223372036854775807
+UPDATE `ezsearch_object_word_link` SET `language_mask` = 9223372036854775807;
 
 --
 -- EZP-31299: end.


### PR DESCRIPTION
Missing semicolon in DML statement.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-XXXXX](https://jira.ez.no/browse/EZP-XXXXX)
| **Bug/Improvement**| yes/no
| **New feature**    | yes/no
| **Target version** | `6.x`/`7.x` for bug fixes or improvements _(on existing features)_, `master` for features
| **BC breaks**      | yes/no
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
