### PR TITLE
EZP-27324: Proper media/binary uri is now shown & generated for old content versions

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -207,7 +207,12 @@
 {% block ezbinaryfile_field %}
 {% apply spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
-        {% set route_reference = ez_route( 'ez_content_download', { 'content': content, 'fieldIdentifier': field.fieldDefIdentifier } ) %}
+        {% set route_reference = ez_route( 'ez_content_download', {
+            'content': content,
+            'fieldIdentifier': field.fieldDefIdentifier,
+            'inLanguage': content.prioritizedFieldLanguageCode,
+            'version': versionInfo.versionNo
+        } ) %}
         <a href="{{ path( route_reference ) }}"
             {{ block( 'field_attributes' ) }}>{{ field.value.fileName }}</a>&nbsp;({{ field.value.fileSize|ez_file_size( 1 ) }})
     {% endif %}
@@ -219,7 +224,11 @@
 {% apply spaceless %}
     {% set type = fieldSettings.mediaType %}
     {% set value = field.value %}
-    {% set route_reference = ez_route( 'ez_content_download', {'content': content, 'fieldIdentifier': field.fieldDefIdentifier} ) %}
+    {% set route_reference = ez_route( 'ez_content_download', {
+        'content': content,
+        'fieldIdentifier': field.fieldDefIdentifier,
+        'version': versionInfo.versionNo
+    } ) %}
     {% set download = path( route_reference ) %}
     {% set width = value.width > 0 ? 'width="' ~ value.width ~ '"' : "" %}
     {% set height = value.height > 0 ? 'height="' ~ value.height ~ '"' : "" %}

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/BinaryBase/ContentDownloadUrlGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/BinaryBase/ContentDownloadUrlGenerator.php
@@ -28,6 +28,7 @@ class ContentDownloadUrlGenerator extends PathGenerator
             [
                 'contentId' => $versionInfo->contentInfo->id,
                 'fieldId' => $field->id,
+                'version' => $versionInfo->versionNo,
             ]
         );
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-27324](https://jira.ez.no/browse/EZP-27324)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
