### PR TITLE
[Tests] Stopped relying on Location ID SortClause in testContentWithMultipleLocations

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -3799,9 +3799,6 @@ class SearchServiceTest extends BaseTest
         $query = new LocationQuery(
             [
                 'filter' => new Criterion\ContentId($content->id),
-                'sortClauses' => [
-                    new SortClause\Location\Id(LocationQuery::SORT_ASC),
-                ],
             ]
         );
 
@@ -3809,14 +3806,14 @@ class SearchServiceTest extends BaseTest
         $result = $searchService->findLocations($query);
 
         $this->assertEquals(2, $result->totalCount);
-        $this->assertEquals(
-            $location1->id,
-            $result->searchHits[0]->valueObject->id
+        $locationIds = array_map(
+            static function (SearchHit $searchHit): int {
+                return $searchHit->valueObject->id;
+            },
+            $result->searchHits
         );
-        $this->assertEquals(
-            $location2->id,
-            $result->searchHits[1]->valueObject->id
-        );
+        $this->assertContains($location1->id, $locationIds);
+        $this->assertContains($location2->id, $locationIds);
     }
 
     protected function createContentForTestUserMetadataGroupHorizontal()


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Work-around due to [EZP-31325](https://jira.ez.no/browse/EZP-31325)
| **Bug/Improvement**| yes
| **Target version** | `7.5` and maybe up
| **BC breaks**      | no
| **Doc needed**     | no

Sorting by Location ID is broken on Solr for some edge cases, see [EZP-31325](https://jira.ez.no/browse/EZP-31325) for more details.

This PR is not an actual solution, but a work-around to unblock [failing](https://travis-ci.org/github/ezsystems/ezpublish-kernel/jobs/684529155#L763) [CI](https://travis-ci.org/github/ezsystems/ezpublish-kernel/jobs/684175531#L763).

The essence of the failing test is not about ordering, so should be fine for now.

The root cause is that Solr treats `"location_id"` Field as a string, thus applies dictionary order on e.g. IDs "999" and "1000", which makes "1000" the first. The same rule would apply to the pair "9" and "10", "99" and "100", etc.

It wasn't detected till now, because right now entire test suite is so big that over a course of its execution it makes `ezcontentobject_tree.node_id` to reach ID 999 and 1000 for the Locations created by the given test. The result is deterministic when executed for the whole suite, but unseen when the amount of tests is smaller. It's a side effect of adding one single new unrelated test... 

Resetting sequences (for failing case executed on SQLite - by recreating schema) after each test is out of the question due to performance.

**TODO**:
- [x] Stop relying on Location ID SortClause in `SearchService::testContentWithMultipleLocations`
- [x] See if Travis is passing (might cause other side effect).
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
