### PR TITLE
[Tests] deprecate isVersion4() & attempt to cleanup some API doc on this

### DIFF
--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -187,17 +187,16 @@ interface ContentService
      * (this is useful for content staging where the transfer process does not
      * have to authenticate with the user which created the content object in the source server).
      * The user has to publish the draft if it should be visible.
-     * In 4.x at least one location has to be provided in the location creation array.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to create the content in the given location
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is a provided remoteId which exists in the system
-     *                                                                        or there is no location provided (4.x) or multiple locations
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is a provided remote ID which exists in the system or multiple Locations
      *                                                                        are under the same parent or if the a field value is not accepted by the field type
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $contentCreateStruct is not valid
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException if a required field is missing or is set to an empty value
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentCreateStruct $contentCreateStruct
      * @param \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct[] $locationCreateStructs an array of {@link \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct} for each location parent under which a location should be created for the content
+     *                                                                                                While optional, it's highly recommended to use Locations for content as a lot of features in the system is usually tied to the tree structure (including default Role policies).
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content - the newly created content draft
      */

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -135,6 +135,8 @@ abstract class BaseTest extends TestCase
     /**
      * Tests if the currently tested api is based on a V4 implementation.
      *
+     * @deprecated Not in use, will be removed.
+     *
      * @return bool
      */
     protected function isVersion4()

--- a/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
@@ -65,10 +65,6 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
      */
     public function testCreateContentThrowsUnauthorizedException()
     {
-        if ($this->isVersion4()) {
-            $this->markTestSkipped('This test requires eZ Publish 5');
-        }
-
         $this->permissionResolver->setCurrentUserReference($this->anonymousUser);
 
         $contentTypeService = $this->getRepository()->getContentTypeService();

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -107,10 +107,6 @@ class ContentServiceTest extends BaseContentServiceTest
      */
     public function testCreateContent()
     {
-        if ($this->isVersion4()) {
-            $this->markTestSkipped('This test requires eZ Publish 5');
-        }
-
         $contentTypeService = $this->getRepository()->getContentTypeService();
 
         $contentType = $contentTypeService->loadContentTypeByIdentifier(self::FORUM_IDENTIFIER);
@@ -143,10 +139,6 @@ class ContentServiceTest extends BaseContentServiceTest
      */
     public function testCreateContentAndPublishWithPrivilegedAnonymousUser()
     {
-        if ($this->isVersion4()) {
-            $this->markTestSkipped('This test requires eZ Publish 5');
-        }
-
         $anonymousUserId = $this->generateId('user', 10);
 
         $repository = $this->getRepository();
@@ -329,10 +321,6 @@ class ContentServiceTest extends BaseContentServiceTest
      */
     public function testCreateContentThrowsInvalidArgumentException()
     {
-        if ($this->isVersion4()) {
-            $this->markTestSkipped('This test requires eZ Publish 5');
-        }
-
         $contentTypeService = $this->getRepository()->getContentTypeService();
 
         $contentType = $contentTypeService->loadContentTypeByIdentifier(self::FORUM_IDENTIFIER);
@@ -4147,10 +4135,6 @@ XML
      */
     public function testCreateContentInTransactionWithRollback()
     {
-        if ($this->isVersion4()) {
-            $this->markTestSkipped('This test requires eZ Publish 5');
-        }
-
         $repository = $this->getRepository();
 
         $contentTypeService = $this->getRepository()->getContentTypeService();
@@ -4199,10 +4183,6 @@ XML
      */
     public function testCreateContentInTransactionWithCommit()
     {
-        if ($this->isVersion4()) {
-            $this->markTestSkipped('This test requires eZ Publish 5');
-        }
-
         $repository = $this->getRepository();
 
         $contentTypeService = $repository->getContentTypeService();

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -245,10 +245,6 @@ class UserServiceTest extends BaseTest
      */
     public function testNewUserGroupCreateStructWithSecondParameter()
     {
-        if ($this->isVersion4()) {
-            $this->markTestSkipped('This test is only relevant for eZ Publish versions > 4');
-        }
-
         $repository = $this->getRepository();
 
         /* BEGIN: Use Case */
@@ -857,10 +853,6 @@ class UserServiceTest extends BaseTest
      */
     public function testNewUserCreateStructWithFifthParameter()
     {
-        if ($this->isVersion4()) {
-            $this->markTestSkipped('This test is only relevant for eZ Publish versions > 4');
-        }
-
         $repository = $this->getRepository();
 
         /* BEGIN: Use Case */


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Integration tests and some API doc refer to 4.x behavior, often as opposed to what _was_ planed for 5.x back in 2011. However in some cases the referred to 4.x behaviour is plain wrong, and if not platform today is either behaving as described as 4.x, and others as 5.x. So time to start to cleanup this I guess. 

There are other cases I don't cover here as I'm unsure what is exactly right in terms of how Platform behaves today, someone will need to check against tests:
![Screenshot 2020-05-05 at 20 00 55 ](https://user-images.githubusercontent.com/289757/81100211-71368780-8f0c-11ea-8b52-02cf86c2e9b3.png)


This PR does:
- Removed effectively unused `isVersion4()` checks in tests, and deprecates the method
- Attempt at getting rid of one of the API doc referring to 4.x, around location less content, which is in fact allowed just like it was in legacy: https://github.com/ezsystems/ezpublish-kernel/blob/2fa1aba4d7607a5ab8df4fb66cfd57a3eb96faa4/eZ/Publish/API/Repository/Tests/ContentServiceTest.php#L120 


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
