### PR TITLE
EZP-31560: [Tests] Fixed namespaces not following PSR

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Bundle\EzPublishCoreBundle\Tests;
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RichTextHtml5ConverterPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;

--- a/eZ/Publish/Core/IO/Tests/MetadataHandler/ImageSizeTest.php
+++ b/eZ/Publish/Core/IO/Tests/MetadataHandler/ImageSizeTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\FieldType\Tests\MetadataHandler;
+namespace eZ\Publish\Core\IO\Tests\MetadataHandler;
 
 use eZ\Publish\Core\IO\MetadataHandler\ImageSize as ImageSizeMetadataHandler;
 use PHPUnit\Framework\TestCase;

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/LocalPurgeClientTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/LocalPurgeClientTest.php
@@ -18,7 +18,7 @@ function time()
     return 1417624982;
 }
 
-namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests;
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http;
 
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\LocalPurgeClient;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ContentPurger;

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/LocationAwareStoreTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/LocationAwareStoreTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\CacheTests\Http;
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http;
 
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\LocationAwareStore;
 use Symfony\Component\Filesystem\Filesystem;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/Relation/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/Relation/ParameterProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\RelationList;
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\Relation;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RelationList/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RelationList/ParameterProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\Relation;
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\RelationList;
 
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Id;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;
 
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id\Content as ContentIdMatcher;
 use eZ\Publish\API\Repository\Values\Content\Location;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTypeGroupTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTypeGroupTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Id;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;
 
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTypeTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Id;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;
 
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id\ContentType as ContentTypeIdMatcher;
 use eZ\Publish\API\Repository\Values\Content\Location;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/LocationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/LocationTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Id;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;
 
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id\Location as LocationIdMatcher;
 use eZ\Publish\API\Repository\Values\Content\Location;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ParentContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ParentContentTypeTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Id;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;
 
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id\ParentContentType as ParentContentTypeMatcher;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ParentLocationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ParentLocationTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Id;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;
 
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id\ParentLocation as ParentLocationIdMatcher;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/RemoteTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/RemoteTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Id;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;
 
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id\Remote as RemoteIdMatcher;
 use eZ\Publish\API\Repository\Values\Content\Location;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/SectionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/SectionTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Id;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;
 
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id\Section as SectionIdMatcher;
 use eZ\Publish\API\Repository\Values\Content\Location;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/ContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/ContentTypeTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Identifier;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Identifier;
 
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/ParentContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/ParentContentTypeTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Identifier;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Identifier;
 
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\ContentTypeService;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/SectionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/SectionTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Identifier;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Identifier;
 
 use eZ\Publish\API\Repository\SectionService;
 use eZ\Publish\API\Repository\Values\Content\Section;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/MultipleValuedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/MultipleValuedTest.php
@@ -6,9 +6,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased;
 
-use eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\BaseTest;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\MultipleValued;
 
 class MultipleValuedTest extends BaseTest

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/UrlAliasTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/UrlAliasTest.php
@@ -6,13 +6,12 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher;
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased;
 
 use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\UrlAlias as UrlAliasMatcher;
-use eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\BaseTest;
 use eZ\Publish\API\Repository\Repository;
 
 class UrlAliasTest extends BaseTest

--- a/eZ/Publish/Core/Persistence/Cache/Tests/URLHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/URLHandlerTest.php
@@ -4,7 +4,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Tests\Core\Persistence\Cache;
+namespace eZ\Publish\Core\Persistence\Cache\Tests;
 
 use eZ\Publish\API\Repository\Values\URL\URLQuery;
 use eZ\Publish\Core\Persistence\Cache\CacheServiceDecorator;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Update/Handler/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Update/Handler/DoctrineDatabaseTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type\UpdateHandler;
+namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type\Update\Handler;
 
 use eZ\Publish\SPI\Persistence\Content\Type;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler\DoctrineDatabase;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
+namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlAlias;
 
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway as UrlAliasGateway;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\Search\Legacy\Tests\Content\Location;
+namespace eZ\Publish\Core\Search\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
 use eZ\Publish\Core\Search\Legacy\Content;

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\Search\Legacy\Tests\Content\Location;
+namespace eZ\Publish\Core\Search\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
 use eZ\Publish\Core\Persistence;

--- a/eZ/Publish/Core/SignalSlot/Tests/SlotFactory/GeneralSlotFactoryTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/SlotFactory/GeneralSlotFactoryTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\SignalSlot\Tests\SignalDispatcher;
+namespace eZ\Publish\Core\SignalSlot\Tests\SlotFactory;
 
 use eZ\Publish\Core\SignalSlot;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31560](https://jira.ez.no/browse/EZP-31560)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`+
| **BC breaks**      | no
| **Doc needed**     | no

This PR aligns namespaces not following defined psr-0 convention. Fortunately for this package only test cases are affected. See [EZP-31560](https://jira.ez.no/browse/EZP-31560) for more details.

**TODO**:
- [x] Fix namespaces
- [x] Wait for Travis
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
