### PR TITLE
EZP-31299: Added semicolon in dbupdate-7.5.6-to-7.5.7.sql

### DIFF
--- a/data/update/mysql/dbupdate-7.5.6-to-7.5.7.sql
+++ b/data/update/mysql/dbupdate-7.5.6-to-7.5.7.sql
@@ -7,7 +7,7 @@ ALTER TABLE `ezsearch_object_word_link`
 ADD COLUMN `language_mask` BIGINT NOT NULL DEFAULT 0;
 
 -- SET DEFAULT MASK VALUE SINCE REINDEX
-UPDATE `ezsearch_object_word_link` SET `language_mask` = 9223372036854775807
+UPDATE `ezsearch_object_word_link` SET `language_mask` = 9223372036854775807;
 
 --
 -- EZP-31299: end.

--- a/data/update/postgres/dbupdate-7.5.6-to-7.5.7.sql
+++ b/data/update/postgres/dbupdate-7.5.6-to-7.5.7.sql
@@ -7,7 +7,7 @@ ALTER TABLE ezsearch_object_word_link
 ADD COLUMN language_mask bigint DEFAULT 0 NOT NULL;
 
 -- SET DEFAULT MASK VALUE SINCE REINDEX
-UPDATE ezsearch_object_word_link SET language_mask = 9223372036854775807
+UPDATE ezsearch_object_word_link SET language_mask = 9223372036854775807;
 
 --
 -- EZP-31299: end.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31299](https://jira.ez.no/browse/EZP-31299)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`, `master (8.0@dev)`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

DML statement closing semicolon was missing.

**TODO**:
- [x] Fix a bug.
- [x] Ask for Code Review.
