### PR TITLE
EZP-31482: Allowed null as $operator in UserMetadata criterion

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -578,6 +578,20 @@ class SearchServiceTest extends BaseTest
             ],
             43 => [
                 [
+                    'filter' => new Criterion\UserMetadata(
+                        Criterion\UserMetadata::GROUP,
+                        null,
+                        [4]
+                    ),
+                    'sortClauses' => [
+                        new SortClause\ContentId(),
+                    ],
+                    'limit' => 50,
+                ],
+                $fixtureDir . 'UserMetadata.php',
+            ],
+            44 => [
+                [
                     'filter' => new Criterion\Ancestor(
                         [
                             '/1/5/44/',

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserMetadata.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserMetadata.php
@@ -51,10 +51,10 @@ class UserMetadata extends Criterion
      * @throws \InvalidArgumentException If target is unknown
      *
      * @param string $target One of UserMetadata::OWNER, UserMetadata::GROUP or UserMetadata::MODIFIED
-     * @param string $operator One of the Operator constants
+     * @param string|null $operator The operator the Criterion uses. If null is given, will default to Operator::IN if $value is an array, Operator::EQ if it is not.
      * @param mixed $value The match value, either as an array of as a single value, depending on the operator
      */
-    public function __construct(string $target, string $operator, $value)
+    public function __construct(string $target, ?string $operator, $value)
     {
         switch ($target) {
             case self::OWNER:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31482](https://jira.ez.no/browse/EZP-31482)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

https://github.com/ezsystems/ezpublish-kernel/pull/2989 follow up: allowed `null` as  $operator` in the`\eZ\Publish\API\Repository\Values\Content\Query\Criterion\UserMetadata` criterion


**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
