### PR TITLE
EZP-31512: Fixed extracting Search Fields from RichText

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/SearchField.php
+++ b/eZ/Publish/Core/FieldType/RichText/SearchField.php
@@ -60,11 +60,11 @@ class SearchField implements Indexable
     {
         $text = '';
 
-        if ($node->childNodes) {
+        if (null !== $node->childNodes && $node->childNodes->length > 0) {
             foreach ($node->childNodes as $child) {
                 $text .= $this->extractText($child);
             }
-        } else {
+        } elseif (!empty($node->nodeValue)) {
             $text .= $node->nodeValue . ' ';
         }
 

--- a/eZ/Publish/Core/FieldType/Tests/RichText/SearchFieldTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/SearchFieldTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\FieldType\Tests\RichText;
+
+use eZ\Publish\Core\FieldType\RichText\SearchField;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\FieldValue;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\Search;
+use PHPUnit\Framework\TestCase;
+
+final class SearchFieldTest extends TestCase
+{
+    /** @var \eZ\Publish\Core\FieldType\RichText\SearchField */
+    private $searchField;
+
+    public function getDataForTestGetIndexData(): array
+    {
+        return [
+            'simple stub' => [
+                $this->getSimpleDocBookXml(),
+                [
+                    new Search\Field(
+                        'value',
+                        'Welcome to eZ Platform',
+                        new Search\FieldType\StringField()
+                    ),
+                    new Search\Field(
+                        'fulltext',
+                        "\n   Welcome to eZ Platform \n   eZ Platform  is the new generation DXP from eZ Systems. \n ",
+                        new Search\FieldType\FullTextField()
+                    ),
+                ],
+            ],
+            'empty xml' => [
+                $this->getEmptyXml(),
+                [
+                    new Search\Field(
+                        'value',
+                        '',
+                        new Search\FieldType\StringField()
+                    ),
+                    new Search\Field(
+                        'fulltext',
+                        '',
+                        new Search\FieldType\FullTextField()
+                    ),
+                ],
+            ],
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        $this->searchField = new SearchField();
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\FieldType\RichText\SearchField::getIndexData
+     *
+     * @dataProvider getDataForTestGetIndexData
+     *
+     * @param array $expectedSearchFields
+     */
+    public function testGetIndexData(string $docBookXml, array $expectedSearchFields): void
+    {
+        $field = new Field(
+            [
+                'id' => 1,
+                'type' => 'ezrichtext',
+                'value' => new FieldValue(['data' => $docBookXml]),
+            ]
+        );
+        $fieldDefinition = new FieldDefinition();
+
+        self::assertEquals(
+            $expectedSearchFields,
+            $this->searchField->getIndexData($field, $fieldDefinition)
+        );
+    }
+
+    private function getSimpleDocBookXml(): string
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="https://ezplatform.com/xmlns/docbook/xhtml">
+  <title ezxhtml:level="2">Welcome to eZ Platform</title>
+  <para><link xlink:href="ezurl://1" xlink:show="none">eZ Platform</link> is the new generation DXP from eZ Systems.</para>
+</section>
+XML;
+    }
+
+    private function getEmptyXml(): string
+    {
+        return '<?xml version="1.0" encoding="UTF-8"?><section></section>';
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31512](https://jira.ez.no/browse/EZP-31512)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5.x` for eZ Platform 2.5.x LTS
| **BC breaks**      | no
| **Tests pass**     | [yes](https://travis-ci.org/github/ezsystems/ezpublish-kernel/builds/666484894)
| **Doc needed**     | no

This PR fixes wrong traversing through child nodes of `\DOMNode` to extract from RichText DocBook XML a Search Field value for indexing. It worked before _most probably_ due to [PHP Bug #79271](https://bugs.php.net/bug.php?id=79271) which was fixed in the most recent patch release of PHP `v7.3.16`.

RichText in Kernel is provided for `7.5` as a BC layer and is used by integration tests. The actual fix for production code will be merged horizontally (or cherry-picked if not possible) from here into [RichText Bundle](https://github.com/ezsystems/ezplatform-richtext) (branch 1.1 there).

The first step was to provide test coverage based on the results we have on PHP 7.1 so we can ensure BC when fixing it for PHP 7.3. See [the build](https://travis-ci.org/github/ezsystems/ezpublish-kernel/builds/666477996) showcasing the issue between PHP versions.

The fix itself was actually quite short:
```diff
-        if ($node->childNodes) {
+        if (null !== $node->childNodes && $node->childNodes->length > 0) {
             foreach ($node->childNodes as $child) {
                 $text .= $this->extractText($child);
             }
-        } else {
+        } elseif (!empty($node->nodeValue)) {
```

There were several considerations here, taking into the account that we support PHP 7.1, 7.2, and 7.3 for eZ Platform 2.5 LTS:
1. In PHP 7.1 `childNodes` can be null.
2. The `\DOMNodeList::count` method is available only since PHP 7.2, so `length` property can be used for the solution to be uniform.
3. Due to buggy behavior of this code, by accident for empty XML document, empty string was returned. With the changes, to ensure that there's no trailing space, we need to check if nodeValue is not empty.

**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.