### PR TITLE
[Tests] Enforced failure on warning

### DIFF
--- a/phpunit-integration-legacy-solr.xml
+++ b/phpunit-integration-legacy-solr.xml
@@ -8,6 +8,7 @@
          convertWarningsToExceptions="true"
          beStrictAboutTestsThatDoNotTestAnything="false"
          colors="true"
+         failOnWarning="true"
          >
     <php>
         <env name="setupFactory" value="EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory" />

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -8,6 +8,7 @@
          convertWarningsToExceptions="true"
          beStrictAboutTestsThatDoNotTestAnything="false"
          colors="true"
+         failOnWarning="true"
          >
     <php>
         <env name="setupFactory" value="eZ\Publish\API\Repository\Tests\SetupFactory\Legacy" />

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,7 @@
   convertWarningsToExceptions="true"
   beStrictAboutTestsThatDoNotTestAnything="false"
   colors="true"
+  failOnWarning="true"
   >
   <php>
     <ini name="error_reporting" value="-1" />


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **Bug/Improvement**| yes
| **Target version** | `7.5`, `master`, `ezplatform-kernel:master`
| **BC breaks**      | no
| **Tests pass**     | [pending](https://travis-ci.org/github/ezsystems/ezpublish-kernel/builds/667251001)
| **Doc needed**     | no

### TL;DR;

This PR changes the default behavior of all test configs to fail on warning.

### Background
Travis gives us a false positive if a warning occurs in PHPUnit test suite. It's because warning is by default a soft issue. Though in many cases it indicates that we missed something (e.g. during refactoring or during implementing tests - AFAIR erroneous data providers trigger such warning as well).

### Examples
See false positive example: https://travis-ci.com/github/ezsystems/ezplatform-kernel/jobs/304586740#L591

See the same example with `failOnWarning` set to `true` in `phpunit*.xml`: https://travis-ci.com/github/ezsystems/ezplatform-kernel/jobs/304617296#L591

**TODO**:
- [x] Improve test config.
- [x] Wait for Travis
- [x] Ask for Code Review.
