### PR TITLE
EZP-31644: Fixed serialization of Compound SiteAccess matcher

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/DecoratedFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/DecoratedFragmentRenderer.php
@@ -8,7 +8,6 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Fragment;
 
-use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,7 +17,7 @@ use Symfony\Component\HttpKernel\Fragment\RoutableFragmentRenderer;
 
 class DecoratedFragmentRenderer implements FragmentRendererInterface, SiteAccessAware
 {
-    use SerializerTrait;
+    use SiteAccessSerializationTrait;
 
     /**
      * @var \Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface
@@ -71,11 +70,7 @@ class DecoratedFragmentRenderer implements FragmentRendererInterface, SiteAccess
             // Serialize the siteaccess to get it back after.
             // @see eZ\Publish\Core\MVC\Symfony\EventListener\SiteAccessMatchListener
             $siteAccess = $request->attributes->get('siteaccess');
-            $uri->attributes['serialized_siteaccess'] = json_encode($siteAccess);
-            $uri->attributes['serialized_siteaccess_matcher'] = $this->getSerializer()->serialize(
-                $siteAccess->matcher,
-                'json'
-            );
+            $this->serializeSiteAccess($siteAccess, $uri);
         }
 
         return $this->innerRenderer->render($uri, $request, $options);

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
@@ -8,7 +8,6 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Fragment;
 
-use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,7 +18,7 @@ use Symfony\Component\HttpKernel\Fragment\RoutableFragmentRenderer;
 
 class InlineFragmentRenderer extends BaseRenderer implements SiteAccessAware
 {
-    use SerializerTrait;
+    use SiteAccessSerializationTrait;
 
     /**
      * @var \Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface
@@ -54,11 +53,7 @@ class InlineFragmentRenderer extends BaseRenderer implements SiteAccessAware
             if ($request->attributes->has('siteaccess')) {
                 /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteAccess */
                 $siteAccess = $request->attributes->get('siteaccess');
-                $uri->attributes['serialized_siteaccess'] = json_encode($siteAccess);
-                $uri->attributes['serialized_siteaccess_matcher'] = $this->getSerializer()->serialize(
-                    $siteAccess->matcher,
-                    'json'
-                );
+                $this->serializeSiteAccess($siteAccess, $uri);
             }
             if ($request->attributes->has('semanticPathinfo')) {
                 $uri->attributes['semanticPathinfo'] = $request->attributes->get('semanticPathinfo');

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/SiteAccessSerializationTrait.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/SiteAccessSerializationTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Fragment;
+
+use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+trait SiteAccessSerializationTrait
+{
+    use SerializerTrait;
+
+    public function serializeSiteAccess(SiteAccess $siteAccess, ControllerReference $uri)
+    {
+        // Serialize the siteaccess to get it back after. @see eZ\Publish\Core\MVC\Symfony\EventListener\SiteAccessMatchListener
+        $uri->attributes['serialized_siteaccess'] = json_encode($siteAccess);
+        $uri->attributes['serialized_siteaccess_matcher'] = $this->getSerializer()->serialize(
+            $siteAccess->matcher,
+            'json'
+        );
+        if ($siteAccess->matcher instanceof SiteAccess\Matcher\CompoundInterface) {
+            $subMatchers = $siteAccess->matcher->getSubMatchers();
+            foreach ($subMatchers as $subMatcher) {
+                $uri->attributes['serialized_siteaccess_sub_matchers'][get_class($subMatcher)] = $this->getSerializer()->serialize(
+                    $subMatcher,
+                    'json'
+                );
+            }
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/DecoratedFragmentRendererTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/DecoratedFragmentRendererTest.php
@@ -9,16 +9,12 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;
 
 use eZ\Bundle\EzPublishCoreBundle\Fragment\DecoratedFragmentRenderer;
-use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
-class DecoratedFragmentRendererTest extends TestCase
+class DecoratedFragmentRendererTest extends FragmentRendererBaseTest
 {
-    use SerializerTrait;
-
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
@@ -123,5 +119,18 @@ class DecoratedFragmentRendererTest extends TestCase
             ),
             $reference->attributes['serialized_siteaccess_matcher']
         );
+    }
+
+    public function getRequest(SiteAccess $siteAccess)
+    {
+        $request = new Request();
+        $request->attributes->set('siteaccess', $siteAccess);
+
+        return $request;
+    }
+
+    public function getRenderer()
+    {
+        return new DecoratedFragmentRenderer($this->innerRenderer);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/FragmentRendererBaseTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/FragmentRendererBaseTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;
+
+use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+abstract class FragmentRendererBaseTest extends TestCase
+{
+    use SerializerTrait;
+
+    public function testRendererControllerReferenceWithCompoundMatcher()
+    {
+        $reference = new ControllerReference('FooBundle:bar:baz');
+        $compoundMatcher = new SiteAccess\Matcher\Compound\LogicalAnd([]);
+        $subMatchers = [
+            'Map\URI' => new SiteAccess\Matcher\Map\URI([]),
+            'Map\Host' => new SiteAccess\Matcher\Map\Host([]),
+        ];
+        $compoundMatcher->setSubMatchers($subMatchers);
+        $siteAccess = new SiteAccess(
+            'test',
+            'test',
+            $compoundMatcher
+        );
+
+        $request = $this->getRequest($siteAccess);
+        $options = ['foo' => 'bar'];
+        $expectedReturn = '/_fragment?foo=bar';
+        $this->innerRenderer
+            ->expects($this->once())
+            ->method('render')
+            ->with($reference, $request, $options)
+            ->will($this->returnValue($expectedReturn));
+
+        $renderer = $this->getRenderer();
+        $this->assertSame($expectedReturn, $renderer->render($reference, $request, $options));
+        $this->assertArrayHasKey('serialized_siteaccess', $reference->attributes);
+        $serializedSiteAccess = json_encode($siteAccess);
+        $this->assertSame($serializedSiteAccess, $reference->attributes['serialized_siteaccess']);
+        $this->assertArrayHasKey('serialized_siteaccess_matcher', $reference->attributes);
+        $this->assertSame(
+            $this->getSerializer()->serialize(
+                $siteAccess->matcher,
+                'json'
+            ),
+            $reference->attributes['serialized_siteaccess_matcher']
+        );
+        $this->assertArrayHasKey('serialized_siteaccess_sub_matchers', $reference->attributes);
+        foreach ($siteAccess->matcher->getSubMatchers() as $subMatcher) {
+            $this->assertSame(
+                $this->getSerializer()->serialize(
+                    $subMatcher,
+                    'json'
+                ),
+                $reference->attributes['serialized_siteaccess_sub_matchers'][get_class($subMatcher)]
+            );
+        }
+
+        return $reference;
+    }
+
+    abstract public function getRequest(SiteAccess $siteAccess);
+
+    abstract public function getRenderer();
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/InlineFragmentRendererTest.php
@@ -7,15 +7,12 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;
 
 use eZ\Bundle\EzPublishCoreBundle\Fragment\InlineFragmentRenderer;
-use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 class InlineFragmentRendererTest extends DecoratedFragmentRendererTest
 {
-    use SerializerTrait;
-
     public function testRendererControllerReference()
     {
         $reference = new ControllerReference('FooBundle:bar:baz');
@@ -54,5 +51,32 @@ class InlineFragmentRendererTest extends DecoratedFragmentRendererTest
         $this->assertSame('/foo/bar', $reference->attributes['semanticPathinfo']);
         $this->assertTrue(isset($reference->attributes['viewParametersString']));
         $this->assertSame('/(foo)/bar', $reference->attributes['viewParametersString']);
+    }
+
+    public function testRendererControllerReferenceWithCompoundMatcher()
+    {
+        $reference = parent::testRendererControllerReferenceWithCompoundMatcher();
+
+        $this->assertArrayHasKey('semanticPathinfo', $reference->attributes);
+        $this->assertSame('/foo/bar', $reference->attributes['semanticPathinfo']);
+        $this->assertArrayHasKey('viewParametersString', $reference->attributes);
+        $this->assertSame('/(foo)/bar', $reference->attributes['viewParametersString']);
+
+        return $reference;
+    }
+
+    public function getRequest(SiteAccess $siteAccess)
+    {
+        $request = new Request();
+        $request->attributes->set('siteaccess', $siteAccess);
+        $request->attributes->set('semanticPathinfo', '/foo/bar');
+        $request->attributes->set('viewParametersString', '/(foo)/bar');
+
+        return $request;
+    }
+
+    public function getRenderer()
+    {
+        return new InlineFragmentRenderer($this->innerRenderer);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
@@ -18,7 +18,7 @@ trait SerializerTrait
     public function getSerializer()
     {
         return new Serializer(
-            [(new PropertyNormalizer())->setIgnoredAttributes(['request'])],
+            [(new PropertyNormalizer())->setIgnoredAttributes(['request', 'container', 'matcherBuilder'])],
             [new JsonEncoder()]
         );
     }

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -95,6 +95,13 @@ class SiteAccessMatchListener implements EventSubscriberInterface
                         )
                     );
                 }
+                if ($request->attributes->get('serialized_siteaccess_sub_matchers')) {
+                    $subMatchers = [];
+                    foreach ($request->attributes->get('serialized_siteaccess_sub_matchers') as $matcherClass => $serializedData) {
+                        $subMatchers[$matcherClass] = $serializer->deserialize($serializedData, $matcherClass, 'json');
+                    }
+                    $siteAccess->matcher->setSubMatchers($subMatchers);
+                }
             }
 
             $request->attributes->set(

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
@@ -134,6 +134,66 @@ class SiteAccessMatchListenerTest extends TestCase
         $this->assertFalse($request->attributes->has('serialized_siteaccess'));
     }
 
+    public function testOnKernelRequestSerializedSAWithCompoundMatcher()
+    {
+        $compoundMatcher = new SiteAccess\Matcher\Compound\LogicalAnd([]);
+        $subMatchers = [
+            SiteAccess\Matcher\Map\URI::class => new SiteAccess\Matcher\Map\URI([]),
+            SiteAccess\Matcher\Map\Host::class => new SiteAccess\Matcher\Map\Host([]),
+        ];
+        $compoundMatcher->setSubMatchers($subMatchers);
+        $siteAccess = new SiteAccess(
+            'test',
+            'matching_type',
+            $compoundMatcher
+        );
+        $request = new Request();
+        $request->attributes->set('serialized_siteaccess', json_encode($siteAccess));
+        $request->attributes->set(
+            'serialized_siteaccess_matcher',
+            $this->getSerializer()->serialize(
+                $siteAccess->matcher,
+                'json'
+            )
+        );
+        $serializedSubMatchers = [];
+        foreach ($subMatchers as $subMatcher) {
+            $serializedSubMatchers[get_class($subMatcher)] = $this->getSerializer()->serialize(
+                $subMatcher,
+                'json'
+            );
+        }
+        $request->attributes->set(
+            'serialized_siteaccess_sub_matchers',
+            $serializedSubMatchers
+        );
+        $event = new GetResponseEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST
+        );
+
+        $this->userHashMatcher
+            ->expects($this->once())
+            ->method('matches')
+            ->with($request)
+            ->will($this->returnValue(false));
+
+        $this->saRouter
+            ->expects($this->never())
+            ->method('match');
+
+        $postSAMatchEvent = new PostSiteAccessMatchEvent($siteAccess, $request, $event->getRequestType());
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(MVCEvents::SITEACCESS, $this->equalTo($postSAMatchEvent));
+
+        $this->listener->onKernelRequest($event);
+        $this->assertEquals($siteAccess, $request->attributes->get('siteaccess'));
+        $this->assertFalse($request->attributes->has('serialized_siteaccess'));
+    }
+
     public function testOnKernelRequestSiteAccessPresent()
     {
         $siteAccess = new SiteAccess();

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/HostText.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/HostText.php
@@ -18,6 +18,13 @@ class HostText extends Regex implements VersatileMatcher
     private $suffix;
 
     /**
+     * The property needed to allow correct deserialization with Symfony serializer.
+     *
+     * @var array
+     */
+    private $siteAccessesConfiguration;
+
+    /**
      * Constructor.
      *
      * @param array $siteAccessesConfiguration SiteAccesses configuration.
@@ -30,6 +37,7 @@ class HostText extends Regex implements VersatileMatcher
             '^' . preg_quote($this->prefix, '@') . "(\w+)" . preg_quote($this->suffix, '@') . '$',
             1
         );
+        $this->siteAccessesConfiguration = $siteAccessesConfiguration;
     }
 
     public function getName()

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex/Host.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex/Host.php
@@ -18,6 +18,13 @@ use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 class Host extends Regex implements Matcher
 {
     /**
+     * The property needed to allow correct deserialization with Symfony serializer.
+     *
+     * @var array
+     */
+    private $siteAccessesConfiguration;
+
+    /**
      * Constructor.
      *
      * @param array $siteAccessesConfiguration SiteAccesses configuration.
@@ -28,6 +35,7 @@ class Host extends Regex implements Matcher
             isset($siteAccessesConfiguration['regex']) ? $siteAccessesConfiguration['regex'] : '',
             isset($siteAccessesConfiguration['itemNumber']) ? (int)$siteAccessesConfiguration['itemNumber'] : 1
         );
+        $this->siteAccessesConfiguration = $siteAccessesConfiguration;
     }
 
     public function getName()

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex/URI.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex/URI.php
@@ -18,6 +18,13 @@ use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 class URI extends Regex implements Matcher
 {
     /**
+     * The property needed to allow correct deserialization with Symfony serializer.
+     *
+     * @var array
+     */
+    private $siteAccessesConfiguration;
+
+    /**
      * Constructor.
      *
      * @param array $siteAccessesConfiguration SiteAccesses configuration.
@@ -28,6 +35,7 @@ class URI extends Regex implements Matcher
             isset($siteAccessesConfiguration['regex']) ? $siteAccessesConfiguration['regex'] : '',
             isset($siteAccessesConfiguration['itemNumber']) ? (int)$siteAccessesConfiguration['itemNumber'] : 1
         );
+        $this->siteAccessesConfiguration = $siteAccessesConfiguration;
     }
 
     public function getName()

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIText.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIText.php
@@ -25,6 +25,13 @@ class URIText extends Regex implements VersatileMatcher, URILexer
     private $suffix;
 
     /**
+     * The property needed to allow correct deserialization with Symfony serializer.
+     *
+     * @var array
+     */
+    private $siteAccessesConfiguration;
+
+    /**
      * Constructor.
      *
      * @param array $siteAccessesConfiguration SiteAccesses configuration.
@@ -38,6 +45,7 @@ class URIText extends Regex implements VersatileMatcher, URILexer
             '^(/' . preg_quote($this->prefix, '@') . '(\w+)' . preg_quote($this->suffix, '@') . ')',
             2
         );
+        $this->siteAccessesConfiguration = $siteAccessesConfiguration;
     }
 
     public function getName()

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/MatcherSerializationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/MatcherSerializationTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
+
+use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;
+use PHPUnit\Framework\TestCase;
+
+class MatcherSerializationTest extends TestCase
+{
+    use SerializerTrait;
+
+    /**
+     * @dataProvider matcherProvider
+     */
+    public function testDeserialize(Matcher $matcher)
+    {
+        $serializedMatcher = $this->serializeMatcher($matcher);
+        $unserializedMatcher = $this->deserializeMatcher($serializedMatcher, get_class($matcher));
+
+        $this->assertEquals($matcher, $unserializedMatcher);
+    }
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher $matcher
+     *
+     * @return string
+     */
+    private function serializeMatcher(Matcher $matcher)
+    {
+        return $this->getSerializer()->serialize(
+            $matcher,
+            'json'
+        );
+    }
+
+    /**
+     * @param string $serializedMatcher
+     * @param string $matcherFQCN
+     *
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher|object
+     */
+    private function deserializeMatcher($serializedMatcher, $matcherFQCN)
+    {
+        return $this->getSerializer()->deserialize(
+            $serializedMatcher,
+            $matcherFQCN,
+            'json'
+        );
+    }
+
+    public function matcherProvider()
+    {
+        return [
+            'URIText' => [
+                new Matcher\URIText([
+                    'prefix' => 'foo',
+                    'suffix' => 'bar',
+                ]),
+            ],
+            'HostText' => [
+                new Matcher\HostText([
+                    'prefix' => 'foo',
+                    'suffix' => 'bar',
+                ]),
+            ],
+            'RegexHost' => [
+                new Matcher\Regex\Host([
+                    'regex' => 'foo',
+                    'itemNumber' => 2,
+                ]),
+            ],
+            'RegexURI' => [
+                new Matcher\Regex\URI([
+                    'regex' => 'foo',
+                    'itemNumber' => 2,
+                ]),
+            ],
+            'URIElement' => [
+                new Matcher\URIElement([
+                    'elementNumber' => 2,
+                ]),
+            ],
+            'HostElement' => [
+                new Matcher\HostElement([
+                    'elementNumber' => 2,
+                ]),
+            ],
+            'MapURI' => [
+                new Matcher\Map\URI([
+                    'map' => ['key' => 'value'],
+                ]),
+            ],
+            'MapPort' => [
+                new Matcher\Map\Port([
+                    'map' => ['key' => 'value'],
+                ]),
+            ],
+            'MapHost' => [
+                new Matcher\Map\Host([
+                    'map' => ['key' => 'value'],
+                ]),
+            ],
+            'CompoundAnd' => [
+                new Matcher\Compound\LogicalAnd(
+                    [
+                        [
+                            'matchers' => [
+                                'Map\URI' => [
+                                    'map' => ['key' => 'value'],
+                                ],
+                                'Map\Host' => [
+                                    'map' => ['key' => 'value'],
+                                ],
+                            ],
+                            'match' => 'site_access_name',
+                        ],
+                    ]
+                ),
+            ],
+            'CompoundOr' => [
+                new Matcher\Compound\LogicalOr(
+                    [
+                        [
+                            'matchers' => [
+                                'Map\URI' => [
+                                    'map' => ['key' => 'value'],
+                                ],
+                                'Map\Host' => [
+                                    'map' => ['key' => 'value'],
+                                ],
+                            ],
+                            'match' => 'site_access_name',
+                        ],
+                    ]
+                ),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31644](https://jira.ez.no/browse/EZP-31644)
| **Bug** | yes
| **New feature**    | no
| **Target version** | `6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

During the serialization of the compound matcher the whole container was serialized which is unnecessary (see: https://github.com/ezsystems/ezpublish-kernel/blob/7.5/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound.php#L127)

Also, Symfony serializer does not serialize correctly nested sub-matchers during serialization of matcher  (when compound matcher is used)


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
