### PR TITLE
EZP-31677: Added normalizer to decrese amount of data when compound matcher is encoded to JSON

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -36,6 +36,11 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    ezpublish.serializer.compound_matcher_normalizer:
+        class: eZ\Publish\Core\MVC\Symfony\Component\Serializer\CompoundMatcherNormalizer
+        tags:
+            - { name: serializer.normalizer }
+
     ezpublish.url_generator.base:
         class: "%ezpublish.url_generator.base.class%"
         abstract: true

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/CompoundMatcherNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/CompoundMatcherNormalizer.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Component\Serializer;
+
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;
+use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
+
+class CompoundMatcherNormalizer extends PropertyNormalizer
+{
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $data = parent::normalize($object, $format, $context);
+        $data['config'] = [];
+        $data['matchersMap'] = [];
+
+        return $data;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof Matcher\Compound;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
@@ -18,7 +18,10 @@ trait SerializerTrait
     public function getSerializer()
     {
         return new Serializer(
-            [(new PropertyNormalizer())->setIgnoredAttributes(['request', 'container', 'matcherBuilder'])],
+            [
+                new CompoundMatcherNormalizer(),
+                (new PropertyNormalizer())->setIgnoredAttributes(['request', 'container', 'matcherBuilder']),
+            ],
             [new JsonEncoder()]
         );
     }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/MatcherSerializationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/MatcherSerializationTest.php
@@ -15,19 +15,20 @@ class MatcherSerializationTest extends TestCase
     use SerializerTrait;
 
     /**
+     * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher|null $expected
+     *
      * @dataProvider matcherProvider
      */
-    public function testDeserialize(Matcher $matcher)
+    public function testDeserialize(Matcher $matcher, $expected = null)
     {
         $serializedMatcher = $this->serializeMatcher($matcher);
         $unserializedMatcher = $this->deserializeMatcher($serializedMatcher, get_class($matcher));
+        $expected = $expected === null ? $matcher : $expected;
 
-        $this->assertEquals($matcher, $unserializedMatcher);
+        $this->assertEquals($expected, $unserializedMatcher);
     }
 
     /**
-     * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher $matcher
-     *
      * @return string
      */
     private function serializeMatcher(Matcher $matcher)
@@ -55,6 +56,36 @@ class MatcherSerializationTest extends TestCase
 
     public function matcherProvider()
     {
+        $subMatchers = [
+            'Map\URI' => [
+                'map' => ['key' => 'value'],
+            ],
+            'Map\Host' => [
+                'map' => ['key' => 'value'],
+            ],
+        ];
+        $logicalAnd = new Matcher\Compound\LogicalAnd(
+            [
+                [
+                    'match' => 'site_access_name',
+                ],
+            ]
+        );
+        $logicalAnd->setSubMatchers($subMatchers);
+        $expectedLogicalAnd = new Matcher\Compound\LogicalAnd([]);
+        $expectedLogicalAnd->setSubMatchers($subMatchers);
+
+        $logicalOr = new Matcher\Compound\LogicalOr(
+            [
+                [
+                    'match' => 'site_access_name',
+                ],
+            ]
+        );
+        $logicalOr->setSubMatchers($subMatchers);
+        $expectedLogicalOr = new Matcher\Compound\LogicalOr([]);
+        $expectedLogicalOr->setSubMatchers($subMatchers);
+
         return [
             'URIText' => [
                 new Matcher\URIText([
@@ -106,38 +137,12 @@ class MatcherSerializationTest extends TestCase
                 ]),
             ],
             'CompoundAnd' => [
-                new Matcher\Compound\LogicalAnd(
-                    [
-                        [
-                            'matchers' => [
-                                'Map\URI' => [
-                                    'map' => ['key' => 'value'],
-                                ],
-                                'Map\Host' => [
-                                    'map' => ['key' => 'value'],
-                                ],
-                            ],
-                            'match' => 'site_access_name',
-                        ],
-                    ]
-                ),
+                $logicalAnd,
+                $expectedLogicalAnd,
             ],
             'CompoundOr' => [
-                new Matcher\Compound\LogicalOr(
-                    [
-                        [
-                            'matchers' => [
-                                'Map\URI' => [
-                                    'map' => ['key' => 'value'],
-                                ],
-                                'Map\Host' => [
-                                    'map' => ['key' => 'value'],
-                                ],
-                            ],
-                            'match' => 'site_access_name',
-                        ],
-                    ]
-                ),
+                $logicalOr,
+                $expectedLogicalOr,
             ],
         ];
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31677](https://jira.ez.no/browse/EZP-31677)
| **Bug** | yes
| **New feature**    | no
| **Target version** | `6.13`/
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

When the compound matcher has many sub matcher defined in his configuration than it results in serialized SiteAccess is much bigger in size than before. Previously serialized compound matcher has no serialized `config` and `matchersMap` properties. This PR removes them in CompoundMatcherNormalizer

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
