### PR TITLE
[Composer] Added conflict with Symfony 3.4.43 due to regressions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "ezsystems/behatbundle": "^6.4"
     },
     "conflict": {
-        "symfony/symfony": "3.4.7",
+        "symfony/symfony": "3.4.7 || 3.4.43",
         "doctrine/dbal": "2.7.0",
         "ezsystems/ezpublish-legacy": "<2019.03"
     },


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **Bug/Improvement**| yes
| **Target version** | `7.5` and possibly all newer supported
| **Doc needed**     | yes/no

Looks like there's some kind of regression in [Symfony 3.4.43](https://github.com/symfony/symfony/releases/tag/v3.4.43) released today. There are [a lot of failures](https://travis-ci.org/github/ezsystems/ezpublish-kernel/builds/711385546) reported by Travis.

Let's see if conflict makes Travis green. Meanwhile I'll try to establish what exactly happened.
