### PR TITLE
[Tests] Added SortClause in testFieldIsEmptyInLocation

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
@@ -216,6 +216,7 @@ class SearchServiceLocationTest extends BaseTest
         $query = new LocationQuery(
             [
                 'query' => new Criterion\IsFieldEmpty('subtitle'),
+                'sortClauses' => [new SortClause\Location\Id()],
             ]
         );
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **Type**| improvement
| **Target version** | `7.5` and up (incl. ezplatform-kernel)
| **BC breaks**      | no

Looks like `SearchServiceLocationTest::testFieldIsEmptyInLocation` fails sometimes due to lack of deterministic ordering. Hopefully this test case won't be affected by [EZP-31325](https://jira.ez.no/browse/EZP-31325).

**TODO**:
- [x] Improve `testFieldIsEmptyInLocation`
- [x] Wait for Travis
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
