### PR TITLE
Improvements on eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\RestLocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ composer.phar
 var/
 composer.lock
 .php_cs.cache
+.idea

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -667,6 +667,7 @@ services:
         class: "%ezpublish_rest.output.value_object_visitor.RestLocation.class%"
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\RestLocation }
+        arguments: ["@router", "@ezpublish.route_reference.generator"]
 
     ezpublish_rest.output.value_object_visitor.Location:
         parent: ezpublish_rest.output.value_object_visitor.base

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -667,7 +667,6 @@ services:
         class: "%ezpublish_rest.output.value_object_visitor.RestLocation.class%"
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\RestLocation }
-        arguments: ["@router", "@ezpublish.route_reference.generator"]
 
     ezpublish_rest.output.value_object_visitor.Location:
         parent: ezpublish_rest.output.value_object_visitor.base

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
@@ -28,7 +28,19 @@ class RestLocation extends ValueObjectVisitor
         $generator->startObjectElement('Location');
         $visitor->setHeader('Content-Type', $generator->getMediaType('Location'));
         $visitor->setHeader('Accept-Patch', $generator->getMediaType('LocationUpdate'));
+        $this->visitLocationAttributes($visitor, $generator, $data);
+        $generator->endObjectElement('Location');
+    }
 
+    /**
+     * Build visit struct attributes.
+     *
+     * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
+     * @param \eZ\Publish\Core\REST\Server\Values\RestLocation $data
+     */
+    protected function visitLocationAttributes(Visitor $visitor, Generator $generator, $data)
+    {
         $location = $data->location;
         $contentInfo = $location->getContentInfo();
 
@@ -141,7 +153,5 @@ class RestLocation extends ValueObjectVisitor
         $generator->endAttribute('href');
         $visitor->visitValueObject(new RestContentValue($contentInfo));
         $generator->endObjectElement('ContentInfo');
-
-        $generator->endObjectElement('Location');
     }
 }

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
@@ -28,7 +28,7 @@ class RestLocation extends ValueObjectVisitor
         $generator->startObjectElement('Location');
         $visitor->setHeader('Content-Type', $generator->getMediaType('Location'));
         $visitor->setHeader('Accept-Patch', $generator->getMediaType('LocationUpdate'));
-        $this->visitLocationAttributes($visitor, $generator, $data);
+        $this->visitRestLocationAttributes($visitor, $generator, $data);
         $generator->endObjectElement('Location');
     }
 
@@ -39,7 +39,7 @@ class RestLocation extends ValueObjectVisitor
      * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
      * @param \eZ\Publish\Core\REST\Server\Values\RestLocation $data
      */
-    protected function visitLocationAttributes(Visitor $visitor, Generator $generator, $data)
+    protected function visitRestLocationAttributes(Visitor $visitor, Generator $generator, $data)
     {
         $location = $data->location;
         $contentInfo = $location->getContentInfo();

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
@@ -6,30 +6,16 @@
  */
 namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 
-use eZ\Publish\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 use eZ\Publish\Core\REST\Server\Values\RestContent as RestContentValue;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * RestLocation value object visitor.
  */
 class RestLocation extends ValueObjectVisitor
 {
-    /** @var \Symfony\Component\Routing\RouterInterface */
-    protected $router;
-
-    /** @var \eZ\Publish\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator */
-    protected $routeReferenceGenerator;
-
-    public function __construct(RouterInterface $router, RouteReferenceGenerator $routeReferenceGenerator)
-    {
-        $this->router = $router;
-        $this->routeReferenceGenerator = $routeReferenceGenerator;
-    }
-
     /**
      * Visit struct returned by controllers.
      *
@@ -106,9 +92,7 @@ class RestLocation extends ValueObjectVisitor
         }
         $generator->endObjectElement('ParentLocation');
 
-        $routeReference = $this->routeReferenceGenerator->generate($data->location);
-
-        $generator->startValueElement('url', $this->router->generate($routeReference));
+        $generator->startValueElement('url', $this->router->generate($location));
         $generator->endValueElement('url');
 
         $generator->startValueElement('pathString', $location->pathString);

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
@@ -6,16 +6,30 @@
  */
 namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 
+use eZ\Publish\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 use eZ\Publish\Core\REST\Server\Values\RestContent as RestContentValue;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * RestLocation value object visitor.
  */
 class RestLocation extends ValueObjectVisitor
 {
+    /** @var \Symfony\Component\Routing\RouterInterface */
+    protected $router;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator */
+    protected $routeReferenceGenerator;
+
+    public function __construct(RouterInterface $router, RouteReferenceGenerator $routeReferenceGenerator)
+    {
+        $this->router = $router;
+        $this->routeReferenceGenerator = $routeReferenceGenerator;
+    }
+
     /**
      * Visit struct returned by controllers.
      *
@@ -91,6 +105,11 @@ class RestLocation extends ValueObjectVisitor
             $generator->endAttribute('href');
         }
         $generator->endObjectElement('ParentLocation');
+
+        $routeReference = $this->routeReferenceGenerator->generate($data->location);
+
+        $generator->startValueElement('url', $this->router->generate($routeReference));
+        $generator->endValueElement('url');
 
         $generator->startValueElement('pathString', $location->pathString);
         $generator->endValueElement('pathString');

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationRootNodeTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationRootNodeTest.php
@@ -61,7 +61,7 @@ class RestLocationRootNodeTest extends RestLocationTest
         $this->addRouteExpectation(
             $location->location,
             [],
-            '/home/news/feed'
+            '/news/lorem-ipsum'
         );
         $this->addRouteExpectation(
             'ezpublish_rest_loadLocationChildren',

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationRootNodeTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationRootNodeTest.php
@@ -59,6 +59,11 @@ class RestLocationRootNodeTest extends RestLocationTest
             '/content/locations/1'
         );
         $this->addRouteExpectation(
+            $location->location,
+            [],
+            '/home/news/feed'
+        );
+        $this->addRouteExpectation(
             'ezpublish_rest_loadLocationChildren',
             ['locationPath' => '1'],
             '/content/locations/1/children'

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationTest.php
@@ -65,6 +65,11 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
             '/content/locations/1/2/21'
         );
         $this->addRouteExpectation(
+            $location->location,
+            [],
+            '/home/news/feed'
+        );
+        $this->addRouteExpectation(
             'ezpublish_rest_loadLocationChildren',
             ['locationPath' => '1/2/21/42'],
             '/content/locations/1/2/21/42/children'
@@ -429,6 +434,26 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
             ],
             $result,
             'Invalid <Content> attributes.',
+            false
+        );
+    }
+
+    /**
+     * Test if result contains pathString value element.
+     *
+     * @param string $result
+     *
+     * @depends testVisit
+     */
+    public function testResultContainsUrlValueElement($result)
+    {
+        $this->assertXMLTag(
+            [
+                'tag' => 'url',
+                'content' => '/home/news/feed',
+            ],
+            $result,
+            'Invalid or non-existing <Location> url value element.',
             false
         );
     }

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationTest.php
@@ -67,7 +67,7 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
         $this->addRouteExpectation(
             $location->location,
             [],
-            '/home/news/feed'
+            '/news/lorem-ipsum'
         );
         $this->addRouteExpectation(
             'ezpublish_rest_loadLocationChildren',
@@ -450,7 +450,7 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
         $this->assertXMLTag(
             [
                 'tag' => 'url',
-                'content' => '/home/news/feed',
+                'content' => '/news/lorem-ipsum',
             ],
             $result,
             'Invalid or non-existing <Location> url value element.',


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-XXXXX](https://jira.ez.no/browse/EZP-XXXXX)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Allow developers to extends ValueObjectVisitor/RestLocation extracting attributes implementation in other function visitRestLocationAttributes.

Additionally, a new attribute "url" has been added, with the web path of the content.
