### PR TITLE
EZP-25484: Implemented dedicated strategy to map remote IDs for search

### DIFF
--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -41,8 +41,8 @@ composer config -g github-oauth.github.com "d0285ed5c8644f30547572ead2ed897431c1
 if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then
     # Install openJDK8 as default v11 is too new for SOLR
     sudo apt-get install openjdk-8-jdk
-    echo "> Require ezsystems/ezplatform-solr-search-engine:^1.3.0@dev"
-    composer require --no-update ezsystems/ezplatform-solr-search-engine:^1.3.0@dev
+    echo "> Require ezsystems/ezplatform-solr-search-engine:^1.7.4@dev"
+    composer require --no-update ezsystems/ezplatform-solr-search-engine:^1.7.4@dev
 fi
 
 # Switch to another Symfony version if asked for

--- a/eZ/Publish/API/Repository/Tests/SearchService/RemoteIdIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/RemoteIdIndexingTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\SearchService;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+final class RemoteIdIndexingTest extends BaseTest
+{
+    /** @var int[] */
+    private static $contentIdByRemoteIdIndex = [];
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (empty(self::$contentIdByRemoteIdIndex)) {
+            foreach ($this->getRemoteIDs() as $remoteId) {
+                self::$contentIdByRemoteIdIndex[$remoteId] = $this->createTestFolder(
+                    $remoteId
+                );
+            }
+
+            $this->refreshSearch($this->getRepository(false));
+        }
+    }
+
+    /**
+     * @dataProvider providerForTestIndexingRemoteId
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     */
+    public function testIndexingRemoteId(Criterion $criterion): void
+    {
+        $repository = $this->getRepository(false);
+        $searchService = $repository->getSearchService();
+
+        $remoteId = $criterion->value[0];
+        if (!isset(self::$contentIdByRemoteIdIndex[$remoteId])) {
+            self::fail("Failed to find Content ID for remote ID = {$criterion->value}");
+        }
+
+        $contentId = self::$contentIdByRemoteIdIndex[$remoteId];
+
+        // test searching using both Content & Location remote IDs for both Content items
+        $query = new Query();
+        $query->filter = $criterion;
+        $result = $searchService->findContent($query);
+        self::assertSame(
+            1,
+            $result->totalCount,
+            "Failed to find Content ID = {$contentId} filtering by remote ID = '{$remoteId}'"
+        );
+        self::assertSame($contentId, $result->searchHits[0]->valueObject->id);
+
+        $query = new LocationQuery();
+        $query->filter = $criterion;
+        $result = $searchService->findLocations($query);
+        self::assertSame(
+            1,
+            $result->totalCount,
+            "Failed to find Location for Content ID = {$contentId} filtering by remote ID = '{$remoteId}'"
+        );
+        self::assertSame($contentId, $result->searchHits[0]->valueObject->contentInfo->id);
+    }
+
+    private function getRemoteIDs(): array
+    {
+        return [
+            'md5sum' => 'dec23f2de27399a4c0561187b805aa74',
+            'sha512' => '3ad11d1424370b5a258f7dc7724b25535f3fb2e1fa3f7047839f68d18cf58eb5',
+            'external:10' => 'external:10',
+            'external_10' => 'external_10',
+            'with space' => 'with space',
+            'with national characters' => 'zażółć gęślą jaźń',
+            'with emoji' => json_decode('"\ud83d\ude00"'),
+        ];
+    }
+
+    /**
+     * Create 2 * number of remote IDs test data sets (one for Content, another for Location).
+     *
+     * @return iterable
+     */
+    public function providerForTestIndexingRemoteId(): iterable
+    {
+        foreach ($this->getRemoteIDs() as $description => $remoteId) {
+            yield "Content remote ID = {$description}" => [new Criterion\RemoteId($remoteId)];
+            yield "Location remote ID = {$description}" => [new Criterion\LocationRemoteId($remoteId)];
+        }
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    private function createTestFolder(string $remoteId): int
+    {
+        $repository = $this->getRepository(false);
+        $contentTypeService = $repository->getContentTypeService();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+
+        $folderType = $contentTypeService->loadContentTypeByIdentifier('folder');
+        $folderCreateStruct = $contentService->newContentCreateStruct($folderType, 'eng-GB');
+        $folderCreateStruct->remoteId = $remoteId;
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+        $locationCreateStruct->remoteId = $remoteId;
+        $folder = $contentService->publishVersion(
+            $contentService->createContent(
+                $folderCreateStruct,
+                [$locationCreateStruct]
+            )->getVersionInfo()
+        );
+
+        return $folder->id;
+    }
+}

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleRemoteIdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleRemoteIdentifierMapper.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common\FieldValueMapper;
+
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\MultipleRemoteIdentifierField;
+
+/**
+ * Common remote ID list field value mapper implementation.
+ */
+final class MultipleRemoteIdentifierMapper extends RemoteIdentifierMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param \eZ\Publish\SPI\Search\Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field): bool
+    {
+        return $field->type instanceof MultipleRemoteIdentifierField;
+    }
+
+    public function map(Field $field)
+    {
+        $values = [];
+
+        foreach ($field->value as $value) {
+            $values[] = $this->convert($value);
+        }
+
+        return $values;
+    }
+}

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/RemoteIdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/RemoteIdentifierMapper.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common\FieldValueMapper;
+
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\RemoteIdentifierField;
+
+/**
+ * Common remote ID field value mapper.
+ *
+ * Currently behaves in the same way as StringMapper.
+ *
+ * @internal for internal use by Search engine field value mapper
+ */
+class RemoteIdentifierMapper extends StringMapper
+{
+    public function canMap(Field $field): bool
+    {
+        return $field->type instanceof RemoteIdentifierField;
+    }
+}

--- a/eZ/Publish/Core/Search/Tests/Common/FieldValueMapper/RemoteIdentifierMapperTest.php
+++ b/eZ/Publish/Core/Search/Tests/Common/FieldValueMapper/RemoteIdentifierMapperTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Search\Tests\Common\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Common\FieldValueMapper\RemoteIdentifierMapper;
+use eZ\Publish\Core\Search\Tests\TestCase;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\IdentifierField;
+use eZ\Publish\SPI\Search\FieldType\IntegerField;
+use eZ\Publish\SPI\Search\FieldType\RemoteIdentifierField;
+use eZ\Publish\SPI\Search\FieldType\StringField;
+
+final class RemoteIdentifierMapperTest extends TestCase
+{
+    /** @var \eZ\Publish\Core\Search\Common\FieldValueMapper\RemoteIdentifierMapper */
+    private $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new RemoteIdentifierMapper();
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Search\Common\FieldValueMapper\RemoteIdentifierMapper::canMap
+     *
+     * @dataProvider getDataForTestCanMap
+     */
+    public function testCanMap(Field $field, bool $canMap): void
+    {
+        self::assertSame($canMap, $this->mapper->canMap($field));
+    }
+
+    public function getDataForTestCanMap(): iterable
+    {
+        yield 'can map' => [
+            new Field('id', 1, new RemoteIdentifierField()),
+            true,
+        ];
+
+        yield 'cannot map (identifier)' => [
+            new Field('id', 1, new IdentifierField()),
+            false,
+        ];
+
+        yield 'cannot map (string)' => [
+            new Field('name', 1, new StringField()),
+            false,
+        ];
+
+        yield 'cannot map (integer)' => [
+            new Field('number', 1, new IntegerField()),
+            false,
+        ];
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Search\Common\FieldValueMapper\IdentifierMapper::map
+     *
+     * @dataProvider getDataForTestMap
+     */
+    public function testMap(Field $field, string $expectedMappedValue): void
+    {
+        self::assertSame($expectedMappedValue, $this->mapper->map($field));
+    }
+
+    public function getDataForTestMap(): iterable
+    {
+        yield 'numeric id' => [
+            new Field('id', 1, new IdentifierField()),
+            1,
+        ];
+
+        yield 'remote_id md5' => [
+            new Field(
+                'remote_id',
+                '1611729231d469e6b53c431f476926ac',
+                new IdentifierField()
+            ),
+            '1611729231d469e6b53c431f476926ac',
+        ];
+
+        yield 'external remote_id' => [
+            new Field(
+                'location_remote_id',
+                'external:10',
+                new IdentifierField()
+            ),
+            'external:10',
+        ];
+
+        yield 'section identifier' => [
+            new Field(
+                'section_identifier',
+                'my_section',
+                new IdentifierField()
+            ),
+            'my_section',
+        ];
+
+        yield 'path string' => [
+            new Field(
+                'path_string',
+                '/1/2/54/',
+                new IdentifierField()
+            ),
+            '/1/2/54/',
+        ];
+
+        yield 'identifier with national characters' => [
+            new Field(
+                'some_identifier',
+                'zażółć gęślą jaźń',
+                new IdentifierField()
+            ),
+            'zażółć gęślą jaźń',
+        ];
+
+        yield 'identifier with non-printable characters' => [
+            new Field(
+                'identifier',
+                utf8_decode("Non\x09Printable\x0EIdentifier"),
+                new IdentifierField()
+            ),
+            'Non PrintableIdentifier',
+        ];
+
+        $value = 'Emoji: ' . json_decode('"\ud83d\ude00"');
+        yield 'identifier with emojis' => [
+            new Field(
+                'identifier',
+                $value,
+                new IdentifierField()
+            ),
+            $value,
+        ];
+    }
+}

--- a/eZ/Publish/Core/settings/search_engines/field_value_mappers.yml
+++ b/eZ/Publish/Core/settings/search_engines/field_value_mappers.yml
@@ -78,3 +78,11 @@ services:
         class: "%ezpublish.search.common.field_value_mapper.string.class%"
         tags:
             - {name: ezpublish.search.common.field_value_mapper}
+
+    eZ\Publish\Core\Search\Common\FieldValueMapper\RemoteIdentifierMapper:
+        tags:
+            - {name: ezpublish.search.common.field_value_mapper}
+
+    eZ\Publish\Core\Search\Common\FieldValueMapper\MultipleRemoteIdentifierMapper:
+        tags:
+            - {name: ezpublish.search.common.field_value_mapper}

--- a/eZ/Publish/SPI/Search/FieldType/MultipleRemoteIdentifierField.php
+++ b/eZ/Publish/SPI/Search/FieldType/MultipleRemoteIdentifierField.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\Search\FieldType;
+
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Remote ID list document field.
+ */
+class MultipleRemoteIdentifierField extends FieldType
+{
+    /**
+     * Search engine field type corresponding to remote ID list. The same MultipleIdentifierField due to BC.
+     *
+     * @see \eZ\Publish\SPI\Search\FieldType\MultipleIdentifierField
+     *
+     * @var string
+     */
+    protected $type = 'ez_mid';
+}

--- a/eZ/Publish/SPI/Search/FieldType/RemoteIdentifierField.php
+++ b/eZ/Publish/SPI/Search/FieldType/RemoteIdentifierField.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\Search\FieldType;
+
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Remote ID document field.
+ */
+final class RemoteIdentifierField extends FieldType
+{
+    /**
+     * Search engine field type corresponding to remote ID. The same as IdentifierField due to BC.
+     *
+     * @see \eZ\Publish\SPI\Search\FieldType\IdentifierField
+     *
+     * @var string
+     */
+    protected $type = 'ez_id';
+}

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -22,6 +22,7 @@
             <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
             <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
             <directory>eZ/Publish/API/Repository/Tests/Limitation</directory>
+            <directory>eZ/Publish/API/Repository/Tests/SearchService</directory>
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/PermissionResolverTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-25484](https://jira.ez.no/browse/EZP-25484)
| **Requires** | ezsystems/ezplatform-solr-search-engine#184
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | eZ Platform `v2.5.x LTS`, `v3.x`
| **BC breaks**      | no
| **Tests pass** | [yes](https://travis-ci.org/github/ezsystems/ezpublish-kernel/builds/689339845)
| **Doc needed**     | yes

### TL;DR;

Since eZ Platform Content Model allows anything as a remote ID as long as it's unique, input cleanup when indexing those fields needs to be relaxed a bit by introducing dedicated strategy to index remote identifiers (see 92fc1931a6).

### Summary

Remote IDs are indexed by noSQL search engines (like Solr) as Identifiers. However those Identifiers have too strict validation rules (`A-Za-z0-9/`), while Content/Location APIs allow anything to be indexed.
Semantically they're still Identifiers, thus need to be distinguished from strings, but can use `StringMapper` internally, which this PR implements. Non-printables and control sequences are still not allowed as this is known to crash Solr.

The simpler, initial, fix included relaxing Identifier regex to allow `[ -~]`, but since we changed requirement to accept all characters, it seemed too risky. Identifiers are used by various other search fields, like numeric IDs[1], path string, Version status, Version number, Section identifier, and Solr Document ID, so it's better it has some strict cleanup rules.

[1] Which causes sorting headache, see [EZP-31325](https://jira.ez.no/browse/EZP-31325).

### Follow-up

As a follow-up we should introduce (in 3.x) to Solr schema `remote_identifier` field mapped to string.

### Doc

It should be documented [here](https://doc.ezplatform.com/en/latest/guide/content_model/#content-information) that Content & Location remote ID allows any characters except non-printable ones and control sequences.

### TODO
- [x] **Remove TMP commit and rebase**.
- [x] Fix a bug.
- [x] Update this description.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
