### PR TITLE
[Travis] Changed notification key after rebranding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,8 +106,7 @@ script:
 notifications:
   slack:
     rooms:
-      - secure: Xb/nKrA5C4E5pNZulEVht1fT4gsOgoQp9WDNWVSBXz8i8JVPUZo20MtKt67pXK2SmxXbgY8aWbHrD1Y3Lv5YLUCHPJQKVxFiDLTh7sACxvHoEa8EuLiQo9naitMSXL1S4PaC8ptaVn9fe2Fwfg+ydSFLCsFDa+qmdBYjNaf8W4M=
-      - secure: qEgnhpVaWJZQNvJRisv5Kb1vfuZ4H0LjPGWdTk9Q1+MmQMhv/zGV1Z/H1+FEmxlZxk7zrC5ooLs5+K5Nf24XycAM1yczYWGBWJa0P+WKO1KfPx/NbOdSugXIKfbW4JcmwY5mpxPHf+9nUbEOv6zu3cOhWJg41MbTLcGRle+NZVc=
+      - secure: veaQhu7RrvtFP+7KdsHF0fC2+Lt8Etlezg/DIRnwCufgrEwrOtXhE7KnBF2lIdAMXLgVPWf4/bZeN+Ojtju2ntf7GkCMBzrSqqaPqLVYUGmniITKGv68KqlRgGFQ7JiVDIBXxVLuRKbp7yTetRTw/tJLYZ9+b127/3ouYWV4USg=
     on_success: change
     on_failure: always
     on_pull_requests: false


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://jira.ez.no/browse/EZP-31613
| **Bug/Improvement**| fix for Travis
| **New feature**    | no
| **Target version** | 6.13, 7.5, separate value for v3 in https://github.com/ezsystems/ezplatform-kernel/pull/61
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Regenerated Slack integration after workspace name change.
I've also removed the integration with our other workspace, as it hasn't really been used.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
