### PR TITLE
[Travis] Specified PHP dev image for jobs using full product setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ matrix:
     - php: 7.1
       env: TEST_CONFIG="phpunit.xml"
     - php: 7.1
-      env: PHP_IMAGE=ezsystems/php:7.1-v1 REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
+      env: PHP_IMAGE=ezsystems/php:7.1-v1 PHP_IMAGE_DEV=ezsystems/php:7.1-v1-dev REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
     - php: 7.1
-      env: PHP_IMAGE=ezsystems/php:7.1-v1 BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat SYMFONY_DEBUG=1
+      env: PHP_IMAGE=ezsystems/php:7.1-v1 PHP_IMAGE_DEV=ezsystems/php:7.1-v1-dev BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat SYMFONY_DEBUG=1
     - php: 7.1
       env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml" JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre/"
     - php: 7.1


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| fix in test setup
| **New feature**    | no
| **Target version** | 7.5, not needed for master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Tests in this repo are failing with:
```
PHP Fatal error:  Declaration of Behat\Behat\Definition\Translator\Translator::trans($id, array $parameters = Array, $domain = NULL, $locale = NULL) must be compatible with Symfony\Contracts\Translation\TranslatorInterface::trans(string $id, array $parameters = Array, ?string $domain = NULL, ?string $locale = NULL) in /var/www/vendor/behat/behat/src/Behat/Behat/Definition/Translator/Translator.php on line 5
```
https://travis-ci.org/github/ezsystems/ezpublish-kernel/jobs/662891976

This is caused by mismatch between the PHP version the tests are running on and the PHP version that is used for `composer install`

From Travis log:
```
Pulling install_dependencies (ezsystems/php:7.3-v1-dev)...
7.3-v1-dev: Pulling from ezsystems/php
install_dependencies_1_5782fe2ece75 | Loading composer repositories with package information
```

But they are executed using:
`7.1-v1-node: Pulling from ezsystems/php`

This is caused by configuration mismatch: the `install-dependencies` container uses PHP_IMAGE_DEV image: https://github.com/ezsystems/ezplatform/blob/2.5/doc/docker/install-dependencies.yml#L6, but the `app` container is based on PHP_IMAGE: https://github.com/ezsystems/ezplatform/blob/2.5/doc/docker/base-dev.yml#L6

Specifying both for the jobs that need them fixes the tests.

This is not the cleanest solution, but I feel like we need to rethink the PHP_IMAGE/PHP_IMAGE_DEV separation once we have some time.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
