### PR TITLE
EZP-31507: Allowed to use Ancestors/Children/Siblings/Subtree Query Types with location search

### DIFF
--- a/eZ/Publish/Core/QueryType/BuiltIn/AbstractLocationQueryType.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/AbstractLocationQueryType.php
@@ -11,6 +11,8 @@ namespace eZ\Publish\Core\QueryType\BuiltIn;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -67,5 +69,10 @@ abstract class AbstractLocationQueryType extends AbstractQueryType
         }
 
         return $location;
+    }
+
+    protected function createQuery(): Query
+    {
+        return new LocationQuery();
     }
 }

--- a/eZ/Publish/Core/QueryType/BuiltIn/AbstractQueryType.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/AbstractQueryType.php
@@ -82,9 +82,14 @@ abstract class AbstractQueryType extends OptionsResolverBasedQueryType
 
     abstract protected function getQueryFilter(array $parameters): Criterion;
 
+    protected function createQuery(): Query
+    {
+        return new Query();
+    }
+
     protected function doGetQuery(array $parameters): Query
     {
-        $query = new Query();
+        $query = $this->createQuery();
         $query->filter = $this->buildFilters($parameters);
 
         if ($parameters['sort'] !== null) {

--- a/eZ/Publish/Core/QueryType/BuiltIn/Tests/AncestorsQueryTypeTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/Tests/AncestorsQueryTypeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\QueryType\BuiltIn\Tests;
 
 use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
@@ -40,7 +41,7 @@ final class AncestorsQueryTypeTest extends AbstractQueryTypeTest
             [
                 'location' => $location,
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new LogicalAnd([
                         new Ancestor(self::EXAMPLE_LOCATION_PATH_STRING),
@@ -61,7 +62,7 @@ final class AncestorsQueryTypeTest extends AbstractQueryTypeTest
                     'visible_only' => false,
                 ],
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new LogicalAnd([
                         new Ancestor(self::EXAMPLE_LOCATION_PATH_STRING),
@@ -85,7 +86,7 @@ final class AncestorsQueryTypeTest extends AbstractQueryTypeTest
                     ],
                 ],
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new LogicalAnd([
                         new Ancestor(self::EXAMPLE_LOCATION_PATH_STRING),
@@ -111,7 +112,7 @@ final class AncestorsQueryTypeTest extends AbstractQueryTypeTest
                     'siteaccess_aware' => false,
                 ],
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new LogicalAnd([
                         new Ancestor(self::EXAMPLE_LOCATION_PATH_STRING),
@@ -130,7 +131,7 @@ final class AncestorsQueryTypeTest extends AbstractQueryTypeTest
                 'limit' => 10,
                 'offset' => 100,
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new LogicalAnd([
                         new Ancestor(self::EXAMPLE_LOCATION_PATH_STRING),
@@ -151,7 +152,7 @@ final class AncestorsQueryTypeTest extends AbstractQueryTypeTest
                 'location' => $location,
                 'sort' => new Priority(Query::SORT_ASC),
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new LogicalAnd([
                         new Ancestor(self::EXAMPLE_LOCATION_PATH_STRING),

--- a/eZ/Publish/Core/QueryType/BuiltIn/Tests/ChildrenQueryTypeTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/Tests/ChildrenQueryTypeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\QueryType\BuiltIn\Tests;
 
 use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
@@ -36,7 +37,7 @@ final class ChildrenQueryTypeTest extends AbstractQueryTypeTest
             [
                 'location' => $location,
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new ParentLocationId(self::EXAMPLE_LOCATION_ID),
                     new Visibility(Visibility::VISIBLE),
@@ -52,7 +53,7 @@ final class ChildrenQueryTypeTest extends AbstractQueryTypeTest
                     'visible_only' => false,
                 ],
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new ParentLocationId(self::EXAMPLE_LOCATION_ID),
                     new Subtree(self::ROOT_LOCATION_PATH_STRING),
@@ -71,7 +72,7 @@ final class ChildrenQueryTypeTest extends AbstractQueryTypeTest
                     ],
                 ],
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new ParentLocationId(self::EXAMPLE_LOCATION_ID),
                     new Visibility(Visibility::VISIBLE),
@@ -92,7 +93,7 @@ final class ChildrenQueryTypeTest extends AbstractQueryTypeTest
                     'siteaccess_aware' => false,
                 ],
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new ParentLocationId(self::EXAMPLE_LOCATION_ID),
                     new Visibility(Visibility::VISIBLE),
@@ -106,7 +107,7 @@ final class ChildrenQueryTypeTest extends AbstractQueryTypeTest
                 'limit' => 10,
                 'offset' => 100,
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new ParentLocationId(self::EXAMPLE_LOCATION_ID),
                     new Visibility(Visibility::VISIBLE),
@@ -122,7 +123,7 @@ final class ChildrenQueryTypeTest extends AbstractQueryTypeTest
                 'location' => $location,
                 'sort' => new Priority(Query::SORT_ASC),
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new ParentLocationId(self::EXAMPLE_LOCATION_ID),
                     new Visibility(Visibility::VISIBLE),

--- a/eZ/Publish/Core/QueryType/BuiltIn/Tests/SiblingsQueryTypeTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/Tests/SiblingsQueryTypeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\QueryType\BuiltIn\Tests;
 
 use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
@@ -37,7 +38,7 @@ final class SiblingsQueryTypeTest extends AbstractQueryTypeTest
             [
                 'location' => $location,
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     Sibling::fromLocation($location),
                     new Visibility(Visibility::VISIBLE),
@@ -53,7 +54,7 @@ final class SiblingsQueryTypeTest extends AbstractQueryTypeTest
                     'visible_only' => false,
                 ],
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     Sibling::fromLocation($location),
                     new Subtree(self::ROOT_LOCATION_PATH_STRING),
@@ -72,7 +73,7 @@ final class SiblingsQueryTypeTest extends AbstractQueryTypeTest
                     ],
                 ],
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     Sibling::fromLocation($location),
                     new Visibility(Visibility::VISIBLE),
@@ -93,7 +94,7 @@ final class SiblingsQueryTypeTest extends AbstractQueryTypeTest
                     'siteaccess_aware' => false,
                 ],
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     Sibling::fromLocation($location),
                     new Visibility(Visibility::VISIBLE),
@@ -107,7 +108,7 @@ final class SiblingsQueryTypeTest extends AbstractQueryTypeTest
                 'limit' => 10,
                 'offset' => 100,
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     Sibling::fromLocation($location),
                     new Visibility(Visibility::VISIBLE),
@@ -123,7 +124,7 @@ final class SiblingsQueryTypeTest extends AbstractQueryTypeTest
                 'location' => $location,
                 'sort' => new Priority(Query::SORT_ASC),
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     Sibling::fromLocation($location),
                     new Visibility(Visibility::VISIBLE),

--- a/eZ/Publish/Core/QueryType/BuiltIn/Tests/SubtreeQueryTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/Tests/SubtreeQueryTest.php
@@ -1,10 +1,15 @@
 <?php
 
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace eZ\Publish\Core\QueryType\BuiltIn\Tests;
 
 use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Location\Depth;
@@ -37,7 +42,7 @@ final class SubtreeQueryTest extends AbstractQueryTypeTest
             [
                 'location' => $location,
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new Subtree(self::EXAMPLE_LOCATION_PATH_STRING),
                     new Visibility(Visibility::VISIBLE),
@@ -51,7 +56,7 @@ final class SubtreeQueryTest extends AbstractQueryTypeTest
                 'location' => $location,
                 'depth' => 2,
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new LogicalAnd([
                         new Subtree(self::EXAMPLE_LOCATION_PATH_STRING),
@@ -70,7 +75,7 @@ final class SubtreeQueryTest extends AbstractQueryTypeTest
                     'visible_only' => false,
                 ],
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new Subtree(self::EXAMPLE_LOCATION_PATH_STRING),
                     new Subtree(self::ROOT_LOCATION_PATH_STRING),
@@ -89,7 +94,7 @@ final class SubtreeQueryTest extends AbstractQueryTypeTest
                     ],
                 ],
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new Subtree(self::EXAMPLE_LOCATION_PATH_STRING),
                     new Visibility(Visibility::VISIBLE),
@@ -110,7 +115,7 @@ final class SubtreeQueryTest extends AbstractQueryTypeTest
                     'siteaccess_aware' => false,
                 ],
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new Subtree(self::EXAMPLE_LOCATION_PATH_STRING),
                     new Visibility(Visibility::VISIBLE),
@@ -124,7 +129,7 @@ final class SubtreeQueryTest extends AbstractQueryTypeTest
                 'limit' => 10,
                 'offset' => 100,
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new Subtree(self::EXAMPLE_LOCATION_PATH_STRING),
                     new Visibility(Visibility::VISIBLE),
@@ -140,7 +145,7 @@ final class SubtreeQueryTest extends AbstractQueryTypeTest
                 'location' => $location,
                 'sort' => new Priority(Query::SORT_ASC),
             ],
-            new Query([
+            new LocationQuery([
                 'filter' => new LogicalAnd([
                     new Subtree(self::EXAMPLE_LOCATION_PATH_STRING),
                     new Visibility(Visibility::VISIBLE),


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31507](https://jira.ez.no/browse/EZP-31507)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Built-in Ancestors/Children/Siblings/Subtree Query Types should produce `\eZ\Publish\API\Repository\Values\Content\LocationQuery` instead of `\eZ\Publish\API\Repository\Values\Content\Query` to be compatible with location search. Issue found by @DominikaK . 


**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
