### PR TITLE
EZP-31718: Added normalizer for SimplifiedRequest

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
@@ -20,6 +20,7 @@ trait SerializerTrait
         return new Serializer(
             [
                 new CompoundMatcherNormalizer(),
+                new SimplifiedRequestNormalizer(),
                 (new PropertyNormalizer())->setIgnoredAttributes(['request', 'container', 'matcherBuilder']),
             ],
             [new JsonEncoder()]

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizer.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Component\Serializer;
+
+use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
+use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
+
+final class SimplifiedRequestNormalizer implements ContextAwareNormalizerInterface
+{
+    /**
+     * @see \Symfony\Component\Serializer\Normalizer\NormalizerInterface::normalize
+     *
+     * @param \eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest $object
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        return [
+            'scheme' => $object->scheme,
+            'host' => $object->host,
+            'port' => $object->port,
+            'pathinfo' => $object->pathinfo,
+            'queryParams' => $object->queryParams,
+            'languages' => $object->languages,
+            'headers' => [],
+        ];
+    }
+
+    public function supportsNormalization($data, $format = null, array $context = [])
+    {
+        return $data instanceof SimplifiedRequest;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizer.php
@@ -7,9 +7,9 @@
 namespace eZ\Publish\Core\MVC\Symfony\Component\Serializer;
 
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
-use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 
-final class SimplifiedRequestNormalizer implements ContextAwareNormalizerInterface
+final class SimplifiedRequestNormalizer extends PropertyNormalizer
 {
     /**
      * @see \Symfony\Component\Serializer\Normalizer\NormalizerInterface::normalize

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/SimplifiedRequestNormalizerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/SimplifiedRequestNormalizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Component\Tests\Serializer;
+
+use eZ\Publish\Core\MVC\Symfony\Component\Serializer\SimplifiedRequestNormalizer;
+use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class SimplifiedRequestNormalizerTest extends TestCase
+{
+    public function testNormalize()
+    {
+        $request = new SimplifiedRequest([
+            'scheme' => 'http',
+            'host' => 'www.example.com',
+            'port' => 8080,
+            'pathinfo' => '/foo',
+            'queryParams' => ['param' => 'value', 'this' => 'that'],
+            'headers' => [
+                'Accept' => 'text/html,application/xhtml+xml',
+                'Accept-Encoding' => 'gzip, deflate, br',
+                'Accept-Language' => 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
+                'User-Agent' => 'Mozilla/5.0',
+                'Cookie' => 'eZSESSID21232f297a57a5a743894a0e4a801fc3=mgbs2p6lv936hb5hmdd2cvq6bq',
+                'Connection' => 'keep-alive',
+            ],
+            'languages' => ['pl-PL', 'en-US'],
+        ]);
+
+        $normalizer = new SimplifiedRequestNormalizer();
+
+        $this->assertEquals([
+            'scheme' => 'http',
+            'host' => 'www.example.com',
+            'port' => 8080,
+            'pathinfo' => '/foo',
+            'queryParams' => ['param' => 'value', 'this' => 'that'],
+            'headers' => [],
+            'languages' => ['pl-PL', 'en-US'],
+        ], $normalizer->normalize($request));
+    }
+
+    public function testSupportsNormalization()
+    {
+        $normalizer = new SimplifiedRequestNormalizer();
+
+        $this->assertTrue($normalizer->supportsNormalization(new SimplifiedRequest()));
+        $this->assertFalse($normalizer->supportsNormalization(new stdClass()));
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31718](https://jira.ez.no/browse/EZP-31718)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

EZP-31437 we changed siteaccess serialization format form PHP build-in to JSON. However `\eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest::__sleep` was never reimplemented as  `\Symfony\Component\Serializer\Normalizer\NormalizerInterface` which leads to issue described in JIRA ticket.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
