### PR TITLE
[Tests] Fixed Solr Bundle dependency issue for ezpublish-kernel:master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
     # In order to specify extra flags like ignoring platform reqs, using only stable packages and so on.
     - COMPOSER_FLAGS=""
     - COMPOSER_MEMORY_LIMIT=4G
+    # Set own version to avoid dependency issues when running PR tests
+    - COMPOSER_ROOT_VERSION=8.0.x-dev
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Attempting to unblock #3009

Seems composer replace can't handle ezplatform-kernel dependency issue on PRs. I prefer to have it stable anyway, so investigating a fix (~probably by forcing older beta~).

The issue ATM:
```
  Problem 1
    - ezsystems/ezplatform-solr-search-engine v3.0.0-rc1 requires ezsystems/ezplatform-kernel ^1.0 -> satisfiable by ezsystems/ezplatform-kernel[1.0.x-dev, v1.0.0-rc1] but these conflict with your requirements or minimum-stability.
    - ezsystems/ezplatform-solr-search-engine v3.0.0-beta4 requires ezsystems/ezpublish-kernel ^8.0 -> satisfiable by ezsystems/ezpublish-kernel[8.0.x-dev, v8.0.0-beta1, v8.0.0-beta2, v8.0.0-beta3, v8.0.0-beta4, v8.0.0-beta5] but these conflict with your requirements or minimum-stability.
    - ezsystems/ezplatform-solr-search-engine v3.0.0-beta3 requires ezsystems/ezpublish-kernel ^8.0 -> satisfiable by ezsystems/ezpublish-kernel[8.0.x-dev, v8.0.0-beta1, v8.0.0-beta2, v8.0.0-beta3, v8.0.0-beta4, v8.0.0-beta5] but these conflict with your requirements or minimum-stability.
    - ezsystems/ezplatform-solr-search-engine v3.0.0-beta2 requires ezsystems/ezpublish-kernel ^8.0 -> satisfiable by ezsystems/ezpublish-kernel[8.0.x-dev, v8.0.0-beta1, v8.0.0-beta2, v8.0.0-beta3, v8.0.0-beta4, v8.0.0-beta5] but these conflict with your requirements or minimum-stability.
    - ezsystems/ezplatform-solr-search-engine v3.0.0-beta1 requires ezsystems/ezpublish-kernel ^8.0 -> satisfiable by ezsystems/ezpublish-kernel[8.0.x-dev, v8.0.0-beta1, v8.0.0-beta2, v8.0.0-beta3, v8.0.0-beta4, v8.0.0-beta5] but these conflict with your requirements or minimum-stability.
    - ezsystems/ezplatform-solr-search-engine 3.0.x-dev requires ezsystems/ezplatform-kernel ^1.0@dev -> satisfiable by ezsystems/ezplatform-kernel[1.0.x-dev, v1.0.0-rc1] but these conflict with your requirements or minimum-stability.
    - Installation request for ezsystems/ezplatform-solr-search-engine ^3.0.0@dev -> satisfiable by ezsystems/ezplatform-solr-search-engine[3.0.x-dev, v3.0.0-beta1, v3.0.0-beta2, v3.0.0-beta3, v3.0.0-beta4, v3.0.0-rc1].
```


Update: Looks like composer has trouble identifying version of the root package (`ezpublish-kernel`). Hard-coded it to have a quick work-around for this branch.



**TODO**:
- [x] Make Travis pass.
- [ ] On horizontal merge to `ezplatform-kernel`: drop any changes from here.