### PR TITLE
EZP-31584: Created LocationResolver service which provides first available Location

### DIFF
--- a/eZ/Publish/Core/Repository/LocationResolver/LocationResolver.php
+++ b/eZ/Publish/Core/Repository/LocationResolver/LocationResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Repository\LocationResolver;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+/**
+ * @internal For internal use by ezsystems packages
+ */
+interface LocationResolver
+{
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     */
+    public function resolveLocation(ContentInfo $contentInfo): Location;
+}

--- a/eZ/Publish/Core/Repository/LocationResolver/LocationResolver.php
+++ b/eZ/Publish/Core/Repository/LocationResolver/LocationResolver.php
@@ -12,7 +12,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 
 /**
- * @internal For internal use by ezsystems packages
+ * @internal For internal use by eZ Platform core packages
  */
 interface LocationResolver
 {

--- a/eZ/Publish/Core/Repository/LocationResolver/PermissionAwareLocationResolver.php
+++ b/eZ/Publish/Core/Repository/LocationResolver/PermissionAwareLocationResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Repository\LocationResolver;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+final class PermissionAwareLocationResolver implements LocationResolver
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     */
+    public function resolveLocation(ContentInfo $contentInfo): Location
+    {
+        try {
+            $location = $this->locationService->loadLocation($contentInfo->mainLocationId);
+        } catch (NotFoundException | UnauthorizedException $e) {
+            // try different locations if main location is not accessible for the user
+            $locations = $this->locationService->loadLocations($contentInfo);
+            if (empty($locations)) {
+                throw $e;
+            }
+
+            // foreach to keep forward compatibility with a type of returned loadLocations() result
+            foreach ($locations as $location) {
+                return $location;
+            }
+        }
+
+        return $location;
+    }
+}

--- a/eZ/Publish/Core/Repository/LocationResolver/PermissionAwareLocationResolver.php
+++ b/eZ/Publish/Core/Repository/LocationResolver/PermissionAwareLocationResolver.php
@@ -13,7 +13,7 @@ use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
-use eZ\Publish\Core\Base\Exceptions\NotFoundException as NotFoundExceptionCore;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException as CoreNotFoundException;
 
 /**
  * @internal For internal use by eZ Platform core packages
@@ -37,7 +37,7 @@ final class PermissionAwareLocationResolver implements LocationResolver
     {
         try {
             if (null === $contentInfo->mainLocationId) {
-                throw new NotFoundExceptionCore('location', $contentInfo->mainLocationId);
+                throw new CoreNotFoundException('location', $contentInfo->mainLocationId);
             }
 
             $location = $this->locationService->loadLocation($contentInfo->mainLocationId);

--- a/eZ/Publish/Core/Repository/LocationResolver/PermissionAwareLocationResolver.php
+++ b/eZ/Publish/Core/Repository/LocationResolver/PermissionAwareLocationResolver.php
@@ -13,7 +13,11 @@ use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException as NotFoundExceptionCore;
 
+/**
+ * @internal For internal use by eZ Platform core packages
+ */
 final class PermissionAwareLocationResolver implements LocationResolver
 {
     /** @var \eZ\Publish\API\Repository\LocationService */
@@ -32,6 +36,10 @@ final class PermissionAwareLocationResolver implements LocationResolver
     public function resolveLocation(ContentInfo $contentInfo): Location
     {
         try {
+            if (null === $contentInfo->mainLocationId) {
+                throw new NotFoundExceptionCore('location', $contentInfo->mainLocationId);
+            }
+
             $location = $this->locationService->loadLocation($contentInfo->mainLocationId);
         } catch (NotFoundException | UnauthorizedException $e) {
             // try different locations if main location is not accessible for the user

--- a/eZ/Publish/Core/Repository/Tests/LocationResolver/PermissionAwareLocationResolverTest.php
+++ b/eZ/Publish/Core/Repository/Tests/LocationResolver/PermissionAwareLocationResolverTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Repository\Tests\LocationResolver;
+
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\Repository\LocationResolver\PermissionAwareLocationResolver;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use PHPUnit\Framework\TestCase;
+
+final class PermissionAwareLocationResolverTest extends TestCase
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /** @var \eZ\Publish\Core\Repository\LocationResolver\LocationResolver */
+    private $locationResolver;
+
+    public function setUp(): void
+    {
+        $this->locationService = $this->createMock(LocationService::class);
+
+        $this->locationResolver = new PermissionAwareLocationResolver($this->locationService);
+    }
+
+    /**
+     * Test for the resolveLocation() method.
+     *
+     * @covers \eZ\Publish\Core\Repository\LocationResolver\PermissionAwareLocationResolver::resolveLocation()
+     */
+    public function testResolveMainLocation(): void
+    {
+        $contentInfo = new ContentInfo(['mainLocationId' => 42]);
+        $location = new Location(['id' => 42]);
+
+        // User has access to the main Location
+        $this->locationService
+            ->method('loadLocation')
+            ->willReturn($location);
+
+        $this->assertSame($location, $this->locationResolver->resolveLocation($contentInfo));
+    }
+
+    /**
+     * Test for the resolveLocation() method.
+     *
+     * @covers \eZ\Publish\Core\Repository\LocationResolver\PermissionAwareLocationResolver::resolveLocation()
+     */
+    public function testResolveSecondaryLocation(): void
+    {
+        $contentInfo = new ContentInfo(['mainLocationId' => 42]);
+        $location1 = new Location(['id' => 43]);
+        $location2 = new Location(['id' => 44]);
+
+        // User doesn't have access to main location but to the third Content's location
+        $this->locationService
+            ->method('loadLocation')
+            ->willThrowException($this->createMock(UnauthorizedException::class));
+
+        $this->locationService
+            ->method('loadLocations')
+            ->willReturn([$location1, $location2]);
+
+        $this->assertSame($location1, $this->locationResolver->resolveLocation($contentInfo));
+    }
+}

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -24,8 +24,6 @@ parameters:
     ezpublish.api.storage_engine.class: eZ\Publish\SPI\Persistence\Handler
     ezpublish.api.search_engine.class: eZ\Publish\SPI\Search\Handler
 
-    ezpublish.repository.permission_aware_location_resolver.class: eZ\Publish\Core\Repository\LocationResolver\PermissionAwareLocationResolver
-
 services:
     ezpublish.api.repository.factory:
         class: "%ezpublish.api.repository.factory.class%"

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -24,6 +24,7 @@ parameters:
     ezpublish.api.storage_engine.class: eZ\Publish\SPI\Persistence\Handler
     ezpublish.api.search_engine.class: eZ\Publish\SPI\Search\Handler
 
+    ezpublish.repository.permission_aware_location_resolver.class: eZ\Publish\Core\Repository\LocationResolver\PermissionAwareLocationResolver
 
 services:
     ezpublish.api.repository.factory:
@@ -153,3 +154,12 @@ services:
             - '@ezpublish.api.persistence_handler'
         calls:
             - ['setLogger', ['@?logger']]
+
+    ezpublish.repository.permission_aware_location_resolver:
+        class: "%ezpublish.repository.permission_aware_location_resolver.class%"
+        arguments:
+            - '@ezpublish.api.service.location'
+
+    ezpublish.repository.location_resolver:
+        alias: "ezpublish.repository.permission_aware_location_resolver"
+        lazy: true

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -155,10 +155,9 @@ services:
         calls:
             - ['setLogger', ['@?logger']]
 
-    ezpublish.repository.permission_aware_location_resolver:
-        class: "%ezpublish.repository.permission_aware_location_resolver.class%"
+    eZ\Publish\Core\Repository\LocationResolver\PermissionAwareLocationResolver:
         arguments:
             - '@ezpublish.api.service.location'
 
-    ezpublish.repository.location_resolver:
-        alias: "ezpublish.repository.permission_aware_location_resolver"
+    eZ\Publish\Core\Repository\LocationResolver\LocationResolver:
+        alias: eZ\Publish\Core\Repository\LocationResolver\PermissionAwareLocationResolver

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -162,4 +162,3 @@ services:
 
     ezpublish.repository.location_resolver:
         alias: "ezpublish.repository.permission_aware_location_resolver"
-        lazy: true


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31584](https://jira.ez.no/browse/EZP-31584)
| **Improvement**| yes
| **New feature**    | no
| **Target version** | 7.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

When loading Relation main Location might not be accessible for the end-user due to permissions which results in Unauthorized Exception even though the user can have access to different Locations of this Relation.

Related `admin-ui` PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/1439

**TODO**:
- [x] Implement improvement.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
