### PR TITLE
EZP-31448: Added missing casting $locationId to int in the URLAliasService::createGlobalUrlAlias

### DIFF
--- a/eZ/Publish/Core/Repository/URLAliasService.php
+++ b/eZ/Publish/Core/Repository/URLAliasService.php
@@ -173,7 +173,7 @@ class URLAliasService implements URLAliasServiceInterface
                 $locationId = end($resourcePath);
             }
 
-            $location = $this->repository->getLocationService()->loadLocation($locationId);
+            $location = $this->repository->getLocationService()->loadLocation((int)$locationId);
 
             if (!$this->permissionResolver->canUser('content', 'urltranslator', $location)) {
                 throw new UnauthorizedException('content', 'urltranslator');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31448](https://jira.ez.no/browse/EZP-31448)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Fixed broken build: https://travis-ci.org/github/ezsystems/ezpublish-kernel/jobs/663994735

`$locationId` should be casted to int in the `\eZ\Publish\Core\Repository\URLAliasService::createGlobalUrlAlias` before passing it to `\eZ\Publish\API\Repository\LocationService::loadLocation` 


**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
