### PR TITLE
EZP-31477: Fixed loading Site Accesses on limitation list

### DIFF
--- a/eZ/Publish/Core/Limitation/SiteAccessLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SiteAccessLimitationType.php
@@ -80,8 +80,9 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
     public function validate(APILimitationValue $limitationValue)
     {
         $validationErrors = [];
+        $siteAccessList = $this->getSiteAccessList();
         foreach ($limitationValue->limitationValues as $key => $value) {
-            if (!isset($this->getSiteAccessList()[$value])) {
+            if (!isset($siteAccessList[$value])) {
                 $validationErrors[] = new ValidationError(
                     "\$limitationValue->limitationValues[%key%] => Invalid SiteAccess value \"$value\"",
                     null,

--- a/eZ/Publish/Core/Limitation/SiteAccessLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SiteAccessLimitationType.php
@@ -23,14 +23,13 @@ use eZ\Publish\SPI\Limitation\Type as SPILimitationTypeInterface;
  */
 class SiteAccessLimitationType implements SPILimitationTypeInterface
 {
-    /** @var array */
-    private $siteAccessList = [];
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface */
+    private $siteAccessService;
 
-    public function __construct(array $siteAccessList = [])
-    {
-        foreach ($siteAccessList as $sa) {
-            $this->siteAccessList[$this->generateSiteAccessValue($sa)] = $sa;
-        }
+    public function __construct(
+        SiteAccess\SiteAccessServiceInterface $siteAccessService
+    ) {
+        $this->siteAccessService = $siteAccessService;
     }
 
     /**
@@ -82,7 +81,7 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $value) {
-            if (!isset($this->siteAccessList[$value])) {
+            if (!isset($this->getSiteAccessList()[$value])) {
                 $validationErrors[] = new ValidationError(
                     "\$limitationValue->limitationValues[%key%] => Invalid SiteAccess value \"$value\"",
                     null,
@@ -172,5 +171,18 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
     public function valueSchema()
     {
         throw new \eZ\Publish\API\Repository\Exceptions\NotImplementedException(__METHOD__);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getSiteAccessList(): array
+    {
+        $siteAccessList = [];
+        foreach ($this->siteAccessService->getAll() as $sa) {
+            $siteAccessList[$this->generateSiteAccessValue($sa->name)] = $sa->name;
+        }
+
+        return $siteAccessList;
     }
 }

--- a/eZ/Publish/Core/Limitation/Tests/SiteAccessLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SiteAccessLimitationTypeTest.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing a Test Case for LimitationType class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -20,14 +18,30 @@ use eZ\Publish\Core\MVC\Symfony\SiteAccess;
  */
 class SiteAccessLimitationTypeTest extends Base
 {
-    private $siteAccessList = ['ezdemo_site', 'eng', 'fre'];
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $siteAccessServiceMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->siteAccessServiceMock = $this->createMock(SiteAccess\SiteAccessServiceInterface::class);
+        $this->siteAccessServiceMock
+            ->method('getAll')
+            ->willReturn([
+                new SiteAccess('ezdemo_site'),
+                new SiteAccess('eng'),
+                new SiteAccess('fre'),
+            ]);
+    }
 
     /**
      * @return \eZ\Publish\Core\Limitation\SiteAccessLimitationType
      */
     public function testConstruct()
     {
-        return new SiteAccessLimitationType($this->siteAccessList);
+        return new SiteAccessLimitationType(
+            $this->siteAccessServiceMock
+        );
     }
 
     /**

--- a/eZ/Publish/Core/settings/roles.yml
+++ b/eZ/Publish/Core/settings/roles.yml
@@ -71,7 +71,7 @@ services:
 
     ezpublish.api.role.limitation_type.siteaccess:
         class: eZ\Publish\Core\Limitation\SiteAccessLimitationType
-        arguments: ["%ezpublish.siteaccess.list%"]
+        arguments: ['@ezpublish.siteaccess_service']
         tags:
             - {name: ezpublish.limitationType, alias: SiteAccess}
 

--- a/eZ/Publish/Core/settings/tests/common.yml
+++ b/eZ/Publish/Core/settings/tests/common.yml
@@ -60,3 +60,19 @@ services:
     ezpublish.siteaccess:
         class: eZ\Publish\Core\MVC\Symfony\SiteAccess
         arguments: ['default', 'uninitialized']
+
+    ezpublish.siteaccess_service:
+        class: eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessService
+        arguments:
+            - "@ezpublish.siteaccess.provider"
+            - "@ezpublish.config.resolver"
+        calls:
+            - [setSiteAccess, ['@ezpublish.siteaccess']]
+
+    ezpublish.siteaccess.provider.chain:
+        class: eZ\Publish\Core\MVC\Symfony\SiteAccess\Provider\ChainSiteAccessProvider
+        arguments:
+            $providers: !tagged ezplatform.siteaccess.provider
+
+    ezpublish.siteaccess.provider:
+        alias: ezpublish.siteaccess.provider.chain

--- a/eZ/Publish/Core/settings/tests/common.yml
+++ b/eZ/Publish/Core/settings/tests/common.yml
@@ -64,8 +64,8 @@ services:
     ezpublish.siteaccess_service:
         class: eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessService
         arguments:
-            - "@ezpublish.siteaccess.provider"
-            - "@ezpublish.config.resolver"
+            - '@ezpublish.siteaccess.provider'
+            - '@ezpublish.config.resolver'
         calls:
             - [setSiteAccess, ['@ezpublish.siteaccess']]
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31477](https://jira.ez.no/browse/EZP-31477)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no
| **Related to**        | https://github.com/ezsystems/ezplatform-admin-ui/pull/1272

List of SiteAccesses on limitation list should be fetched from the service, not from configuration. We have an extension point which allows extending the list of SiteAccesses. To fetch all of SiteAccesses the siteAccessService should be used.

**QA**:
you need to check whether the limitations based on SiteAccesses continue to work

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
