### PR TITLE
EZP-31558: Updated loadByIdentifier to use escapeForCacheKey function before get value from cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "friendsofsymfony/http-cache-bundle": "^1.3.13 | ^2.5.1",
         "sensio/framework-extra-bundle": "^5.2",
         "jms/translation-bundle": "^1.4",
-        "twig/twig": "^2.10"
+        "twig/twig": "^2.10",
+        "ezsystems/ezplatform-solr-search-engine": "dev-EZP-31420 as 1.7.x-dev"
     },
     "require-dev": {
         "brianium/paratest": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
         "friendsofsymfony/http-cache-bundle": "^1.3.13 | ^2.5.1",
         "sensio/framework-extra-bundle": "^5.2",
         "jms/translation-bundle": "^1.4",
-        "twig/twig": "^2.10",
-        "ezsystems/ezplatform-solr-search-engine": "dev-EZP-31420 as 1.7.x-dev"
+        "twig/twig": "^2.10"
     },
     "require-dev": {
         "brianium/paratest": "^2.2",

--- a/eZ/Publish/Core/Persistence/Cache/ContentLanguageHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentLanguageHandler.php
@@ -32,7 +32,7 @@ class ContentLanguageHandler extends AbstractInMemoryPersistenceHandler implemen
         $this->getKeys = static function (Language $language) {
             return [
                 'ez-language-' . $language->id,
-                'ez-language-code-' . $language->languageCode,
+                'ez-language-code-' . $this->escapeForCacheKey($language->languageCode),
             ];
         };
     }
@@ -59,7 +59,7 @@ class ContentLanguageHandler extends AbstractInMemoryPersistenceHandler implemen
         $this->cache->deleteItems([
             'ez-language-list',
             'ez-language-' . $struct->id,
-            'ez-language-code-' . $struct->languageCode,
+            'ez-language-code-' . $this->escapeForCacheKey($struct->languageCode),
         ]);
 
         return $return;
@@ -103,10 +103,10 @@ class ContentLanguageHandler extends AbstractInMemoryPersistenceHandler implemen
     public function loadByLanguageCode($languageCode)
     {
         return $this->getCacheValue(
-            $languageCode,
+            $this->escapeForCacheKey($languageCode),
             'ez-language-code-',
-            function ($languageCode) {
-                return $this->persistenceHandler->contentLanguageHandler()->loadByLanguageCode($languageCode);
+            function ($escapedLanguageCode) use ($languageCode) {
+                return $this->persistenceHandler->contentLanguageHandler()->loadByLanguageCode($escapedLanguageCode);
             },
             $this->getTags,
             $this->getKeys
@@ -119,10 +119,10 @@ class ContentLanguageHandler extends AbstractInMemoryPersistenceHandler implemen
     public function loadListByLanguageCodes(array $languageCodes): iterable
     {
         return $this->getMultipleCacheValues(
-            $languageCodes,
+            array_map(array($this, 'escapeForCacheKey'), $languageCodes),
             'ez-language-code-',
-            function (array $languageCodes) {
-                return $this->persistenceHandler->contentLanguageHandler()->loadListByLanguageCodes($languageCodes);
+            function (array $escapedLanguageCodes) use ($languageCodes) {
+                return $this->persistenceHandler->contentLanguageHandler()->loadListByLanguageCodes($escapedLanguageCodes);
             },
             $this->getTags,
             $this->getKeys

--- a/eZ/Publish/Core/Persistence/Cache/ContentLanguageHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentLanguageHandler.php
@@ -29,7 +29,7 @@ class ContentLanguageHandler extends AbstractInMemoryPersistenceHandler implemen
     protected function init(): void
     {
         $this->getTags = static function (Language $language) { return ['language-' . $language->id]; };
-        $this->getKeys = static function (Language $language) {
+        $this->getKeys = function (Language $language) {
             return [
                 'ez-language-' . $language->id,
                 'ez-language-code-' . $this->escapeForCacheKey($language->languageCode),

--- a/eZ/Publish/Core/Persistence/Cache/ContentLanguageHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentLanguageHandler.php
@@ -105,8 +105,8 @@ class ContentLanguageHandler extends AbstractInMemoryPersistenceHandler implemen
         return $this->getCacheValue(
             $this->escapeForCacheKey($languageCode),
             'ez-language-code-',
-            function ($escapedLanguageCode) use ($languageCode) {
-                return $this->persistenceHandler->contentLanguageHandler()->loadByLanguageCode($escapedLanguageCode);
+            function () use ($languageCode) {
+                return $this->persistenceHandler->contentLanguageHandler()->loadByLanguageCode($languageCode);
             },
             $this->getTags,
             $this->getKeys
@@ -121,8 +121,8 @@ class ContentLanguageHandler extends AbstractInMemoryPersistenceHandler implemen
         return $this->getMultipleCacheValues(
             array_map([$this, 'escapeForCacheKey'], $languageCodes),
             'ez-language-code-',
-            function (array $escapedLanguageCodes) use ($languageCodes) {
-                return $this->persistenceHandler->contentLanguageHandler()->loadListByLanguageCodes($escapedLanguageCodes);
+            function () use ($languageCodes) {
+                return $this->persistenceHandler->contentLanguageHandler()->loadListByLanguageCodes($languageCodes);
             },
             $this->getTags,
             $this->getKeys

--- a/eZ/Publish/Core/Persistence/Cache/ContentLanguageHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentLanguageHandler.php
@@ -119,7 +119,7 @@ class ContentLanguageHandler extends AbstractInMemoryPersistenceHandler implemen
     public function loadListByLanguageCodes(array $languageCodes): iterable
     {
         return $this->getMultipleCacheValues(
-            array_map(array($this, 'escapeForCacheKey'), $languageCodes),
+            array_map([$this, 'escapeForCacheKey'], $languageCodes),
             'ez-language-code-',
             function (array $escapedLanguageCodes) use ($languageCodes) {
                 return $this->persistenceHandler->contentLanguageHandler()->loadListByLanguageCodes($escapedLanguageCodes);

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -241,7 +241,7 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
         return $this->getCacheValue(
             $this->escapeForCacheKey($identifier),
             'ez-content-type-',
-            function ($identifier) {
+            function ($escapedIdentifier) use ($identifier) {
                 return $this->persistenceHandler->contentTypeHandler()->loadByIdentifier($identifier);
             },
             $this->getTypeTags,

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -43,7 +43,7 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
     protected function init(): void
     {
         $this->getGroupTags = static function (Type\Group $group) { return ['type-group-' . $group->id]; };
-        $this->getGroupKeys = static function (Type\Group $group) {
+        $this->getGroupKeys = function (Type\Group $group) {
             return [
                 'ez-content-type-group-' . $group->id,
                 'ez-content-type-group-' . $this->escapeForCacheKey($group->identifier) . '-by-identifier',
@@ -56,7 +56,7 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
                 'type-' . $type->id,
             ];
         };
-        $this->getTypeKeys = static function (Type $type, int $status = Type::STATUS_DEFINED) {
+        $this->getTypeKeys = function (Type $type, int $status = Type::STATUS_DEFINED) {
             return [
                 'ez-content-type-' . $type->id . '-' . $status,
                 'ez-content-type-' . $this->escapeForCacheKey($type->identifier) . '-by-identifier',

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -46,7 +46,7 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
         $this->getGroupKeys = static function (Type\Group $group) {
             return [
                 'ez-content-type-group-' . $group->id,
-                'ez-content-type-group-' . $group->identifier . '-by-identifier',
+                'ez-content-type-group-' . $this->escapeForCacheKey($group->identifier) . '-by-identifier',
             ];
         };
 
@@ -59,8 +59,8 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
         $this->getTypeKeys = static function (Type $type, int $status = Type::STATUS_DEFINED) {
             return [
                 'ez-content-type-' . $type->id . '-' . $status,
-                'ez-content-type-' . $type->identifier . '-by-identifier',
-                'ez-content-type-' . $type->remoteId . '-by-remote',
+                'ez-content-type-' . $this->escapeForCacheKey($type->identifier) . '-by-identifier',
+                'ez-content-type-' . $this->escapeForCacheKey($type->remoteId) . '-by-remote',
             ];
         };
     }
@@ -87,7 +87,7 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
         $this->cache->deleteItems([
             'ez-content-type-group-list',
             'ez-content-type-group-' . $struct->id,
-            'ez-content-type-group-' . $struct->identifier . '-by-identifier',
+            'ez-content-type-group-' . $this->escapeForCacheKey($struct->identifier) . '-by-identifier',
         ]);
 
         return $group;
@@ -144,9 +144,9 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
     public function loadGroupByIdentifier($identifier)
     {
         return $this->getCacheValue(
-            $identifier,
+            $this->escapeForCacheKey($identifier),
             'ez-content-type-group-',
-            function (string $identifier) {
+            function () use ($identifier) {
                 return $this->persistenceHandler->contentTypeHandler()->loadGroupByIdentifier($identifier);
             },
             $this->getGroupTags,
@@ -241,7 +241,7 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
         return $this->getCacheValue(
             $this->escapeForCacheKey($identifier),
             'ez-content-type-',
-            function ($escapedIdentifier) use ($identifier) {
+            function () use ($identifier) {
                 return $this->persistenceHandler->contentTypeHandler()->loadByIdentifier($identifier);
             },
             $this->getTypeTags,
@@ -256,9 +256,9 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
     public function loadByRemoteId($remoteId)
     {
         return $this->getCacheValue(
-            $remoteId,
+            $this->escapeForCacheKey($remoteId),
             'ez-content-type-',
-            function ($remoteId) {
+            function () use ($remoteId) {
                 return $this->persistenceHandler->contentTypeHandler()->loadByRemoteId($remoteId);
             },
             $this->getTypeTags,

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -239,7 +239,7 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
     public function loadByIdentifier($identifier)
     {
         return $this->getCacheValue(
-            $identifier,
+            $this->escapeForCacheKey($identifier),
             'ez-content-type-',
             function ($identifier) {
                 return $this->persistenceHandler->contentTypeHandler()->loadByIdentifier($identifier);

--- a/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
@@ -54,7 +54,7 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
      */
     public function loadGroupByIdentifier($identifier)
     {
-        $cacheItem = $this->cache->getItem('ez-state-group-' . $identifier . '-by-identifier');
+        $cacheItem = $this->cache->getItem('ez-state-group-' . $this->escapeForCacheKey($identifier) . '-by-identifier');
         if ($cacheItem->isHit()) {
             return $cacheItem->get();
         }
@@ -181,7 +181,7 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
      */
     public function loadByIdentifier($identifier, $groupId)
     {
-        $cacheItem = $this->cache->getItem('ez-state-identifier-' . $identifier . '-by-group-' . $groupId);
+        $cacheItem = $this->cache->getItem('ez-state-identifier-' . $this->escapeForCacheKey($identifier) . '-by-group-' . $groupId);
         if ($cacheItem->isHit()) {
             return $cacheItem->get();
         }

--- a/eZ/Publish/Core/Persistence/Cache/SectionHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/SectionHandler.php
@@ -73,7 +73,7 @@ class SectionHandler extends AbstractHandler implements SectionHandlerInterface
      */
     public function loadByIdentifier($identifier)
     {
-        $cacheItem = $this->cache->getItem('ez-section-' . $identifier . '-by-identifier');
+        $cacheItem = $this->cache->getItem('ez-section-' . $this->escapeForCacheKey($identifier) . '-by-identifier');
         if ($cacheItem->isHit()) {
             return $cacheItem->get();
         }

--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -61,7 +61,7 @@ class UserHandler extends AbstractInMemoryPersistenceHandler implements UserHand
         $this->getRoleKeys = static function (Role $role) {
             return [
                 'ez-role-' . $role->id,
-                'ez-role-' . $role->identifier . '-by-identifier',
+                'ez-role-' . $this->escapeForCacheKey($role->identifier) . '-by-identifier',
             ];
         };
         $this->getRoleAssignmentTags = static function (RoleAssignment $roleAssignment) {
@@ -121,7 +121,7 @@ class UserHandler extends AbstractInMemoryPersistenceHandler implements UserHand
         return $this->getCacheValue(
             $this->escapeForCacheKey($login),
             'ez-user-',
-            function ($escapedLogin) use ($login) {
+            function () use ($login) {
                 return $this->persistenceHandler->userHandler()->loadByLogin($login);
             },
             $this->getUserTags,
@@ -288,9 +288,9 @@ class UserHandler extends AbstractInMemoryPersistenceHandler implements UserHand
         }
 
         return $this->getCacheValue(
-            $identifier,
+            $this->escapeForCacheKey($identifier),
             'ez-role-',
-            function ($identifier) {
+            function () use ($identifier) {
                 return $this->persistenceHandler->userHandler()->loadRoleByIdentifier($identifier);
             },
             $this->getRoleTags,

--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -58,7 +58,7 @@ class UserHandler extends AbstractInMemoryPersistenceHandler implements UserHand
         $this->getRoleTags = static function (Role $role) {
             return ['role-' . $role->id];
         };
-        $this->getRoleKeys = static function (Role $role) {
+        $this->getRoleKeys = function (Role $role) {
             return [
                 'ez-role-' . $role->id,
                 'ez-role-' . $this->escapeForCacheKey($role->identifier) . '-by-identifier',


### PR DESCRIPTION

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31558](https://jira.ez.no/browse/EZP-31558)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`/`master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
