### PR TITLE
[EZP-31664] Fix undefined index notice in legacy content mapper when previewing draft

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -361,7 +361,7 @@ class Mapper
                 $versionInfo->creationDate = (int)$row['ezcontentobject_version_created'];
                 $versionInfo->modificationDate = (int)$row['ezcontentobject_version_modified'];
                 $versionInfo->status = (int)$row['ezcontentobject_version_status'];
-                $versionInfo->names = $nameData[$versionId];
+                $versionInfo->names = $nameData[$versionId] ?? [];
                 $versionInfoList[$versionId] = $versionInfo;
                 $versionInfo->languageCodes = $this->extractLanguageCodesFromMask(
                     (int)$row['ezcontentobject_version_language_mask'],


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31664](https://jira.ez.no/browse/EZP-31664)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

In some cases (I have yet to find the pattern), I get the following notice when previewing a draft:

![image](https://user-images.githubusercontent.com/362286/83270064-41576880-a1c8-11ea-9f07-54da71def7bf.png)

This fixes the issue.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
