### PR TITLE
EZEE-3065: Changed parameter $locationId from mandatory to optional

### DIFF
--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -42,13 +42,13 @@ interface LocationService
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read this location
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the specified location is not found
      *
-     * @param mixed $locationId
+     * @param int|null $locationId
      * @param string[]|null $prioritizedLanguages Filter on and use as prioritized language code on translated properties of returned object.
      * @param bool|null $useAlwaysAvailable Respect always available flag on content when filtering on $prioritizedLanguages.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Location
      */
-    public function loadLocation(int $locationId, ?array $prioritizedLanguages = null, ?bool $useAlwaysAvailable = null): Location;
+    public function loadLocation(?int $locationId = null, ?array $prioritizedLanguages = null, ?bool $useAlwaysAvailable = null): Location;
 
     /**
      * Loads several location objects from its $locationIds.

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -196,7 +196,7 @@ class LocationService implements LocationServiceInterface
     /**
      * {@inheritdoc}
      */
-    public function loadLocation(int $locationId, ?array $prioritizedLanguages = null, ?bool $useAlwaysAvailable = null): APILocation
+    public function loadLocation(?int $locationId = null, ?array $prioritizedLanguages = null, ?bool $useAlwaysAvailable = null): APILocation
     {
         $spiLocation = $this->persistenceHandler->locationHandler()->load($locationId, $prioritizedLanguages, $useAlwaysAvailable ?? true);
         $location = $this->contentDomainMapper->buildLocation($spiLocation, $prioritizedLanguages ?: [], $useAlwaysAvailable ?? true);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
@@ -49,7 +49,7 @@ class LocationService implements LocationServiceInterface
         return $this->service->copySubtree($subtree, $targetParentLocation);
     }
 
-    public function loadLocation(int $locationId, ?array $prioritizedLanguages = null, ?bool $useAlwaysAvailable = null): Location
+    public function loadLocation(?int $locationId = null, ?array $prioritizedLanguages = null, ?bool $useAlwaysAvailable = null): Location
     {
         return $this->service->loadLocation(
             $locationId,

--- a/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
@@ -34,7 +34,7 @@ abstract class LocationServiceDecorator implements LocationService
     }
 
     public function loadLocation(
-        int $locationId,
+        ?int $locationId = null,
         ?array $prioritizedLanguages = null,
         ?bool $useAlwaysAvailable = null
     ): Location {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-3065](https://jira.ez.no/browse/EZEE-3065)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master - for 3.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Changed parameter $locationId from mandatory to optional because the draft (without published version) does not have a location identifier yet


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
