### PR TITLE
EZP-30857: Fixed assessment of image removal feasibility

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -151,14 +151,14 @@ class ImageStorage extends GatewayBasedStorage
                 continue;
             }
 
-            if ($this->aliasCleaner) {
-                $this->aliasCleaner->removeAliases($storedFiles['original']);
-            }
-
             foreach ($storedFiles as $storedFilePath) {
                 $this->gateway->removeImageReferences($storedFilePath, $versionInfo->versionNo, $fieldId);
                 if ($this->gateway->countImageReferences($storedFilePath) === 0) {
                     $binaryFile = $this->IOService->loadBinaryFileByUri($storedFilePath);
+                    if ($this->aliasCleaner) {
+                        // removeAliases expects original file "id" (relative path) to prepend alias prefixes
+                        $this->aliasCleaner->removeAliases($binaryFile->id);
+                    }
                     $this->IOService->deleteBinaryFile($binaryFile);
                 }
             }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30857](https://jira.ez.no/browse/EZP-30857)
| **Alternative to** | #2835
| **Required by** | #3057
| **Bug/Improvement**| yes
| **Target version** | `7.5`, `ezplatform-kernel:1.1`+
| **BC breaks**      | no
| **Doc needed**     | no

When removing a Content item (or its Version) with a changed Image Field Type file, the file associated with a previous Version was not deleted from a file system. 

This happened because relation of `ezimagefile`.`contentobject_attribute_id` to `ezcontentobject_attribute.id` does not contain Version number (attribute - a.k.a. Field - ID is the same for every Version).
One of the approaches would be to introduce versioning for `ezimagefile` (#2835). This however always causes issues due to BC break on schema. 

Instead, I'm proposing an alternative - change of assessment if image can be removed based on `ezimage` `data_text` XML, which contains proper URI for a given Version. Instead of getting a `count` against a product of `ezimagefile` and `ezcontentobject_attribute`, data is fetched and processed to find the actual file system file URI for a given Version.

The count cannot work because the resulting Cartesian product (slice/intersection of data) is incorrect - joins file paths for all Versions with a Field. The join itself is kept to make sure we're joining existing `ezimage` entry (7dca764df01dc51cb8e304453a559545ae30946f).

Additionally, I've discovered that image variations (aliases) are not removed at all. It didn't work because a produced file path was in the form of  `../var/site/storage/images/_aliases/medium/var/site/storage/images/...`. 
Fixed it by applying removal service on a relative original binay file identifier (41a0e4372b851087db94a0697e49bde4abb7c9f0).

I've discovered two other CS and DX issues, but for now I'll make follow-up PRs. Moreover we deal here with a responsibility mixup - Doctrine Gateway should not process XML but just return data. That however is a candidate for `ezplatform-kernel:master` - see ezsystems/ezplatform-kernel#96.

### QA
 - [ ] Filesystem state before/after Content & Version removal as described in the JIRA ticket.
 - [ ] Regression against [EZP-30857](https://jira.ez.no/browse/EZP-30857).
 - [ ] Image variations (aliases) removal (can be generated by e.g. embedding image into a content - image and content removal did not delete variations).

Note: Physical files can be found (and should not be found after deleting) by the following command:
```
find web/var/site/storage -type f
```

**TODO**:
- [x] Wait for Travis.
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Fix removal of aliases (image variations)
- [x] Shift responsibility of processing XML from Doctrine Gateway to Storage handler (ezsystems/ezplatform-kernel#96)
- [x] Ask for Code Review.
