### PR TITLE
EZP-31592: Added missing deprecation info to data/mysql/schema.sql

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -1,3 +1,9 @@
+-- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+-- @deprecated since eZ Platform 2.5.0 and no longer used.
+-- Relying on data/mysql/schema.sql to install eZ Platform schema is deprecated since eZ Platform v2.5.0.
+-- The file was removed in eZ Platform v3.0.0.
+-- Rely on \EzSystems\PlatformInstallerBundle\Installer\CoreInstaller instead
+-- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- MySQL dump 10.13  Distrib 5.5.32, for debian-linux-gnu (x86_64)
 --
 -- Host: localhost    Database: behattestdb


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31592](https://jira.ez.no/browse/EZP-31592)
| **Bug/Improvement**| yes
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | ezsystems/developer-documentation#1029

When introducing PostgreSQL support via #2552 I've replaced usage of `data/mysql/schema.sql` with generic `eZ/Bundle/EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml`.
The intention was to deprecate `schema.sql` because it was possible 3rd party packages or project relied on it directly or at least on `CleanInstaller` consuming it. I've forgotten to do it, which I've fixed in this PR.

Please note that I'm not deprecating anything in the next 2.5.x, just adding a missing statement about the fact it's deprecated since eZ Platform 2.5.0.

I've tried to make this warning appear on console, but while it's possible, with hack-ish `SELECT`, it breaks `CleanInstaller`. MySQL, compared to other engines, is quite poor unfortunately.

### QA
Sanity on SQL script execution
Common branch for #3024 and #3025: [ezp-31592-31586-schema-sql-combo-for-qa](https://github.com/ezsystems/ezpublish-kernel/compare/7.5...ezp-31592-31586-schema-sql-combo-for-qa)


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
