### PR TITLE
EZP-31557: Adjusted default time in ezdate fieldtype

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
@@ -292,7 +292,7 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
             [
                 DateValue::fromTimestamp($timestamp),
                 [
-                    'timestamp' => $dateTime->setTime(0, 0, 0)->getTimestamp(),
+                    'timestamp' => $dateTime->getTimestamp(),
                     'rfc850' => $dateTime->format(DateTime::RFC850),
                 ],
             ],

--- a/eZ/Publish/Core/FieldType/Date/Value.php
+++ b/eZ/Publish/Core/FieldType/Date/Value.php
@@ -39,10 +39,6 @@ class Value extends BaseValue
      */
     public function __construct(DateTime $dateTime = null)
     {
-        if ($dateTime !== null) {
-            $dateTime = clone $dateTime;
-            $dateTime->setTime(0, 0, 0);
-        }
         $this->date = $dateTime;
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/DateTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateTest.php
@@ -268,7 +268,7 @@ class DateTest extends FieldTypeTest
                 [
                     // Timezone is not abbreviated because PHP converts it to non-abbreviated local name,
                     // but this is sufficient to test conversion
-                    'rfc850' => 'Thursday, 04-Jul-13 23:59:59 Europe/Zagreb',
+                    'rfc850' => 'Thursday, 04-Jul-13 02:00:00 Europe/Zagreb',
                 ],
                 new DateValue(
                     $dateTime


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31557](https://jira.ez.no/browse/EZP-31557)
| **Bug**| yes
| **New feature**    | no
| **Target version** | 7.5 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Setting the time to midnight is not really necessary (?) for `ezdate` and may cause problems with different timezones.

Issue example:
Let's assume its 4PM currently in the current timezone. When creating new `Content` with `ezdate` fieldtype (with default current time) the timestamp is subtracted with **16*3600** seconds. Then, when user is in different timezone and `ezdate` field is initialized the date could be adjusted by browser timezone's settings and finally set to 8AM of previous day (0AM - 16 hours = 8AM).

Related admin-ui PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/1350

**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
