### PR TITLE
EZP-31779: Add missing language filter parameter in LocationSearchHitAdapter->getNbResult()

### DIFF
--- a/eZ/Publish/Core/Pagination/Pagerfanta/LocationSearchHitAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/LocationSearchHitAdapter.php
@@ -59,7 +59,7 @@ class LocationSearchHitAdapter implements AdapterInterface
         $countQuery = clone $this->query;
         $countQuery->limit = 0;
 
-        return $this->nbResults = $this->searchService->findLocations($countQuery)->totalCount;
+        return $this->nbResults = $this->searchService->findLocations($countQuery, $this->languageFilter)->totalCount;
     }
 
     /**


### PR DESCRIPTION
Adding language filter parameter.
Forgotten here: https://github.com/ezsystems/ezpublish-kernel/commit/494b58835b3992ba8caf9b8300d44b98b1e76983

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31779](https://jira.ez.no/browse/EZP-31779)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.x`/`7.x` for bug fixes or improvements _(on existing features)_, `master` for features
| **BC breaks**      | yes/no
| **Tests pass**     | yes/no
| **Doc needed**     |no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
