### PR TITLE
EZP-31482: Introduced strict types for FieldType & VO

### DIFF
--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -83,7 +83,7 @@ Changes affecting version compatibility with former or future versions.
     * `\eZ\Publish\API\Repository\RoleService::unassignRoleFromUser`
     * `\eZ\Publish\API\Repository\RoleService::unassignRoleFromUserGroup`
     * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion::createFromQueryBuilder`
-    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor::createFromQueryBuilder`
+    * `\eZ\Publish\API\R\Values\Content\Query\Criterion\Ancestor::createFromQueryBuilder`
     * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentId::createFromQueryBuilder`
     * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeGroupId::createFromQueryBuilder`
     * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeId::createFromQueryBuilder`
@@ -320,3 +320,5 @@ site:
 * `eZ\Bundle\EzPublishCoreBundle\Controller` extends `Symfony\Bundle\FrameworkBundle\Controller\AbstractController` instead of `Symfony\Bundle\FrameworkBundle\Controller\Controller` which has limited access to the dependency injection container. See https://symfony.com/doc/current/service_container/service_subscribers_locators.html
 
 * SiteAccessAware Repository layer is now used by default. If you need to load repository object in all translations, explicitly pass `\eZ\Publish\API\Repository\Values\Content\Language::ALL` as as prioritized languages list.
+
+* Changed `$valueFormat` type from `string` to `int` in `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications::__construct`  

--- a/doc/bc/changes-8.0.md
+++ b/doc/bc/changes-8.0.md
@@ -83,7 +83,7 @@ Changes affecting version compatibility with former or future versions.
     * `\eZ\Publish\API\Repository\RoleService::unassignRoleFromUser`
     * `\eZ\Publish\API\Repository\RoleService::unassignRoleFromUserGroup`
     * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion::createFromQueryBuilder`
-    * `\eZ\Publish\API\R\Values\Content\Query\Criterion\Ancestor::createFromQueryBuilder`
+    * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor::createFromQueryBuilder`
     * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentId::createFromQueryBuilder`
     * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeGroupId::createFromQueryBuilder`
     * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeId::createFromQueryBuilder`

--- a/eZ/Publish/API/Repository/FieldType.php
+++ b/eZ/Publish/API/Repository/FieldType.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\FieldType class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository;
 
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
@@ -23,7 +23,7 @@ interface FieldType
      *
      * @return string
      */
-    public function getFieldTypeIdentifier();
+    public function getFieldTypeIdentifier(): string;
 
     /**
      * Returns a human readable string representation from the given $value.
@@ -97,21 +97,21 @@ interface FieldType
      *
      * @return bool
      */
-    public function isSearchable();
+    public function isSearchable(): bool;
 
     /**
      * Indicates if the field definition of this type can appear only once in the same ContentType.
      *
      * @return bool
      */
-    public function isSingular();
+    public function isSingular(): bool;
 
     /**
      * Indicates if the field definition of this type can be added to a ContentType with Content instances.
      *
      * @return bool
      */
-    public function onlyEmptyInstance();
+    public function onlyEmptyInstance(): bool;
 
     /**
      * Returns the empty value for this field type.
@@ -133,7 +133,7 @@ interface FieldType
      *
      * @return bool
      */
-    public function isEmptyValue($value);
+    public function isEmptyValue($value): bool;
 
     /**
      * Converts an $hash to the Value defined by the field type.
@@ -204,7 +204,7 @@ interface FieldType
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validateValidatorConfiguration($validatorConfiguration);
+    public function validateValidatorConfiguration($validatorConfiguration): iterable;
 
     /**
      * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
@@ -216,7 +216,7 @@ interface FieldType
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validateFieldSettings($fieldSettings);
+    public function validateFieldSettings($fieldSettings): iterable;
 
     /**
      * Validates a field value based on the validator configuration in the field definition.
@@ -226,5 +226,5 @@ interface FieldType
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validateValue(FieldDefinition $fieldDef, Value $value);
+    public function validateValue(FieldDefinition $fieldDef, Value $value): iterable;
 }

--- a/eZ/Publish/API/Repository/Values/Bookmark/BookmarkList.php
+++ b/eZ/Publish/API/Repository/Values/Bookmark/BookmarkList.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\API\Repository\Values\Bookmark;
 use ArrayIterator;
 use IteratorAggregate;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use Traversable;
 
 /**
  * List of bookmarked locations.
@@ -34,7 +35,7 @@ class BookmarkList extends ValueObject implements IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->items);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Content.php
+++ b/eZ/Publish/API/Repository/Values/Content/Content.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Content class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -15,7 +15,7 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentType;
  * this class represents a content object in a specific version.
  *
  * @property-read \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo convenience getter for getVersionInfo()->getContentInfo()
- * @property-read mixed $id convenience getter for retrieving the contentId: $versionInfo->contentInfo->id
+ * @property-read int $id convenience getter for retrieving the contentId: $versionInfo->contentInfo->id
  * @property-read \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo calls getVersionInfo()
  * @property-read \eZ\Publish\API\Repository\Values\Content\Field[] $fields access fields, calls getFields()
  * @property-read \eZ\Publish\API\Repository\Values\Content\Thumbnail|null $thumbnail calls getThumbnail()
@@ -27,7 +27,7 @@ abstract class Content extends ValueObject
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo
      */
-    abstract public function getVersionInfo();
+    abstract public function getVersionInfo(): VersionInfo;
 
     /**
      * Shorthand method for getVersionInfo()->getName().
@@ -39,7 +39,7 @@ abstract class Content extends ValueObject
      * @return string|null The name for a given language, or null if $languageCode is not set
      *         or does not exist.
      */
-    public function getName($languageCode = null)
+    public function getName(?string $languageCode = null): ?string
     {
         return $this->getVersionInfo()->getName($languageCode);
     }
@@ -56,18 +56,18 @@ abstract class Content extends ValueObject
      * On non translatable fields this method ignores the languageCode parameter, and return main language field value.
      *
      * @param string $fieldDefIdentifier
-     * @param string $languageCode
+     * @param string|null $languageCode
      *
      * @return \eZ\Publish\SPI\FieldType\Value|null a primitive type or a field type Value object depending on the field type.
      */
-    abstract public function getFieldValue($fieldDefIdentifier, $languageCode = null);
+    abstract public function getFieldValue(string $fieldDefIdentifier, ?string $languageCode = null): ?\eZ\Publish\SPI\FieldType\Value;
 
     /**
      * This method returns the complete fields collection.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Field[] An array of {@link Field}
      */
-    abstract public function getFields();
+    abstract public function getFields(): iterable;
 
     /**
      * This method returns the fields for a given language and non translatable fields.
@@ -76,11 +76,11 @@ abstract class Content extends ValueObject
      * - If not pick using prioritized languages (if provided to api on object retrieval)
      * - Otherwise return in main language
      *
-     * @param string $languageCode
+     * @param string|null $languageCode
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Field[] An array of {@link Field} with field identifier as keys
      */
-    abstract public function getFieldsByLanguage($languageCode = null);
+    abstract public function getFieldsByLanguage(?string $languageCode = null): iterable;
 
     /**
      * This method returns the field for a given field definition identifier and language.
@@ -98,7 +98,7 @@ abstract class Content extends ValueObject
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Field|null A {@link Field} or null if nothing is found
      */
-    abstract public function getField($fieldDefIdentifier, $languageCode = null);
+    abstract public function getField(string $fieldDefIdentifier, ?string $languageCode = null): ?Field;
 
     /**
      * Returns the ContentType for this content.

--- a/eZ/Publish/API/Repository/Values/Content/ContentCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\ContentCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 /**

--- a/eZ/Publish/API/Repository/Values/Content/ContentDraftList.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentDraftList.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use ArrayIterator;
-use Iterator;
 use IteratorAggregate;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use Traversable;
 
 /**
  * List of content drafts.
@@ -31,7 +31,7 @@ class ContentDraftList extends ValueObject implements IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator(): Iterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->items);
     }

--- a/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
@@ -13,39 +15,39 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 /**
  * This class provides all version independent information of the Content object.
  *
- * @property-read mixed $id The unique id of the Content object
- * @property-read mixed $contentTypeId The unique id of the Content Type object the Content object is an instance of
+ * @property-read int $id The unique id of the Content object
+ * @property-read int $contentTypeId The unique id of the Content Type object the Content object is an instance of
  * @property-read string $name the computed name (via name schema) in the main language of the Content object
- * @property-read mixed $sectionId the section to which the Content object is assigned
+ * @property-read int $sectionId the section to which the Content object is assigned
  * @property-read int $currentVersionNo Current Version number is the version number of the published version or the version number of a newly created draft (which is 1).
  * @property-read bool $published true if there exists a published version false otherwise
- * @property-read mixed $ownerId the user id of the owner of the Content object
+ * @property-read int $ownerId the user id of the owner of the Content object
  * @property-read \DateTime $modificationDate Content object modification date
  * @property-read \DateTime $publishedDate date of the first publish
  * @property-read bool $alwaysAvailable Indicates if the Content object is shown in the mainlanguage if its not present in an other requested language
  * @property-read string $remoteId a global unique id of the Content object
  * @property-read string $mainLanguageCode The main language code of the Content object. If the available flag is set to true the Content is shown in this language if the requested language does not exist.
- * @property-read mixed $mainLocationId Identifier of the main location.
+ * @property-read int|null $mainLocationId Identifier of the main location.
  * @property-read int $status status of the Content object
  * @property-read bool $isHidden status of the Content object
  */
 class ContentInfo extends ValueObject
 {
-    const STATUS_DRAFT = 0;
-    const STATUS_PUBLISHED = 1;
-    const STATUS_TRASHED = 2;
+    public const STATUS_DRAFT = 0;
+    public const STATUS_PUBLISHED = 1;
+    public const STATUS_TRASHED = 2;
 
     /**
      * The unique id of the Content object.
      *
-     * @var mixed
+     * @var int
      */
     protected $id;
 
     /**
      * The Content Type id of the Content object.
      *
-     * @var mixed
+     * @var int
      */
     protected $contentTypeId;
 
@@ -61,7 +63,7 @@ class ContentInfo extends ValueObject
     /**
      * The section to which the Content object is assigned.
      *
-     * @var mixed
+     * @var int
      */
     protected $sectionId;
 
@@ -83,7 +85,7 @@ class ContentInfo extends ValueObject
     /**
      * The owner of the Content object.
      *
-     * @var mixed
+     * @var int
      */
     protected $ownerId;
 
@@ -128,7 +130,7 @@ class ContentInfo extends ValueObject
      * If the Content object has multiple locations,
      * $mainLocationId will point to the main one.
      *
-     * @var mixed
+     * @var int|null
      */
     protected $mainLocationId;
 
@@ -162,7 +164,7 @@ class ContentInfo extends ValueObject
     /**
      * @return bool
      */
-    public function isDraft()
+    public function isDraft(): bool
     {
         return $this->status === self::STATUS_DRAFT;
     }
@@ -170,7 +172,7 @@ class ContentInfo extends ValueObject
     /**
      * @return bool
      */
-    public function isPublished()
+    public function isPublished(): bool
     {
         return $this->status === self::STATUS_PUBLISHED;
     }
@@ -178,7 +180,7 @@ class ContentInfo extends ValueObject
     /**
      * @return bool
      */
-    public function isTrashed()
+    public function isTrashed(): bool
     {
         return $this->status === self::STATUS_TRASHED;
     }

--- a/eZ/Publish/API/Repository/Values/Content/ContentMetadataUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentMetadataUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/ContentStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentStruct.php
@@ -1,10 +1,11 @@
 <?php
+
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -28,5 +29,5 @@ abstract class ContentStruct extends ValueObject
      *                     field type or an instance of a Value class provided by the field type
      * @param string|null $language If not given on a translatable field the initial language is used
      */
-    abstract public function setField($fieldDefIdentifier, $value, $language = null);
+    abstract public function setField(string $fieldDefIdentifier, $value, ?string $language = null): void;
 }

--- a/eZ/Publish/API/Repository/Values/Content/ContentUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 /**

--- a/eZ/Publish/API/Repository/Values/Content/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Field.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Field class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/Language.php
+++ b/eZ/Publish/API/Repository/Values/Content/Language.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Language class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/LanguageCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/LanguageCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\LanguageCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Location.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Location class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
@@ -16,14 +16,14 @@ use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
  * This class represents a location in the repository.
  *
  * @property-read \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo calls getContentInfo()
- * @property-read mixed $contentId calls getContentInfo()->id
- * @property-read mixed $id the id of the location
+ * @property-read int $contentId calls getContentInfo()->id
+ * @property-read int $id the id of the location
  * @property-read int $priority Position of the Location among its siblings when sorted using priority
  * @property-read bool $hidden Indicates that the Location entity is hidden (explicitly or hidden by content).
  * @property-read bool $invisible  Indicates that the Location is implicitly marked as hidden by a parent location
  * @property-read bool $explicitlyHidden Indicates that the Location entity has been explicitly marked as hidden.
  * @property-read string $remoteId a global unique id of the content object
- * @property-read mixed $parentLocationId the id of the parent location
+ * @property-read int $parentLocationId the id of the parent location
  * @property-read string $pathString the path to this location e.g. /1/2/4/23 where 23 is current id.
  * @property-read array $path Same as $pathString but as array, e.g. [ 1, 2, 4, 23 ]
  * @property-read int $depth Depth location has in the location tree
@@ -34,29 +34,29 @@ use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 abstract class Location extends ValueObject
 {
     // @todo Rename these to better fit current naming, also reuse these in Persistence or copy the change over.
-    const SORT_FIELD_PATH = 1;
-    const SORT_FIELD_PUBLISHED = 2;
-    const SORT_FIELD_MODIFIED = 3;
-    const SORT_FIELD_SECTION = 4;
-    const SORT_FIELD_DEPTH = 5;
-    const SORT_FIELD_CLASS_IDENTIFIER = 6;
-    const SORT_FIELD_CLASS_NAME = 7;
-    const SORT_FIELD_PRIORITY = 8;
-    const SORT_FIELD_NAME = 9;
+    public const SORT_FIELD_PATH = 1;
+    public const SORT_FIELD_PUBLISHED = 2;
+    public const SORT_FIELD_MODIFIED = 3;
+    public const SORT_FIELD_SECTION = 4;
+    public const SORT_FIELD_DEPTH = 5;
+    public const SORT_FIELD_CLASS_IDENTIFIER = 6;
+    public const SORT_FIELD_CLASS_NAME = 7;
+    public const SORT_FIELD_PRIORITY = 8;
+    public const SORT_FIELD_NAME = 9;
 
     /**
      * @deprecated
      */
-    const SORT_FIELD_MODIFIED_SUBNODE = 10;
+    public const SORT_FIELD_MODIFIED_SUBNODE = 10;
 
-    const SORT_FIELD_NODE_ID = 11;
-    const SORT_FIELD_CONTENTOBJECT_ID = 12;
+    public const SORT_FIELD_NODE_ID = 11;
+    public const SORT_FIELD_CONTENTOBJECT_ID = 12;
 
-    const SORT_ORDER_DESC = 0;
-    const SORT_ORDER_ASC = 1;
+    public const SORT_ORDER_DESC = 0;
+    public const SORT_ORDER_ASC = 1;
 
-    const STATUS_DRAFT = 0;
-    const STATUS_PUBLISHED = 1;
+    public const STATUS_DRAFT = 0;
+    public const STATUS_PUBLISHED = 1;
 
     /**
      * Map for Location sort fields to their respective SortClauses.
@@ -64,7 +64,7 @@ abstract class Location extends ValueObject
      * Those not here (class name/identifier and modified subnode) are
      * missing/deprecated and will most likely be removed in the future.
      */
-    const SORT_FIELD_MAP = [
+    public const SORT_FIELD_MAP = [
         self::SORT_FIELD_PATH => SortClause\Location\Path::class,
         self::SORT_FIELD_PUBLISHED => SortClause\DatePublished::class,
         self::SORT_FIELD_MODIFIED => SortClause\DateModified::class,
@@ -82,7 +82,7 @@ abstract class Location extends ValueObject
     /**
      * Map for Location sort order to their respective Query SORT constants.
      */
-    const SORT_ORDER_MAP = [
+    public const SORT_ORDER_MAP = [
         self::SORT_ORDER_DESC => Query::SORT_DESC,
         self::SORT_ORDER_ASC => Query::SORT_ASC,
     ];
@@ -90,7 +90,7 @@ abstract class Location extends ValueObject
     /**
      * Location ID.
      *
-     * @var mixed Location ID.
+     * @var int Location ID.
      */
     protected $id;
 
@@ -146,33 +146,9 @@ abstract class Location extends ValueObject
     protected $remoteId;
 
     /**
-     * Returns the content info of the content object of this location.
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo
-     */
-    abstract public function getContentInfo();
-
-    /**
-     * Return the parent location of of this location.
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location|null
-     */
-    abstract public function getParentLocation(): ?Location;
-
-    /**
-     * Returns true if current location is a draft.
-     *
-     * @return bool
-     */
-    public function isDraft()
-    {
-        return $this->status === self::STATUS_DRAFT;
-    }
-
-    /**
      * Parent ID.
      *
-     * @var mixed Location ID.
+     * @var int Location ID.
      */
     protected $parentLocationId;
 
@@ -212,6 +188,30 @@ abstract class Location extends ValueObject
     protected $content;
 
     /**
+     * Returns the content info of the content object of this location.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo
+     */
+    abstract public function getContentInfo(): ContentInfo;
+
+    /**
+     * Return the parent location of of this location.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location|null
+     */
+    abstract public function getParentLocation(): ?Location;
+
+    /**
+     * Returns true if current location is a draft.
+     *
+     * @return bool
+     */
+    public function isDraft(): bool
+    {
+        return $this->status === self::STATUS_DRAFT;
+    }
+
+    /**
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
     public function getContent(): Content
@@ -222,11 +222,11 @@ abstract class Location extends ValueObject
     /**
      * Get SortClause objects built from Locations's sort options.
      *
-     * @throws NotImplementedException If sort field has a deprecated/unsupported value which does not have a Sort Clause.
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException If sort field has a deprecated/unsupported value which does not have a Sort Clause.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\SortClause[]
      */
-    public function getSortClauses()
+    public function getSortClauses(): array
     {
         $map = self::SORT_FIELD_MAP;
         if (!isset($map[$this->sortField])) {

--- a/eZ/Publish/API/Repository/Values/Content/LocationCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\LocationCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/LocationList.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationList.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\LocationList class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use ArrayIterator;

--- a/eZ/Publish/API/Repository/Values/Content/LocationQuery.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationQuery.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\LocationQuery class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 /**

--- a/eZ/Publish/API/Repository/Values/Content/LocationUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -15,9 +15,8 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  */
 class Query extends ValueObject
 {
-    const SORT_ASC = 'ascending';
-
-    const SORT_DESC = 'descending';
+    public const SORT_ASC = 'ascending';
+    public const SORT_DESC = 'descending';
 
     /**
      * The Query filter.

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value;
@@ -57,7 +57,7 @@ abstract class Criterion implements CriterionInterface
      *
      * @throws \InvalidArgumentException if the provided operator isn't supported
      */
-    public function __construct($target, $operator, $value, Value $valueData = null)
+    public function __construct(?string $target, ?string $operator, $value, ?Value $valueData = null)
     {
         if ($operator === null) {
             $operator = is_array($value) ? Operator::IN : Operator::EQ;
@@ -143,16 +143,16 @@ abstract class Criterion implements CriterionInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications[]
      */
-    abstract public function getSpecifications();
+    abstract public function getSpecifications(): array;
 
     /**
      * Returns a callback that checks the values types depending on the operator specifications.
      *
      * @param int $valueTypes The accepted values, as a bit field of Specifications::TYPE_* constants
      *
-     * @return \Closure
+     * @return callable
      */
-    private function getValueTypeCheckCallback($valueTypes)
+    private function getValueTypeCheckCallback(int $valueTypes): callable
     {
         $callback = function ($value) {
             return false;

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -40,7 +40,7 @@ class Ancestor extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentId.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentId class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -33,7 +33,7 @@ class ContentId extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         $types = Specifications::TYPE_INTEGER | Specifications::TYPE_STRING;
 

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeGroupId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeGroupId.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeGroupId class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -35,7 +35,7 @@ class ContentTypeGroupId extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         $types = Specifications::TYPE_INTEGER | Specifications::TYPE_STRING;
 

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeId.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeId class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -35,7 +35,7 @@ class ContentTypeId extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         $types = Specifications::TYPE_INTEGER | Specifications::TYPE_STRING;
 

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeIdentifier.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -34,7 +34,7 @@ class ContentTypeIdentifier extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/CustomField.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/CustomField.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\Field class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specificat
  */
 class CustomField extends Criterion
 {
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(Operator::IN, Specifications::FORMAT_ARRAY),

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/DateMetadata.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/DateMetadata.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\DateMetadata class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -35,12 +35,12 @@ class DateMetadata extends Criterion
     /**
      * DateMetadata target: modification date.
      */
-    const MODIFIED = 'modified';
+    public const MODIFIED = 'modified';
 
     /**
      * DateMetadata target: creation date.
      */
-    const CREATED = 'created';
+    public const CREATED = 'created';
 
     /**
      * Creates a new DateMetadata criterion on $metadata.
@@ -51,7 +51,7 @@ class DateMetadata extends Criterion
      * @param string $operator One of the Operator constants
      * @param mixed $value The match value, either as an array of as a single value, depending on the operator
      */
-    public function __construct($target, $operator, $value)
+    public function __construct(string $target, string $operator, $value)
     {
         if ($target != self::MODIFIED && $target != self::CREATED) {
             throw new InvalidArgumentException("Unknown DateMetadata $target");
@@ -59,7 +59,7 @@ class DateMetadata extends Criterion
         parent::__construct($target, $operator, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Field.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\Field class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -26,7 +26,7 @@ class Field extends Criterion implements CustomFieldInterface
      */
     protected $customFields = [];
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(Operator::IN, Specifications::FORMAT_ARRAY),
@@ -50,7 +50,7 @@ class Field extends Criterion implements CustomFieldInterface
      * @param string $field
      * @param string $customField
      */
-    public function setCustomField($type, $field, $customField)
+    public function setCustomField(string $type, string $field, string $customField): void
     {
         $this->customFields[$type][$field] = $customField;
     }
@@ -63,9 +63,9 @@ class Field extends Criterion implements CustomFieldInterface
      * @param string $type
      * @param string $field
      *
-     * @return mixed
+     * @return string|null
      */
-    public function getCustomField($type, $field)
+    public function getCustomField(string $type, string $field): ?string
     {
         if (!isset($this->customFields[$type]) ||
              !isset($this->customFields[$type][$field])) {

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FieldRelation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FieldRelation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\FieldRelation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -23,7 +23,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specificat
  */
 class FieldRelation extends Criterion
 {
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         $types = Specifications::TYPE_INTEGER | Specifications::TYPE_STRING;
 

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FullText.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FullText.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\FullText class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -115,7 +115,7 @@ class FullText extends Criterion implements CustomFieldInterface
         }
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(Operator::LIKE, Specifications::FORMAT_SINGLE),
@@ -131,7 +131,7 @@ class FullText extends Criterion implements CustomFieldInterface
      * @param string $field
      * @param string $customField
      */
-    public function setCustomField($type, $field, $customField)
+    public function setCustomField(string $type, string $field, string $customField): void
     {
         $this->customFields[$type][$field] = $customField;
     }
@@ -146,7 +146,7 @@ class FullText extends Criterion implements CustomFieldInterface
      *
      * @return mixed
      */
-    public function getCustomField($type, $field)
+    public function getCustomField(string $type, string $field): ?string
     {
         if (!isset($this->customFields[$type]) ||
              !isset($this->customFields[$type][$field])) {

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsFieldEmpty.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsFieldEmpty.php
@@ -28,7 +28,7 @@ class IsFieldEmpty extends Criterion
         parent::__construct($fieldDefinitionIdentifier, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_BOOLEAN),

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LanguageCode.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LanguageCode.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\LanguageCode class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -38,7 +38,7 @@ class LanguageCode extends Criterion
      * @throws \InvalidArgumentException if non string value is given
      * @throws \InvalidArgumentException if the value type doesn't match the operator
      */
-    public function __construct($value, $matchAlwaysAvailable = true)
+    public function __construct($value, bool $matchAlwaysAvailable = true)
     {
         if (!is_bool($matchAlwaysAvailable)) {
             throw new InvalidArgumentType('matchAlwaysAvailable', 'boolean', $matchAlwaysAvailable);
@@ -48,7 +48,7 @@ class LanguageCode extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\Location class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/Depth.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/Depth.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\Location\Depth class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion\Location;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Location;
@@ -28,12 +28,12 @@ class Depth extends Location
      * @param string $operator One of the Operator constants
      * @param mixed $value The match value, either as an array of as a single value, depending on the operator
      */
-    public function __construct($operator, $value)
+    public function __construct(string $operator, $value)
     {
         parent::__construct(null, $operator, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/IsMainLocation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/IsMainLocation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\Location\IsMainLocation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion\Location;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Location;
@@ -44,7 +44,7 @@ class IsMainLocation extends Location
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/Priority.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/Priority.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\Location\Priority class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion\Location;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Location;
@@ -28,12 +28,12 @@ class Priority extends Location
      * @param string $operator One of the Operator constants
      * @param mixed $value The match value, either as an array of as a single value, depending on the operator
      */
-    public function __construct($operator, $value)
+    public function __construct(string $operator, $value)
     {
         parent::__construct(null, $operator, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(Operator::BETWEEN, Specifications::FORMAT_ARRAY, Specifications::TYPE_INTEGER),

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationId.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationId class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -35,7 +35,7 @@ class LocationId extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationRemoteId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationRemoteId.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationRemoteId class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -33,7 +33,7 @@ class LocationRemoteId extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalAnd.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalAnd.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 /**

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalNot.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalNot.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalNot class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -20,7 +20,7 @@ class LogicalNot extends LogicalOperator
      *
      * Will match of the given criterion doesn't match
      *
-     * @param Criterion[] $criteria One criterion, as an array
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion[] $criteria One criterion, as an array
      *
      * @throws \InvalidArgumentException if more than one criterion is given in the array parameter
      */

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
@@ -21,14 +21,14 @@ abstract class LogicalOperator extends Criterion
     /**
      * The set of criteria combined by the logical operator.
      *
-     * @var Criterion[]
+     * @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion[]
      */
     public $criteria = [];
 
     /**
      * Creates a Logic operation with the given criteria.
      *
-     * @param Criterion[] $criteria
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion[] $criteria
      *
      * @throws \InvalidArgumentException
      */
@@ -55,10 +55,11 @@ abstract class LogicalOperator extends Criterion
     }
 
     /**
+     * @return array
      * @deprecated in LogicalOperators since 7.2.
      * It will be removed in 8.0 when Logical Operator no longer extends Criterion.
      */
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
 

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOr.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOr.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOr class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 /**

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MapLocationDistance.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MapLocationDistance.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\MapLocationDistance class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -42,13 +42,13 @@ class MapLocationDistance extends Criterion implements CustomFieldInterface
      * @param float $latitude Latitude of the location that distance is calculated from
      * @param float $longitude Longitude of the location that distance is calculated from
      */
-    public function __construct($target, $operator, $distance, $latitude, $longitude)
+    public function __construct(string $target, string $operator, $distance, float $latitude, float $longitude)
     {
         $distanceStart = new MapLocationValue($latitude, $longitude);
         parent::__construct($target, $operator, $distance, $distanceStart);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(Operator::IN, Specifications::FORMAT_ARRAY),
@@ -70,7 +70,7 @@ class MapLocationDistance extends Criterion implements CustomFieldInterface
      * @param string $field
      * @param string $customField
      */
-    public function setCustomField($type, $field, $customField)
+    public function setCustomField(string $type, string $field, string $customField): void
     {
         $this->customFields[$type][$field] = $customField;
     }
@@ -83,9 +83,9 @@ class MapLocationDistance extends Criterion implements CustomFieldInterface
      * @param string $type
      * @param string $field
      *
-     * @return mixed
+     * @return ?string
      */
-    public function getCustomField($type, $field)
+    public function getCustomField(string $type, string $field): ?string
     {
         if (!isset($this->customFields[$type]) ||
              !isset($this->customFields[$type][$field])) {

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchAll.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchAll.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchAll class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -23,7 +23,7 @@ class MatchAll extends Criterion
         // Do NOT call parent constructor. It tries to be too smart.
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [];
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchNone.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchNone.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * This file is part of the eZ Publish package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -23,7 +23,7 @@ class MatchNone extends Criterion
         // Do NOT call parent constructor. It tries to be too smart.
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [];
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MoreLikeThis.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MoreLikeThis.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\MoreLikeThis class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -17,9 +17,9 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specificat
  */
 class MoreLikeThis extends Criterion
 {
-    const CONTENT = 1;
-    const TEXT = 2;
-    const URL = 3;
+    public const CONTENT = 1;
+    public const TEXT = 2;
+    public const URL = 3;
 
     /**
      * The type of the parameter from which terms are extracted for finding similar objects.
@@ -36,14 +36,14 @@ class MoreLikeThis extends Criterion
      *
      * @throws \InvalidArgumentException if the value type doesn't match the expected type
      */
-    public function __construct($type, $value)
+    public function __construct(int $type, $value)
     {
         $this->type = $type;
 
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE),

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateId.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\ObjectStateId class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -33,7 +33,7 @@ class ObjectStateId extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Operator.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Operator.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 /**
@@ -15,19 +15,19 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
  */
 abstract class Operator
 {
-    const EQ = '=';
-    const GT = '>';
-    const GTE = '>=';
-    const LT = '<';
-    const LTE = '<=';
-    const IN = 'in';
-    const BETWEEN = 'between';
+    public const EQ = '=';
+    public const GT = '>';
+    public const GTE = '>=';
+    public const LT = '<';
+    public const LTE = '<=';
+    public const IN = 'in';
+    public const BETWEEN = 'between';
 
     /**
      * Does a lookup where a the value _can_ contain a "*" (a wildcard) in order to match a pattern.
      *
      * E.g: $criterion->value = "Oper*or";
      */
-    const LIKE = 'like';
-    const CONTAINS = 'contains';
+    public const LIKE = 'like';
+    public const CONTAINS = 'contains';
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Operator/Specifications.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Operator/Specifications.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 
 /**
@@ -18,16 +18,16 @@ class Specifications
     /**
      * Criterion input type description constants.
      */
-    const FORMAT_SINGLE = 'single';
-    const FORMAT_ARRAY = 'array';
+    public const FORMAT_SINGLE = 1;
+    public const FORMAT_ARRAY = 2;
 
     /**
      * Criterion input value type description constants.
      * Used by {@see getDescription()} to say which type of values an operator expects.
      */
-    const TYPE_INTEGER = 1;
-    const TYPE_STRING = 2;
-    const TYPE_BOOLEAN = 4;
+    public const TYPE_INTEGER = 1;
+    public const TYPE_STRING = 2;
+    public const TYPE_BOOLEAN = 4;
 
     /**
      * Specified operator, as one of the Operator::* constants.
@@ -40,7 +40,7 @@ class Specifications
      *
      * @see self::FORMAT_*
      *
-     * @var string
+     * @var int
      */
     public $valueFormat;
 
@@ -67,11 +67,11 @@ class Specifications
      * Creates a new Specifications object.
      *
      * @param string $operator The specified operator, as one of the Operator::* constants
-     * @param string $valueFormat The accepted value format, either {@see self::FORMAT_ARRAY} or {@see self::FORMAT_SINGLE}
+     * @param int $valueFormat The accepted value format, either {@see self::FORMAT_ARRAY} or {@see self::FORMAT_SINGLE}
      * @param int $valueTypes The supported value types, as a bit field of the {@see self::TYPE_*} constants
      * @param int $valueCount The required number of values, when the accepted format is {@see self::FORMAT_ARRAY}
      */
-    public function __construct($operator, $valueFormat, $valueTypes = null, $valueCount = null)
+    public function __construct(string $operator, int $valueFormat, ?int $valueTypes = null, ?int $valueCount = null)
     {
         $this->operator = $operator;
         $this->valueFormat = $valueFormat;

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ParentLocationId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ParentLocationId.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -35,7 +35,7 @@ class ParentLocationId extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/RemoteId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/RemoteId.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\RemoteId class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -33,7 +33,7 @@ class RemoteId extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/SectionId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/SectionId.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\SectionId class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -33,7 +33,7 @@ class SectionId extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Subtree.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Subtree.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -38,7 +38,7 @@ class Subtree extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserMetadata.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserMetadata.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\UserMetadata class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -33,17 +33,17 @@ class UserMetadata extends Criterion
     /**
      * UserMetadata target: Owner user.
      */
-    const OWNER = 'owner';
+    public const OWNER = 'owner';
 
     /**
      * UserMetadata target: Owner user group.
      */
-    const GROUP = 'group';
+    public const GROUP = 'group';
 
     /**
      * UserMetadata target: Modifier.
      */
-    const MODIFIER = 'modifier';
+    public const MODIFIER = 'modifier';
 
     /**
      * Creates a new UserMetadata criterion on $metadata.
@@ -54,7 +54,7 @@ class UserMetadata extends Criterion
      * @param string $operator One of the Operator constants
      * @param mixed $value The match value, either as an array of as a single value, depending on the operator
      */
-    public function __construct($target, $operator, $value)
+    public function __construct(string $target, string $operator, $value)
     {
         switch ($target) {
             case self::OWNER:
@@ -68,7 +68,7 @@ class UserMetadata extends Criterion
         throw new InvalidArgumentException("Unknown UserMetadata $target");
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Value.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Value.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 /**

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Value/MapLocationValue.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Value/MapLocationValue.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value\MapLocationValue class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value;
@@ -33,7 +33,7 @@ class MapLocationValue extends Value
      * @param float $latitude
      * @param float $longitude
      */
-    public function __construct($latitude, $longitude)
+    public function __construct(float $latitude, float $longitude)
     {
         $this->latitude = $latitude;
         $this->longitude = $longitude;

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Visibility.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Visibility.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -24,12 +24,12 @@ class Visibility extends Criterion
     /**
      * Visibility constant: visible.
      */
-    const VISIBLE = 0;
+    public const VISIBLE = 0;
 
     /**
      * Visibility constant: hidden.
      */
-    const HIDDEN = 1;
+    public  const HIDDEN = 1;
 
     /**
      * Creates a new Visibility criterion.
@@ -38,7 +38,7 @@ class Visibility extends Criterion
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($value)
+    public function __construct(int $value)
     {
         if ($value !== self::VISIBLE && $value !== self::HIDDEN) {
             throw new InvalidArgumentException("Invalid visibility value $value");
@@ -47,7 +47,7 @@ class Visibility extends Criterion
         parent::__construct(null, null, $value);
     }
 
-    public function getSpecifications()
+    public function getSpecifications(): array
     {
         return [
             new Specifications(

--- a/eZ/Publish/API/Repository/Values/Content/Query/CriterionInterface.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/CriterionInterface.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query;
 
 /**

--- a/eZ/Publish/API/Repository/Values/Content/Query/CustomFieldInterface.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/CustomFieldInterface.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the custom field interface.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query;
 
 /**
@@ -27,7 +27,7 @@ interface CustomFieldInterface
      * @param string $field
      * @param string $customField
      */
-    public function setCustomField($type, $field, $customField);
+    public function setCustomField(string $type, string $field, string $customField): void;
 
     /**
      * Return the custom field to query or sort on if set.
@@ -35,7 +35,7 @@ interface CustomFieldInterface
      * @param string $type
      * @param string $field
      *
-     * @return mixed If no custom field is set, return null
+     * @return string|null If no custom field is set, return null
      */
-    public function getCustomField($type, $field);
+    public function getCustomField(string $type, string $field): ?string;
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/ContentTypeFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/ContentTypeFacetBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\ContentTypeFacetBuilder class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/CriterionFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/CriterionFacetBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\CriterionFacetBuilder class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/DateRangeFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/DateRangeFacetBuilder.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\DateRangeFacetBuilder class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -18,9 +16,9 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
  */
 abstract class DateRangeFacetBuilder extends FacetBuilder
 {
-    const PUBLISHED = 0;
-    const CREATED = 1;
-    const MODIFIED = 2;
+    public const PUBLISHED = 0;
+    public const CREATED = 1;
+    public const MODIFIED = 2;
 
     public $type = self::PUBLISHED;
 

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/FieldFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/FieldFacetBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\FieldFacetBuilder class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
@@ -19,10 +19,10 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
  */
 class FieldFacetBuilder extends FacetBuilder
 {
-    const COUNT_ASC = 0;
-    const COUNT_DESC = 1;
-    const TERM_ASC = 2;
-    const TERM_DESC = 3;
+    public const COUNT_ASC = 0;
+    public const COUNT_DESC = 1;
+    public const TERM_ASC = 2;
+    public const TERM_DESC = 3;
 
     /**
      * The field paths starts with a field identifier and a sub path (for complex types).

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/FieldRangeFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/FieldRangeFacetBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\DateRangeFacetBuilder class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/Location.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\ContentFacetBuilder class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/Location/LocationFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/Location/LocationFacetBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\Location\LocationFacetBuilder class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\Location;
 
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\Location;

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/LocationFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/LocationFacetBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\SubtreeFacetBuilder class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/SectionFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/SectionFacetBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\SectionFacetBuilder class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/TermFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/TermFacetBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\TermFacetBuilder class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/UserFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/UserFacetBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\UserFacetBuilder class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 
 use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
@@ -20,17 +20,17 @@ class UserFacetBuilder extends FacetBuilder
     /**
      * Owner user.
      */
-    const OWNER = 'owner';
+    public const OWNER = 'owner';
 
     /**
      * Owner user group.
      */
-    const GROUP = 'group';
+    public const GROUP = 'group';
 
     /**
      * Modifier.
      */
-    const MODIFIER = 'modifier';
+    public const MODIFIER = 'modifier';
 
     /**
      * The type of the user facet.

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause.php
@@ -1,14 +1,15 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target;
 use InvalidArgumentException;
 
 /**
@@ -34,7 +35,7 @@ abstract class SortClause
     /**
      * Extra target data, required by some sort clauses, field for instance.
      *
-     * @var SortClause\Target
+     * @var \eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target|null
      */
     public $targetData;
 
@@ -43,11 +44,11 @@ abstract class SortClause
      *
      * @param string $sortTarget
      * @param string $sortDirection one of Query::SORT_ASC or Query::SORT_DESC
-     * @param string $targetData Extra target data, used by some clauses (field for instance)
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target|null $targetData Extra target data, used by some clauses (field for instance)
      *
      * @throws InvalidArgumentException if the given sort order isn't one of Query::SORT_ASC or Query::SORT_DESC
      */
-    public function __construct($sortTarget, $sortDirection, $targetData = null)
+    public function __construct(string $sortTarget, string $sortDirection, ?Target $targetData = null)
     {
         if ($sortDirection !== Query::SORT_ASC && $sortDirection !== Query::SORT_DESC) {
             throw new InvalidArgumentException('Sort direction must be one of Query::SORT_ASC or Query::SORT_DESC');

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentId.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -30,7 +30,7 @@ class ContentId extends SortClause
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = Query::SORT_ASC)
+    public function __construct(string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct('content_id', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentName.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentName.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentName class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -21,7 +21,7 @@ class ContentName extends SortClause
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = Query::SORT_ASC)
+    public function __construct(string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct('content_name', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/DateModified.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/DateModified.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\DateModified class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -21,7 +21,7 @@ class DateModified extends SortClause
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = Query::SORT_ASC)
+    public function __construct(string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct('date_modified', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/DatePublished.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/DatePublished.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -21,7 +21,7 @@ class DatePublished extends SortClause
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = Query::SORT_ASC)
+    public function __construct(string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct('date_published', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Field.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\Field class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target\FieldTarget;
@@ -40,7 +40,7 @@ class Field extends SortClause implements CustomFieldInterface
      * @param string $fieldIdentifier
      * @param string $sortDirection
      */
-    public function __construct($typeIdentifier, $fieldIdentifier, $sortDirection = Query::SORT_ASC)
+    public function __construct(string $typeIdentifier, string $fieldIdentifier, string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct(
             'field',
@@ -58,7 +58,7 @@ class Field extends SortClause implements CustomFieldInterface
      * @param string $field
      * @param string $customField
      */
-    public function setCustomField($type, $field, $customField)
+    public function setCustomField(string $type, string $field, string $customField): void
     {
         $this->customFields[$type][$field] = $customField;
     }
@@ -73,7 +73,7 @@ class Field extends SortClause implements CustomFieldInterface
      *
      * @return mixed
      */
-    public function getCustomField($type, $field)
+    public function getCustomField(string $type, string $field): ?string
     {
         if (!isset($this->customFields[$type][$field])) {
             return null;

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\ContentSortClause class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Depth.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Depth.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Depth class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -21,7 +21,7 @@ class Depth extends Location
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = Query::SORT_ASC)
+    public function __construct(string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct('location_depth', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Id.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Id.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Id class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -23,7 +23,7 @@ class Id extends Location
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = Query::SORT_ASC)
+    public function __construct(string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct('location_id', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/IsMainLocation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/IsMainLocation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\IsMainLocation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -21,7 +21,7 @@ class IsMainLocation extends Location
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = Query::SORT_ASC)
+    public function __construct(string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct('location_is_main', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Path.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Path.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -21,7 +21,7 @@ class Path extends Location
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = Query::SORT_ASC)
+    public function __construct(string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct('location_path', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Priority.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Priority.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Priority class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -21,7 +21,7 @@ class Priority extends Location
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = Query::SORT_ASC)
+    public function __construct(string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct('location_priority', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Visibility.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Visibility.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Visibility class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -21,7 +21,7 @@ class Visibility extends Location
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = Query::SORT_ASC)
+    public function __construct(string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct('location_visibility', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/MapLocationDistance.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/MapLocationDistance.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\MapLocationDistance class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -35,11 +35,11 @@ class MapLocationDistance extends SortClause implements CustomFieldInterface
      * @param string $sortDirection
      */
     public function __construct(
-        $typeIdentifier,
-        $fieldIdentifier,
-        $latitude,
-        $longitude,
-        $sortDirection = Query::SORT_ASC
+        string $typeIdentifier,
+        string $fieldIdentifier,
+        float $latitude,
+        float $longitude,
+        string $sortDirection = Query::SORT_ASC
     ) {
         parent::__construct(
             'maplocation_distance',
@@ -62,7 +62,7 @@ class MapLocationDistance extends SortClause implements CustomFieldInterface
      * @param string $field
      * @param string $customField
      */
-    public function setCustomField($type, $field, $customField)
+    public function setCustomField(string $type, string $field, string $customField): void
     {
         $this->customFields[$type][$field] = $customField;
     }
@@ -77,7 +77,7 @@ class MapLocationDistance extends SortClause implements CustomFieldInterface
      *
      * @return mixed
      */
-    public function getCustomField($type, $field)
+    public function getCustomField(string $type, string $field): ?string
     {
         if (!isset($this->customFields[$type]) ||
             !isset($this->customFields[$type][$field])) {

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Random.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Random.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target\RandomTarget;

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/SectionIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/SectionIdentifier.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionIdentifier class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -21,7 +21,7 @@ class SectionIdentifier extends SortClause
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = Query::SORT_ASC)
+    public function __construct(string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct('section_identifier', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/SectionName.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/SectionName.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionName class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -21,7 +21,7 @@ class SectionName extends SortClause
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = Query::SORT_ASC)
+    public function __construct(string $sortDirection = Query::SORT_ASC)
     {
         parent::__construct('section_name', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 /**

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/FieldTarget.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/FieldTarget.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target\FieldTarget class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target;
 
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target;
@@ -29,7 +29,7 @@ class FieldTarget extends Target
      */
     public $fieldIdentifier;
 
-    public function __construct($typeIdentifier, $fieldIdentifier)
+    public function __construct(string $typeIdentifier, string $fieldIdentifier)
     {
         $this->typeIdentifier = $typeIdentifier;
         $this->fieldIdentifier = $fieldIdentifier;

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/MapLocationTarget.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/MapLocationTarget.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target\MapLocationTarget class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target;
 
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target;
@@ -50,10 +50,10 @@ class MapLocationTarget extends Target
      * @param string $fieldIdentifier
      */
     public function __construct(
-        $latitude,
-        $longitude,
-        $typeIdentifier,
-        $fieldIdentifier
+        float $latitude,
+        float $longitude,
+        string $typeIdentifier,
+        string $fieldIdentifier
     ) {
         $this->latitude = $latitude;
         $this->longitude = $longitude;

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/RandomTarget.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/RandomTarget.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target;
 
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target;

--- a/eZ/Publish/API/Repository/Values/Content/Relation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Relation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Relation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -78,14 +78,14 @@ abstract class Relation extends ValueObject
      *
      * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo
      */
-    abstract public function getSourceContentInfo();
+    abstract public function getSourceContentInfo(): ContentInfo;
 
     /**
      * the content of the destination content of the relation.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo
      */
-    abstract public function getDestinationContentInfo();
+    abstract public function getDestinationContentInfo(): ContentInfo;
 
     /**
      * The relation type bitmask.

--- a/eZ/Publish/API/Repository/Values/Content/RelationList.php
+++ b/eZ/Publish/API/Repository/Values/Content/RelationList.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use ArrayIterator;
-use Iterator;
 use IteratorAggregate;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use Traversable;
 
 /**
  * List of relations.
@@ -28,7 +28,7 @@ class RelationList extends ValueObject implements IteratorAggregate
      */
     public $items = [];
 
-    public function getIterator(): Iterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->items);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\Facet class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/ContentTypeFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/ContentTypeFacet.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\Facet\ContentTypeFacet class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/CriterionFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/CriterionFacet.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\Facet\CriterionFacet class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/DateRangeFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/DateRangeFacet.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\Facet\DateRangeFacet class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/FieldFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/FieldFacet.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\Facet\FieldFacet class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/FieldRangeFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/FieldRangeFacet.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\Facet\FieldRangeFacet class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/LocationFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/LocationFacet.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\Facet\FieldFacet class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/RangeFacetEntry.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/RangeFacetEntry.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\Facet\RangeFacetEntry class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/SectionFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/SectionFacet.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\Facet\SectionFacet class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/TermFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/TermFacet.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\Facet\TermFacet class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/UserFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/UserFacet.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\Facet\UserFacet class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 use eZ\Publish\API\Repository\Values\Content\Search\Facet;

--- a/eZ/Publish/API/Repository/Values/Content/Search/SearchHit.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/SearchHit.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\SearchHit class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\SearchResult class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Search;
 
 use ArrayIterator;

--- a/eZ/Publish/API/Repository/Values/Content/Section.php
+++ b/eZ/Publish/API/Repository/Values/Content/Section.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Section class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/SectionCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/SectionCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\SectionCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 /**

--- a/eZ/Publish/API/Repository/Values/Content/SectionStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/SectionStruct.php
@@ -1,10 +1,11 @@
 <?php
+
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/SectionUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/SectionUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\SectionUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 /**

--- a/eZ/Publish/API/Repository/Values/Content/Trash/SearchResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Trash/SearchResult.php
@@ -1,9 +1,16 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Trash;
 
 use ArrayIterator;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use Traversable;
 
 class SearchResult extends ValueObject implements \IteratorAggregate
 {
@@ -38,10 +45,7 @@ class SearchResult extends ValueObject implements \IteratorAggregate
      */
     public $items = [];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->items);
     }

--- a/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResult.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Trash;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResultList.php
+++ b/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResultList.php
@@ -4,9 +4,13 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content\Trash;
 
+use ArrayIterator;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use Traversable;
 
 class TrashItemDeleteResultList extends ValueObject implements \IteratorAggregate
 {
@@ -16,8 +20,8 @@ class TrashItemDeleteResultList extends ValueObject implements \IteratorAggregat
     /**
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
-        return new \ArrayIterator($this->items);
+        return new ArrayIterator($this->items);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/TrashItem.php
+++ b/eZ/Publish/API/Repository/Values/Content/TrashItem.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\TrashItem class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 /**

--- a/eZ/Publish/API/Repository/Values/Content/URLAlias.php
+++ b/eZ/Publish/API/Repository/Values/Content/URLAlias.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\URLAlias class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/URLWildcard.php
+++ b/eZ/Publish/API/Repository/Values/Content/URLWildcard.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\URLWildcard class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/URLWildcardTranslationResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/URLWildcardTranslationResult.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\URLWildcardTranslationResult class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Content/VersionInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/VersionInfo.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\VersionInfo class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\User\User;

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\ContentType\ContentType class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -38,13 +38,13 @@ use eZ\Publish\SPI\Repository\Values\MultiLanguageDescription;
 abstract class ContentType extends ValueObject implements MultiLanguageName, MultiLanguageDescription
 {
     /** @var int Status constant for defined (aka "published") Type */
-    const STATUS_DEFINED = 0;
+    public const STATUS_DEFINED = 0;
 
     /** @var int Status constant for draft (aka "temporary") Type */
-    const STATUS_DRAFT = 1;
+    public const STATUS_DRAFT = 1;
 
     /** @var int Status constant for modified (aka "deferred for publishing") Type */
-    const STATUS_MODIFIED = 2;
+    public const STATUS_MODIFIED = 2;
 
     /**
      * Content type ID.

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\ContentType\ContentTypeCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -109,9 +109,9 @@ abstract class ContentTypeCreateStruct extends ValueObject
     /**
      * Adds a new field definition.
      *
-     * @param FieldDefinitionCreateStruct $fieldDef
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct $fieldDef
      */
-    abstract public function addFieldDefinition(FieldDefinitionCreateStruct $fieldDef);
+    abstract public function addFieldDefinition(FieldDefinitionCreateStruct $fieldDef): void;
 
     /**
      * If set this value overrides the current user as creator.

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeDraft.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeDraft.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ContentType;
 
 /**

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroup.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroup.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the ContentTypeGroup class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroupCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroupCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroupCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ContentType;
 
 /**

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroupStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroupStruct.php
@@ -1,10 +1,11 @@
 <?php
+
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroupUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroupUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroupUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ContentType;
 
 /**

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\ContentType\ContentTypeUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\ContentType\FieldDefinition class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -15,8 +15,8 @@ use eZ\Publish\SPI\Repository\Values\MultiLanguageDescription;
 /**
  * This class represents a field definition.
  *
- * @property-read mixed $fieldSettings calls getFieldSettings()
- * @property-read mixed $validatorConfiguration calls getValidatorConfiguration()
+ * @property-read array $fieldSettings calls getFieldSettings()
+ * @property-read array $validatorConfiguration calls getValidatorConfiguration()
  * @property-read mixed $id the id of the field definition
  * @property-read string $identifier the identifier of the field definition
  * @property-read string $fieldGroup the field group name
@@ -98,16 +98,16 @@ abstract class FieldDefinition extends ValueObject implements MultiLanguageName,
     /**
      * This method returns the validator configuration of this field definition supported by the field type.
      *
-     * @return mixed
+     * @return array
      */
-    abstract public function getValidatorConfiguration();
+    abstract public function getValidatorConfiguration(): array;
 
     /**
      * This method returns settings for the field definition supported by the field type.
      *
-     * @return mixed
+     * @return array
      */
-    abstract public function getFieldSettings();
+    abstract public function getFieldSettings(): array;
 
     /**
      * Default value of the field.

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Notification/NotificationList.php
+++ b/eZ/Publish/API/Repository/Values/Notification/NotificationList.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\API\Repository\Values\Notification;
 use ArrayIterator;
 use IteratorAggregate;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use Traversable;
 
 class NotificationList extends ValueObject implements IteratorAggregate
 {
@@ -23,7 +24,7 @@ class NotificationList extends ValueObject implements IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->items);
     }

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectState.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectState.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the ObjectState class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ObjectState;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -56,5 +56,5 @@ abstract class ObjectState extends ValueObject implements MultiLanguageName, Mul
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
      */
-    abstract public function getObjectStateGroup();
+    abstract public function getObjectStateGroup(): ObjectStateGroup;
 }

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the ObjectStateCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ObjectState;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroup.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroup.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the ObjectStateGroup class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ObjectState;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroupCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroupCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the ObjectStateGroupCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ObjectState;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroupUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroupUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the ObjectStateGroupUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ObjectState;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the ObjectStateUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\ObjectState;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/Translation.php
+++ b/eZ/Publish/API/Repository/Values/Translation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Message class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values;
 
 /**

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query;
 
 abstract class Criterion

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalAnd.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalAnd.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 
 class LogicalAnd extends LogicalOperator

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalNot.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalNot.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
@@ -15,7 +17,7 @@ class LogicalNot extends LogicalOperator
      *
      * Will match of the given criterion doesn't match
      *
-     * @param Criterion $criterion criterion
+     * @param \eZ\Publish\API\Repository\Values\URL\Query\Criterion $criterion criterion
      * @throws \InvalidArgumentException if more than one criterion is given in the array parameter
      */
     public function __construct(Criterion $criterion)

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalOperator.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalOperator.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalOr.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalOr.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 
 class LogicalOr extends LogicalOperator

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/MatchAll.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/MatchAll.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 
 class MatchAll extends Matcher

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/MatchNone.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/MatchNone.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 
 class MatchNone extends Matcher

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/Matcher.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/Matcher.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/Pattern.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/Pattern.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 
 /**
@@ -23,9 +25,9 @@ class Pattern extends Matcher
      *
      * @param string $pattern
      */
-    public function __construct($pattern)
+    public function __construct(string $pattern)
     {
-        if ($pattern === null || $pattern === '') {
+        if ($pattern === '') {
             throw new \InvalidArgumentException('URL pattern cannot be empty.');
         }
 

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/Validity.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/Validity.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 
 /**
@@ -23,7 +25,7 @@ class Validity extends Matcher
      *
      * @param bool $isValid
      */
-    public function __construct($isValid)
+    public function __construct(bool $isValid)
     {
         $this->isValid = $isValid;
     }

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/VisibleOnly.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/VisibleOnly.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 
 /**

--- a/eZ/Publish/API/Repository/Values/URL/Query/SortClause.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/SortClause.php
@@ -15,8 +15,8 @@ use InvalidArgumentException;
  */
 abstract class SortClause
 {
-    const SORT_ASC = 'ascending';
-    const SORT_DESC = 'descending';
+    public const SORT_ASC = 'ascending';
+    public const SORT_DESC = 'descending';
 
     /**
      * Sort direction.

--- a/eZ/Publish/API/Repository/Values/URL/Query/SortClause.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/SortClause.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query;
 
 use InvalidArgumentException;
@@ -38,7 +40,7 @@ abstract class SortClause
      *
      * @throws InvalidArgumentException if the given sort order isn't one of SortClause::SORT_ASC or SortClause::SORT_DESC
      */
-    public function __construct($sortTarget, $sortDirection)
+    public function __construct(string $sortTarget, string $sortDirection)
     {
         if ($sortDirection !== self::SORT_ASC && $sortDirection !== self::SORT_DESC) {
             throw new InvalidArgumentException('Sort direction must be either SortClause::SORT_ASC or SortClause::SORT_DESC');

--- a/eZ/Publish/API/Repository/Values/URL/Query/SortClause/Id.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/SortClause/Id.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query\SortClause;
 
 use eZ\Publish\API\Repository\Values\URL\Query\SortClause;
@@ -15,7 +17,7 @@ class Id extends SortClause
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = self::SORT_ASC)
+    public function __construct(string $sortDirection = self::SORT_ASC)
     {
         parent::__construct('id', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/URL/Query/SortClause/URL.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/SortClause/URL.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL\Query\SortClause;
 
 use eZ\Publish\API\Repository\Values\URL\Query\SortClause;
@@ -15,7 +17,7 @@ class URL extends SortClause
      *
      * @param string $sortDirection
      */
-    public function __construct($sortDirection = self::SORT_ASC)
+    public function __construct(string $sortDirection = self::SORT_ASC)
     {
         parent::__construct('url', $sortDirection);
     }

--- a/eZ/Publish/API/Repository/Values/URL/SearchResult.php
+++ b/eZ/Publish/API/Repository/Values/URL/SearchResult.php
@@ -4,10 +4,13 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL;
 
 use ArrayIterator;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use Traversable;
 
 class SearchResult extends ValueObject implements \IteratorAggregate
 {
@@ -28,7 +31,7 @@ class SearchResult extends ValueObject implements \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->items);
     }

--- a/eZ/Publish/API/Repository/Values/URL/URL.php
+++ b/eZ/Publish/API/Repository/Values/URL/URL.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/URL/URLQuery.php
+++ b/eZ/Publish/API/Repository/Values/URL/URLQuery.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/URL/URLUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/URL/URLUpdateStruct.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/URL/UsageSearchResult.php
+++ b/eZ/Publish/API/Repository/Values/URL/UsageSearchResult.php
@@ -4,10 +4,13 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\URL;
 
 use ArrayIterator;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use Traversable;
 
 class UsageSearchResult extends ValueObject implements \IteratorAggregate
 {
@@ -25,10 +28,7 @@ class UsageSearchResult extends ValueObject implements \IteratorAggregate
      */
     public $items = [];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->items);
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -16,29 +16,22 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 abstract class Limitation extends ValueObject
 {
     // consts for BC
-    const CONTENTTYPE = 'Class';
-    const LANGUAGE = 'Language';
-    const LOCATION = 'Node';
-    const OWNER = 'Owner';
-    const PARENTOWNER = 'ParentOwner';
-    const PARENTCONTENTTYPE = 'ParentClass';
-    const PARENTDEPTH = 'ParentDepth';
-    const SECTION = 'Section';
-    const NEWSECTION = 'NewSection';
-    const SITEACCESS = 'SiteAccess';
-    const STATE = 'State';
-    const NEWSTATE = 'NewState';
-    const SUBTREE = 'Subtree';
-    const USERGROUP = 'Group';
-    const PARENTUSERGROUP = 'ParentGroup';
-    const STATUS = 'Status';
-
-    /**
-     * Returns the limitation identifier (one of the defined constants) or a custom limitation.
-     *
-     * @return string
-     */
-    abstract public function getIdentifier();
+    public const CONTENTTYPE = 'Class';
+    public const LANGUAGE = 'Language';
+    public const LOCATION = 'Node';
+    public const OWNER = 'Owner';
+    public const PARENTOWNER = 'ParentOwner';
+    public const PARENTCONTENTTYPE = 'ParentClass';
+    public const PARENTDEPTH = 'ParentDepth';
+    public const SECTION = 'Section';
+    public const NEWSECTION = 'NewSection';
+    public const SITEACCESS = 'SiteAccess';
+    public const STATE = 'State';
+    public const NEWSTATE = 'NewState';
+    public const SUBTREE = 'Subtree';
+    public const USERGROUP = 'Group';
+    public const PARENTUSERGROUP = 'ParentGroup';
+    public const STATUS = 'Status';
 
     /**
      * A read-only list of IDs or identifiers for which the limitation should be applied.
@@ -50,4 +43,11 @@ abstract class Limitation extends ValueObject
      * @var mixed[]
      */
     public $limitationValues = [];
+
+    /**
+     * Returns the limitation identifier (one of the defined constants) or a custom limitation.
+     *
+     * @return string
+     */
+    abstract public function getIdentifier(): string;
 }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/BlockingLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/BlockingLimitation.php
@@ -28,7 +28,7 @@ class BlockingLimitation extends Limitation
      * @param string $identifier The identifier of the limitation
      * @param array $limitationValues
      */
-    public function __construct($identifier, array $limitationValues)
+    public function __construct(string $identifier, array $limitationValues)
     {
         if (empty($identifier)) {
             throw new \InvalidArgumentException('Argument $identifier cannot be empty');

--- a/eZ/Publish/API/Repository/Values/User/Limitation/BlockingLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/BlockingLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * This file is part of the eZ Publish package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -42,7 +42,7 @@ class BlockingLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ContentTypeLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ContentTypeLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -17,7 +17,7 @@ class ContentTypeLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::CONTENTTYPE;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/LanguageLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/LanguageLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -17,7 +17,7 @@ class LanguageLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::LANGUAGE;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/LocationLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/LocationLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\LocationLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -17,7 +17,7 @@ class LocationLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::LOCATION;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/NewObjectStateLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/NewObjectStateLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\NewObjectStateLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -17,7 +17,7 @@ class NewObjectStateLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::NEWSTATE;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/NewSectionLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/NewSectionLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\NewSectionLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -17,7 +17,7 @@ class NewSectionLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::NEWSECTION;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ObjectStateLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ObjectStateLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -24,7 +24,7 @@ class ObjectStateLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::STATE;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/OwnerLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/OwnerLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\OwnerLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -17,7 +17,7 @@ class OwnerLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::OWNER;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ParentContentTypeLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ParentContentTypeLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\ParentContentTypeLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -17,7 +17,7 @@ class ParentContentTypeLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::PARENTCONTENTTYPE;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ParentDepthLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ParentDepthLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\ParentDepthLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -17,7 +17,7 @@ class ParentDepthLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::PARENTDEPTH;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ParentOwnerLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ParentOwnerLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\ParentOwnerLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -17,7 +17,7 @@ class ParentOwnerLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::PARENTOWNER;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ParentUserGroupLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ParentUserGroupLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\ParentUserGroupLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -17,7 +17,7 @@ class ParentUserGroupLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::PARENTUSERGROUP;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/RoleLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/RoleLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Values/User/Limitation/SectionLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/SectionLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -17,7 +17,7 @@ class SectionLimitation extends RoleLimitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::SECTION;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/SiteAccessLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/SiteAccessLimitation.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Values/User/Limitation/SiteAccessLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/SiteAccessLimitation.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\SiteAccessLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -17,7 +15,7 @@ class SiteAccessLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::SITEACCESS;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/StatusLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/StatusLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\StatusLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -20,7 +20,7 @@ class StatusLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::STATUS;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/SubtreeLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/SubtreeLimitation.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;
@@ -17,7 +17,7 @@ class SubtreeLimitation extends RoleLimitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::SUBTREE;
     }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/UserGroupLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/UserGroupLimitation.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User\Limitation;
 
 use eZ\Publish\API\Repository\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Values/User/Limitation/UserGroupLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/UserGroupLimitation.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Limitation\UserGroupLimitation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -17,7 +15,7 @@ class UserGroupLimitation extends Limitation
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return Limitation::USERGROUP;
     }

--- a/eZ/Publish/API/Repository/Values/User/Policy.php
+++ b/eZ/Publish/API/Repository/Values/User/Policy.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Policy class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -17,21 +17,21 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read mixed $roleId the role id this policy belongs to
  * @property-read string $module Name of module, associated with the Policy
  * @property-read string $function  Name of the module function Or all functions with '*'
- * @property-read array $limitations an array of \eZ\Publish\API\Repository\Values\User\Limitation
+ * @property-read \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations an array of \eZ\Publish\API\Repository\Values\User\Limitation
  */
 abstract class Policy extends ValueObject
 {
     /**
      * ID of the policy.
      *
-     * @var mixed
+     * @var int
      */
     protected $id;
 
     /**
      * the ID of the role this policy belongs to.
      *
-     * @var mixed
+     * @var int
      */
     protected $roleId;
 
@@ -56,5 +56,5 @@ abstract class Policy extends ValueObject
     /**
      * @return \eZ\Publish\API\Repository\Values\User\Limitation[]
      */
-    abstract public function getLimitations();
+    abstract public function getLimitations(): iterable;
 }

--- a/eZ/Publish/API/Repository/Values/User/PolicyCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/PolicyCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\PolicyCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 /**

--- a/eZ/Publish/API/Repository/Values/User/PolicyDraft.php
+++ b/eZ/Publish/API/Repository/Values/User/PolicyDraft.php
@@ -1,10 +1,11 @@
 <?php
+
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 /**
@@ -16,7 +17,7 @@ abstract class PolicyDraft extends Policy
      * Original policy ID the policy was created from.
      * Used when role status is Role::STATUS_DRAFT.
      *
-     * @var mixed
+     * @var int
      */
     protected $originalId;
 }

--- a/eZ/Publish/API/Repository/Values/User/PolicyStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/PolicyStruct.php
@@ -1,10 +1,11 @@
 <?php
+
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -16,12 +17,12 @@ abstract class PolicyStruct extends ValueObject
      *
      * @return \eZ\Publish\API\Repository\Values\User\Limitation[]
      */
-    abstract public function getLimitations();
+    abstract public function getLimitations(): iterable;
 
     /**
      * Adds a limitation with the given identifier and list of values.
      *
-     * @param Limitation $limitation
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitation
      */
-    abstract public function addLimitation(Limitation $limitation);
+    abstract public function addLimitation(Limitation $limitation): void;
 }

--- a/eZ/Publish/API/Repository/Values/User/PolicyUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/PolicyUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 /**

--- a/eZ/Publish/API/Repository/Values/User/Role.php
+++ b/eZ/Publish/API/Repository/Values/User/Role.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Role class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -13,10 +13,10 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 /**
  * This class represents a role.
  *
- * @property-read mixed $id the internal id of the role
+ * @property-read int $id the internal id of the role
  * @property-read string $identifier the identifier of the role
  *
- * @property-read array $policies an array of the policies {@link \eZ\Publish\API\Repository\Values\User\Policy} of the role.
+ * @property-read \eZ\Publish\API\Repository\Values\User\Policy[] $policies an array of the policies {@link \eZ\Publish\API\Repository\Values\User\Policy} of the role.
  */
 abstract class Role extends ValueObject
 {
@@ -29,7 +29,7 @@ abstract class Role extends ValueObject
     /**
      * ID of the user role.
      *
-     * @var mixed
+     * @var int
      */
     protected $id;
 
@@ -53,5 +53,5 @@ abstract class Role extends ValueObject
      *
      * @return \eZ\Publish\API\Repository\Values\User\Policy[]
      */
-    abstract public function getPolicies();
+    abstract public function getPolicies(): iterable;
 }

--- a/eZ/Publish/API/Repository/Values/User/RoleAssignment.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleAssignment.php
@@ -1,19 +1,20 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\RoleAssignment class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
+use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\ValueObject;
 
 /**
  * This value object represents an assignment od a user or user group to a role including a limitation.
  *
- * @property-read \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation $limitation the limitation of this role assignment
+ * @property-read \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation|null $limitation the limitation of this role assignment
  * @property-read \eZ\Publish\API\Repository\Values\User\Role $role the role which is assigned to the user or user group
  */
 abstract class RoleAssignment extends ValueObject
@@ -21,7 +22,7 @@ abstract class RoleAssignment extends ValueObject
     /**
      * The unique id of the role assignment.
      *
-     * @var mixed
+     * @var int
      */
     protected $id;
 
@@ -30,12 +31,12 @@ abstract class RoleAssignment extends ValueObject
      *
      * @return \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation|null
      */
-    abstract public function getRoleLimitation();
+    abstract public function getRoleLimitation(): ?RoleLimitation;
 
     /**
      * Returns the role to which the user or user group is assigned to.
      *
      * @return \eZ\Publish\API\Repository\Values\User\Role
      */
-    abstract public function getRole();
+    abstract public function getRole(): Role;
 }

--- a/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\RoleCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -27,12 +27,12 @@ abstract class RoleCreateStruct extends ValueObject
      *
      * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct[]
      */
-    abstract public function getPolicies();
+    abstract public function getPolicies(): iterable;
 
     /**
      * Adds a policy to this role.
      *
      * @param \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct $policyCreateStruct
      */
-    abstract public function addPolicy(PolicyCreateStruct $policyCreateStruct);
+    abstract public function addPolicy(PolicyCreateStruct $policyCreateStruct): void;
 }

--- a/eZ/Publish/API/Repository/Values/User/RoleDraft.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleDraft.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\RoleDraft class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 /**

--- a/eZ/Publish/API/Repository/Values/User/RoleUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\RoleUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/User/User.php
+++ b/eZ/Publish/API/Repository/Values/User/User.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\User class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use DateTime;
@@ -90,9 +90,9 @@ abstract class User extends Content implements UserReference
     /**
      * The User id of the User.
      *
-     * @return mixed
+     * @return int
      */
-    public function getUserId()
+    public function getUserId(): int
     {
         return $this->id;
     }

--- a/eZ/Publish/API/Repository/Values/User/UserCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/UserCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\UserCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;

--- a/eZ/Publish/API/Repository/Values/User/UserGroup.php
+++ b/eZ/Publish/API/Repository/Values/User/UserGroup.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\UserGroup class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\Content\Content;

--- a/eZ/Publish/API/Repository/Values/User/UserGroupCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/UserGroupCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\UserGroupCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;

--- a/eZ/Publish/API/Repository/Values/User/UserGroupRoleAssignment.php
+++ b/eZ/Publish/API/Repository/Values/User/UserGroupRoleAssignment.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\UserGroupRoleAssignment class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 /**
@@ -20,5 +20,5 @@ abstract class UserGroupRoleAssignment extends RoleAssignment
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup
      */
-    abstract public function getUserGroup();
+    abstract public function getUserGroup(): UserGroup;
 }

--- a/eZ/Publish/API/Repository/Values/User/UserGroupUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/UserGroupUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\UserGroupUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/User/UserReference.php
+++ b/eZ/Publish/API/Repository/Values/User/UserReference.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\UserReference interface.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 /**
@@ -16,7 +16,7 @@ interface UserReference
     /**
      * The User id of the User this reference represent.
      *
-     * @return mixed
+     * @return int
      */
-    public function getUserId();
+    public function getUserId(): int;
 }

--- a/eZ/Publish/API/Repository/Values/User/UserRoleAssignment.php
+++ b/eZ/Publish/API/Repository/Values/User/UserRoleAssignment.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\UserRoleAssignment class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 /**
@@ -20,5 +20,5 @@ abstract class UserRoleAssignment extends RoleAssignment
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      */
-    abstract public function getUser();
+    abstract public function getUser(): User;
 }

--- a/eZ/Publish/API/Repository/Values/User/UserTokenUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/UserTokenUpdateStruct.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/API/Repository/Values/User/UserUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/UserUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\UserUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserCheckerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserCheckerTest.php
@@ -24,6 +24,8 @@ use DateTimeImmutable;
 
 final class UserCheckerTest extends TestCase
 {
+    private const EXAMPLE_USER_ID = 14;
+
     /** @var \PHPUnit\Framework\MockObject\MockObject */
     private $userServiceMock;
 
@@ -44,7 +46,11 @@ final class UserCheckerTest extends TestCase
                     [
                         'versionInfo' => new VersionInfo(
                             [
-                                'contentInfo' => new ContentInfo(),
+                                'contentInfo' => new ContentInfo(
+                                    [
+                                        'id' => self::EXAMPLE_USER_ID,
+                                    ]
+                                ),
                             ]
                         ),
                     ]
@@ -68,7 +74,11 @@ final class UserCheckerTest extends TestCase
                     [
                         'versionInfo' => new VersionInfo(
                             [
-                                'contentInfo' => new ContentInfo(),
+                                'contentInfo' => new ContentInfo(
+                                    [
+                                        'id' => self::EXAMPLE_USER_ID,
+                                    ]
+                                ),
                             ]
                         ),
                     ]
@@ -91,7 +101,11 @@ final class UserCheckerTest extends TestCase
                     [
                         'versionInfo' => new VersionInfo(
                             [
-                                'contentInfo' => new ContentInfo(),
+                                'contentInfo' => new ContentInfo(
+                                    [
+                                        'id' => self::EXAMPLE_USER_ID,
+                                    ]
+                                ),
                             ]
                         ),
                     ]
@@ -120,7 +134,11 @@ final class UserCheckerTest extends TestCase
                     [
                         'versionInfo' => new VersionInfo(
                             [
-                                'contentInfo' => new ContentInfo(),
+                                'contentInfo' => new ContentInfo(
+                                    [
+                                        'id' => self::EXAMPLE_USER_ID,
+                                    ]
+                                ),
                             ]
                         ),
                     ]

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserTest.php
@@ -94,7 +94,7 @@ class UserTest extends TestCase
 
     public function testIsEqualToNotSameUserType()
     {
-        $user = new User();
+        $user = new User($this->createMock(APIUser::class));
         $user2 = $this->createMock(ReferenceUserInterface::class);
         $user2
             ->expects($this->once())
@@ -105,10 +105,12 @@ class UserTest extends TestCase
 
     public function testSetAPIUser()
     {
-        $apiUser = $this->createMock(APIUser::class);
-        $user = new User();
-        $user->setAPIUser($apiUser);
-        $this->assertSame($apiUser, $user->getAPIUser());
+        $apiUserA = $this->createMock(APIUser::class);
+        $apiUserB = $this->createMock(APIUser::class);
+
+        $user = new User($apiUserA);
+        $user->setAPIUser($apiUserB);
+        $this->assertSame($apiUserB, $user->getAPIUser());
     }
 
     public function testToString()

--- a/eZ/Publish/Core/MVC/Symfony/Security/User.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the User class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\MVC\Symfony\Security;
 
 use eZ\Publish\API\Repository\Values\User\User as APIUser;
@@ -24,10 +24,10 @@ class User implements ReferenceUserInterface, EquatableInterface
     /** @var array */
     private $roles;
 
-    public function __construct(APIUser $user = null, array $roles = [])
+    public function __construct(APIUser $user, array $roles = [])
     {
         $this->user = $user;
-        $this->reference = new UserReference($user ? $user->getUserId() : null);
+        $this->reference = new UserReference($user->getUserId());
         $this->roles = $roles;
     }
 

--- a/eZ/Publish/Core/Repository/Permission/PermissionCriterionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionCriterionResolver.php
@@ -78,7 +78,7 @@ class PermissionCriterionResolver implements APIPermissionCriterionResolver
             /** @var \eZ\Publish\API\Repository\Values\User\Policy */
             foreach ($permissionSet['policies'] as $policy) {
                 $limitations = $policy->getLimitations();
-                if ($limitations === '*' || empty($limitations)) {
+                if (empty($limitations)) {
                     // Given policy gives full access, optimize away all role policies (but not role limitation if any)
                     // This should be optimized on create/update of Roles, however we keep this here for bc with older data
                     $policyOrCriteria = [];

--- a/eZ/Publish/Core/Repository/Tests/Permission/PermissionCriterionResolverTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Permission/PermissionCriterionResolverTest.php
@@ -75,17 +75,6 @@ class PermissionCriterionResolverTest extends TestCase
                 [
                     [
                         'limitation' => null,
-                        'policies' => [new Policy(['limitations' => '*']), $policy1],
-                    ],
-                ],
-                false,
-            ],
-            [
-                $criterionMock,
-                0,
-                [
-                    [
-                        'limitation' => null,
                         'policies' => [new Policy(['limitations' => []]), $policy1],
                     ],
                 ],
@@ -205,7 +194,7 @@ class PermissionCriterionResolverTest extends TestCase
                 [
                     [
                         'limitation' => $limitationMock,
-                        'policies' => [new Policy(['limitations' => '*'])],
+                        'policies' => [new Policy(['limitations' => []])],
                     ],
                 ],
                 $criterionMock,
@@ -216,11 +205,11 @@ class PermissionCriterionResolverTest extends TestCase
                 [
                     [
                         'limitation' => $limitationMock,
-                        'policies' => [new Policy(['limitations' => '*'])],
+                        'policies' => [new Policy(['limitations' => []])],
                     ],
                     [
                         'limitation' => $limitationMock,
-                        'policies' => [new Policy(['limitations' => '*'])],
+                        'policies' => [new Policy(['limitations' => []])],
                     ],
                 ],
                 new Criterion\LogicalOr([$criterionMock, $criterionMock]),

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
@@ -130,17 +130,6 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
                 [
                     [
                         'limitation' => null,
-                        'policies' => [new Policy(['limitations' => '*']), $policy1],
-                    ],
-                ],
-                false,
-            ],
-            [
-                $criterionMock,
-                0,
-                [
-                    [
-                        'limitation' => null,
                         'policies' => [new Policy(['limitations' => []]), $policy1],
                     ],
                 ],
@@ -260,7 +249,7 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
                 [
                     [
                         'limitation' => $limitationMock,
-                        'policies' => [new Policy(['limitations' => '*'])],
+                        'policies' => [new Policy(['limitations' => []])],
                     ],
                 ],
                 $criterionMock,
@@ -271,11 +260,11 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
                 [
                     [
                         'limitation' => $limitationMock,
-                        'policies' => [new Policy(['limitations' => '*'])],
+                        'policies' => [new Policy(['limitations' => []])],
                     ],
                     [
                         'limitation' => $limitationMock,
-                        'policies' => [new Policy(['limitations' => '*'])],
+                        'policies' => [new Policy(['limitations' => []])],
                     ],
                 ],
                 new Criterion\LogicalOr([$criterionMock, $criterionMock]),

--- a/eZ/Publish/Core/Repository/Values/Content/Content.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Content.php
@@ -1,23 +1,26 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\Content\Content class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\SPI\FieldType\Value;
 
 /**
  * this class represents a content object in a specific version.
  *
  * @property-read \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo convenience getter for $versionInfo->contentInfo
  * @property-read \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType convenience getter for $versionInfo->contentInfo->contentType
- * @property-read mixed $id convenience getter for retrieving the contentId: $versionInfo->content->id
+ * @property-read int $id convenience getter for retrieving the contentId: $versionInfo->content->id
  * @property-read \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo calls getVersionInfo()
  * @property-read \eZ\Publish\API\Repository\Values\Content\Field[] $fields Access fields, calls getFields()
  *
@@ -25,19 +28,19 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentType;
  */
 class Content extends APIContent
 {
-    /** @var Thumbnail|null */
+    /** @var \eZ\Publish\API\Repository\Values\Content\Thumbnail|null */
     protected $thumbnail;
 
     /** @var mixed[][] An array of array of field values like[$fieldDefIdentifier][$languageCode] */
     protected $fields;
 
-    /** @var \eZ\Publish\API\Repository\Values\Content\VersionInfo */
+    /** @var APIVersionInfo */
     protected $versionInfo;
 
     /** @var \eZ\Publish\API\Repository\Values\ContentType\ContentType */
     protected $contentType;
 
-    /** @var \eZ\Publish\API\Repository\Values\Content\Field[] An array of {@link Field} */
+    /** @var Field[] An array of {@link Field} */
     private $internalFields = [];
 
     /**
@@ -69,7 +72,7 @@ class Content extends APIContent
     /**
      * {@inheritdoc}
      */
-    public function getVersionInfo()
+    public function getVersionInfo(): APIVersionInfo
     {
         return $this->versionInfo;
     }
@@ -85,7 +88,7 @@ class Content extends APIContent
     /**
      * {@inheritdoc}
      */
-    public function getFieldValue($fieldDefIdentifier, $languageCode = null)
+    public function getFieldValue(string $fieldDefIdentifier, ?string $languageCode = null): ?Value
     {
         if (null === $languageCode) {
             $languageCode = $this->prioritizedFieldLanguageCode ?: $this->versionInfo->contentInfo->mainLanguageCode;
@@ -101,7 +104,7 @@ class Content extends APIContent
     /**
      * {@inheritdoc}
      */
-    public function getFields()
+    public function getFields(): iterable
     {
         return $this->internalFields;
     }
@@ -109,7 +112,7 @@ class Content extends APIContent
     /**
      * {@inheritdoc}
      */
-    public function getFieldsByLanguage($languageCode = null)
+    public function getFieldsByLanguage(?string $languageCode = null): iterable
     {
         $fields = [];
 
@@ -130,7 +133,7 @@ class Content extends APIContent
     /**
      * {@inheritdoc}
      */
-    public function getField($fieldDefIdentifier, $languageCode = null)
+    public function getField(string $fieldDefIdentifier, ?string $languageCode = null): ?Field
     {
         if (null === $languageCode) {
             $languageCode = $this->prioritizedFieldLanguageCode ?: $this->versionInfo->contentInfo->mainLanguageCode;

--- a/eZ/Publish/Core/Repository/Values/Content/ContentCreateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/Content/ContentCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct as APIContentCreateStruct;
@@ -39,7 +39,7 @@ class ContentCreateStruct extends APIContentCreateStruct
      *                     field type or an instance of a Value class provided by the field type
      * @param string|null $language If not given on a translatable field the initial language is used
      */
-    public function setField($fieldDefIdentifier, $value, $language = null)
+    public function setField(string $fieldDefIdentifier, $value, ?string $language = null): void
     {
         if (!isset($language)) {
             $language = $this->mainLanguageCode;

--- a/eZ/Publish/Core/Repository/Values/Content/ContentUpdateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/Content/ContentUpdateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\Content\ContentUpdateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\Content;
 
 use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct as APIContentUpdateStruct;
@@ -37,7 +37,7 @@ class ContentUpdateStruct extends APIContentUpdateStruct
      * @param mixed $value Either a plain value which is understandable by the field type or an instance of a Value class provided by the field type
      * @param string|null $language If not given on a translatable field the initial language is used,
      */
-    public function setField($fieldDefIdentifier, $value, $language = null)
+    public function setField(string $fieldDefIdentifier, $value, ?string $language = null): void
     {
         $this->fields[] = new Field(
             [

--- a/eZ/Publish/Core/Repository/Values/Content/Location.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Location.php
@@ -1,13 +1,14 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\Content\Location class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\Content;
 
+use eZ\Publish\API\Repository\Values\Content\ContentInfo as APIContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 
 /**
@@ -35,7 +36,7 @@ class Location extends APILocation
      *
      * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo
      */
-    public function getContentInfo()
+    public function getContentInfo(): APIContentInfo
     {
         return $this->contentInfo;
     }

--- a/eZ/Publish/Core/Repository/Values/Content/Relation.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Relation.php
@@ -1,13 +1,14 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\Content\Relation class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\Content;
 
+use eZ\Publish\API\Repository\Values\Content\ContentInfo as APIContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Relation as APIRelation;
 
 /**
@@ -43,7 +44,7 @@ class Relation extends APIRelation
      *
      * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo
      */
-    public function getSourceContentInfo()
+    public function getSourceContentInfo(): APIContentInfo
     {
         return $this->sourceContentInfo;
     }
@@ -53,7 +54,7 @@ class Relation extends APIRelation
      *
      * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo
      */
-    public function getDestinationContentInfo()
+    public function getDestinationContentInfo(): APIContentInfo
     {
         return $this->destinationContentInfo;
     }

--- a/eZ/Publish/Core/Repository/Values/Content/TrashItem.php
+++ b/eZ/Publish/Core/Repository/Values/Content/TrashItem.php
@@ -1,13 +1,14 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\Content\TrashItem class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\Content;
 
+use eZ\Publish\API\Repository\Values\Content\ContentInfo as APIContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\TrashItem as APITrashItem;
 
@@ -36,7 +37,7 @@ class TrashItem extends APITrashItem
      *
      * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo
      */
-    public function getContentInfo()
+    public function getContentInfo(): APIContentInfo
     {
         return $this->contentInfo;
     }

--- a/eZ/Publish/Core/Repository/Values/ContentType/ContentTypeCreateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/ContentTypeCreateStruct.php
@@ -32,7 +32,7 @@ class ContentTypeCreateStruct extends APIContentTypeCreateStruct
      *
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct $fieldDef
      */
-    public function addFieldDefinition(FieldDefinitionCreateStruct $fieldDef)
+    public function addFieldDefinition(FieldDefinitionCreateStruct $fieldDef): void
     {
         $this->fieldDefinitions[] = $fieldDef;
     }

--- a/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinition.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinition.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition as APIFieldDefinition;
@@ -18,8 +18,8 @@ use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
  *
  * @property-read string[] $names calls getNames() or on access getName($language)
  * @property-read string[] $descriptions calls getDescriptions() or on access getDescription($language)
- * @property-read mixed $fieldSettings calls getFieldSettings()
- * @property-read mixed $validatorConfiguration calls getValidatorConfiguration()
+ * @property-read array $fieldSettings calls getFieldSettings()
+ * @property-read array $validatorConfiguration calls getValidatorConfiguration()
  * @property-read mixed $id the id of the field definition
  * @property-read string $identifier the identifier of the field definition
  * @property-read string $fieldGroup the field group name
@@ -44,21 +44,21 @@ class FieldDefinition extends APIFieldDefinition
      *
      * @var array
      */
-    protected $fieldSettings;
+    protected $fieldSettings = [];
 
     /**
      * Holds validator configuration of this field definition supported by the field type.
      *
-     * @var mixed
+     * @var array
      */
-    protected $validatorConfiguration;
+    protected $validatorConfiguration = [];
 
     /**
      * This method returns the validator configuration of this field definition supported by the field type.
      *
-     * @return mixed
+     * @return array
      */
-    public function getValidatorConfiguration()
+    public function getValidatorConfiguration(): array
     {
         return $this->validatorConfiguration;
     }
@@ -68,7 +68,7 @@ class FieldDefinition extends APIFieldDefinition
      *
      * @return array
      */
-    public function getFieldSettings()
+    public function getFieldSettings(): array
     {
         return $this->fieldSettings;
     }

--- a/eZ/Publish/Core/Repository/Values/ContentType/FieldType.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/FieldType.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\FieldType class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\FieldType as FieldTypeInterface;
@@ -42,7 +42,7 @@ class FieldType implements FieldTypeInterface
      *
      * @return string
      */
-    public function getFieldTypeIdentifier()
+    public function getFieldTypeIdentifier(): string
     {
         return $this->internalFieldType->getFieldTypeIdentifier();
     }
@@ -125,7 +125,7 @@ class FieldType implements FieldTypeInterface
      *
      * @return bool
      */
-    public function isSearchable()
+    public function isSearchable(): bool
     {
         return $this->internalFieldType->isSearchable();
     }
@@ -135,7 +135,7 @@ class FieldType implements FieldTypeInterface
      *
      * @return bool
      */
-    public function isSingular()
+    public function isSingular(): bool
     {
         return $this->internalFieldType->isSingular();
     }
@@ -145,7 +145,7 @@ class FieldType implements FieldTypeInterface
      *
      * @return bool
      */
-    public function onlyEmptyInstance()
+    public function onlyEmptyInstance(): bool
     {
         return $this->internalFieldType->onlyEmptyInstance();
     }
@@ -174,7 +174,7 @@ class FieldType implements FieldTypeInterface
      *
      * @return bool
      */
-    public function isEmptyValue($value)
+    public function isEmptyValue($value): bool
     {
         return $this->internalFieldType->isEmptyValue($value);
     }
@@ -264,7 +264,7 @@ class FieldType implements FieldTypeInterface
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validateValidatorConfiguration($validatorConfiguration)
+    public function validateValidatorConfiguration($validatorConfiguration): iterable
     {
         return $this->internalFieldType->validateValidatorConfiguration($validatorConfiguration);
     }
@@ -279,7 +279,7 @@ class FieldType implements FieldTypeInterface
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validateFieldSettings($fieldSettings)
+    public function validateFieldSettings($fieldSettings): iterable
     {
         return $this->internalFieldType->validateFieldSettings($fieldSettings);
     }
@@ -292,7 +292,7 @@ class FieldType implements FieldTypeInterface
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validateValue(APIFieldDefinition $fieldDef, Value $value)
+    public function validateValue(APIFieldDefinition $fieldDef, Value $value): iterable
     {
         return $this->internalFieldType->validate($fieldDef, $value);
     }

--- a/eZ/Publish/Core/Repository/Values/ObjectState/ObjectState.php
+++ b/eZ/Publish/Core/Repository/Values/ObjectState/ObjectState.php
@@ -1,14 +1,15 @@
 <?php
 
 /**
- * File containing the ObjectState class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\ObjectState;
 
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState as APIObjectState;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup as APIObjectStateGroup;
 use eZ\Publish\Core\Repository\Values\MultiLanguageDescriptionTrait;
 use eZ\Publish\Core\Repository\Values\MultiLanguageNameTrait;
 use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
@@ -40,7 +41,7 @@ class ObjectState extends APIObjectState
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
      */
-    public function getObjectStateGroup()
+    public function getObjectStateGroup(): APIObjectStateGroup
     {
         return $this->objectStateGroup;
     }

--- a/eZ/Publish/Core/Repository/Values/User/Policy.php
+++ b/eZ/Publish/Core/Repository/Values/User/Policy.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\User\Policy class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\User\Policy as APIPolicy;
@@ -29,7 +29,7 @@ class Policy extends APIPolicy
      *
      * @return \eZ\Publish\API\Repository\Values\User\Limitation[]
      */
-    public function getLimitations()
+    public function getLimitations(): iterable
     {
         return $this->limitations;
     }

--- a/eZ/Publish/Core/Repository/Values/User/PolicyCreateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/User/PolicyCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\User\PolicyCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\User\PolicyCreateStruct as APIPolicyCreateStruct;
@@ -30,7 +30,7 @@ class PolicyCreateStruct extends APIPolicyCreateStruct
      *
      * @return \eZ\Publish\API\Repository\Values\User\Limitation[]
      */
-    public function getLimitations()
+    public function getLimitations(): iterable
     {
         return $this->limitations;
     }
@@ -40,7 +40,7 @@ class PolicyCreateStruct extends APIPolicyCreateStruct
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitation
      */
-    public function addLimitation(Limitation $limitation)
+    public function addLimitation(Limitation $limitation): void
     {
         $limitationIdentifier = $limitation->getIdentifier();
         $this->limitations[$limitationIdentifier] = $limitation;

--- a/eZ/Publish/Core/Repository/Values/User/PolicyDraft.php
+++ b/eZ/Publish/Core/Repository/Values/User/PolicyDraft.php
@@ -1,10 +1,11 @@
 <?php
+
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\User\PolicyDraft as APIPolicyDraft;
@@ -56,7 +57,7 @@ class PolicyDraft extends APIPolicyDraft
     /**
      * @return \eZ\Publish\API\Repository\Values\User\Limitation[]
      */
-    public function getLimitations()
+    public function getLimitations(): iterable
     {
         return $this->innerPolicy->getLimitations();
     }

--- a/eZ/Publish/Core/Repository/Values/User/PolicyUpdateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/User/PolicyUpdateStruct.php
@@ -31,7 +31,7 @@ class PolicyUpdateStruct extends APIPolicyUpdateStruct
      *
      * @return \eZ\Publish\API\Repository\Values\User\Limitation[]
      */
-    public function getLimitations()
+    public function getLimitations(): iterable
     {
         return $this->limitations;
     }
@@ -42,7 +42,7 @@ class PolicyUpdateStruct extends APIPolicyUpdateStruct
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitation
      */
-    public function addLimitation(Limitation $limitation)
+    public function addLimitation(Limitation $limitation): void
     {
         $limitationIdentifier = $limitation->getIdentifier();
         $this->limitations[$limitationIdentifier] = $limitation;

--- a/eZ/Publish/Core/Repository/Values/User/Role.php
+++ b/eZ/Publish/Core/Repository/Values/User/Role.php
@@ -31,7 +31,7 @@ class Role extends APIRole
      *
      * @return \eZ\Publish\API\Repository\Values\User\Policy[]
      */
-    public function getPolicies()
+    public function getPolicies(): iterable
     {
         return $this->policies;
     }

--- a/eZ/Publish/Core/Repository/Values/User/RoleCreateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/User/RoleCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\User\RoleCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\User\RoleCreateStruct as APIRoleCreateStruct;
@@ -30,7 +30,7 @@ class RoleCreateStruct extends APIRoleCreateStruct
      *
      * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct[]
      */
-    public function getPolicies()
+    public function getPolicies(): iterable
     {
         return $this->policies;
     }
@@ -38,10 +38,10 @@ class RoleCreateStruct extends APIRoleCreateStruct
     /**
      * Adds a policy to this role.
      *
-     * @param \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct $policyCreate
+     * @param \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct $policyCreateStruct
      */
-    public function addPolicy(APIPolicyCreateStruct $policyCreate)
+    public function addPolicy(APIPolicyCreateStruct $policyCreateStruct): void
     {
-        $this->policies[] = $policyCreate;
+        $this->policies[] = $policyCreateStruct;
     }
 }

--- a/eZ/Publish/Core/Repository/Values/User/RoleDraft.php
+++ b/eZ/Publish/Core/Repository/Values/User/RoleDraft.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\User\RoleDraft class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\User\RoleDraft as APIRoleDraft;
@@ -66,7 +66,7 @@ class RoleDraft extends APIRoleDraft
      *
      * @return \eZ\Publish\API\Repository\Values\User\PolicyDraft[]
      */
-    public function getPolicies()
+    public function getPolicies(): iterable
     {
         return $this->innerRole->getPolicies();
     }

--- a/eZ/Publish/Core/Repository/Values/User/User.php
+++ b/eZ/Publish/Core/Repository/Values/User/User.php
@@ -1,16 +1,19 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\User\User class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\User;
 
+use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\API\Repository\Values\User\User as APIUser;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\SPI\FieldType\Value;
 
 /**
  * This class represents a user value.
@@ -31,7 +34,7 @@ class User extends APIUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo
      */
-    public function getVersionInfo()
+    public function getVersionInfo(): APIVersionInfo
     {
         return $this->content->getVersionInfo();
     }
@@ -53,7 +56,7 @@ class User extends APIUser
      *
      * @return mixed a primitive type or a field type Value object depending on the field type.
      */
-    public function getFieldValue($fieldDefIdentifier, $languageCode = null)
+    public function getFieldValue(string $fieldDefIdentifier, ?string $languageCode = null): ?Value
     {
         return $this->content->getFieldValue($fieldDefIdentifier, $languageCode);
     }
@@ -63,7 +66,7 @@ class User extends APIUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Field[]
      */
-    public function getFields()
+    public function getFields(): iterable
     {
         return $this->content->getFields();
     }
@@ -75,9 +78,9 @@ class User extends APIUser
      *
      * @param string $languageCode
      *
-     * @return \eZ\Publish\API\Repository\Values\Content\Field[] with field identifier as keys
+     * @return Field[] with field identifier as keys
      */
-    public function getFieldsByLanguage($languageCode = null)
+    public function getFieldsByLanguage(?string $languageCode = null): iterable
     {
         return $this->content->getFieldsByLanguage($languageCode);
     }
@@ -92,7 +95,7 @@ class User extends APIUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Field|null A {@link Field} or null if nothing is found
      */
-    public function getField($fieldDefIdentifier, $languageCode = null)
+    public function getField(string $fieldDefIdentifier, ?string $languageCode = null): ?Field
     {
         return $this->content->getField($fieldDefIdentifier, $languageCode);
     }

--- a/eZ/Publish/Core/Repository/Values/User/UserCreateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\User\UserCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\User\UserCreateStruct as APIUserCreateStruct;
@@ -37,7 +37,7 @@ class UserCreateStruct extends APIUserCreateStruct
      *                     field type or an instance of a Value class provided by the field type
      * @param string|null $language If not given on a translatable field the initial language is used
      */
-    public function setField($fieldDefIdentifier, $value, $language = null)
+    public function setField(string $fieldDefIdentifier, $value, ?string $language = null): void
     {
         if (!isset($language)) {
             $language = $this->mainLanguageCode;

--- a/eZ/Publish/Core/Repository/Values/User/UserGroup.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserGroup.php
@@ -1,16 +1,18 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\User\UserGroup class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\User;
 
+use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
 use eZ\Publish\API\Repository\Values\User\UserGroup as APIUserGroup;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\SPI\FieldType\Value;
 
 /**
  * This class represents a user group.
@@ -31,7 +33,7 @@ class UserGroup extends APIUserGroup
      *
      * @return \eZ\Publish\API\Repository\Values\Content\VersionInfo
      */
-    public function getVersionInfo()
+    public function getVersionInfo(): \eZ\Publish\API\Repository\Values\Content\VersionInfo
     {
         return $this->content->getVersionInfo();
     }
@@ -49,11 +51,11 @@ class UserGroup extends APIUserGroup
      * On non translatable fields this method ignores the languageCode parameter.
      *
      * @param string $fieldDefIdentifier
-     * @param string $languageCode
+     * @param string|null $languageCode
      *
      * @return mixed a primitive type or a field type Value object depending on the field type.
      */
-    public function getFieldValue($fieldDefIdentifier, $languageCode = null)
+    public function getFieldValue(string $fieldDefIdentifier, ?string $languageCode = null): ?Value
     {
         return $this->content->getFieldValue($fieldDefIdentifier, $languageCode);
     }
@@ -63,7 +65,7 @@ class UserGroup extends APIUserGroup
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Field[]
      */
-    public function getFields()
+    public function getFields(): iterable
     {
         return $this->content->getFields();
     }
@@ -77,7 +79,7 @@ class UserGroup extends APIUserGroup
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Field[] with field identifier as keys
      */
-    public function getFieldsByLanguage($languageCode = null)
+    public function getFieldsByLanguage(?string $languageCode = null): iterable
     {
         return $this->content->getFieldsByLanguage($languageCode);
     }
@@ -92,7 +94,7 @@ class UserGroup extends APIUserGroup
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Field|null A {@link Field} or null if nothing is found
      */
-    public function getField($fieldDefIdentifier, $languageCode = null)
+    public function getField(string $fieldDefIdentifier, ?string $languageCode = null): ?Field
     {
         return $this->content->getField($fieldDefIdentifier, $languageCode);
     }

--- a/eZ/Publish/Core/Repository/Values/User/UserGroupCreateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserGroupCreateStruct.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\User\UserGroupCreateStruct class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\User\UserGroupCreateStruct as APIUserGroupCreateStruct;
@@ -37,7 +37,7 @@ class UserGroupCreateStruct extends APIUserGroupCreateStruct
      *                     field type or an instance of a Value class provided by the field type
      * @param string|null $language If not given on a translatable field the initial language is used
      */
-    public function setField($fieldDefIdentifier, $value, $language = null)
+    public function setField(string $fieldDefIdentifier, $value, ?string $language = null): void
     {
         if (!isset($language)) {
             $language = $this->mainLanguageCode;

--- a/eZ/Publish/Core/Repository/Values/User/UserGroupRoleAssignment.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserGroupRoleAssignment.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Repository\Values\User;
 
+use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation as APIRoleLimitation;
+use eZ\Publish\API\Repository\Values\User\Role as APIRole;
 use eZ\Publish\API\Repository\Values\User\UserGroup as APIUserGroup;
 use eZ\Publish\API\Repository\Values\User\UserGroupRoleAssignment as APIUserGroupRoleAssignment;
 
@@ -44,7 +46,7 @@ class UserGroupRoleAssignment extends APIUserGroupRoleAssignment
      *
      * @return \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation|null
      */
-    public function getRoleLimitation()
+    public function getRoleLimitation(): ?APIRoleLimitation
     {
         return $this->limitation;
     }
@@ -54,7 +56,7 @@ class UserGroupRoleAssignment extends APIUserGroupRoleAssignment
      *
      * @return \eZ\Publish\API\Repository\Values\User\Role
      */
-    public function getRole()
+    public function getRole(): APIRole
     {
         return $this->role;
     }

--- a/eZ/Publish/Core/Repository/Values/User/UserGroupRoleAssignment.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserGroupRoleAssignment.php
@@ -1,13 +1,14 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\User\UserGroupRoleAssignment class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\User;
 
+use eZ\Publish\API\Repository\Values\User\UserGroup as APIUserGroup;
 use eZ\Publish\API\Repository\Values\User\UserGroupRoleAssignment as APIUserGroupRoleAssignment;
 
 /**
@@ -63,7 +64,7 @@ class UserGroupRoleAssignment extends APIUserGroupRoleAssignment
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup
      */
-    public function getUserGroup()
+    public function getUserGroup(): APIUserGroup
     {
         return $this->userGroup;
     }

--- a/eZ/Publish/Core/Repository/Values/User/UserReference.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserReference.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\User\User class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\User;
 
 use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
@@ -17,13 +17,10 @@ use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
  */
 class UserReference implements APIUserReference
 {
-    /** @var mixed */
+    /** @var int */
     private $userId;
 
-    /**
-     * @param mixed $userId
-     */
-    public function __construct($userId)
+    public function __construct(int $userId)
     {
         $this->userId = $userId;
     }
@@ -31,9 +28,9 @@ class UserReference implements APIUserReference
     /**
      * The User id of the User this reference represent.
      *
-     * @return mixed
+     * @return int
      */
-    public function getUserId()
+    public function getUserId(): int
     {
         return $this->userId;
     }

--- a/eZ/Publish/Core/Repository/Values/User/UserRoleAssignment.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserRoleAssignment.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Repository\Values\User;
 
+use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation as APIRoleLimitation;
+use eZ\Publish\API\Repository\Values\User\Role as APIRole;
 use eZ\Publish\API\Repository\Values\User\User as APIUser;
 use eZ\Publish\API\Repository\Values\User\UserRoleAssignment as APIUserRoleAssignment;
 
@@ -44,7 +46,7 @@ class UserRoleAssignment extends APIUserRoleAssignment
      *
      * @return \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation|null
      */
-    public function getRoleLimitation()
+    public function getRoleLimitation(): ?APIRoleLimitation
     {
         return $this->limitation;
     }
@@ -54,7 +56,7 @@ class UserRoleAssignment extends APIUserRoleAssignment
      *
      * @return \eZ\Publish\API\Repository\Values\User\Role
      */
-    public function getRole()
+    public function getRole(): APIRole
     {
         return $this->role;
     }

--- a/eZ/Publish/Core/Repository/Values/User/UserRoleAssignment.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserRoleAssignment.php
@@ -1,13 +1,14 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\User\UserRoleAssignment class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\Repository\Values\User;
 
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
 use eZ\Publish\API\Repository\Values\User\UserRoleAssignment as APIUserRoleAssignment;
 
 /**
@@ -63,7 +64,7 @@ class UserRoleAssignment extends APIUserRoleAssignment
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      */
-    public function getUser()
+    public function getUser(): APIUser
     {
         return $this->user;
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31482](https://jira.ez.no/browse/EZP-31482)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR introduces strict types for the `\eZ\Publish\API\Repository\FieldType` and `eZ\Publish\API\Repository\Values\**`. The most important changes are:

* Added `declare(strict_types=1)` and and type hints for methods parameters and return value
* Aligned licence header
* Added visibility modifier to `const`
* Changed `$valueFormat` type from `string` to `int` in `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications::__construct`  
* `\eZ\Publish\API\Repository\Values\User\Policy::getLimitations` will no longer return '*'

**TODO**:
- [x] Introduce strict types for `\eZ\Publish\API\Repository\Values\Content\Query\**`
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
