### PR TITLE
EZP-31584: Implemented loadFirstAvailableLocation method in LocationService

### DIFF
--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -244,4 +244,12 @@ interface LocationService
      * @return \eZ\Publish\API\Repository\Values\Content\Location[]
      */
     public function loadAllLocations(int $offset = 0, int $limit = 25): array;
+
+    /**
+     * Load first available Location for chosen Content for the current User.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if there is no published version yet
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user is not allowed read any of the Content's Locations
+     */
+    public function loadFirstAvailableLocation(ContentInfo $contentInfo, array $prioritizedLanguages = null): Location;
 }

--- a/eZ/Publish/Core/REST/Client/LocationService.php
+++ b/eZ/Publish/Core/REST/Client/LocationService.php
@@ -109,7 +109,7 @@ class LocationService implements APILocationService, Sessionable
         $values = $this->requestParser->parse('object', $contentInfo->id);
         $result = $this->client->request(
             'POST',
-            $this->requestParser->generate('objectLocations', array('object' => $values['object'])),
+            $this->requestParser->generate('objectLocations', ['object' => $values['object']]),
             $inputMessage
         );
 
@@ -117,7 +117,7 @@ class LocationService implements APILocationService, Sessionable
     }
 
     /**
-     * {@inheritdoc)
+     * {@inheritdoc).
      */
     public function loadLocation($locationId, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null)
     {
@@ -125,7 +125,7 @@ class LocationService implements APILocationService, Sessionable
             'GET',
             $locationId,
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('Location'))
+                ['Accept' => $this->outputVisitor->getMediaType('Location')]
             )
         );
 
@@ -133,7 +133,7 @@ class LocationService implements APILocationService, Sessionable
     }
 
     /**
-     * {@inheritdoc)
+     * {@inheritdoc).
      */
     public function loadLocationList(array $locationIds, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null): iterable
     {
@@ -149,15 +149,15 @@ class LocationService implements APILocationService, Sessionable
     }
 
     /**
-     * {@inheritdoc)
+     * {@inheritdoc).
      */
     public function loadLocationByRemoteId($remoteId, array $prioritizedLanguages = null, bool $useAlwaysAvailable = null)
     {
         $response = $this->client->request(
             'GET',
-            $this->requestParser->generate('locationByRemote', array('location' => $remoteId)),
+            $this->requestParser->generate('locationByRemote', ['location' => $remoteId]),
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('LocationList'))
+                ['Accept' => $this->outputVisitor->getMediaType('LocationList')]
             )
         );
 
@@ -219,9 +219,9 @@ class LocationService implements APILocationService, Sessionable
         $values = $this->requestParser->parse('object', $contentInfo->id);
         $response = $this->client->request(
             'GET',
-            $this->requestParser->generate('objectLocations', array('object' => $values['object'])),
+            $this->requestParser->generate('objectLocations', ['object' => $values['object']]),
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('LocationList'))
+                ['Accept' => $this->outputVisitor->getMediaType('LocationList')]
             )
         );
 
@@ -243,9 +243,9 @@ class LocationService implements APILocationService, Sessionable
         $values = $this->requestParser->parse('location', $location->id);
         $response = $this->client->request(
             'GET',
-            $this->requestParser->generate('locationChildren', array('location' => $values['location'])),
+            $this->requestParser->generate('locationChildren', ['location' => $values['location']]),
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('LocationList'))
+                ['Accept' => $this->outputVisitor->getMediaType('LocationList')]
             )
         );
 
@@ -384,6 +384,14 @@ class LocationService implements APILocationService, Sessionable
      * @throws \Exception
      */
     public function loadAllLocations(int $offset = 0, int $limit = 25): array
+    {
+        throw new \Exception('@todo: Implement.');
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function loadFirstAvailableLocation(ContentInfo $contentInfo, array $prioritizedLanguages = null): Location
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -895,4 +895,21 @@ class LocationService implements LocationServiceInterface
 
         return $locations;
     }
+
+    public function loadFirstAvailableLocation(ContentInfo $contentInfo, array $prioritizedLanguages = null): Location
+    {
+        try {
+            $location = $this->loadLocation($contentInfo->mainLocationId, $prioritizedLanguages);
+        } catch (Exception $e) {
+            // try different locations if main location is not accessible for the user
+            $locations = $this->loadLocations($contentInfo, null, $prioritizedLanguages);
+            if (empty($locations)) {
+                throw $e;
+            }
+
+            return reset($locations);
+        }
+
+        return $location;
+    }
 }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
@@ -174,4 +174,9 @@ class LocationService implements LocationServiceInterface
     {
         return $this->service->loadAllLocations($offset, $limit);
     }
+
+    public function loadFirstAvailableLocation(ContentInfo $contentInfo, array $prioritizedLanguages = null): Location
+    {
+        return $this->service->loadFirstAvailableLocation($contentInfo, $prioritizedLanguages);
+    }
 }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LocationServiceTest.php
@@ -59,6 +59,8 @@ class LocationServiceTest extends AbstractServiceTest
 
             ['getAllLocationsCount', [], 100],
             ['loadAllLocations', [10, 100], [$location]],
+
+            ['loadFirstAvailableLocation', [$contentInfo], $location],
         ];
     }
 

--- a/eZ/Publish/Core/SignalSlot/LocationService.php
+++ b/eZ/Publish/Core/SignalSlot/LocationService.php
@@ -379,4 +379,9 @@ class LocationService implements LocationServiceInterface
     {
         return $this->service->loadAllLocations($offset, $limit);
     }
+
+    public function loadFirstAvailableLocation(ContentInfo $contentInfo, array $prioritizedLanguages = null): Location
+    {
+        return $this->service->loadFirstAvailableLocation($contentInfo, $prioritizedLanguages);
+    }
 }

--- a/eZ/Publish/Core/SignalSlot/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/LocationServiceTest.php
@@ -225,7 +225,7 @@ class LocationServiceTest extends ServiceTest
             [
                 'loadFirstAvailableLocation',
                 [$locationContentInfo, []],
-                [$location],
+                $location,
                 0,
             ],
         ];

--- a/eZ/Publish/Core/SignalSlot/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/LocationServiceTest.php
@@ -222,6 +222,12 @@ class LocationServiceTest extends ServiceTest
                 $locationUpdateStruct,
                 0,
             ],
+            [
+                'loadFirstAvailableLocation',
+                [$locationContentInfo, []],
+                [$location],
+                0,
+            ],
         ];
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31584](https://jira.ez.no/browse/EZP-31584)
| **Improvement**| yes
| **New feature**    | no
| **Target version** | 7.5
| **BC breaks**      | no
| **Tests pass**     | ?
| **Doc needed**     | no

The new method `loadFirstAvailableLocation()` has been added to the `LocationService`, which gets first `Location` which is accessible for the current user.

i.e.: `Content` has two locations. The user has access only to the second one when the first one is the main `Location` of the `Content`. Therefore the second `Location` will be found in this case instead of throwing an `UnauthorizedException`.

Related `ezplatform-admin-ui` PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/1351

**TODO**:
- [x] Implement an improvement.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
