### PR TITLE
EZP-31680: Provided `languageCode` param to REST Views

### DIFF
--- a/eZ/Publish/Core/REST/Server/Controller/Views.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Views.php
@@ -55,7 +55,7 @@ class Views extends Controller
         if (!empty($viewInput->query->query->value)) {
             $languageFilter['excludeTranslationsFromAlwaysAvailable'] = false;
         }
-        
+
         return new Values\RestExecutedView(
             [
                 'identifier' => $viewInput->identifier,

--- a/eZ/Publish/Core/REST/Server/Controller/Views.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Views.php
@@ -52,7 +52,8 @@ class Views extends Controller
             'languages' => null !== $viewInput->languageCode ? [$viewInput->languageCode] : Language::ALL,
             'useAlwaysAvailable' => $viewInput->useAlwaysAvailable ?? true,
         ];
-        if (!empty($viewInput->query->query->value)) {
+        $query = $viewInput->query->query;
+        if (!empty($query->value)) {
             $languageFilter['excludeTranslationsFromAlwaysAvailable'] = false;
         }
 

--- a/eZ/Publish/Core/REST/Server/Controller/Views.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Views.php
@@ -53,7 +53,7 @@ class Views extends Controller
                 'identifier' => $viewInput->identifier,
                 'searchResults' => $this->searchService->$method(
                     $viewInput->query,
-                    ['languages' => Language::ALL]
+                    ['languages' => null !== $viewInput->languageCode ? [$viewInput->languageCode] : Language::ALL]
                 ),
             ]
         );

--- a/eZ/Publish/Core/REST/Server/Controller/Views.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Views.php
@@ -48,12 +48,20 @@ class Views extends Controller
             $method = 'findContent';
         }
 
+        $languageFilter = [
+            'languages' => null !== $viewInput->languageCode ? [$viewInput->languageCode] : Language::ALL,
+            'useAlwaysAvailable' => $viewInput->useAlwaysAvailable ?? true,
+        ];
+        if (!empty($viewInput->query->query->value)) {
+            $languageFilter['excludeTranslationsFromAlwaysAvailable'] = false;
+        }
+        
         return new Values\RestExecutedView(
             [
                 'identifier' => $viewInput->identifier,
                 'searchResults' => $this->searchService->$method(
                     $viewInput->query,
-                    ['languages' => null !== $viewInput->languageCode ? [$viewInput->languageCode] : Language::ALL]
+                    $languageFilter
                 ),
             ]
         );

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
@@ -36,7 +36,7 @@ class ViewInput extends BaseParser
         }
         $restViewInput->identifier = $data['identifier'];
         $restViewInput->languageCode = $data['languageCode'] ?? null;
-        $restViewInput->useAlwaysAvailable = $data['useAlwaysAvailable'] ?? true;
+        $restViewInput->useAlwaysAvailable = $data['useAlwaysAvailable'] ?? null;
 
         // query
         if (!array_key_exists('Query', $data) || !is_array($data['Query'])) {

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
@@ -35,6 +35,7 @@ class ViewInput extends BaseParser
             throw new Exceptions\Parser('Missing <identifier> attribute for <ViewInput>.');
         }
         $restViewInput->identifier = $data['identifier'];
+        $restViewInput->languageCode = $data['languageCode'] ?? null;
 
         // query
         if (!array_key_exists('Query', $data) || !is_array($data['Query'])) {

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
@@ -36,6 +36,7 @@ class ViewInput extends BaseParser
         }
         $restViewInput->identifier = $data['identifier'];
         $restViewInput->languageCode = $data['languageCode'] ?? null;
+        $restViewInput->useAlwaysAvailable = $data['useAlwaysAvailable'] ?? true;
 
         // query
         if (!array_key_exists('Query', $data) || !is_array($data['Query'])) {

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInputOneDotOne.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInputOneDotOne.php
@@ -36,7 +36,7 @@ class ViewInputOneDotOne extends CriterionParser
         }
         $restViewInput->identifier = $data['identifier'];
         $restViewInput->languageCode = $data['languageCode'] ?? null;
-        $restViewInput->useAlwaysAvailable = $data['useAlwaysAvailable'] ?? true;
+        $restViewInput->useAlwaysAvailable = $data['useAlwaysAvailable'] ?? null;
 
         // query
         if (array_key_exists('ContentQuery', $data) && is_array($data['ContentQuery'])) {

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInputOneDotOne.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInputOneDotOne.php
@@ -36,6 +36,7 @@ class ViewInputOneDotOne extends CriterionParser
         }
         $restViewInput->identifier = $data['identifier'];
         $restViewInput->languageCode = $data['languageCode'] ?? null;
+        $restViewInput->useAlwaysAvailable = $data['useAlwaysAvailable'] ?? true;
 
         // query
         if (array_key_exists('ContentQuery', $data) && is_array($data['ContentQuery'])) {

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInputOneDotOne.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInputOneDotOne.php
@@ -35,6 +35,7 @@ class ViewInputOneDotOne extends CriterionParser
             throw new Exceptions\Parser('Missing <identifier> attribute for <ViewInput>.');
         }
         $restViewInput->identifier = $data['identifier'];
+        $restViewInput->languageCode = $data['languageCode'] ?? null;
 
         // query
         if (array_key_exists('ContentQuery', $data) && is_array($data['ContentQuery'])) {

--- a/eZ/Publish/Core/REST/Server/Values/RestViewInput.php
+++ b/eZ/Publish/Core/REST/Server/Values/RestViewInput.php
@@ -31,4 +31,9 @@ class RestViewInput extends RestValue
      * @var string|null
      */
     public $languageCode;
+
+    /**
+     * @var bool
+     */
+    public $useAlwaysAvailable;
 }

--- a/eZ/Publish/Core/REST/Server/Values/RestViewInput.php
+++ b/eZ/Publish/Core/REST/Server/Values/RestViewInput.php
@@ -33,7 +33,7 @@ class RestViewInput extends RestValue
     public $languageCode;
 
     /**
-     * @var bool
+     * @var bool|null
      */
     public $useAlwaysAvailable;
 }

--- a/eZ/Publish/Core/REST/Server/Values/RestViewInput.php
+++ b/eZ/Publish/Core/REST/Server/Values/RestViewInput.php
@@ -26,4 +26,9 @@ class RestViewInput extends RestValue
      * @var string
      */
     public $identifier;
+
+    /**
+     * @var string|null
+     */
+    public $languageCode;
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31680](https://jira.ez.no/browse/EZP-31680)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

REST views will now utilize `languageCode` param in order to find `Content` in the chosen language.

Related PR: https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/286

Side note: Rest visitor is not able to receive any language info as it is created out of `Location` object - https://github.com/ezsystems/ezpublish-kernel/blob/7.5/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php#L41 It would be great to force a language on this line, but I don't think its really possible right now without some heavy alterations.

**TODO**:
- [x] Implement feature.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
