### PR TITLE
EZP-31674: Make content fields value properties nullable in phpdoc

### DIFF
--- a/eZ/Publish/Core/FieldType/BinaryBase/Value.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/Value.php
@@ -28,35 +28,35 @@ abstract class Value extends BaseValue
     /**
      * Input file URI, as a path to a file on a disk.
      *
-     * @var string
+     * @var string|null
      */
     public $inputUri;
 
     /**
      * Display file name.
      *
-     * @var string
+     * @var string|null
      */
     public $fileName;
 
     /**
      * Size of the image file.
      *
-     * @var int
+     * @var int|null
      */
     public $fileSize;
 
     /**
      * Mime type of the file.
      *
-     * @var string
+     * @var string|null
      */
     public $mimeType;
 
     /**
      * HTTP URI.
      *
-     * @var string
+     * @var string|null
      */
     public $uri;
 

--- a/eZ/Publish/Core/FieldType/Date/Value.php
+++ b/eZ/Publish/Core/FieldType/Date/Value.php
@@ -19,7 +19,7 @@ class Value extends BaseValue
     /**
      * Date content.
      *
-     * @var \DateTime
+     * @var \DateTime|null
      */
     public $date;
 

--- a/eZ/Publish/Core/FieldType/DateAndTime/Value.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/Value.php
@@ -19,7 +19,7 @@ class Value extends BaseValue
     /**
      * Date content.
      *
-     * @var \DateTime
+     * @var \DateTime|null
      */
     public $value;
 

--- a/eZ/Publish/Core/FieldType/Float/Value.php
+++ b/eZ/Publish/Core/FieldType/Float/Value.php
@@ -16,7 +16,7 @@ class Value extends BaseValue
     /**
      * Float content.
      *
-     * @var float
+     * @var float|null
      */
     public $value;
 

--- a/eZ/Publish/Core/FieldType/Image/Value.php
+++ b/eZ/Publish/Core/FieldType/Image/Value.php
@@ -26,7 +26,7 @@ class Value extends BaseValue
      *
      * Required.
      *
-     * @var mixed
+     * @var mixed|null
      */
     public $id;
 
@@ -42,7 +42,7 @@ class Value extends BaseValue
      *
      * Required.
      *
-     * @var string
+     * @var string|null
      */
     public $fileName;
 
@@ -51,42 +51,42 @@ class Value extends BaseValue
      *
      * Required.
      *
-     * @var int
+     * @var int|null
      */
     public $fileSize;
 
     /**
      * The image's HTTP URI.
      *
-     * @var string
+     * @var string|null
      */
     public $uri;
 
     /**
      * External image ID (required by REST for now, see https://jira.ez.no/browse/EZP-20831).
      *
-     * @var mixed
+     * @var mixed|null
      */
     public $imageId;
 
     /**
      * Input image file URI.
      *
-     * @var string
+     * @var string|null
      */
     public $inputUri;
 
     /**
      * Original image width.
      *
-     * @var int
+     * @var int|null
      */
     public $width;
 
     /**
      * Original image height.
      *
-     * @var int
+     * @var int|null
      */
     public $height;
 

--- a/eZ/Publish/Core/FieldType/Integer/Value.php
+++ b/eZ/Publish/Core/FieldType/Integer/Value.php
@@ -16,7 +16,7 @@ class Value extends BaseValue
     /**
      * Content of the value.
      *
-     * @var int
+     * @var int|null
      */
     public $value;
 

--- a/eZ/Publish/Core/FieldType/MapLocation/Value.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/Value.php
@@ -16,21 +16,21 @@ class Value extends BaseValue
     /**
      * Latitude of the location.
      *
-     * @var float
+     * @var float|null
      */
     public $latitude;
 
     /**
      * Longitude of the location.
      *
-     * @var float
+     * @var float|null
      */
     public $longitude;
 
     /**
      * Display address for the location.
      *
-     * @var string
+     * @var string|null
      */
     public $address;
 

--- a/eZ/Publish/Core/FieldType/Url/Value.php
+++ b/eZ/Publish/Core/FieldType/Url/Value.php
@@ -16,14 +16,14 @@ class Value extends BaseValue
     /**
      * Link content.
      *
-     * @var string
+     * @var string|null
      */
     public $link;
 
     /**
      * Text content.
      *
-     * @var string
+     * @var string|null
      */
     public $text;
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31674](https://jira.ez.no/browse/EZP-31674)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Currently, incorrect property types defined in PHPDoc.
For example, in "eZ\Publish\Core\FieldType\Integer\Value"
```
/**
 * Content of the value.
 *
 * @var int
 */
public $value;
```
So, it's not clear for developer if this value will be 0 when not set.
And, if the developer created app-level value object following the same type, it will throw error.
```
class MyValueObject {
    public int $count;
}
// error here:
$objInstance->count = $content->getFieldValue('some_integer')->value;
```

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
