### PR TITLE
[WIP] EZP-31449: Added versioning to Keyword Field Type

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -1097,6 +1097,7 @@ CREATE TABLE `ezkeyword_attribute_link` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `keyword_id` int(11) NOT NULL DEFAULT '0',
   `objectattribute_id` int(11) NOT NULL DEFAULT '0',
+  `versions` text NULL DEFAULT NULL
   PRIMARY KEY (`id`),
   KEY `ezkeyword_attr_link_kid_oaid` (`keyword_id`,`objectattribute_id`),
   KEY `ezkeyword_attr_link_oaid` (`objectattribute_id`)

--- a/data/update/mysql/dbupdate-7.5.7-to-7.5.8.sql
+++ b/data/update/mysql/dbupdate-7.5.7-to-7.5.8.sql
@@ -1,0 +1,11 @@
+UPDATE ezsite_data SET value='7.5.8' WHERE name='ezpublish-version';
+--
+-- EZP-31471: Keywords versioning
+--
+
+ALTER TABLE `ezkeyword_attribute_link`
+ADD COLUMN `versions` TEXT NULL DEFAULT NULL;
+
+--
+-- EZP-31471: end.
+--

--- a/data/update/postgres/dbupdate-7.5.7-to-7.5.8.sql
+++ b/data/update/postgres/dbupdate-7.5.7-to-7.5.8.sql
@@ -1,0 +1,11 @@
+UPDATE ezsite_data SET value='7.5.8' WHERE name='ezpublish-version';
+--
+-- EZP-31471: Keywords versioning
+--
+
+ALTER TABLE `ezkeyword_attribute_link`
+ADD COLUMN `versions` TEXT NULL DEFAULT NULL;
+
+--
+-- EZP-31471: end.
+--

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage.php
@@ -62,16 +62,8 @@ class KeywordStorage extends GatewayBasedStorage
      */
     public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds, array $context)
     {
-        // If current version being asked to be deleted is not published, then don't delete keywords
-        // if there is some other version which is published (as keyword table is not versioned)
-        if ($versionInfo->status !== VersionInfo::STATUS_PUBLISHED &&
-            $versionInfo->contentInfo->isPublished
-        ) {
-            return false;
-        }
-
         foreach ($fieldIds as $fieldId) {
-            $this->gateway->deleteFieldData($fieldId);
+            $this->gateway->deleteFieldData($fieldId, $versionInfo->versionNo);
         }
 
         return true;

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway.php
@@ -40,5 +40,5 @@ abstract class Gateway extends StorageGateway
     /**
      * @see \eZ\Publish\SPI\FieldType\FieldStorage::deleteFieldData()
      */
-    abstract public function deleteFieldData($fieldId);
+    abstract public function deleteFieldData($fieldId, $versionNo);
 }

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/LegacyStorage.php
@@ -49,7 +49,7 @@ class LegacyStorage extends Gateway
 
         $existingKeywordMap = $this->getExistingKeywords($field->value->externalData, $contentTypeId);
 
-        $this->deleteOldKeywordAssignments($field->id);
+        //$this->deleteOldKeywordAssignments($field->id);
 
         $this->assignKeywords(
             $field->id,
@@ -91,8 +91,9 @@ class LegacyStorage extends Gateway
      * Stores the keyword list from $field->value->externalData.
      *
      * @param mixed $fieldId
+     * @param int $versionNo
      */
-    public function deleteFieldData($fieldId)
+    public function deleteFieldData($fieldId, $versionNo)
     {
         $this->deleteOldKeywordAssignments($fieldId);
         $this->deleteOrphanedKeywords();


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31471](https://jira.ez.no/browse/EZP-31471)
| **Improvement**| yes
| **New feature**    |no
| **Target version** | 7.x
| **BC breaks**      | probably not
| **Tests pass**     | probably not
| **Doc needed**     | no

`Keyword` field type was not being able to recognize versions of `Content`. 
`ezkeyword_attribute_link` table had to be updated - a column with serialized versions has been added.
`DoctrineStorage` `Gateway` for `Keyword` had to be reworked in order to recognize `Content` versions.

BC breaks and legacy - please, correct me if I'm wrong here:
`LegacyStorage` `Gateway` had not been changed as the versioning is not implemented in legacy.
BC breaks should not be present, as relations with the empty new column (`versions`) are treated differently. When we had existing keyword relations before, after the creation of a new `Content` version, the mentioned column will be filled - that means older versions will not contain keywords that have been added to the newest version. It can be I guess resolved in two ways, additional db script which adds versions to each keyword relations or leave it as it is - keywords versioning has not implemented either way, so it will be a big deal.

**TODO**:
- [x] Implement improvement.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
