### PR TITLE
EZP-31511: Fixed validation of custom URL alias entry

### DIFF
--- a/doc/bc/changes-7.5.md
+++ b/doc/bc/changes-7.5.md
@@ -26,6 +26,10 @@ Changes affecting version compatibility with former or future versions.
   contain any of the translations that are within the scope of the Language Limitations.
   This is due to the fact that when creating a Draft, an intent of translating is not known yet.
 
+* The `ForbiddenException` message thrown by `URLAliasService::createUrlAlias` and
+  `URLAliasService::createGlobalUrlAlias` methods states now `Path '%path%' already exists for the given context`
+  instead of `Path '%path%' already exists for the given language` for the same cases.
+
 ## Deprecations
 
 * The `\EzSystems\PlatformInstallerBundle\Installer\CleanInstaller` class and its Service Container

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/translations/repository_exceptions.en.xlf
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/translations/repository_exceptions.en.xlf
@@ -163,10 +163,10 @@
         <note>key: Only version in status DRAFT can be updated</note>
         <jms:reference-file line="461">eZ/Publish/Core/REST/Server/Controller/Content.php</jms:reference-file>
       </trans-unit>
-      <trans-unit id="3467ebb6448f4d8dd9f8a99cbea79415f25fa26d" resname="Path '%path%' already exists for the given language">
-        <source>Path '%path%' already exists for the given language</source>
-        <target>Path '%path%' already exists for the given language</target>
-        <note>key: Path '%path%' already exists for the given language</note>
+      <trans-unit id="3467ebb6448f4d8dd9f8a99cbea79415f25fa26d" resname="Path '%path%' already exists for the given context">
+        <source>Path '%path%' already exists for the given context</source>
+        <target>Path '%path%' already exists for the given context</target>
+        <note>key: Path '%path%' already exists for the given context</note>
         <jms:reference-file line="397">eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="b2d83ff8d535b64b36eaab04237a3091fc10ee5a" resname="Placeholders are not matching with wildcards.">

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -698,8 +698,11 @@ abstract class BaseTest extends TestCase
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    protected function createFolder(array $names, $parentLocationId)
-    {
+    protected function createFolder(
+        array $names,
+        $parentLocationId,
+        bool $alwaysAvailable = true
+    ): Content {
         $repository = $this->getRepository(false);
         $contentService = $repository->getContentService();
         $contentTypeService = $repository->getContentTypeService();
@@ -714,6 +717,7 @@ abstract class BaseTest extends TestCase
             $contentTypeService->loadContentTypeByIdentifier('folder'),
             $mainLanguageCode
         );
+        $struct->alwaysAvailable = $alwaysAvailable;
         foreach ($names as $languageCode => $translatedName) {
             $struct->setField('name', $translatedName, $languageCode);
         }

--- a/eZ/Publish/API/Repository/Tests/URLAliasService/CustomUrlAliasForMultilingualContentTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasService/CustomUrlAliasForMultilingualContentTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\URLAliasService;
+
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
+use eZ\Publish\API\Repository\Tests\BaseTest;
+
+final class CustomUrlAliasForMultilingualContentTest extends BaseTest
+{
+    /**
+     * @covers \eZ\Publish\API\Repository\ContentService::publishVersion
+     * @covers \eZ\Publish\API\Repository\URLAliasService::createUrlAlias
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testCreateCustomUrlAliasWithTheSamePathThrowsException(): void
+    {
+        $repository = $this->getRepository();
+        $urlAliasService = $repository->getURLAliasService();
+        $locationService = $repository->getLocationService();
+        $language = 'ger-DE';
+
+        $names = [
+            'eng-GB' => 'Contact',
+            'ger-DE' => 'Kontakt',
+            'eng-US' => 'Contact',
+        ];
+        $contactFolder = $this->createFolder(
+            $names,
+            2,
+            false // not always available, so the created content behaves the same as "article"
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Argument \'$path\' is invalid: Path \'Contact\' already exists for the given language'
+        );
+        // attempt to create custom alias for German translation while a system one
+        // for a different translation already exists
+        $urlAliasService->createUrlAlias(
+            $locationService->loadLocation(
+                $contactFolder->contentInfo->mainLocationId
+            ),
+            'Contact',
+            $language,
+            true, // forwarding
+            true // always available
+        );
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/URLAliasService/CustomUrlAliasForMultilingualContentTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasService/CustomUrlAliasForMultilingualContentTest.php
@@ -41,7 +41,7 @@ final class CustomUrlAliasForMultilingualContentTest extends BaseTest
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Argument \'$path\' is invalid: Path \'Contact\' already exists for the given language'
+            'Argument \'$path\' is invalid: Path \'Contact\' already exists for the given context'
         );
         // attempt to create custom alias for German translation while a system one
         // for a different translation already exists

--- a/eZ/Publish/API/Repository/URLAliasService.php
+++ b/eZ/Publish/API/Repository/URLAliasService.php
@@ -29,7 +29,7 @@ interface URLAliasService
      * @param bool $alwaysAvailable
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to create url alias
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the path already exists for the given language
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the path already exists for the given context
      *
      * @return \eZ\Publish\API\Repository\Values\Content\URLAlias
      */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway.php
@@ -14,7 +14,10 @@ abstract class Gateway
     /**
      * Default database table.
      */
-    const TABLE = 'ezurlalias_ml';
+    public const TABLE = 'ezurlalias_ml';
+
+    public const NOP = 'nop';
+    public const NOP_ACTION = self::NOP . ':';
 
     /**
      * Changes the gateway database table.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -28,7 +28,7 @@ class DoctrineDatabase extends Gateway
      * 2^30, since PHP_INT_MAX can cause overflows in DB systems, if PHP is run
      * on 64 bit systems.
      */
-    const MAX_LIMIT = 1073741824;
+    public const MAX_LIMIT = 1073741824;
 
     /**
      * Columns of database tables.
@@ -648,7 +648,7 @@ class DoctrineDatabase extends Gateway
         if ($values['is_alias']) {
             $values['is_original'] = 1;
         }
-        if ($values['action'] === 'nop:') {
+        if ($values['action'] === self::NOP_ACTION) {
             $values['is_original'] = 0;
         }
 
@@ -1504,7 +1504,7 @@ class DoctrineDatabase extends Gateway
             ->where(
                 sprintf('EXISTS (%s)', $wrapperQueryBuilder)
             )
-            ->setParameter('actionType', 'nop');
+            ->setParameter('actionType', self::NOP);
 
         return $queryBuilder->execute();
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -16,7 +16,6 @@ use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\Persistence\Database\Query;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator as LanguageMaskGenerator;
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway;
-use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Language;
 use RuntimeException;
 
 /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -233,7 +233,11 @@ class Handler implements UrlAliasHandlerInterface
             // 1. NOP entry
             // 2. existing location or custom alias entry
             // 3. history entry
-            if ($row['action'] == 'nop:' || $row['action'] == $action || $row['is_original'] == 0) {
+            if (
+                $row['action'] === Gateway::NOP_ACTION ||
+                $row['action'] === $action ||
+                (int)$row['is_original'] === 0
+            ) {
                 // Check for existing location entry on this level, if it exists and it's id differs from reusable
                 // entry id then reusable entry should be updated with the existing location entry id.
                 // Note: existing location entry may be downgraded and relinked later, depending on its language.
@@ -431,7 +435,7 @@ class Handler implements UrlAliasHandlerInterface
         if ($isPathNew || empty($row)) {
             $data['lang_mask'] = $languageId | (int)$alwaysAvailable;
             $id = $this->gateway->insertRow($data);
-        } elseif ($row['action'] === 'nop:' || (int)$row['is_original'] === 0) {
+        } elseif ($row['action'] === Gateway::NOP_ACTION || (int)$row['is_original'] === 0) {
             // Row exists, check if it is reusable. There are 2 cases when this is possible:
             // 1. NOP entry
             // 2. history entry
@@ -482,7 +486,7 @@ class Handler implements UrlAliasHandlerInterface
         return $this->gateway->insertRow(
             [
                 'lang_mask' => 1,
-                'action' => 'nop:',
+                'action' => Gateway::NOP_ACTION,
                 'parent' => $parentId,
                 'text' => $text,
                 'text_md5' => $textMD5,
@@ -1144,8 +1148,8 @@ class Handler implements UrlAliasHandlerInterface
 
     private function insertAliasEntryAsNop(array $aliasEntry): void
     {
-        $aliasEntry['action'] = 'nop:';
-        $aliasEntry['action_type'] = 'nop';
+        $aliasEntry['action'] = Gateway::NOP_ACTION;
+        $aliasEntry['action_type'] = Gateway::NOP;
 
         $this->gateway->insertRow($aliasEntry);
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -335,7 +335,7 @@ class Handler implements UrlAliasHandlerInterface
      * If $languageCode is null the $alias is created in the system's default
      * language. $alwaysAvailable makes the alias available in all languages.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException if the path already exists for the given language
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException if the path already exists for the given resource
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the path is broken
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      *
@@ -361,7 +361,7 @@ class Handler implements UrlAliasHandlerInterface
     /**
      * Internal method for creating global or custom URL alias (these are handled in the same way).
      *
-     * @throws \eZ\Publish\Core\Base\Exceptions\ForbiddenException if the path already exists for the given language
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException if the path already exists for the given context
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      *
@@ -457,7 +457,10 @@ class Handler implements UrlAliasHandlerInterface
                 $data
             );
         } else {
-            throw new ForbiddenException("Path '%path%' already exists for the given language", ['%path%' => $path]);
+            throw new ForbiddenException(
+                "Path '%path%' already exists for the given context",
+                ['%path%' => $path]
+            );
         }
 
         $data['raw_path_data'] = $this->gateway->loadPathData($id);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator;
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\DTO\SwappedLocationProperties;
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\DTO\UrlAliasForSwappedLocation;
 use eZ\Publish\SPI\Persistence\Content\Language;
+use eZ\Publish\SPI\Persistence\Content\UrlAlias;
 use eZ\Publish\SPI\Persistence\Content\UrlAlias\Handler as UrlAliasHandlerInterface;
 use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
@@ -372,7 +373,7 @@ class Handler implements UrlAliasHandlerInterface
      *
      * @return \eZ\Publish\SPI\Persistence\Content\UrlAlias
      */
-    protected function createUrlAlias($action, $path, $forward, $languageCode, $alwaysAvailable)
+    protected function createUrlAlias($action, $path, $forward, $languageCode, $alwaysAvailable): UrlAlias
     {
         $pathElements = explode('/', $path);
         $topElement = array_pop($pathElements);
@@ -399,11 +400,14 @@ class Handler implements UrlAliasHandlerInterface
         }
 
         // Handle topmost path element
-        $topElement = $this->slugConverter->convert($topElement, 'noname' . (count($pathElements) + 1));
+        $topElement = $this->slugConverter->convert(
+            $topElement,
+            'noname' . (count($pathElements) + 1)
+        );
 
         // If last (next to topmost) entry parent is special root entry we handle topmost entry as first level entry
         // That is why we need to reset $parentId to 0
-        if ($parentId != 0 && $this->gateway->isRootEntry($parentId)) {
+        if ($parentId !== 0 && $this->gateway->isRootEntry($parentId)) {
             $parentId = 0;
         }
 
@@ -427,7 +431,7 @@ class Handler implements UrlAliasHandlerInterface
         if ($isPathNew || empty($row)) {
             $data['lang_mask'] = $languageId | (int)$alwaysAvailable;
             $id = $this->gateway->insertRow($data);
-        } elseif ($row['action'] == 'nop:' || $row['is_original'] == 0) {
+        } elseif ($row['action'] === 'nop:' || (int)$row['is_original'] === 0) {
             // Row exists, check if it is reusable. There are 2 cases when this is possible:
             // 1. NOP entry
             // 2. history entry

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -439,7 +439,11 @@ class Handler implements UrlAliasHandlerInterface
                 $topElementMD5,
                 $data
             );
-        } elseif ($row['action'] == $action && 0 === ((int)$row['lang_mask'] & $languageId)) {
+        } elseif (
+            $row['action'] === $action &&
+            (int)$row['is_alias'] === 1 &&
+            0 === ((int)$row['lang_mask'] & $languageId)
+        ) {
             // add another language to the same custom alias
             $data['link'] = $id = $row['id'];
             $data['lang_mask'] = $row['lang_mask'] | $languageId | (int)$alwaysAvailable;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
@@ -2262,21 +2262,22 @@ class UrlAliasHandlerTest extends TestCase
     }
 
     /**
-     * Test for the createUrlAlias() method.
-     *
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Handler::createUrlAlias
      * @group create
      * @group custom
      */
-    public function testCreateCustomUrlAliasAddLanguage()
+    public function testCreateCustomUrlAliasAddLanguage(): void
     {
         $handler = $this->getHandler();
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/publish_base.php');
 
+        // create a new custom entry since the existing one is a system URL
+        $handler->createCustomUrlAlias(314, 'custom-path314', false, 'cro-HR', true);
+
         $countBeforeReusing = $this->countRows();
         $handler->createCustomUrlAlias(
             314,
-            'path314',
+            'custom-path314',
             false,
             'eng-GB',
             true
@@ -2289,7 +2290,7 @@ class UrlAliasHandlerTest extends TestCase
         self::assertEquals(
             new UrlAlias(
                 [
-                    'id' => '0-fdbbfa1e24e78ef56cb16ba4482c7771',
+                    'id' => '0-e8797691eeba6b598a353e5c5af99438',
                     'type' => UrlAlias::LOCATION,
                     'destination' => '314',
                     'languageCodes' => ['cro-HR', 'eng-GB'],
@@ -2297,8 +2298,8 @@ class UrlAliasHandlerTest extends TestCase
                         [
                             'always-available' => true,
                             'translations' => [
-                                'cro-HR' => 'path314',
-                                'eng-GB' => 'path314',
+                                'cro-HR' => 'custom-path314',
+                                'eng-GB' => 'custom-path314',
                             ],
                         ],
                     ],
@@ -2308,7 +2309,7 @@ class UrlAliasHandlerTest extends TestCase
                     'forward' => false,
                 ]
             ),
-            $handler->lookup('path314')
+            $handler->lookup('custom-path314')
         );
     }
 

--- a/eZ/Publish/Core/REST/Client/URLAliasService.php
+++ b/eZ/Publish/Core/REST/Client/URLAliasService.php
@@ -75,9 +75,7 @@ class URLAliasService implements APIURLAliasService, Sessionable
      * @param bool $forwarding if true a redirect is performed
      * @param bool $alwaysAvailable
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the path already exists for the given language
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\URLAlias
+     * @throws \Exception
      */
     public function createUrlAlias(Location $location, $path, $languageCode, $forwarding = false, $alwaysAvailable = false)
     {

--- a/eZ/Publish/Core/Repository/URLAliasService.php
+++ b/eZ/Publish/Core/Repository/URLAliasService.php
@@ -83,7 +83,8 @@ class URLAliasService implements URLAliasServiceInterface
      * @param bool $alwaysAvailable
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to create url alias
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the path already exists for the given language
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the path already exists for the given context
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      *
      * @return \eZ\Publish\API\Repository\Values\Content\URLAlias
      */

--- a/eZ/Publish/Core/SignalSlot/URLAliasService.php
+++ b/eZ/Publish/Core/SignalSlot/URLAliasService.php
@@ -60,9 +60,10 @@ class URLAliasService implements URLAliasServiceInterface
      * @param bool $forwarding if true a redirect is performed
      * @param bool $alwaysAvailable
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the path already exists for the given language
-     *
      * @return \eZ\Publish\API\Repository\Values\Content\URLAlias
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the path already exists for the given Location
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
     public function createUrlAlias(Location $location, $path, $languageCode, $forwarding = false, $alwaysAvailable = false)
     {

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -23,6 +23,7 @@
             <directory>eZ/Publish/API/Repository/Tests/FieldType/</directory>
             <directory>eZ/Publish/API/Repository/Tests/Limitation</directory>
             <directory>eZ/Publish/API/Repository/Tests/SearchService</directory>
+            <directory>eZ/Publish/API/Repository/Tests/URLAliasService</directory>
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/PermissionResolverTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31511](https://jira.ez.no/browse/EZP-31511)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`+
| **BC breaks**      | yes, minor[1]
| **Doc needed**     | maybe

Creating a custom URL alias  (e.g. `/eng/Contact`, where `eng` is a SiteAccess matched by the first URI Element), when there's already a system one for the same path, **should throw an exception**. It's because URL alias is not constrained by its language mask - it's only a "metadata" for lookups. Changing the behavior of the system proved to be more complicated than initially expected (see #3047) because URL alias accepts and processes semantic path only - the part w/o SiteAccess entry point - e.g. `/Contact`.

To restore the exception, the validation introduced in [EZP-30865](https://jira.ez.no/browse/EZP-30865) has been fixed, so system URL alias is not accidentally overridden by a custom one. If there's a matching custom URL alias for a given path, but not a system one, language mask can be safely updated, so [EZP-30865](https://jira.ez.no/browse/EZP-30865) requirements are still valid.

Additionally I've changed the exception message from 

> `Path '<parent>/<path>' already exists for the given language` 

to 
> `Path '<parent>/<path>' already exists for the given context`

because it was misleading - it created an expectation that the same path can be set for different types of aliases if its language is different.

At the same time using here "context", because it can apply to aliases not tied to any Location.

###  QA
- [ ] remember to setup `admin_group` or `admin` scope with all used languages to see all URL aliases in AdminUI
- [ ] creating custom URL alias now should again throw an exception, as it was in the case of Kernel `v7.5.5`.
- [ ] regression against [EZP-30865](https://jira.ez.no/browse/EZP-30865) - for this specific use case, when there's only a custom alias, there should be no exception - language should be updated

---
[1] Exception message has been changed slightly as it was incorrect

**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
