### PR TITLE
Testing Symfony cache invalidation fix (symfony/symfony#37671)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-xsl": "*",
         "ext-curl": "*",
         "ezsystems/doctrine-dbal-schema": "^0.1@dev",
-        "symfony/symfony": "^3.4.17",
+        "symfony/symfony": "^3.4@dev",
         "symfony-cmf/routing": "^2.1",
         "kriswallsmith/buzz": "^0.17.2",
         "sensio/distribution-bundle": "^5.0.22",


### PR DESCRIPTION
Looks like the latest patch release of Symfony (`3.4.43`, `4.4.11`, `5.0.11`, and `5.1.3`) introduced some kind of regression in cache invalidation. Our Travis integration tests jobs [fail all over the place](https://travis-ci.org/github/ezsystems/ezpublish-kernel/builds/711385546) because outdated information is loaded.

The fix symfony/symfony#37671 seems to solve the issue.

See:
* [Failing](https://travis-ci.org/github/ezsystems/ezpublish-kernel/builds/711966995) build for e68e7df with `symfony/symfony:^3.4@dev`:
* [Passing](https://travis-ci.org/github/ezsystems/ezpublish-kernel/builds/712114610) build for 349d2ad with symfony/symfony#37671 fix.