### PR TITLE
EZP-31457: Fix supportsClass in user provider

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/User/Provider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User/Provider.php
@@ -104,9 +104,7 @@ class Provider implements APIUserProviderInterface
      */
     public function supportsClass($class)
     {
-        $supportedClass = 'eZ\\Publish\\Core\\MVC\\Symfony\\Security\\User';
-
-        return $class === $supportedClass || is_subclass_of($class, $supportedClass);
+        return $class === UserInterface::class || is_subclass_of($class, UserInterface::class);
     }
 
     /**


### PR DESCRIPTION

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31457](https://jira.ez.no/browse/EZP-31457)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.x`,master
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | no

Issue introduced by recent changes in Symfony:

https://github.com/symfony/symfony/commit/fb0be81b7a26f96f65bed5d774771bba026a78fd#diff-3f33c4b578f7ceb90dae8836c3c9a9a7R178

https://github.com/symfony/symfony/blob/fb0be81b7a26f96f65bed5d774771bba026a78fd/src/Symfony/Component/Security/Http/Firewall/ContextListener.php#L178


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
