### PR TITLE
EZP-31460: Added filtering by status to loadContentTypes API

### DIFF
--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -41,8 +41,8 @@ composer config -g github-oauth.github.com "d0285ed5c8644f30547572ead2ed897431c1
 if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then
     # Install openJDK8 as default v11 is too new for SOLR
     sudo apt-get install openjdk-8-jdk
-    echo "> Require ezsystems/ezplatform-solr-search-engine:^1.3.0@dev"
-    composer require --no-update ezsystems/ezplatform-solr-search-engine:^1.3.0@dev
+    echo "> Require ezsystems/ezplatform-solr-search-engine:^1.7.4@dev"
+    composer require --no-update ezsystems/ezplatform-solr-search-engine:^1.7.4@dev
 fi
 
 # Switch to another Symfony version if asked for

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/DecoratedFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/DecoratedFragmentRenderer.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Fragment;
 
+use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\HttpFoundation\Request;
@@ -17,6 +18,8 @@ use Symfony\Component\HttpKernel\Fragment\RoutableFragmentRenderer;
 
 class DecoratedFragmentRenderer implements FragmentRendererInterface, SiteAccessAware
 {
+    use SerializerTrait;
+
     /**
      * @var \Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface
      */
@@ -67,7 +70,12 @@ class DecoratedFragmentRenderer implements FragmentRendererInterface, SiteAccess
         if ($uri instanceof ControllerReference && $request->attributes->has('siteaccess')) {
             // Serialize the siteaccess to get it back after.
             // @see eZ\Publish\Core\MVC\Symfony\EventListener\SiteAccessMatchListener
-            $uri->attributes['serialized_siteaccess'] = serialize($request->attributes->get('siteaccess'));
+            $siteAccess = $request->attributes->get('siteaccess');
+            $uri->attributes['serialized_siteaccess'] = json_encode($siteAccess);
+            $uri->attributes['serialized_siteaccess_matcher'] = $this->getSerializer()->serialize(
+                $siteAccess->matcher,
+                'json'
+            );
         }
 
         return $this->innerRenderer->render($uri, $request, $options);

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/DecoratedFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/DecoratedFragmentRenderer.php
@@ -8,7 +8,6 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Fragment;
 
-use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,7 +17,7 @@ use Symfony\Component\HttpKernel\Fragment\RoutableFragmentRenderer;
 
 class DecoratedFragmentRenderer implements FragmentRendererInterface, SiteAccessAware
 {
-    use SerializerTrait;
+    use SiteAccessSerializationTrait;
 
     /**
      * @var \Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface
@@ -71,11 +70,7 @@ class DecoratedFragmentRenderer implements FragmentRendererInterface, SiteAccess
             // Serialize the siteaccess to get it back after.
             // @see eZ\Publish\Core\MVC\Symfony\EventListener\SiteAccessMatchListener
             $siteAccess = $request->attributes->get('siteaccess');
-            $uri->attributes['serialized_siteaccess'] = json_encode($siteAccess);
-            $uri->attributes['serialized_siteaccess_matcher'] = $this->getSerializer()->serialize(
-                $siteAccess->matcher,
-                'json'
-            );
+            $this->serializeSiteAccess($siteAccess, $uri);
         }
 
         return $this->innerRenderer->render($uri, $request, $options);

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Fragment;
 
+use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,6 +19,8 @@ use Symfony\Component\HttpKernel\Fragment\RoutableFragmentRenderer;
 
 class InlineFragmentRenderer extends BaseRenderer implements SiteAccessAware
 {
+    use SerializerTrait;
+
     /**
      * @var \Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface
      */
@@ -49,7 +52,13 @@ class InlineFragmentRenderer extends BaseRenderer implements SiteAccessAware
     {
         if ($uri instanceof ControllerReference) {
             if ($request->attributes->has('siteaccess')) {
-                $uri->attributes['serialized_siteaccess'] = serialize($request->attributes->get('siteaccess'));
+                /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteAccess */
+                $siteAccess = $request->attributes->get('siteaccess');
+                $uri->attributes['serialized_siteaccess'] = json_encode($siteAccess);
+                $uri->attributes['serialized_siteaccess_matcher'] = $this->getSerializer()->serialize(
+                    $siteAccess->matcher,
+                    'json'
+                );
             }
             if ($request->attributes->has('semanticPathinfo')) {
                 $uri->attributes['semanticPathinfo'] = $request->attributes->get('semanticPathinfo');

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
@@ -8,7 +8,6 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Fragment;
 
-use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,7 +18,7 @@ use Symfony\Component\HttpKernel\Fragment\RoutableFragmentRenderer;
 
 class InlineFragmentRenderer extends BaseRenderer implements SiteAccessAware
 {
-    use SerializerTrait;
+    use SiteAccessSerializationTrait;
 
     /**
      * @var \Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface
@@ -54,11 +53,7 @@ class InlineFragmentRenderer extends BaseRenderer implements SiteAccessAware
             if ($request->attributes->has('siteaccess')) {
                 /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteAccess */
                 $siteAccess = $request->attributes->get('siteaccess');
-                $uri->attributes['serialized_siteaccess'] = json_encode($siteAccess);
-                $uri->attributes['serialized_siteaccess_matcher'] = $this->getSerializer()->serialize(
-                    $siteAccess->matcher,
-                    'json'
-                );
+                $this->serializeSiteAccess($siteAccess, $uri);
             }
             if ($request->attributes->has('semanticPathinfo')) {
                 $uri->attributes['semanticPathinfo'] = $request->attributes->get('semanticPathinfo');

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/SiteAccessSerializationTrait.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/SiteAccessSerializationTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Fragment;
+
+use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+trait SiteAccessSerializationTrait
+{
+    use SerializerTrait;
+
+    public function serializeSiteAccess(SiteAccess $siteAccess, ControllerReference $uri)
+    {
+        // Serialize the siteaccess to get it back after. @see eZ\Publish\Core\MVC\Symfony\EventListener\SiteAccessMatchListener
+        $uri->attributes['serialized_siteaccess'] = json_encode($siteAccess);
+        $uri->attributes['serialized_siteaccess_matcher'] = $this->getSerializer()->serialize(
+            $siteAccess->matcher,
+            'json'
+        );
+        if ($siteAccess->matcher instanceof SiteAccess\Matcher\CompoundInterface) {
+            $subMatchers = $siteAccess->matcher->getSubMatchers();
+            foreach ($subMatchers as $subMatcher) {
+                $uri->attributes['serialized_siteaccess_sub_matchers'][get_class($subMatcher)] = $this->getSerializer()->serialize(
+                    $subMatcher,
+                    'json'
+                );
+            }
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -207,7 +207,12 @@
 {% block ezbinaryfile_field %}
 {% apply spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
-        {% set route_reference = ez_route( 'ez_content_download', { 'content': content, 'fieldIdentifier': field.fieldDefIdentifier } ) %}
+        {% set route_reference = ez_route( 'ez_content_download', {
+            'content': content,
+            'fieldIdentifier': field.fieldDefIdentifier,
+            'inLanguage': content.prioritizedFieldLanguageCode,
+            'version': versionInfo.versionNo
+        } ) %}
         <a href="{{ path( route_reference ) }}"
             {{ block( 'field_attributes' ) }}>{{ field.value.fileName }}</a>&nbsp;({{ field.value.fileSize|ez_file_size( 1 ) }})
     {% endif %}
@@ -219,7 +224,11 @@
 {% apply spaceless %}
     {% set type = fieldSettings.mediaType %}
     {% set value = field.value %}
-    {% set route_reference = ez_route( 'ez_content_download', {'content': content, 'fieldIdentifier': field.fieldDefIdentifier} ) %}
+    {% set route_reference = ez_route( 'ez_content_download', {
+        'content': content,
+        'fieldIdentifier': field.fieldDefIdentifier,
+        'version': versionInfo.versionNo
+    } ) %}
     {% set download = path( route_reference ) %}
     {% set width = value.width > 0 ? 'width="' ~ value.width ~ '"' : "" %}
     {% set height = value.height > 0 ? 'height="' ~ value.height ~ '"' : "" %}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/DecoratedFragmentRendererTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/DecoratedFragmentRendererTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;
 
 use eZ\Bundle\EzPublishCoreBundle\Fragment\DecoratedFragmentRenderer;
+use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -16,6 +17,8 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 class DecoratedFragmentRendererTest extends TestCase
 {
+    use SerializerTrait;
+
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -91,7 +94,12 @@ class DecoratedFragmentRendererTest extends TestCase
     public function testRendererControllerReference()
     {
         $reference = new ControllerReference('FooBundle:bar:baz');
-        $siteAccess = new SiteAccess('test', 'test');
+        $matcher = new SiteAccess\Matcher\URIElement(1);
+        $siteAccess = new SiteAccess(
+            'test',
+            'test',
+            $matcher
+        );
         $request = new Request();
         $request->attributes->set('siteaccess', $siteAccess);
         $options = ['foo' => 'bar'];
@@ -105,6 +113,15 @@ class DecoratedFragmentRendererTest extends TestCase
         $renderer = new DecoratedFragmentRenderer($this->innerRenderer);
         $this->assertSame($expectedReturn, $renderer->render($reference, $request, $options));
         $this->assertTrue(isset($reference->attributes['serialized_siteaccess']));
-        $this->assertSame(serialize($siteAccess), $reference->attributes['serialized_siteaccess']);
+        $serializedSiteAccess = json_encode($siteAccess);
+        $this->assertSame($serializedSiteAccess, $reference->attributes['serialized_siteaccess']);
+        $this->assertTrue(isset($reference->attributes['serialized_siteaccess_matcher']));
+        $this->assertSame(
+            $this->getSerializer()->serialize(
+                $siteAccess->matcher,
+                'json'
+            ),
+            $reference->attributes['serialized_siteaccess_matcher']
+        );
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/DecoratedFragmentRendererTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/DecoratedFragmentRendererTest.php
@@ -9,16 +9,12 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;
 
 use eZ\Bundle\EzPublishCoreBundle\Fragment\DecoratedFragmentRenderer;
-use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
-class DecoratedFragmentRendererTest extends TestCase
+class DecoratedFragmentRendererTest extends FragmentRendererBaseTest
 {
-    use SerializerTrait;
-
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -123,5 +119,18 @@ class DecoratedFragmentRendererTest extends TestCase
             ),
             $reference->attributes['serialized_siteaccess_matcher']
         );
+    }
+
+    public function getRequest(SiteAccess $siteAccess)
+    {
+        $request = new Request();
+        $request->attributes->set('siteaccess', $siteAccess);
+
+        return $request;
+    }
+
+    public function getRenderer()
+    {
+        return new DecoratedFragmentRenderer($this->innerRenderer);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/FragmentRendererBaseTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/FragmentRendererBaseTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;
+
+use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+abstract class FragmentRendererBaseTest extends TestCase
+{
+    use SerializerTrait;
+
+    public function testRendererControllerReferenceWithCompoundMatcher()
+    {
+        $reference = new ControllerReference('FooBundle:bar:baz');
+        $compoundMatcher = new SiteAccess\Matcher\Compound\LogicalAnd([]);
+        $subMatchers = [
+            'Map\URI' => new SiteAccess\Matcher\Map\URI([]),
+            'Map\Host' => new SiteAccess\Matcher\Map\Host([]),
+        ];
+        $compoundMatcher->setSubMatchers($subMatchers);
+        $siteAccess = new SiteAccess(
+            'test',
+            'test',
+            $compoundMatcher
+        );
+
+        $request = $this->getRequest($siteAccess);
+        $options = ['foo' => 'bar'];
+        $expectedReturn = '/_fragment?foo=bar';
+        $this->innerRenderer
+            ->expects($this->once())
+            ->method('render')
+            ->with($reference, $request, $options)
+            ->will($this->returnValue($expectedReturn));
+
+        $renderer = $this->getRenderer();
+        $this->assertSame($expectedReturn, $renderer->render($reference, $request, $options));
+        $this->assertArrayHasKey('serialized_siteaccess', $reference->attributes);
+        $serializedSiteAccess = json_encode($siteAccess);
+        $this->assertSame($serializedSiteAccess, $reference->attributes['serialized_siteaccess']);
+        $this->assertArrayHasKey('serialized_siteaccess_matcher', $reference->attributes);
+        $this->assertSame(
+            $this->getSerializer()->serialize(
+                $siteAccess->matcher,
+                'json'
+            ),
+            $reference->attributes['serialized_siteaccess_matcher']
+        );
+        $this->assertArrayHasKey('serialized_siteaccess_sub_matchers', $reference->attributes);
+        foreach ($siteAccess->matcher->getSubMatchers() as $subMatcher) {
+            $this->assertSame(
+                $this->getSerializer()->serialize(
+                    $subMatcher,
+                    'json'
+                ),
+                $reference->attributes['serialized_siteaccess_sub_matchers'][get_class($subMatcher)]
+            );
+        }
+
+        return $reference;
+    }
+
+    abstract public function getRequest(SiteAccess $siteAccess);
+
+    abstract public function getRenderer();
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/InlineFragmentRendererTest.php
@@ -7,15 +7,12 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;
 
 use eZ\Bundle\EzPublishCoreBundle\Fragment\InlineFragmentRenderer;
-use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 class InlineFragmentRendererTest extends DecoratedFragmentRendererTest
 {
-    use SerializerTrait;
-
     public function testRendererControllerReference()
     {
         $reference = new ControllerReference('FooBundle:bar:baz');
@@ -54,5 +51,32 @@ class InlineFragmentRendererTest extends DecoratedFragmentRendererTest
         $this->assertSame('/foo/bar', $reference->attributes['semanticPathinfo']);
         $this->assertTrue(isset($reference->attributes['viewParametersString']));
         $this->assertSame('/(foo)/bar', $reference->attributes['viewParametersString']);
+    }
+
+    public function testRendererControllerReferenceWithCompoundMatcher()
+    {
+        $reference = parent::testRendererControllerReferenceWithCompoundMatcher();
+
+        $this->assertArrayHasKey('semanticPathinfo', $reference->attributes);
+        $this->assertSame('/foo/bar', $reference->attributes['semanticPathinfo']);
+        $this->assertArrayHasKey('viewParametersString', $reference->attributes);
+        $this->assertSame('/(foo)/bar', $reference->attributes['viewParametersString']);
+
+        return $reference;
+    }
+
+    public function getRequest(SiteAccess $siteAccess)
+    {
+        $request = new Request();
+        $request->attributes->set('siteaccess', $siteAccess);
+        $request->attributes->set('semanticPathinfo', '/foo/bar');
+        $request->attributes->set('viewParametersString', '/(foo)/bar');
+
+        return $request;
+    }
+
+    public function getRenderer()
+    {
+        return new InlineFragmentRenderer($this->innerRenderer);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/InlineFragmentRendererTest.php
@@ -1,11 +1,10 @@
 <?php
 
 /**
- * File containing the InlineFragmentRendererTest class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;
 
 use eZ\Bundle\EzPublishCoreBundle\Fragment\InlineFragmentRenderer;
@@ -21,7 +20,7 @@ class InlineFragmentRendererTest extends DecoratedFragmentRendererTest
     public function testRendererControllerReference()
     {
         $reference = new ControllerReference('FooBundle:bar:baz');
-        $matcher = new SiteAccess\Matcher\HostElement( 1);
+        $matcher = new SiteAccess\Matcher\HostElement(1);
         $siteAccess = new SiteAccess(
             'test',
             'test',

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/InlineFragmentRendererTest.php
@@ -4,7 +4,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;
 
 use eZ\Bundle\EzPublishCoreBundle\Fragment\InlineFragmentRenderer;

--- a/eZ/Publish/API/Repository/ContentTypeService.php
+++ b/eZ/Publish/API/Repository/ContentTypeService.php
@@ -181,9 +181,13 @@ interface ContentTypeService
      * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      * @param int $status One of the available statuses {@link ContentType}
      *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType[] an array of {@link ContentType} which have status DEFINED
+     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType[] an array of {@link ContentType}
      */
-    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [], int $status = ContentType::STATUS_DEFINED);
+    public function loadContentTypes(
+        ContentTypeGroup $contentTypeGroup,
+        array $prioritizedLanguages = [],
+        int $status = ContentType::STATUS_DEFINED
+    ): array;
 
     /**
      * Creates a draft from an existing content type.

--- a/eZ/Publish/API/Repository/ContentTypeService.php
+++ b/eZ/Publish/API/Repository/ContentTypeService.php
@@ -179,10 +179,11 @@ interface ContentTypeService
      *
      * @param \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup $contentTypeGroup
      * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
+     * @param int $status One of the available statuses {@link ContentType}
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType[] an array of {@link ContentType} which have status DEFINED
      */
-    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = []);
+    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [], int $status = ContentType::STATUS_DEFINED);
 
     /**
      * Creates a draft from an existing content type.

--- a/eZ/Publish/API/Repository/Tests/SearchService/DeleteTranslationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/DeleteTranslationTest.php
@@ -8,11 +8,14 @@ declare(strict_types=1);
 
 namespace eZ\Publish\API\Repository\Tests\SearchService;
 
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Tests\BaseTest;
 use eZ\Publish\API\Repository\Tests\SetupFactory\LegacyElasticsearch;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation;
+use eZ\Publish\API\Repository\Values\User\User;
 
 /**
  * Test case for delete content translation with the SearchService.
@@ -85,5 +88,73 @@ final class DeleteTranslationTest extends BaseTest
         // check if unrelated items were not affected
         $searchResult = $this->findContent('OtherGerContent', 'ger-DE');
         $this->assertEquals(1, $searchResult->totalCount, 'Unrelated translation was deleted');
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testDeleteContentTranslationWithContentRemovePolicy(): void
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $testContent = $this->createFolder(['eng-GB' => 'Contact', 'ger-DE' => 'Kontakt'], 2);
+        $this->refreshSearch($repository);
+
+        $user = $this->provideUserWithContentRemovePolicies();
+        $repository->getPermissionResolver()->setCurrentUserReference($user);
+
+        $searchResult = $this->findContent('Kontakt', 'ger-DE');
+
+        $this->assertEquals(1, $searchResult->totalCount);
+        $contentService->deleteTranslation($testContent->contentInfo, 'ger-DE');
+
+        $this->refreshSearch($repository);
+        $searchResult = $this->findContent('Kontakt', 'ger-DE');
+        $this->assertEquals(0, $searchResult->totalCount);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testPreventTranslationDeletionIfNoAccess(): void
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $testContent = $this->createFolder(
+            [
+                'eng-GB' => 'Contact',
+                'ger-DE' => 'Kontakt',
+                'eng-US' => 'Contact',
+            ],
+            2);
+
+        $user = $this->provideUserWithContentRemovePolicies();
+        $repository->getPermissionResolver()->setCurrentUserReference($user);
+
+        $this->expectException(UnauthorizedException::class);
+
+        $contentService->deleteTranslation($testContent->contentInfo, 'eng-US');
+    }
+
+    public function provideUserWithContentRemovePolicies(): User
+    {
+        $limitations = [
+            new LanguageLimitation(['limitationValues' => ['ger-DE']]),
+        ];
+
+        return $this->createUserWithPolicies(
+            'test',
+            [
+                ['module' => 'content', 'function' => 'remove', 'limitations' => $limitations],
+                ['module' => 'content', 'function' => 'versionread'],
+                ['module' => 'content', 'function' => 'read'],
+            ]
+        );
     }
 }

--- a/eZ/Publish/API/Repository/Tests/SearchService/RemoteIdIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/RemoteIdIndexingTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\SearchService;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+final class RemoteIdIndexingTest extends BaseTest
+{
+    /** @var int[] */
+    private static $contentIdByRemoteIdIndex = [];
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (empty(self::$contentIdByRemoteIdIndex)) {
+            foreach ($this->getRemoteIDs() as $remoteId) {
+                self::$contentIdByRemoteIdIndex[$remoteId] = $this->createTestFolder(
+                    $remoteId
+                );
+            }
+
+            $this->refreshSearch($this->getRepository(false));
+        }
+    }
+
+    /**
+     * @dataProvider providerForTestIndexingRemoteId
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     */
+    public function testIndexingRemoteId(Criterion $criterion): void
+    {
+        $repository = $this->getRepository(false);
+        $searchService = $repository->getSearchService();
+
+        $remoteId = $criterion->value[0];
+        if (!isset(self::$contentIdByRemoteIdIndex[$remoteId])) {
+            self::fail("Failed to find Content ID for remote ID = {$criterion->value}");
+        }
+
+        $contentId = self::$contentIdByRemoteIdIndex[$remoteId];
+
+        // test searching using both Content & Location remote IDs for both Content items
+        $query = new Query();
+        $query->filter = $criterion;
+        $result = $searchService->findContent($query);
+        self::assertSame(
+            1,
+            $result->totalCount,
+            "Failed to find Content ID = {$contentId} filtering by remote ID = '{$remoteId}'"
+        );
+        self::assertSame($contentId, $result->searchHits[0]->valueObject->id);
+
+        $query = new LocationQuery();
+        $query->filter = $criterion;
+        $result = $searchService->findLocations($query);
+        self::assertSame(
+            1,
+            $result->totalCount,
+            "Failed to find Location for Content ID = {$contentId} filtering by remote ID = '{$remoteId}'"
+        );
+        self::assertSame($contentId, $result->searchHits[0]->valueObject->contentInfo->id);
+    }
+
+    private function getRemoteIDs(): array
+    {
+        return [
+            'md5sum' => 'dec23f2de27399a4c0561187b805aa74',
+            'sha512' => '3ad11d1424370b5a258f7dc7724b25535f3fb2e1fa3f7047839f68d18cf58eb5',
+            'external:10' => 'external:10',
+            'external_10' => 'external_10',
+            'with space' => 'with space',
+            'with national characters' => 'zażółć gęślą jaźń',
+            'with emoji' => json_decode('"\ud83d\ude00"'),
+        ];
+    }
+
+    /**
+     * Create 2 * number of remote IDs test data sets (one for Content, another for Location).
+     *
+     * @return iterable
+     */
+    public function providerForTestIndexingRemoteId(): iterable
+    {
+        foreach ($this->getRemoteIDs() as $description => $remoteId) {
+            yield "Content remote ID = {$description}" => [new Criterion\RemoteId($remoteId)];
+            yield "Location remote ID = {$description}" => [new Criterion\LocationRemoteId($remoteId)];
+        }
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    private function createTestFolder(string $remoteId): int
+    {
+        $repository = $this->getRepository(false);
+        $contentTypeService = $repository->getContentTypeService();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+
+        $folderType = $contentTypeService->loadContentTypeByIdentifier('folder');
+        $folderCreateStruct = $contentService->newContentCreateStruct($folderType, 'eng-GB');
+        $folderCreateStruct->remoteId = $remoteId;
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+        $locationCreateStruct->remoteId = $remoteId;
+        $folder = $contentService->publishVersion(
+            $contentService->createContent(
+                $folderCreateStruct,
+                [$locationCreateStruct]
+            )->getVersionInfo()
+        );
+
+        return $folder->id;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
@@ -18,7 +18,7 @@ trait SerializerTrait
     public function getSerializer()
     {
         return new Serializer(
-            [(new PropertyNormalizer())->setIgnoredAttributes(['request'])],
+            [(new PropertyNormalizer())->setIgnoredAttributes(['request', 'container', 'matcherBuilder'])],
             [new JsonEncoder()]
         );
     }

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Component\Serializer;
+
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+trait SerializerTrait
+{
+    /**
+     * @return \Symfony\Component\Serializer\SerializerInterface
+     */
+    public function getSerializer()
+    {
+        return new Serializer(
+            [(new PropertyNormalizer())->setIgnoredAttributes(['request'])],
+            [new JsonEncoder()]
+        );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -95,6 +95,13 @@ class SiteAccessMatchListener implements EventSubscriberInterface
                         )
                     );
                 }
+                if ($request->attributes->get('serialized_siteaccess_sub_matchers')) {
+                    $subMatchers = [];
+                    foreach ($request->attributes->get('serialized_siteaccess_sub_matchers') as $matcherClass => $serializedData) {
+                        $subMatchers[$matcherClass] = $serializer->deserialize($serializedData, $matcherClass, 'json');
+                    }
+                    $siteAccess->matcher->setSubMatchers($subMatchers);
+                }
             }
 
             $request->attributes->set(

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
@@ -134,6 +134,66 @@ class SiteAccessMatchListenerTest extends TestCase
         $this->assertFalse($request->attributes->has('serialized_siteaccess'));
     }
 
+    public function testOnKernelRequestSerializedSAWithCompoundMatcher()
+    {
+        $compoundMatcher = new SiteAccess\Matcher\Compound\LogicalAnd([]);
+        $subMatchers = [
+            SiteAccess\Matcher\Map\URI::class => new SiteAccess\Matcher\Map\URI([]),
+            SiteAccess\Matcher\Map\Host::class => new SiteAccess\Matcher\Map\Host([]),
+        ];
+        $compoundMatcher->setSubMatchers($subMatchers);
+        $siteAccess = new SiteAccess(
+            'test',
+            'matching_type',
+            $compoundMatcher
+        );
+        $request = new Request();
+        $request->attributes->set('serialized_siteaccess', json_encode($siteAccess));
+        $request->attributes->set(
+            'serialized_siteaccess_matcher',
+            $this->getSerializer()->serialize(
+                $siteAccess->matcher,
+                'json'
+            )
+        );
+        $serializedSubMatchers = [];
+        foreach ($subMatchers as $subMatcher) {
+            $serializedSubMatchers[get_class($subMatcher)] = $this->getSerializer()->serialize(
+                $subMatcher,
+                'json'
+            );
+        }
+        $request->attributes->set(
+            'serialized_siteaccess_sub_matchers',
+            $serializedSubMatchers
+        );
+        $event = new GetResponseEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST
+        );
+
+        $this->userHashMatcher
+            ->expects($this->once())
+            ->method('matches')
+            ->with($request)
+            ->will($this->returnValue(false));
+
+        $this->saRouter
+            ->expects($this->never())
+            ->method('match');
+
+        $postSAMatchEvent = new PostSiteAccessMatchEvent($siteAccess, $request, $event->getRequestType());
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(MVCEvents::SITEACCESS, $this->equalTo($postSAMatchEvent));
+
+        $this->listener->onKernelRequest($event);
+        $this->assertEquals($siteAccess, $request->attributes->get('siteaccess'));
+        $this->assertFalse($request->attributes->has('serialized_siteaccess'));
+    }
+
     public function testOnKernelRequestSiteAccessPresent()
     {
         $siteAccess = new SiteAccess();

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\EventListener\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
 use eZ\Publish\Core\MVC\Symfony\EventListener\SiteAccessMatchListener;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
@@ -24,6 +25,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class SiteAccessMatchListenerTest extends TestCase
 {
+    use SerializerTrait;
+
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -89,9 +92,21 @@ class SiteAccessMatchListenerTest extends TestCase
 
     public function testOnKernelRequestSerializedSA()
     {
-        $siteAccess = new SiteAccess();
+        $matcher = new SiteAccess\Matcher\URIElement(1);
+        $siteAccess = new SiteAccess(
+            'test',
+            'matching_type',
+            $matcher
+        );
         $request = new Request();
-        $request->attributes->set('serialized_siteaccess', serialize($siteAccess));
+        $request->attributes->set('serialized_siteaccess', json_encode($siteAccess));
+        $request->attributes->set(
+            'serialized_siteaccess_matcher',
+            $this->getSerializer()->serialize(
+                $siteAccess->matcher,
+                'json'
+            )
+        );
         $event = new GetResponseEvent(
             $this->createMock(HttpKernelInterface::class),
             $request,

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/BinaryBase/ContentDownloadUrlGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/BinaryBase/ContentDownloadUrlGenerator.php
@@ -28,6 +28,7 @@ class ContentDownloadUrlGenerator extends PathGenerator
             [
                 'contentId' => $versionInfo->contentInfo->id,
                 'fieldId' => $field->id,
+                'version' => $versionInfo->versionNo,
             ]
         );
     }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
@@ -9,11 +9,12 @@
 namespace eZ\Publish\Core\MVC\Symfony;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
+use JsonSerializable;
 
 /**
  * Base struct for a siteaccess representation.
  */
-class SiteAccess extends ValueObject
+class SiteAccess extends ValueObject implements JsonSerializable
 {
     /**
      * Name of the siteaccess.
@@ -47,5 +48,16 @@ class SiteAccess extends ValueObject
     public function __toString()
     {
         return "$this->name (matched by '$this->matchingType')";
+    }
+
+    public function jsonSerialize()
+    {
+        $matcher = is_object($this->matcher) ? get_class($this->matcher) : null;
+
+        return [
+            'name' => $this->name,
+            'matchingType' => $this->matchingType,
+            'matcher' => $matcher
+        ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
@@ -4,7 +4,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace eZ\Publish\Core\MVC\Symfony;
 
 use eZ\Publish\API\Repository\Values\ValueObject;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
@@ -1,11 +1,10 @@
 <?php
 
 /**
- * File containing the SiteAccess class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace eZ\Publish\Core\MVC\Symfony;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -57,7 +56,7 @@ class SiteAccess extends ValueObject implements JsonSerializable
         return [
             'name' => $this->name,
             'matchingType' => $this->matchingType,
-            'matcher' => $matcher
+            'matcher' => $matcher,
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/HostText.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/HostText.php
@@ -18,6 +18,13 @@ class HostText extends Regex implements VersatileMatcher
     private $suffix;
 
     /**
+     * The property needed to allow correct deserialization with Symfony serializer.
+     *
+     * @var array
+     */
+    private $siteAccessesConfiguration;
+
+    /**
      * Constructor.
      *
      * @param array $siteAccessesConfiguration SiteAccesses configuration.
@@ -30,6 +37,7 @@ class HostText extends Regex implements VersatileMatcher
             '^' . preg_quote($this->prefix, '@') . "(\w+)" . preg_quote($this->suffix, '@') . '$',
             1
         );
+        $this->siteAccessesConfiguration = $siteAccessesConfiguration;
     }
 
     public function getName()

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex/Host.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex/Host.php
@@ -18,6 +18,13 @@ use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 class Host extends Regex implements Matcher
 {
     /**
+     * The property needed to allow correct deserialization with Symfony serializer.
+     *
+     * @var array
+     */
+    private $siteAccessesConfiguration;
+
+    /**
      * Constructor.
      *
      * @param array $siteAccessesConfiguration SiteAccesses configuration.
@@ -28,6 +35,7 @@ class Host extends Regex implements Matcher
             isset($siteAccessesConfiguration['regex']) ? $siteAccessesConfiguration['regex'] : '',
             isset($siteAccessesConfiguration['itemNumber']) ? (int)$siteAccessesConfiguration['itemNumber'] : 1
         );
+        $this->siteAccessesConfiguration = $siteAccessesConfiguration;
     }
 
     public function getName()

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex/URI.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex/URI.php
@@ -18,6 +18,13 @@ use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 class URI extends Regex implements Matcher
 {
     /**
+     * The property needed to allow correct deserialization with Symfony serializer.
+     *
+     * @var array
+     */
+    private $siteAccessesConfiguration;
+
+    /**
      * Constructor.
      *
      * @param array $siteAccessesConfiguration SiteAccesses configuration.
@@ -28,6 +35,7 @@ class URI extends Regex implements Matcher
             isset($siteAccessesConfiguration['regex']) ? $siteAccessesConfiguration['regex'] : '',
             isset($siteAccessesConfiguration['itemNumber']) ? (int)$siteAccessesConfiguration['itemNumber'] : 1
         );
+        $this->siteAccessesConfiguration = $siteAccessesConfiguration;
     }
 
     public function getName()

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIText.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIText.php
@@ -25,6 +25,13 @@ class URIText extends Regex implements VersatileMatcher, URILexer
     private $suffix;
 
     /**
+     * The property needed to allow correct deserialization with Symfony serializer.
+     *
+     * @var array
+     */
+    private $siteAccessesConfiguration;
+
+    /**
      * Constructor.
      *
      * @param array $siteAccessesConfiguration SiteAccesses configuration.
@@ -38,6 +45,7 @@ class URIText extends Regex implements VersatileMatcher, URILexer
             '^(/' . preg_quote($this->prefix, '@') . '(\w+)' . preg_quote($this->suffix, '@') . ')',
             2
         );
+        $this->siteAccessesConfiguration = $siteAccessesConfiguration;
     }
 
     public function getName()

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/MatcherSerializationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/MatcherSerializationTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
+
+use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;
+use PHPUnit\Framework\TestCase;
+
+class MatcherSerializationTest extends TestCase
+{
+    use SerializerTrait;
+
+    /**
+     * @dataProvider matcherProvider
+     */
+    public function testDeserialize(Matcher $matcher)
+    {
+        $serializedMatcher = $this->serializeMatcher($matcher);
+        $unserializedMatcher = $this->deserializeMatcher($serializedMatcher, get_class($matcher));
+
+        $this->assertEquals($matcher, $unserializedMatcher);
+    }
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher $matcher
+     *
+     * @return string
+     */
+    private function serializeMatcher(Matcher $matcher)
+    {
+        return $this->getSerializer()->serialize(
+            $matcher,
+            'json'
+        );
+    }
+
+    /**
+     * @param string $serializedMatcher
+     * @param string $matcherFQCN
+     *
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher|object
+     */
+    private function deserializeMatcher($serializedMatcher, $matcherFQCN)
+    {
+        return $this->getSerializer()->deserialize(
+            $serializedMatcher,
+            $matcherFQCN,
+            'json'
+        );
+    }
+
+    public function matcherProvider()
+    {
+        return [
+            'URIText' => [
+                new Matcher\URIText([
+                    'prefix' => 'foo',
+                    'suffix' => 'bar',
+                ]),
+            ],
+            'HostText' => [
+                new Matcher\HostText([
+                    'prefix' => 'foo',
+                    'suffix' => 'bar',
+                ]),
+            ],
+            'RegexHost' => [
+                new Matcher\Regex\Host([
+                    'regex' => 'foo',
+                    'itemNumber' => 2,
+                ]),
+            ],
+            'RegexURI' => [
+                new Matcher\Regex\URI([
+                    'regex' => 'foo',
+                    'itemNumber' => 2,
+                ]),
+            ],
+            'URIElement' => [
+                new Matcher\URIElement([
+                    'elementNumber' => 2,
+                ]),
+            ],
+            'HostElement' => [
+                new Matcher\HostElement([
+                    'elementNumber' => 2,
+                ]),
+            ],
+            'MapURI' => [
+                new Matcher\Map\URI([
+                    'map' => ['key' => 'value'],
+                ]),
+            ],
+            'MapPort' => [
+                new Matcher\Map\Port([
+                    'map' => ['key' => 'value'],
+                ]),
+            ],
+            'MapHost' => [
+                new Matcher\Map\Host([
+                    'map' => ['key' => 'value'],
+                ]),
+            ],
+            'CompoundAnd' => [
+                new Matcher\Compound\LogicalAnd(
+                    [
+                        [
+                            'matchers' => [
+                                'Map\URI' => [
+                                    'map' => ['key' => 'value'],
+                                ],
+                                'Map\Host' => [
+                                    'map' => ['key' => 'value'],
+                                ],
+                            ],
+                            'match' => 'site_access_name',
+                        ],
+                    ]
+                ),
+            ],
+            'CompoundOr' => [
+                new Matcher\Compound\LogicalOr(
+                    [
+                        [
+                            'matchers' => [
+                                'Map\URI' => [
+                                    'map' => ['key' => 'value'],
+                                ],
+                                'Map\Host' => [
+                                    'map' => ['key' => 'value'],
+                                ],
+                            ],
+                            'match' => 'site_access_name',
+                        ],
+                    ]
+                ),
+            ],
+        ];
+    }
+}

--- a/eZ/Publish/Core/REST/Client/ContentTypeService.php
+++ b/eZ/Publish/Core/REST/Client/ContentTypeService.php
@@ -589,8 +589,11 @@ class ContentTypeService implements APIContentTypeService, Sessionable
     /**
      * {@inheritdoc}
      */
-    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [], int $status = ContentType::STATUS_DEFINED)
-    {
+    public function loadContentTypes(
+        ContentTypeGroup $contentTypeGroup,
+        array $prioritizedLanguages = [],
+        int $status = ContentType::STATUS_DEFINED
+    ): array {
         $response = $this->client->request(
             'GET',
             $this->requestParser->generate(

--- a/eZ/Publish/Core/REST/Client/ContentTypeService.php
+++ b/eZ/Publish/Core/REST/Client/ContentTypeService.php
@@ -24,8 +24,7 @@ use eZ\Publish\Core\REST\Common\Exceptions\NotFoundException;
 use eZ\Publish\Core\REST\Common\RequestParser;
 use eZ\Publish\Core\REST\Common\Input\Dispatcher;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
-use eZ\Publish\Core\REST\Common\Message;
-use eZ\Publish\Core\REST\Client\Exceptions\InvalidArgumentValue;
+use eZ\Publish\Core\REST\Common\Message; use eZ\Publish\Core\REST\Client\Exceptions\InvalidArgumentValue;
 use eZ\Publish\Core\REST\Common\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\REST\Common\Exceptions\ForbiddenException;
 use eZ\Publish\Core\REST\Client\Exceptions\BadStateException;
@@ -114,7 +113,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $contentTypeGroupId,
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('Section')]
+                array('Accept' => $this->outputVisitor->getMediaType('Section'))
             )
         );
 
@@ -128,9 +127,9 @@ class ContentTypeService implements APIContentTypeService, Sessionable
     {
         $response = $this->client->request(
             'GET',
-            $this->requestParser->generate('typegroupByIdentifier', ['typegroup' => $contentTypeGroupIdentifier]),
+            $this->requestParser->generate('typegroupByIdentifier', array('typegroup' => $contentTypeGroupIdentifier)),
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupList')]
+                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupList'))
             )
         );
 
@@ -139,7 +138,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
                 'GET',
                 $response->headers['Location'],
                 new Message(
-                    ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroup')]
+                    array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroup'))
                 )
             );
         }
@@ -156,7 +155,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $this->requestParser->generate('typegroups'),
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupList')]
+                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupList'))
             )
         );
 
@@ -209,11 +208,11 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'DELETE',
             $contentTypeGroup->id,
             new Message(
-                // @todo: What media-type should we set here? Actually, it should be
-                // all expected exceptions + none? Or is "Section" correct,
-                // since this is what is to be expected by the resource
-                // identified by the URL?
-                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroup')]
+            // @todo: What media-type should we set here? Actually, it should be
+            // all expected exceptions + none? Or is "Section" correct,
+            // since this is what is to be expected by the resource
+            // identified by the URL?
+                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroup'))
             )
         );
 
@@ -301,7 +300,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
                 $this->requestParser->parse('type', $contentType->id)
             ),
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList')]
+                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList'))
             )
         );
 
@@ -310,7 +309,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
 
         return new RestContentType(
             $this,
-            [
+            array(
                 'id' => $contentType->id,
                 'remoteId' => $contentType->remoteId,
                 'identifier' => $contentType->identifier,
@@ -335,7 +334,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
                 // dynamic
                 //"fieldDefinitions" => $contentType->fieldDefinitions,
                 //"contentTypeGroups" => $contentType->contentTypeGroups,
-            ]
+            )
         );
     }
 
@@ -348,9 +347,9 @@ class ContentTypeService implements APIContentTypeService, Sessionable
      */
     protected function isErrorResponse(Message $response)
     {
-        return
+        return (
             strpos($response->headers['Content-Type'], 'application/vnd.ez.api.ErrorMessage') === 0
-        ;
+        );
     }
 
     /**
@@ -369,7 +368,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $contentTypeId,
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('ContentType')]
+                array('Accept' => $this->outputVisitor->getMediaType('ContentType'))
             )
         );
 
@@ -468,7 +467,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $contentTypeId,
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('ContentType')]
+                array('Accept' => $this->outputVisitor->getMediaType('ContentType'))
             )
         );
 
@@ -491,7 +490,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $fieldDefinitionId,
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('FieldDefinition')]
+                array('Accept' => $this->outputVisitor->getMediaType('FieldDefinition'))
             )
         );
 
@@ -514,7 +513,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $fieldDefinitionListReference,
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('FieldDefinitionList')]
+                array('Accept' => $this->outputVisitor->getMediaType('FieldDefinitionList'))
             )
         );
 
@@ -537,7 +536,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $contentTypeGroupListReference,
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList')]
+                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList'))
             )
         );
 
@@ -551,9 +550,9 @@ class ContentTypeService implements APIContentTypeService, Sessionable
     {
         $response = $this->client->request(
             'GET',
-            $this->requestParser->generate('typeByIdentifier', ['type' => $identifier]),
+            $this->requestParser->generate('typeByIdentifier', array('type' => $identifier)),
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeList')]
+                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeList'))
             )
         );
         $contentTypes = $this->inputDispatcher->parse($response);
@@ -568,9 +567,9 @@ class ContentTypeService implements APIContentTypeService, Sessionable
     {
         $response = $this->client->request(
             'GET',
-            $this->requestParser->generate('typeByRemoteId', ['type' => $remoteId]),
+            $this->requestParser->generate('typeByRemoteId', array('type' => $remoteId)),
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeList')]
+                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeList'))
             )
         );
         $contentTypes = $this->inputDispatcher->parse($response);
@@ -593,7 +592,8 @@ class ContentTypeService implements APIContentTypeService, Sessionable
         ContentTypeGroup $contentTypeGroup,
         array $prioritizedLanguages = [],
         int $status = ContentType::STATUS_DEFINED
-    ): array {
+    ): array
+    {
         $response = $this->client->request(
             'GET',
             $this->requestParser->generate(
@@ -601,10 +601,10 @@ class ContentTypeService implements APIContentTypeService, Sessionable
                 $this->requestParser->parse('typegroup', $contentTypeGroup->id)
             ),
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeList')]
+                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeList'))
             )
         );
-        $completedContentTypes = [];
+        $completedContentTypes = array();
         $contentTypes = $this->inputDispatcher->parse($response);
         foreach ($contentTypes as $contentType) {
             $completedContentTypes[] = $this->completeContentType($contentType);
@@ -686,7 +686,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'POST',
             $this->requestParser->generate('typeGroupAssign', $urlValues),
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList')]
+                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList'))
             )
         );
 
@@ -723,7 +723,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'DELETE',
             $this->requestParser->generate('groupOfType', $urlValues),
             new Message(
-                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList')]
+                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList'))
             )
         );
 
@@ -752,9 +752,9 @@ class ContentTypeService implements APIContentTypeService, Sessionable
         }
 
         return new ContentTypeGroupCreateStruct(
-            [
+            array(
                 'identifier' => $identifier,
-            ]
+            )
         );
     }
 
@@ -772,9 +772,9 @@ class ContentTypeService implements APIContentTypeService, Sessionable
         }
 
         return new ContentTypeCreateStruct(
-            [
+            array(
                 'identifier' => $identifier,
-            ]
+            )
         );
     }
 
@@ -817,10 +817,10 @@ class ContentTypeService implements APIContentTypeService, Sessionable
         }
 
         return new FieldDefinitionCreateStruct(
-            [
+            array(
                 'identifier' => $identifier,
                 'fieldTypeIdentifier' => $fieldTypeIdentifier,
-            ]
+            )
         );
     }
 
@@ -868,4 +868,6 @@ class ContentTypeService implements APIContentTypeService, Sessionable
     {
         throw new \RuntimeException('Not implemented yet');
     }
+
+
 }

--- a/eZ/Publish/Core/REST/Client/ContentTypeService.php
+++ b/eZ/Publish/Core/REST/Client/ContentTypeService.php
@@ -208,10 +208,10 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'DELETE',
             $contentTypeGroup->id,
             new Message(
-            // @todo: What media-type should we set here? Actually, it should be
-            // all expected exceptions + none? Or is "Section" correct,
-            // since this is what is to be expected by the resource
-            // identified by the URL?
+                // @todo: What media-type should we set here? Actually, it should be
+                // all expected exceptions + none? Or is "Section" correct,
+                // since this is what is to be expected by the resource
+                // identified by the URL?
                 array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroup'))
             )
         );

--- a/eZ/Publish/Core/REST/Client/ContentTypeService.php
+++ b/eZ/Publish/Core/REST/Client/ContentTypeService.php
@@ -24,7 +24,8 @@ use eZ\Publish\Core\REST\Common\Exceptions\NotFoundException;
 use eZ\Publish\Core\REST\Common\RequestParser;
 use eZ\Publish\Core\REST\Common\Input\Dispatcher;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
-use eZ\Publish\Core\REST\Common\Message; use eZ\Publish\Core\REST\Client\Exceptions\InvalidArgumentValue;
+use eZ\Publish\Core\REST\Common\Message;
+use eZ\Publish\Core\REST\Client\Exceptions\InvalidArgumentValue;
 use eZ\Publish\Core\REST\Common\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\REST\Common\Exceptions\ForbiddenException;
 use eZ\Publish\Core\REST\Client\Exceptions\BadStateException;
@@ -113,7 +114,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $contentTypeGroupId,
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('Section'))
+                ['Accept' => $this->outputVisitor->getMediaType('Section')]
             )
         );
 
@@ -127,9 +128,9 @@ class ContentTypeService implements APIContentTypeService, Sessionable
     {
         $response = $this->client->request(
             'GET',
-            $this->requestParser->generate('typegroupByIdentifier', array('typegroup' => $contentTypeGroupIdentifier)),
+            $this->requestParser->generate('typegroupByIdentifier', ['typegroup' => $contentTypeGroupIdentifier]),
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupList'))
+                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupList')]
             )
         );
 
@@ -138,7 +139,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
                 'GET',
                 $response->headers['Location'],
                 new Message(
-                    array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroup'))
+                    ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroup')]
                 )
             );
         }
@@ -155,7 +156,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $this->requestParser->generate('typegroups'),
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupList'))
+                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupList')]
             )
         );
 
@@ -212,7 +213,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
                 // all expected exceptions + none? Or is "Section" correct,
                 // since this is what is to be expected by the resource
                 // identified by the URL?
-                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroup'))
+                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroup')]
             )
         );
 
@@ -300,7 +301,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
                 $this->requestParser->parse('type', $contentType->id)
             ),
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList'))
+                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList')]
             )
         );
 
@@ -309,7 +310,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
 
         return new RestContentType(
             $this,
-            array(
+            [
                 'id' => $contentType->id,
                 'remoteId' => $contentType->remoteId,
                 'identifier' => $contentType->identifier,
@@ -334,7 +335,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
                 // dynamic
                 //"fieldDefinitions" => $contentType->fieldDefinitions,
                 //"contentTypeGroups" => $contentType->contentTypeGroups,
-            )
+            ]
         );
     }
 
@@ -347,9 +348,9 @@ class ContentTypeService implements APIContentTypeService, Sessionable
      */
     protected function isErrorResponse(Message $response)
     {
-        return (
+        return
             strpos($response->headers['Content-Type'], 'application/vnd.ez.api.ErrorMessage') === 0
-        );
+        ;
     }
 
     /**
@@ -368,7 +369,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $contentTypeId,
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('ContentType'))
+                ['Accept' => $this->outputVisitor->getMediaType('ContentType')]
             )
         );
 
@@ -467,7 +468,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $contentTypeId,
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('ContentType'))
+                ['Accept' => $this->outputVisitor->getMediaType('ContentType')]
             )
         );
 
@@ -490,7 +491,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $fieldDefinitionId,
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('FieldDefinition'))
+                ['Accept' => $this->outputVisitor->getMediaType('FieldDefinition')]
             )
         );
 
@@ -513,7 +514,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $fieldDefinitionListReference,
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('FieldDefinitionList'))
+                ['Accept' => $this->outputVisitor->getMediaType('FieldDefinitionList')]
             )
         );
 
@@ -536,7 +537,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'GET',
             $contentTypeGroupListReference,
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList'))
+                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList')]
             )
         );
 
@@ -550,9 +551,9 @@ class ContentTypeService implements APIContentTypeService, Sessionable
     {
         $response = $this->client->request(
             'GET',
-            $this->requestParser->generate('typeByIdentifier', array('type' => $identifier)),
+            $this->requestParser->generate('typeByIdentifier', ['type' => $identifier]),
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeList'))
+                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeList')]
             )
         );
         $contentTypes = $this->inputDispatcher->parse($response);
@@ -567,9 +568,9 @@ class ContentTypeService implements APIContentTypeService, Sessionable
     {
         $response = $this->client->request(
             'GET',
-            $this->requestParser->generate('typeByRemoteId', array('type' => $remoteId)),
+            $this->requestParser->generate('typeByRemoteId', ['type' => $remoteId]),
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeList'))
+                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeList')]
             )
         );
         $contentTypes = $this->inputDispatcher->parse($response);
@@ -588,7 +589,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
     /**
      * {@inheritdoc}
      */
-    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [])
+    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [], int $status = ContentType::STATUS_DEFINED)
     {
         $response = $this->client->request(
             'GET',
@@ -597,10 +598,10 @@ class ContentTypeService implements APIContentTypeService, Sessionable
                 $this->requestParser->parse('typegroup', $contentTypeGroup->id)
             ),
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeList'))
+                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeList')]
             )
         );
-        $completedContentTypes = array();
+        $completedContentTypes = [];
         $contentTypes = $this->inputDispatcher->parse($response);
         foreach ($contentTypes as $contentType) {
             $completedContentTypes[] = $this->completeContentType($contentType);
@@ -682,7 +683,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'POST',
             $this->requestParser->generate('typeGroupAssign', $urlValues),
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList'))
+                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList')]
             )
         );
 
@@ -719,7 +720,7 @@ class ContentTypeService implements APIContentTypeService, Sessionable
             'DELETE',
             $this->requestParser->generate('groupOfType', $urlValues),
             new Message(
-                array('Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList'))
+                ['Accept' => $this->outputVisitor->getMediaType('ContentTypeGroupRefList')]
             )
         );
 
@@ -748,9 +749,9 @@ class ContentTypeService implements APIContentTypeService, Sessionable
         }
 
         return new ContentTypeGroupCreateStruct(
-            array(
+            [
                 'identifier' => $identifier,
-            )
+            ]
         );
     }
 
@@ -768,9 +769,9 @@ class ContentTypeService implements APIContentTypeService, Sessionable
         }
 
         return new ContentTypeCreateStruct(
-            array(
+            [
                 'identifier' => $identifier,
-            )
+            ]
         );
     }
 
@@ -813,10 +814,10 @@ class ContentTypeService implements APIContentTypeService, Sessionable
         }
 
         return new FieldDefinitionCreateStruct(
-            array(
+            [
                 'identifier' => $identifier,
                 'fieldTypeIdentifier' => $fieldTypeIdentifier,
-            )
+            ]
         );
     }
 
@@ -864,6 +865,4 @@ class ContentTypeService implements APIContentTypeService, Sessionable
     {
         throw new \RuntimeException('Not implemented yet');
     }
-
-
 }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -2285,12 +2285,14 @@ class ContentService implements ContentServiceInterface
         $translationWasFound = false;
         $this->repository->beginTransaction();
         try {
+            $target = (new Target\Builder\VersionBuilder())->translateToAnyLanguageOf([$languageCode])->build();
+
             foreach ($this->loadVersions($contentInfo) as $versionInfo) {
-                if (!$this->repository->canUser('content', 'remove', $versionInfo)) {
+                if (!$this->repository->canUser('content', 'remove', $versionInfo, [$target])) {
                     throw new UnauthorizedException(
                         'content',
                         'remove',
-                        ['contentId' => $contentInfo->id, 'versionNo' => $versionInfo->versionNo]
+                        ['contentId' => $contentInfo->id, 'versionNo' => $versionInfo->versionNo, 'languageCode' => $languageCode]
                     );
                 }
 

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -934,11 +934,11 @@ class ContentTypeService implements ContentTypeServiceInterface
     /**
      * {@inheritdoc}
      */
-    public function loadContentTypes(APIContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [])
+    public function loadContentTypes(APIContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [], int $status = SPIContentType::STATUS_DEFINED)
     {
         $spiContentTypes = $this->contentTypeHandler->loadContentTypes(
             $contentTypeGroup->id,
-            SPIContentType::STATUS_DEFINED
+            $status
         );
         $contentTypes = [];
 

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -934,8 +934,11 @@ class ContentTypeService implements ContentTypeServiceInterface
     /**
      * {@inheritdoc}
      */
-    public function loadContentTypes(APIContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [], int $status = SPIContentType::STATUS_DEFINED)
-    {
+    public function loadContentTypes(
+        APIContentTypeGroup $contentTypeGroup,
+        array $prioritizedLanguages = [],
+        int $status = SPIContentType::STATUS_DEFINED
+    ): array {
         $spiContentTypes = $this->contentTypeHandler->loadContentTypes(
             $contentTypeGroup->id,
             $status

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -937,7 +937,7 @@ class ContentTypeService implements ContentTypeServiceInterface
     public function loadContentTypes(
         APIContentTypeGroup $contentTypeGroup,
         array $prioritizedLanguages = [],
-        int $status = SPIContentType::STATUS_DEFINED
+        int $status = APIContentType::STATUS_DEFINED
     ): array {
         $spiContentTypes = $this->contentTypeHandler->loadContentTypes(
             $contentTypeGroup->id,

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
@@ -119,7 +119,7 @@ class ContentTypeService implements ContentTypeServiceInterface
         return $this->service->loadContentTypeList($contentTypeIds, $prioritizedLanguages);
     }
 
-    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = null, int $status = ContentType::STATUS_DEFINED)
+    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = null, int $status = ContentType::STATUS_DEFINED): array
     {
         $prioritizedLanguages = $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages);
 

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
@@ -119,11 +119,11 @@ class ContentTypeService implements ContentTypeServiceInterface
         return $this->service->loadContentTypeList($contentTypeIds, $prioritizedLanguages);
     }
 
-    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = null)
+    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = null, int $status = ContentType::STATUS_DEFINED)
     {
         $prioritizedLanguages = $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages);
 
-        return $this->service->loadContentTypes($contentTypeGroup, $prioritizedLanguages);
+        return $this->service->loadContentTypes($contentTypeGroup, $prioritizedLanguages, $status);
     }
 
     public function createContentTypeDraft(ContentType $contentType)

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentTypeServiceTest.php
@@ -123,7 +123,7 @@ class ContentTypeServiceTest extends AbstractServiceTest
 
             ['loadContentTypeByRemoteId', ['w4ini3tn4f', self::LANG_ARG], true, 1],
 
-            ['loadContentTypes', [$contentTypeGroup, self::LANG_ARG], true, 1],
+            ['loadContentTypes', [$contentTypeGroup, self::LANG_ARG], [$contentType], 1],
         ];
     }
 }

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleRemoteIdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleRemoteIdentifierMapper.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common\FieldValueMapper;
+
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\MultipleRemoteIdentifierField;
+
+/**
+ * Common remote ID list field value mapper implementation.
+ */
+final class MultipleRemoteIdentifierMapper extends RemoteIdentifierMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param \eZ\Publish\SPI\Search\Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field): bool
+    {
+        return $field->type instanceof MultipleRemoteIdentifierField;
+    }
+
+    public function map(Field $field)
+    {
+        $values = [];
+
+        foreach ($field->value as $value) {
+            $values[] = $this->convert($value);
+        }
+
+        return $values;
+    }
+}

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/RemoteIdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/RemoteIdentifierMapper.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common\FieldValueMapper;
+
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\RemoteIdentifierField;
+
+/**
+ * Common remote ID field value mapper.
+ *
+ * Currently behaves in the same way as StringMapper.
+ *
+ * @internal for internal use by Search engine field value mapper
+ */
+class RemoteIdentifierMapper extends StringMapper
+{
+    public function canMap(Field $field): bool
+    {
+        return $field->type instanceof RemoteIdentifierField;
+    }
+}

--- a/eZ/Publish/Core/Search/Tests/Common/FieldValueMapper/RemoteIdentifierMapperTest.php
+++ b/eZ/Publish/Core/Search/Tests/Common/FieldValueMapper/RemoteIdentifierMapperTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Search\Tests\Common\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Common\FieldValueMapper\RemoteIdentifierMapper;
+use eZ\Publish\Core\Search\Tests\TestCase;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\IdentifierField;
+use eZ\Publish\SPI\Search\FieldType\IntegerField;
+use eZ\Publish\SPI\Search\FieldType\RemoteIdentifierField;
+use eZ\Publish\SPI\Search\FieldType\StringField;
+
+final class RemoteIdentifierMapperTest extends TestCase
+{
+    /** @var \eZ\Publish\Core\Search\Common\FieldValueMapper\RemoteIdentifierMapper */
+    private $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new RemoteIdentifierMapper();
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Search\Common\FieldValueMapper\RemoteIdentifierMapper::canMap
+     *
+     * @dataProvider getDataForTestCanMap
+     */
+    public function testCanMap(Field $field, bool $canMap): void
+    {
+        self::assertSame($canMap, $this->mapper->canMap($field));
+    }
+
+    public function getDataForTestCanMap(): iterable
+    {
+        yield 'can map' => [
+            new Field('id', 1, new RemoteIdentifierField()),
+            true,
+        ];
+
+        yield 'cannot map (identifier)' => [
+            new Field('id', 1, new IdentifierField()),
+            false,
+        ];
+
+        yield 'cannot map (string)' => [
+            new Field('name', 1, new StringField()),
+            false,
+        ];
+
+        yield 'cannot map (integer)' => [
+            new Field('number', 1, new IntegerField()),
+            false,
+        ];
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Search\Common\FieldValueMapper\IdentifierMapper::map
+     *
+     * @dataProvider getDataForTestMap
+     */
+    public function testMap(Field $field, string $expectedMappedValue): void
+    {
+        self::assertSame($expectedMappedValue, $this->mapper->map($field));
+    }
+
+    public function getDataForTestMap(): iterable
+    {
+        yield 'numeric id' => [
+            new Field('id', 1, new IdentifierField()),
+            1,
+        ];
+
+        yield 'remote_id md5' => [
+            new Field(
+                'remote_id',
+                '1611729231d469e6b53c431f476926ac',
+                new IdentifierField()
+            ),
+            '1611729231d469e6b53c431f476926ac',
+        ];
+
+        yield 'external remote_id' => [
+            new Field(
+                'location_remote_id',
+                'external:10',
+                new IdentifierField()
+            ),
+            'external:10',
+        ];
+
+        yield 'section identifier' => [
+            new Field(
+                'section_identifier',
+                'my_section',
+                new IdentifierField()
+            ),
+            'my_section',
+        ];
+
+        yield 'path string' => [
+            new Field(
+                'path_string',
+                '/1/2/54/',
+                new IdentifierField()
+            ),
+            '/1/2/54/',
+        ];
+
+        yield 'identifier with national characters' => [
+            new Field(
+                'some_identifier',
+                'zażółć gęślą jaźń',
+                new IdentifierField()
+            ),
+            'zażółć gęślą jaźń',
+        ];
+
+        yield 'identifier with non-printable characters' => [
+            new Field(
+                'identifier',
+                utf8_decode("Non\x09Printable\x0EIdentifier"),
+                new IdentifierField()
+            ),
+            'Non PrintableIdentifier',
+        ];
+
+        $value = 'Emoji: ' . json_decode('"\ud83d\ude00"');
+        yield 'identifier with emojis' => [
+            new Field(
+                'identifier',
+                $value,
+                new IdentifierField()
+            ),
+            $value,
+        ];
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/ContentTypeService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentTypeService.php
@@ -246,9 +246,9 @@ class ContentTypeService implements ContentTypeServiceInterface
     /**
      * {@inheritdoc}
      */
-    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [])
+    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [], int $status = ContentType::STATUS_DEFINED)
     {
-        return $this->service->loadContentTypes($contentTypeGroup, $prioritizedLanguages);
+        return $this->service->loadContentTypes($contentTypeGroup, $prioritizedLanguages, $status);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/ContentTypeService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentTypeService.php
@@ -246,7 +246,7 @@ class ContentTypeService implements ContentTypeServiceInterface
     /**
      * {@inheritdoc}
      */
-    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [], int $status = ContentType::STATUS_DEFINED)
+    public function loadContentTypes(ContentTypeGroup $contentTypeGroup, array $prioritizedLanguages = [], int $status = ContentType::STATUS_DEFINED): array
     {
         return $this->service->loadContentTypes($contentTypeGroup, $prioritizedLanguages, $status);
     }

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentTypeServiceTest.php
@@ -173,7 +173,7 @@ class ContentTypeServiceTest extends ServiceTest
             ],
             [
                 'loadContentTypes',
-                [$contentTypeGroup, ['eng-GB']],
+                [$contentTypeGroup, ['eng-GB'], ContentType::STATUS_DEFINED],
                 [$contentType],
                 0,
             ],

--- a/eZ/Publish/Core/settings/policies.yml
+++ b/eZ/Publish/Core/settings/policies.yml
@@ -11,7 +11,7 @@ parameters:
             hide: { Class: true, Section: true, Owner: true, Group: true, Node: true, Subtree: true, Language: true }
             reverserelatedlist: ~
             translate: { Class: true, Section: true, Owner: true, Node: true, Subtree: true, Language: true }
-            remove: { Class: true, Section: true, Owner: true, Node: true, Subtree: true, State: true }
+            remove: { Class: true, Section: true, Owner: true, Node: true, Subtree: true, Language: true, State: true }
             versionread: { Class: true, Section: true, Owner: true, Status: true, Node: true, Subtree: true, State: true }
             versionremove: { Class: true, Section: true, Owner: true, Status: true, Node: true, Subtree: true, State: true }
             translations: ~

--- a/eZ/Publish/Core/settings/search_engines/field_value_mappers.yml
+++ b/eZ/Publish/Core/settings/search_engines/field_value_mappers.yml
@@ -78,3 +78,11 @@ services:
         class: "%ezpublish.search.common.field_value_mapper.string.class%"
         tags:
             - {name: ezpublish.search.common.field_value_mapper}
+
+    eZ\Publish\Core\Search\Common\FieldValueMapper\RemoteIdentifierMapper:
+        tags:
+            - {name: ezpublish.search.common.field_value_mapper}
+
+    eZ\Publish\Core\Search\Common\FieldValueMapper\MultipleRemoteIdentifierMapper:
+        tags:
+            - {name: ezpublish.search.common.field_value_mapper}

--- a/eZ/Publish/SPI/Search/FieldType/MultipleRemoteIdentifierField.php
+++ b/eZ/Publish/SPI/Search/FieldType/MultipleRemoteIdentifierField.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\Search\FieldType;
+
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Remote ID list document field.
+ */
+class MultipleRemoteIdentifierField extends FieldType
+{
+    /**
+     * Search engine field type corresponding to remote ID list. The same MultipleIdentifierField due to BC.
+     *
+     * @see \eZ\Publish\SPI\Search\FieldType\MultipleIdentifierField
+     *
+     * @var string
+     */
+    protected $type = 'ez_mid';
+}

--- a/eZ/Publish/SPI/Search/FieldType/RemoteIdentifierField.php
+++ b/eZ/Publish/SPI/Search/FieldType/RemoteIdentifierField.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\Search\FieldType;
+
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Remote ID document field.
+ */
+final class RemoteIdentifierField extends FieldType
+{
+    /**
+     * Search engine field type corresponding to remote ID. The same as IdentifierField due to BC.
+     *
+     * @see \eZ\Publish\SPI\Search\FieldType\IdentifierField
+     *
+     * @var string
+     */
+    protected $type = 'ez_id';
+}

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -22,6 +22,7 @@
             <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>
             <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
             <directory>eZ/Publish/API/Repository/Tests/Limitation</directory>
+            <directory>eZ/Publish/API/Repository/Tests/SearchService</directory>
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/PermissionResolverTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31460](https://jira.ez.no/browse/EZP-31460)
| **Improvement**| yes
| **New feature**    | no
| **Target version** | 7.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

`loadContentTypes()` method in `ContentTypeService` has been modified to allow to use different status than the hard-coded `STATUS_DEFINED` for `ContentType` searching.

Related `ezplatform-admin-ui` PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/1377

**TODO**:
- [x] Implement improvement.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
