### PR TITLE
EZP-31325: Added test coverage for sorting by Content & Location IDs

### DIFF
--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -30,8 +30,8 @@ composer config -g github-oauth.github.com "d0285ed5c8644f30547572ead2ed897431c1
 
 # solr package search API integration tests
 if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then
-    echo "> Require ezsystems/ezplatform-solr-search-engine:^1.3.0@dev"
-    composer require --no-update ezsystems/ezplatform-solr-search-engine:^1.3.0@dev
+    echo "> Require ezsystems/ezplatform-solr-search-engine:^1.5.0@dev"
+    composer require --dev --no-update ezsystems/ezplatform-solr-search-engine:^1.5.0@dev
 fi
 
 # Switch to another Symfony version if asked for

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -708,7 +708,7 @@ abstract class BaseTest extends TestCase
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    protected function createContentType(
+    protected function createSimpleContentType(
         $identifier,
         $mainTranslation,
         array $fieldsToDefine,

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -2205,7 +2205,7 @@ XML
         $locationService = $repository->getLocationService();
 
         // create a Content Type which is not always available by default
-        $contentType = $this->createContentType(
+        $contentType = $this->createSimpleContentType(
             'test_t',
             self::ENG_GB,
             [

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -20,6 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+use function count;
 
 /**
  * Test case for operations in the SearchService.
@@ -4317,13 +4318,24 @@ class SearchServiceTest extends BaseTest
      * Assert that query result matches the given fixture.
      *
      * @param Query $query
-     * @param string $fixture
+     * @param string $fixtureFilePath
      * @param null|callable $closure
+     * @param bool $ignoreScore
      * @param bool $info
      * @param bool $id
+     *
+     * @throws \ErrorException
+     * @throws \ReflectionException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
-    protected function assertQueryFixture(Query $query, $fixture, $closure = null, $ignoreScore = true, $info = false, $id = true)
-    {
+    protected function assertQueryFixture(
+        Query $query,
+        $fixtureFilePath,
+        $closure = null,
+        $ignoreScore = true,
+        $info = false,
+        $id = true
+    ) {
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
@@ -4335,8 +4347,8 @@ class SearchServiceTest extends BaseTest
                 }
 
                 if ($setupFactory instanceof LegacyElasticsearch) {
-                    $position = strrpos($fixture, '/');
-                    $fixture = substr_replace($fixture, '/Location', $position, 0);
+                    $position = strrpos($fixtureFilePath, '/');
+                    $fixtureFilePath = substr_replace($fixtureFilePath, '/Location', $position, 0);
                 }
 
                 $result = $searchService->findLocations($query);
@@ -4356,19 +4368,19 @@ class SearchServiceTest extends BaseTest
             );
         }
 
-        if (!is_file($fixture)) {
+        if (!is_file($fixtureFilePath)) {
             if (isset($_ENV['ez_tests_record'])) {
                 file_put_contents(
-                    $record = $fixture . '.recording',
+                    $record = $fixtureFilePath . '.recording',
                     "<?php\n\nreturn " . var_export($result, true) . ";\n\n"
                 );
                 $this->markTestIncomplete("No fixture available. Result recorded at $record. Result: \n" . $this->printResult($result));
             } else {
-                $this->markTestIncomplete("No fixture available. Set \$_ENV['ez_tests_record'] to generate:\n " . $fixture);
+                $this->markTestIncomplete("No fixture available. Set \$_ENV['ez_tests_record'] to generate:\n " . $fixtureFilePath);
             }
         }
 
-        $fixture = include $fixture;
+        $fixture = require $fixtureFilePath;
 
         if ($closure !== null) {
             $closure($fixture);
@@ -4408,7 +4420,7 @@ class SearchServiceTest extends BaseTest
         $this->assertEquals(
             $fixture,
             $result,
-            'Search results do not match.',
+            'Search results do not match the fixture: ' . $fixtureFilePath,
             .99 // Be quite generous regarding delay -- most important for scores
         );
     }
@@ -4496,5 +4508,100 @@ class SearchServiceTest extends BaseTest
                 $closure($data);
             }
         };
+    }
+
+    /**
+     * @dataProvider providerForTestSortingByNumericFieldsWithValuesOfDifferentLength
+     *
+     * @param int[] $expectedOrderedIds
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testSortingByNumericFieldsWithValuesOfDifferentLength(
+        LocationQuery $query,
+        array $expectedOrderedIds
+    ) {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+
+        $result = $searchService->findLocations($query);
+
+        self::assertEquals(count($expectedOrderedIds), $result->totalCount);
+        $actualIds = array_map(
+            static function (SearchHit $searchHit) {
+                /** @var \eZ\Publish\API\Repository\Values\Content\Location $location */
+                $location = $searchHit->valueObject;
+
+                return $location->id;
+            },
+            $result->searchHits
+        );
+        self::assertEquals($expectedOrderedIds, $actualIds);
+    }
+
+    public function providerForTestSortingByNumericFieldsWithValuesOfDifferentLength()
+    {
+        yield 'Location ID ASC' => [
+            new LocationQuery(
+                [
+                    'filter' => new Criterion\LocationId([43, 5]),
+                    'sortClauses' => [
+                        new SortClause\Location\Id(LocationQuery::SORT_ASC),
+                    ],
+                ]
+            ),
+            [5, 43],
+        ];
+
+        yield 'Location ID DESC' => [
+            new LocationQuery(
+                [
+                    'filter' => new Criterion\LocationId([5, 43]),
+                    'sortClauses' => [
+                        new SortClause\Location\Id(LocationQuery::SORT_DESC),
+                    ],
+                ]
+            ),
+            [43, 5],
+        ];
+
+        yield 'Content ID ASC' => [
+            new LocationQuery(
+                [
+                    'filter' => new Criterion\ContentId([14, 4]),
+                    'sortClauses' => [
+                        new SortClause\ContentId(LocationQuery::SORT_ASC),
+                    ],
+                ]
+            ),
+            // those are still Location IDs as it's LocationQuery
+            [5, 15],
+        ];
+
+        yield 'Content ID DESC' => [
+            new LocationQuery(
+                [
+                    'filter' => new Criterion\ContentId([4, 14]),
+                    'sortClauses' => [
+                        new SortClause\ContentId(LocationQuery::SORT_DESC),
+                    ],
+                ]
+            ),
+            // those are still Location IDs as it's LocationQuery
+            [15, 5],
+        ];
+
+        yield 'Content ID DESC' => [
+            new LocationQuery(
+                [
+                    'filter' => new Criterion\ContentId([4, 14]),
+                    'sortClauses' => [
+                        new SortClause\ContentId(LocationQuery::SORT_DESC),
+                    ],
+                ]
+            ),
+            // those are still Location IDs as it's LocationQuery
+            [15, 5],
+        ];
     }
 }

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/AncestorContent.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/AncestorContent.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1.0,
        'index' => NULL,
@@ -22,8 +22,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 1.0,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/ContentId.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/ContentId.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1.0,
        'index' => null,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 1.0,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/ContentTypeGroupId.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/ContentTypeGroupId.php
@@ -10,6 +10,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1.0,
+       'index' => null,
+       'highlight' => null,
+    )),
+    1 =>
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' =>
+      array(
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -17,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    1 =>
+    2 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -28,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    2 =>
+    3 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -39,7 +50,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    3 =>
+    4 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -50,23 +61,12 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    4 =>
+    5 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
         'id' => 14,
         'title' => 'Administrator User',
-      ),
-       'score' => 1.0,
-       'index' => null,
-       'highlight' => null,
-    )),
-    5 =>
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' =>
-      array(
-        'id' => 4,
-        'title' => 'Users',
       ),
        'score' => 1.0,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/CustomFieldGte.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/CustomFieldGte.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 11,
-        'title' => 'Members',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => null,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 11,
+        'title' => 'Members',
       ),
        'score' => 1,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/DateMetadataLte.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/DateMetadataLte.php
@@ -10,6 +10,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1.0,
+       'index' => null,
+       'highlight' => null,
+    )),
+    1 =>
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' =>
+      array(
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -17,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    1 =>
+    2 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -28,23 +39,12 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    2 =>
+    3 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
         'id' => 13,
         'title' => 'Editors',
-      ),
-       'score' => 1.0,
-       'index' => null,
-       'highlight' => null,
-    )),
-    3 =>
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' =>
-      array(
-        'id' => 4,
-        'title' => 'Users',
       ),
        'score' => 1.0,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/DeprecatedContentIdQuery.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/DeprecatedContentIdQuery.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 0.57124877,
        'index' => null,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 0.57124877,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/DepthIn.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/DepthIn.php
@@ -7,8 +7,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
             0 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
                 array(
                     'valueObject' => array(
-                        'id' => 10,
-                        'title' => 'Anonymous User',
+                        'id' => 4,
+                        'title' => 'Users',
                     ),
                     'score' => 1.8414208999999999,
                     'index' => null,
@@ -18,8 +18,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
             1 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
                 array(
                     'valueObject' => array(
-                        'id' => 14,
-                        'title' => 'Administrator User',
+                        'id' => 10,
+                        'title' => 'Anonymous User',
                     ),
                     'score' => 1.8414208999999999,
                     'index' => null,
@@ -29,8 +29,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
             2 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
                 array(
                     'valueObject' => array(
-                        'id' => 4,
-                        'title' => 'Users',
+                        'id' => 14,
+                        'title' => 'Administrator User',
                     ),
                     'score' => 1.384091,
                     'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/DepthLte.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/DepthLte.php
@@ -7,6 +7,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
             0 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
                 array(
                     'valueObject' => array(
+                        'id' => 4,
+                        'title' => 'Users',
+                    ),
+                    'score' => 1.9200476,
+                    'index' => null,
+                    'highlight' => null,
+                )
+            ),
+            1 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
                         'id' => 11,
                         'title' => 'Members',
                     ),
@@ -15,7 +26,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
                     'highlight' => null,
                 )
             ),
-            1 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+            2 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
                 array(
                     'valueObject' => array(
                         'id' => 12,
@@ -26,22 +37,11 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
                     'highlight' => null,
                 )
             ),
-            2 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+            3 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
                 array(
                     'valueObject' => array(
                         'id' => 13,
                         'title' => 'Editors',
-                    ),
-                    'score' => 1.9200476,
-                    'index' => null,
-                    'highlight' => null,
-                )
-            ),
-            3 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
-                array(
-                    'valueObject' => array(
-                        'id' => 4,
-                        'title' => 'Users',
                     ),
                     'score' => 1.9200476,
                     'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/LogicalOr.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/LogicalOr.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1.0,
        'index' => null,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 12,
-        'title' => 'Administrator users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 1.0,
        'index' => null,
@@ -32,8 +32,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 12,
+        'title' => 'Administrator users',
       ),
        'score' => 1.0,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/RemoteId.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/RemoteId.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1.0,
        'index' => null,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 1.0,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SectionId.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SectionId.php
@@ -10,6 +10,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1.0,
+       'index' => null,
+       'highlight' => null,
+    )),
+    1 =>
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' =>
+      array(
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -17,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    1 =>
+    2 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -28,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    2 =>
+    3 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -39,7 +50,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    3 =>
+    4 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -50,23 +61,12 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    4 =>
+    5 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
         'id' => 14,
         'title' => 'Administrator User',
-      ),
-       'score' => 1.0,
-       'index' => null,
-       'highlight' => null,
-    )),
-    5 =>
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' =>
-      array(
-        'id' => 4,
-        'title' => 'Users',
       ),
        'score' => 1.0,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortDesc.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortDesc.php
@@ -32,6 +32,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1.0,
+       'index' => null,
+       'highlight' => null,
+    )),
+    3 =>
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' =>
+      array(
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -39,7 +50,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    3 =>
+    4 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -50,24 +61,12 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    4 =>
+    5 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
         'id' => 14,
         'title' => 'Administrator User',
-      ),
-       'score' => 1.0,
-       'index' => null,
-       'highlight' => null,
-    )),
-    // In ElasticSearch/Slor id is identifier (like API), hence "4" is after "14"
-    5 =>
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' =>
-      array(
-        'id' => 4,
-        'title' => 'Users',
       ),
        'score' => 1.0,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortFieldMultipleTypes.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortFieldMultipleTypes.php
@@ -76,6 +76,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1,
+       'index' => null,
+       'highlight' => null,
+    )),
+    7 =>
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' =>
+      array(
         'id' => 11,
         'title' => 'Members',
       ),
@@ -83,7 +94,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    7 =>
+    8 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -94,23 +105,12 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    8 =>
+    9 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
         'id' => 13,
         'title' => 'Editors',
-      ),
-       'score' => 1,
-       'index' => null,
-       'highlight' => null,
-    )),
-    9 =>
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' =>
-      array(
-        'id' => 4,
-        'title' => 'Users',
       ),
        'score' => 1,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortFieldMultipleTypesReverse.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortFieldMultipleTypesReverse.php
@@ -76,6 +76,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1,
+       'index' => null,
+       'highlight' => null,
+    )),
+    7 =>
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' =>
+      array(
         'id' => 11,
         'title' => 'Members',
       ),
@@ -83,7 +94,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    7 =>
+    8 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -94,23 +105,12 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    8 =>
+    9 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
         'id' => 13,
         'title' => 'Editors',
-      ),
-       'score' => 1,
-       'index' => null,
-       'highlight' => null,
-    )),
-    9 =>
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' =>
-      array(
-        'id' => 4,
-        'title' => 'Users',
       ),
        'score' => 1,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortFieldMultipleTypesSlice.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortFieldMultipleTypesSlice.php
@@ -43,8 +43,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 11,
-        'title' => 'Members',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => null,
@@ -54,8 +54,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 12,
-        'title' => 'Administrator users',
+        'id' => 11,
+        'title' => 'Members',
       ),
        'score' => 1,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortFieldMultipleTypesSliceReverse.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortFieldMultipleTypesSliceReverse.php
@@ -43,8 +43,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 11,
-        'title' => 'Members',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => null,
@@ -54,8 +54,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
-        'id' => 12,
-        'title' => 'Administrator users',
+        'id' => 11,
+        'title' => 'Members',
       ),
        'score' => 1,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortSectionIdentifier.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortSectionIdentifier.php
@@ -76,6 +76,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
       eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
           'valueObject' =>
           array(
+              'id' => 4,
+              'title' => 'Users',
+          ),
+          'score' => 1.0,
+          'index' => null,
+          'highlight' => null,
+      )),
+      7 =>
+      eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+          'valueObject' =>
+          array(
               'id' => 10,
               'title' => 'Anonymous User',
           ),
@@ -83,7 +94,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
           'index' => null,
           'highlight' => null,
       )),
-      7 =>
+      8 =>
       eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
           'valueObject' =>
           array(
@@ -94,7 +105,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
           'index' => null,
           'highlight' => null,
       )),
-      8 =>
+      9 =>
       eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
           'valueObject' =>
           array(
@@ -105,7 +116,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
           'index' => null,
           'highlight' => null,
       )),
-      9 =>
+      10 =>
       eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
           'valueObject' =>
           array(
@@ -116,23 +127,12 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
           'index' => null,
           'highlight' => null,
       )),
-      10 =>
+      11 =>
       eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
           'valueObject' =>
           array(
               'id' => 14,
               'title' => 'Administrator User',
-          ),
-          'score' => 1.0,
-          'index' => null,
-          'highlight' => null,
-      )),
-      11 =>
-      eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-          'valueObject' =>
-          array(
-              'id' => 4,
-              'title' => 'Users',
           ),
           'score' => 1.0,
           'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortSectionName.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/SortSectionName.php
@@ -76,6 +76,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1.0,
+       'index' => null,
+       'highlight' => null,
+    )),
+    7 =>
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' =>
+      array(
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -83,7 +94,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    7 =>
+    8 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -94,7 +105,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    8 =>
+    9 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -105,7 +116,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    9 =>
+    10 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -116,23 +127,12 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    10 =>
+    11 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
         'id' => 14,
         'title' => 'Administrator User',
-      ),
-       'score' => 1.0,
-       'index' => null,
-       'highlight' => null,
-    )),
-    11 =>
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' =>
-      array(
-        'id' => 4,
-        'title' => 'Users',
       ),
        'score' => 1.0,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/Subtree.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/Subtree.php
@@ -10,6 +10,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1.0,
+       'index' => null,
+       'highlight' => null,
+    )),
+    1 =>
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' =>
+      array(
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -17,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    1 =>
+    2 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -28,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    2 =>
+    3 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -39,7 +50,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    3 =>
+    4 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -50,23 +61,12 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    4 =>
+    5 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
         'id' => 14,
         'title' => 'Administrator User',
-      ),
-       'score' => 1.0,
-       'index' => null,
-       'highlight' => null,
-    )),
-    5 =>
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' =>
-      array(
-        'id' => 4,
-        'title' => 'Users',
       ),
        'score' => 1.0,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/UserMetadata.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/UserMetadata.php
@@ -10,6 +10,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1,
+       'index' => null,
+       'highlight' => null,
+    )),
+    1 =>
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' =>
+      array(
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -17,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    1 =>
+    2 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -28,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    2 =>
+    3 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -39,7 +50,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    3 =>
+    4 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
@@ -50,23 +61,12 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => null,
        'highlight' => null,
     )),
-    4 =>
+    5 =>
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' =>
       array(
         'id' => 14,
         'title' => 'Administrator User',
-      ),
-       'score' => 1,
-       'index' => null,
-       'highlight' => null,
-    )),
-    5 =>
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' =>
-      array(
-        'id' => 4,
-        'title' => 'Users',
       ),
        'score' => 1,
        'index' => null,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/Visibility.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/Visibility.php
@@ -7,6 +7,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
             0 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
                 array(
                     'valueObject' => array(
+                        'id' => 4,
+                        'title' => 'Users',
+                    ),
+                    'score' => 0.9459328,
+                    'index' => null,
+                    'highlight' => null,
+                )
+            ),
+            1 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
                         'id' => 10,
                         'title' => 'Anonymous User',
                     ),
@@ -15,7 +26,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
                     'highlight' => null,
                 )
             ),
-            1 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+            2 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
                 array(
                     'valueObject' => array(
                         'id' => 11,
@@ -26,7 +37,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
                     'highlight' => null,
                 )
             ),
-            2 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+            3 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
                 array(
                     'valueObject' => array(
                         'id' => 12,
@@ -37,7 +48,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
                     'highlight' => null,
                 )
             ),
-            3 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+            4 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
                 array(
                     'valueObject' => array(
                         'id' => 13,
@@ -48,22 +59,11 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
                     'highlight' => null,
                 )
             ),
-            4 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+            5 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
                 array(
                     'valueObject' => array(
                         'id' => 14,
                         'title' => 'Administrator User',
-                    ),
-                    'score' => 0.9459328,
-                    'index' => null,
-                    'highlight' => null,
-                )
-            ),
-            5 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
-                array(
-                    'valueObject' => array(
-                        'id' => 4,
-                        'title' => 'Users',
                     ),
                     'score' => 0.9459328,
                     'index' => null,


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Test coverage for [EZP-31325](https://jira.ez.no/browse/EZP-31325)
| **Requires** | ezsystems/ezplatform-solr-search-engine#181
| **Type**| bug
| **Target version** | `6.13`, `7.5`, `master`, `ezplatform-kernel:1.0+`
| **Language level** | PHP 5.6
| **BC breaks**      | no
| **Tests pass**     | [yes](https://travis-ci.org/github/ezsystems/ezpublish-kernel/builds/688979067) with ezsystems/ezplatform-solr-search-engine#181
| **Doc needed**     | no

This PR adds dedicated test coverage for sorting by Content IDs and Location IDs of different length (order of magnitude), to check if ordering by integer values works. 

It also fixes other Solr fixtures supporting wrong assumption that Solr results should be different. At the same time DX for working with those tests was improved by producing more verbose message (there's a lot of fixtures).

`6.13` only: Additionally the PR enforces using Solr Bundle `1.5.x-dev` to run tests against as that version of the Bundle is the newest supporting Solr 4.10 and documented as the one to use with eZ Platform 1.13.

Some minor required fixes for the test cases are introduced as well (they're already done on upper branches).

**TODO**:
- [x] **Drop TMP commit**
- [x] Implement tests.
- [x] Fix test fixtures.
- [x] Switch to Solr patch branch to run tests for the fix (ezsystems/ezplatform-solr-search-engine#181).
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
