### PR TITLE
EZP-31586: Added missing columns to data/mysql/schema.sql

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -528,7 +528,7 @@ CREATE TABLE `ezcontentclass_attribute` (
   `data_int2` int(11) DEFAULT NULL,
   `data_int3` int(11) DEFAULT NULL,
   `data_int4` int(11) DEFAULT NULL,
-  `data_text1` varchar(50) DEFAULT NULL,
+  `data_text1` varchar(255) DEFAULT NULL,
   `data_text2` varchar(50) DEFAULT NULL,
   `data_text3` varchar(50) DEFAULT NULL,
   `data_text4` varchar(255) DEFAULT NULL,
@@ -2231,6 +2231,7 @@ CREATE TABLE `ezuser` (
   `login` varchar(150) NOT NULL DEFAULT '',
   `password_hash` varchar(255) DEFAULT NULL,
   `password_hash_type` int(11) NOT NULL DEFAULT '1',
+  `password_updated_at` int(11) NULL,
   PRIMARY KEY (`contentobject_id`),
   UNIQUE KEY `ezuser_login` (`login`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31586](https://jira.ez.no/browse/EZP-31586)
| **Bug/Improvement**| yes
| **Target version** | `7.5` for eZ Platform `v2.5.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR updates `data/mysql/schema.sql` according to upgrade scripts in `data/update/mysql/dbupdate-*-to-7.5.*sql` - note that only two updates were missing.

While `data/mysql/schema.sql` is deprecated, custom installation process relying on that file results in a broken instance if not maintained during 2.5.x LTS service life. This wasn't the intention.
In eZ Platform v3.0.0 (eZ Platform Kernel) this file is gone completely.

### QA
You can override your installation with `data/mysql/schema.sql`, `data/mysql/dfs_schema.sql`, and `data/mysql/cleandata.sql` to observe it's gonna be broken in two aspects:
1. [EZP-30571](https://jira.ez.no/browse/EZP-30571)
2. When accessing Admin panel (so I'm not sure if 1. is gonna be visible).

Common branch for #3024 and #3025: [ezp-31592-31586-schema-sql-combo-for-qa](https://github.com/ezsystems/ezpublish-kernel/compare/7.5...ezp-31592-31586-schema-sql-combo-for-qa)

**TODO**:
- [x] Add missing columns.
- [x] Ask for Code Review.
