### PR TITLE
EZP-31449: Fixed clearing description field in Content Type

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -1417,6 +1417,43 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
     }
 
     /**
+     * @covers \eZ\Publish\API\Repository\ContentTypeService::updateContentTypeDraft
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testUpdateContentTypeWithDescriptionClearing()
+    {
+        $repository = $this->getRepository();
+        $contentTypeService = $repository->getContentTypeService();
+
+        $contentTypeDraft = $this->createContentTypeDraft();
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+
+        $contentType = $contentTypeService->loadContentType($contentTypeDraft->id);
+        // sanity check
+        self::assertEquals(
+            ['eng-US', 'ger-DE'],
+            array_keys($contentType->getNames())
+        );
+
+        $contentTypeDraft = $contentTypeService->createContentTypeDraft($contentType);
+        $updateStruct = $contentTypeService->newContentTypeUpdateStruct();
+        $updateStruct->languageCode = 'ger-DE';
+        $updateStruct->descriptions = null;
+        $contentTypeService->updateContentTypeDraft($contentTypeDraft, $updateStruct);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+
+        self::assertEquals(
+            [
+                'eng-US' => 'A blog post',
+            ],
+            $contentTypeService->loadContentType($contentType->id)->getDescriptions()
+        );
+    }
+
+    /**
      * Test for the updateContentTypeDraft() method.
      *
      * @see \eZ\Publish\API\Repository\ContentTypeService::updateContentTypeDraft()

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeUpdateStruct.php
@@ -44,11 +44,18 @@ class ContentTypeUpdateStruct extends ValueObject
     public $nameSchema;
 
     /**
-     * If set the container fllag is set to this value.
+     * If set the container flag is set to this value.
      *
      * @var bool
      */
     public $isContainer;
+
+    /**
+     * Language code of this struct.
+     *
+     * @var string
+     */
+    public $languageCode;
 
     /**
      * If set the main language is changed to this value.

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -1059,7 +1059,13 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         //Merge new translations into existing before update
         $contentTypeUpdateStruct->names = array_merge($contentTypeDraft->getNames(), $contentTypeUpdateStruct->names ?? []);
-        $contentTypeUpdateStruct->descriptions = array_merge($contentTypeDraft->getDescriptions(), $contentTypeUpdateStruct->descriptions ?? []);
+
+        $existingDescriptions = $contentTypeDraft->getDescriptions();
+        $newDescriptions = $contentTypeUpdateStruct->descriptions ?? [];
+        if (in_array($contentTypeUpdateStruct->languageCode, array_keys($existingDescriptions)) && empty($newDescriptions)) {
+            unset($existingDescriptions[$contentTypeUpdateStruct->languageCode]);
+        }
+        $contentTypeUpdateStruct->descriptions = array_merge($existingDescriptions, $newDescriptions);
 
         $this->repository->beginTransaction();
         try {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31449](https://jira.ez.no/browse/EZP-31449)
| **Bug**| yes
| **New feature**    | no
| **Target version** | 7.5
| **BC breaks**      |no
| **Tests pass**     | yes
| **Doc needed**     | no

When a new description is set to `null` it must be removed from merged language array instead of simply being added to it.

**TODO**:
- [x] Fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
