### PR TITLE
EZP-31287: Added FullText search Fields for Email and ISBN

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/EmailAddressIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/EmailAddressIntegrationTest.php
@@ -353,7 +353,7 @@ class EmailAddressIntegrationTest extends SearchBaseIntegrationTest
 
     protected function getValidSearchValueTwo()
     {
-        return 'wyoming.knott@ez.no';
+        return 'wyoming.knott@o2.ru';
     }
 
     protected function getSearchTargetValueTwo()
@@ -365,7 +365,7 @@ class EmailAddressIntegrationTest extends SearchBaseIntegrationTest
     protected function getFullTextIndexedFieldData()
     {
         return [
-            ['holmes4@ez.no', 'wyoming.knott@ez.no'],
+            ['holmes4@ez.no', 'wyoming.knott@o2.ru'],
         ];
     }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/EmailAddressIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/EmailAddressIntegrationTest.php
@@ -361,4 +361,11 @@ class EmailAddressIntegrationTest extends SearchBaseIntegrationTest
         // ensure case-insensitivity
         return strtoupper($this->getValidSearchValueTwo());
     }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return [
+            ['holmes4@ez.no', 'wyoming.knott@ez.no'],
+        ];
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/ISBNIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/ISBNIntegrationTest.php
@@ -358,4 +358,11 @@ class ISBNIntegrationTest extends SearchBaseIntegrationTest
     {
         return '9780380448340';
     }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return [
+            ['9780099067504', '9780380448340'],
+        ];
+    }
 }

--- a/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
@@ -32,6 +32,11 @@ class SearchField implements Indexable
                 $field->value->data,
                 new Search\FieldType\StringField()
             ),
+            new Search\Field(
+                'fulltext',
+                $field->value->data,
+                new Search\FieldType\FullTextField()
+            ),
         ];
     }
 

--- a/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
@@ -35,7 +35,10 @@ class SearchField implements Indexable
             new Search\Field(
                 'fulltext',
                 $field->value->data,
-                new Search\FieldType\FullTextField()
+                new Search\FieldType\FullTextField([
+                    'space_normalize',
+                    'latin1_lowercase',
+                ], true)
             ),
         ];
     }

--- a/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
@@ -38,7 +38,7 @@ class SearchField implements Indexable
                 new Search\FieldType\FullTextField([
                     'space_normalize',
                     'latin1_lowercase',
-                ], true)
+                ], false)
             ),
         ];
     }

--- a/eZ/Publish/Core/FieldType/ISBN/SearchField.php
+++ b/eZ/Publish/Core/FieldType/ISBN/SearchField.php
@@ -32,6 +32,11 @@ class SearchField implements Indexable
                 $field->value->data,
                 new Search\FieldType\StringField()
             ),
+            new Search\Field(
+                'fulltext',
+                $field->value->data,
+                new Search\FieldType\FullTextField()
+            ),
         ];
     }
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
@@ -196,6 +196,9 @@ class FullText extends CriterionHandler
             $wordExpressions[] = $this->getWordExpression($subQuery, $token);
         }
 
+        // Search for provided string itself as well
+        $wordExpressions[] = $this->getWordExpression($subQuery, $string);
+
         $whereCondition = $subQuery->expr->lOr($wordExpressions);
 
         // If stop word threshold is below 100%, make it part of $whereCondition

--- a/eZ/Publish/Core/Search/Legacy/Content/FullTextValue.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FullTextValue.php
@@ -50,4 +50,18 @@ class FullTextValue extends ValueObject
      * @var bool
      */
     public $isMainAndAlwaysAvailable;
+
+    /**
+     * Array of rules to be used when transforming the value.
+     *
+     * @var array
+     */
+    public $transformationRules;
+
+    /**
+     * Flag whether the value should be split by non-words.
+     *
+     * @var bool
+     */
+    public $splitFlag;
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Mapper/FullTextMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Mapper/FullTextMapper.php
@@ -101,6 +101,8 @@ class FullTextMapper
                     'isMainAndAlwaysAvailable' => (
                         $field->languageCode === $contentInfo->mainLanguageCode && $contentInfo->alwaysAvailable
                     ),
+                    'transformationRules' => $this->getTransformationRules($fieldDefinition),
+                    'splitFlag' => $this->getSplitFlag($fieldDefinition),
                 ]
             );
         }
@@ -133,5 +135,32 @@ class FullTextMapper
 
         // some full text fields are stored as an array of strings
         return !is_array($fullTextFieldValue) ? $fullTextFieldValue : implode(' ', $fullTextFieldValue);
+    }
+
+    /**
+     * Get transformation rules based on a given field type.
+     */
+    private function getTransformationRules(Type\FieldDefinition $fieldDefinition): array
+    {
+        $rules = [
+            'ezemail' => [
+                'space_normalize',
+                'latin1_lowercase',
+            ],
+        ];
+
+        return $rules[$fieldDefinition->fieldType] ?? [];
+    }
+
+    /**
+     * Get transformation rules based on a given field type.
+     */
+    private function getSplitFlag(Type\FieldDefinition $fieldDefinition): bool
+    {
+        $split = [
+            'ezemail' => false,
+        ];
+
+        return $split[$fieldDefinition->fieldType] ?? true;
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Mapper/FullTextMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Mapper/FullTextMapper.php
@@ -153,7 +153,7 @@ class FullTextMapper
     }
 
     /**
-     * Get transformation rules based on a given field type.
+     * Decide whether transformed string should be later split by non-words.
      */
     private function getSplitFlag(Type\FieldDefinition $fieldDefinition): bool
     {

--- a/eZ/Publish/Core/Search/Legacy/Content/Mapper/FullTextMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Mapper/FullTextMapper.php
@@ -10,6 +10,7 @@ use eZ\Publish\Core\Search\Common\FieldRegistry;
 use eZ\Publish\Core\Search\Legacy\Content\FullTextData;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Type;
+use eZ\Publish\SPI\Search\Field;
 use eZ\Publish\SPI\Search\FieldType;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\Core\Search\Legacy\Content\FullTextValue;
@@ -73,8 +74,10 @@ class FullTextMapper
      * @param \eZ\Publish\SPI\Persistence\Content $content
      *
      * @return \eZ\Publish\Core\Search\Legacy\Content\FullTextValue[]
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    protected function getFullTextValues(Content $content)
+    protected function getFullTextValues(Content $content): array
     {
         $fullTextValues = [];
         foreach ($content->fields as $field) {
@@ -85,10 +88,13 @@ class FullTextMapper
                 continue;
             }
 
-            list($value, $transformationRules, $splitFlag) = $this->getFullTextFieldData($field, $fieldDefinition);
-            if (empty($value)) {
+            $fullTextField = $this->extractFullTextField($field, $fieldDefinition);
+            if (null === $fullTextField || empty($fullTextField->value)) {
                 continue;
             }
+            $fullTextValue = !is_array($fullTextField->value)
+                ? $fullTextField->value
+                : implode(' ', $fullTextField->value);
 
             $contentInfo = $content->versionInfo->contentInfo;
             $fullTextValues[] = new FullTextValue(
@@ -97,12 +103,12 @@ class FullTextMapper
                     'fieldDefinitionId' => $field->fieldDefinitionId,
                     'fieldDefinitionIdentifier' => $fieldDefinition->identifier,
                     'languageCode' => $field->languageCode,
-                    'value' => !is_array($value) ? $value : implode(' ', $value),
+                    'value' => $fullTextValue,
                     'isMainAndAlwaysAvailable' => (
                         $field->languageCode === $contentInfo->mainLanguageCode && $contentInfo->alwaysAvailable
                     ),
-                    'transformationRules' => $transformationRules,
-                    'splitFlag' => $splitFlag,
+                    'transformationRules' => $fullTextField->type->transformationRules,
+                    'splitFlag' => $fullTextField->type->splitFlag,
                 ]
             );
         }
@@ -110,30 +116,18 @@ class FullTextMapper
         return $fullTextValues;
     }
 
-    private function getFullTextFieldData(Content\Field $field, Type\FieldDefinition $fieldDefinition): array
-    {
+    private function extractFullTextField(
+        Content\Field $field,
+        Type\FieldDefinition $fieldDefinition
+    ): ?Field {
         $fieldType = $this->fieldRegistry->getType($field->type);
-        $indexFields = $fieldType->getIndexData($field, $fieldDefinition);
-
-        // find value to be returned (stored in FullTextField)
-        $fullTextFieldValue = '';
-        $fullTextFieldTransformationRules = [];
-        $fullTextFieldSplitFlag = true;
-        foreach ($indexFields as $field) {
-            /** @var \eZ\Publish\SPI\Search\Field $field */
-            if ($field->type instanceof FieldType\FullTextField) {
-                $fullTextFieldValue = $field->value;
-                $fullTextFieldTransformationRules = $field->type->transformationRules;
-                $fullTextFieldSplitFlag = $field->type->splitFlag;
-                break;
+        $fullTextFields = array_filter(
+            $fieldType->getIndexData($field, $fieldDefinition),
+            static function ($indexField) {
+                return $indexField->type instanceof FieldType\FullTextField;
             }
-        }
+        );
 
-        // some full text fields are stored as an array of strings
-        return [
-            !is_array($fullTextFieldValue) ? $fullTextFieldValue : implode(' ', $fullTextFieldValue),
-            $fullTextFieldTransformationRules,
-            $fullTextFieldSplitFlag,
-        ];
+        return !empty($fullTextFields) ? array_values($fullTextFields)[0] : null;
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
@@ -128,9 +128,14 @@ class DoctrineDatabase extends Gateway
             } else {
                 $integerValue = 0;
             }
-            $text = $this->transformationProcessor->transform($fullTextValue->value, $this->fullTextSearchConfiguration['commands']);
+            $text = $this->transformationProcessor->transform(
+                $fullTextValue->value,
+                !empty($fullTextValue->transformationRules)
+                    ? $fullTextValue->transformationRules
+                    : $this->fullTextSearchConfiguration['commands']
+            );
             // split by non-words
-            $wordArray = preg_split('/\W/u', $text, -1, PREG_SPLIT_NO_EMPTY);
+            $wordArray = $fullTextValue->splitFlag ? preg_split('/\W/u', $text, -1, PREG_SPLIT_NO_EMPTY) : [$text];
             foreach ($wordArray as $word) {
                 if (trim($word) === '') {
                     continue;

--- a/eZ/Publish/SPI/Search/FieldType/FullTextField.php
+++ b/eZ/Publish/SPI/Search/FieldType/FullTextField.php
@@ -19,4 +19,26 @@ class FullTextField extends FieldType
      * @var string
      */
     protected $type = 'ez_fulltext';
+
+    /**
+     * Transformation rules to be used when transforming the given string.
+     *
+     * @var array
+     */
+    public $transformationRules;
+
+    /**
+     * Flag whether the string should be split by non-words.
+     *
+     * @var bool
+     */
+    public $splitFlag;
+
+    public function __construct(array $transformationRules = [], bool $splitFlag = true)
+    {
+        $this->transformationRules = $transformationRules;
+        $this->splitFlag = $splitFlag;
+
+        parent::__construct();
+    }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31287](https://jira.ez.no/browse/EZP-31287)
| **Bug**| yes
| **New feature**    | no
| **Target version** | 7.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

`Email address` and `ISBN` fieldtypes were not searchable due to lacking `FullTextField` search field assignment.

Also citing @alongosz from the related PR comment (https://github.com/ezsystems/ezpublish-kernel/pull/2206#discussion_r158247819):

> {So here's the thing: if I do a FullText search for the entire e-mail, e.g. holmes4@ez.no, I get all Content items containing parts of e-mail: holmes4 or ez or no. It looks like parser treats this as separate words.

> {My expectation in this case would be to find one Content item with field matching exactly the given e-mail.
However Solr FullText search gets me the same result, so maybe my expectations are wrong?

The e-mail address was split into parts when indexing, that's why it was behaving like that. In order to prevent such behavior for chosen field types this specific commit has been created: https://github.com/ezsystems/ezpublish-kernel/pull/3023/commits/59859e880f75c1fed08b4585eb65249650884ed5 which handles such case and is easily adaptable for other field types. 

// @alongosz note:
### QA
Besides tests for LSE, do a regression for Solr as well please, because in the past I had some unexpected results there with this task. Should not be affected though because changes are related to LSE only. But... you know ;)
// -- end of the note

// author's note:
Old parts of the e-mail string will still be able to be found when searching for the full e-mail address as they were indexed like that previously, before this change. Example:
`eZ Platform` - folder
`support@ez.no` - e-mail

When searching for `support@ez.no` one will find eZ Platform folder as well.


**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
