### PR TITLE
Introduced fallback image variation cleaner and fixed CS issue

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -130,6 +130,9 @@ services:
         class: "%ezpublish.image_alias.imagine.alias_cleaner.class%"
         arguments: ["@ezpublish.image_alias.imagine.cache_resolver"]
 
+    eZ\Publish\Core\FieldType\Image\AliasCleanerInterface:
+        alias: ezpublish.image_alias.imagine.alias_cleaner
+
     ezpublish.image_alias.imagine.placeholder_provider.configurator:
         class: 'eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderAliasGeneratorConfigurator'
         arguments:

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
@@ -24,7 +24,7 @@ class BinaryBaseStorage extends GatewayBasedStorage
      *
      * @var \eZ\Publish\Core\IO\IOServiceInterface
      */
-    protected $IOService;
+    protected $ioService;
 
     /** @var \eZ\Publish\SPI\FieldType\BinaryBase\PathGenerator */
     protected $pathGenerator;
@@ -42,18 +42,18 @@ class BinaryBaseStorage extends GatewayBasedStorage
      * Construct from gateways.
      *
      * @param \eZ\Publish\SPI\FieldType\StorageGateway $gateway
-     * @param \eZ\Publish\Core\IO\IOServiceInterface $IOService
+     * @param \eZ\Publish\Core\IO\IOServiceInterface $ioService
      * @param \eZ\Publish\SPI\FieldType\BinaryBase\PathGenerator $pathGenerator
      * @param \eZ\Publish\SPI\IO\MimeTypeDetector $mimeTypeDetector
      */
     public function __construct(
         StorageGateway $gateway,
-        IOServiceInterface $IOService,
+        IOServiceInterface $ioService,
         PathGenerator $pathGenerator,
         MimeTypeDetector $mimeTypeDetector
     ) {
         parent::__construct($gateway);
-        $this->IOService = $IOService;
+        $this->ioService = $ioService;
         $this->pathGenerator = $pathGenerator;
         $this->mimeTypeDetector = $mimeTypeDetector;
     }
@@ -76,9 +76,9 @@ class BinaryBaseStorage extends GatewayBasedStorage
 
         if (isset($field->value->externalData['inputUri'])) {
             $field->value->externalData['mimeType'] = $this->mimeTypeDetector->getFromPath($field->value->externalData['inputUri']);
-            $createStruct = $this->IOService->newBinaryCreateStructFromLocalFile($field->value->externalData['inputUri']);
+            $createStruct = $this->ioService->newBinaryCreateStructFromLocalFile($field->value->externalData['inputUri']);
             $createStruct->id = $this->pathGenerator->getStoragePathForField($field, $versionInfo);
-            $binaryFile = $this->IOService->createBinaryFile($createStruct);
+            $binaryFile = $this->ioService->createBinaryFile($createStruct);
 
             $field->value->externalData['id'] = $binaryFile->id;
             $field->value->externalData['mimeType'] = $createStruct->mimeType;
@@ -89,7 +89,7 @@ class BinaryBaseStorage extends GatewayBasedStorage
 
         // copy from another field
         if (!isset($field->value->externalData['mimeType']) && isset($field->value->externalData['id'])) {
-            $field->value->externalData['mimeType'] = $this->IOService->getMimeType($field->value->externalData['id']);
+            $field->value->externalData['mimeType'] = $this->ioService->getMimeType($field->value->externalData['id']);
         }
 
         $referenced = $this->gateway->getReferencedFiles([$field->id], $versionInfo->versionNo);
@@ -133,8 +133,8 @@ class BinaryBaseStorage extends GatewayBasedStorage
         $fileCounts = $this->gateway->countFileReferences([$fileReference['id']]);
 
         if ($fileCounts[$fileReference['id']] === 0) {
-            $binaryFile = $this->IOService->loadBinaryFile($fileReference['id']);
-            $this->IOService->deleteBinaryFile($binaryFile);
+            $binaryFile = $this->ioService->loadBinaryFile($fileReference['id']);
+            $this->ioService->deleteBinaryFile($binaryFile);
         }
     }
 
@@ -142,7 +142,7 @@ class BinaryBaseStorage extends GatewayBasedStorage
     {
         $field->value->externalData = $this->gateway->getFileReferenceData($field->id, $versionInfo->versionNo);
         if ($field->value->externalData !== null) {
-            $binaryFile = $this->IOService->loadBinaryFile($field->value->externalData['id']);
+            $binaryFile = $this->ioService->loadBinaryFile($field->value->externalData['id']);
             $field->value->externalData['fileSize'] = $binaryFile->size;
             $field->value->externalData['uri'] = isset($this->downloadUrlGenerator) ?
                 $this->downloadUrlGenerator->getStoragePathForField($field, $versionInfo) :
@@ -164,8 +164,8 @@ class BinaryBaseStorage extends GatewayBasedStorage
 
         foreach ($referenceCountMap as $filePath => $count) {
             if ($count === 0) {
-                $binaryFile = $this->IOService->loadBinaryFile($filePath);
-                $this->IOService->deleteBinaryFile($binaryFile);
+                $binaryFile = $this->ioService->loadBinaryFile($filePath);
+                $this->ioService->deleteBinaryFile($binaryFile);
             }
         }
     }

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -44,7 +44,7 @@ class ImageStorage extends GatewayBasedStorage
         PathGenerator $pathGenerator,
         MetadataHandler $imageSizeMetadataHandler,
         DeprecationWarner $deprecationWarner,
-        AliasCleanerInterface $aliasCleaner = null
+        AliasCleanerInterface $aliasCleaner
     ) {
         parent::__construct($gateway);
         $this->IOService = $IOService;
@@ -155,10 +155,9 @@ class ImageStorage extends GatewayBasedStorage
                 $this->gateway->removeImageReferences($storedFilePath, $versionInfo->versionNo, $fieldId);
                 if ($this->gateway->countImageReferences($storedFilePath) === 0) {
                     $binaryFile = $this->IOService->loadBinaryFileByUri($storedFilePath);
-                    if ($this->aliasCleaner) {
-                        // removeAliases expects original file "id" (relative path) to prepend alias prefixes
-                        $this->aliasCleaner->removeAliases($binaryFile->id);
-                    }
+                    // remove aliases (real path is prepended with alias prefixes)
+                    $this->aliasCleaner->removeAliases($binaryFile->id);
+                    // delete original file
                     $this->IOService->deleteBinaryFile($binaryFile);
                 }
             }

--- a/eZ/Publish/Core/FieldType/Image/NullAliasCleaner.php
+++ b/eZ/Publish/Core/FieldType/Image/NullAliasCleaner.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\FieldType\Image;
+
+/**
+ * Default, IO-independent, implementation of image variation (alias) cleaner.
+ *
+ * It should be overridden by IO/filesystem and image manipulation specific integration,
+ * on a Bundle level.
+ *
+ * @internal for internal use by Repository Image Field Type External Storage
+ */
+final class NullAliasCleaner implements AliasCleanerInterface
+{
+    public function removeAliases($originalPath): void
+    {
+        // Nothing to do
+    }
+}

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -22,7 +22,7 @@ services:
         class: '%ezpublish.fieldType.ezimage.externalStorage.class%'
         arguments:
             $gateway: '@ezpublish.fieldType.ezimage.storage_gateway'
-            $IOService: '@ezpublish.fieldType.ezimage.io_service'
+            $ioService: '@ezpublish.fieldType.ezimage.io_service'
             $pathGenerator: '@ezpublish.fieldType.ezimage.pathGenerator'
             $imageSizeMetadataHandler: '@ezpublish.fieldType.metadataHandler.imagesize'
             $deprecationWarner: '@ezpublish.utils.deprecation_warner'

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -19,14 +19,14 @@ services:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezbinaryfile}
 
     ezpublish.fieldType.ezimage.externalStorage:
-        class: "%ezpublish.fieldType.ezimage.externalStorage.class%"
+        class: '%ezpublish.fieldType.ezimage.externalStorage.class%'
         arguments:
-            - "@ezpublish.fieldType.ezimage.storage_gateway"
-            - "@ezpublish.fieldType.ezimage.io_service"
-            - "@ezpublish.fieldType.ezimage.pathGenerator"
-            - "@ezpublish.fieldType.metadataHandler.imagesize"
-            - "@ezpublish.utils.deprecation_warner"
-            - "@?ezpublish.image_alias.imagine.alias_cleaner"
+            $gateway: '@ezpublish.fieldType.ezimage.storage_gateway'
+            $IOService: '@ezpublish.fieldType.ezimage.io_service'
+            $pathGenerator: '@ezpublish.fieldType.ezimage.pathGenerator'
+            $imageSizeMetadataHandler: '@ezpublish.fieldType.metadataHandler.imagesize'
+            $deprecationWarner: '@ezpublish.utils.deprecation_warner'
+            $aliasCleaner: '@eZ\Publish\Core\FieldType\Image\AliasCleanerInterface'
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezimage}
 

--- a/eZ/Publish/Core/settings/fieldtype_services.yml
+++ b/eZ/Publish/Core/settings/fieldtype_services.yml
@@ -43,6 +43,9 @@ services:
     ezpublish.fieldType.ezimage.pathGenerator:
         class: "%ezpublish.fieldType.ezimage.pathGenerator.class%"
 
+    eZ\Publish\Core\FieldType\Image\NullAliasCleaner: ~
+    eZ\Publish\Core\FieldType\Image\AliasCleanerInterface: '@eZ\Publish\Core\FieldType\Image\NullAliasCleaner'
+
     # BinaryFile
     ezpublish.fieldType.ezbinaryfile.io_service:
         parent: ezpublish.core.io.service


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Related to [EZP-30857](https://jira.ez.no/browse/EZP-30857)
| **Requires** | #3057
| **Target branch** | `alongosz:fix-7.5/ezp-30857-remove-deleted-image-file`

Follow-up to #3056 with CS and DX fixes:

- [x] [DX] Introduced fallback image variation cleaner for Image Field Type (cb842d4195208c7f7cdceea8fb0e6fc879bc35c7)
  Default implementation of `\eZ\Publish\Core\FieldType\Image\AliasCleanerInterface` allows to reduce cognitive complexity of `\eZ\Publish\Core\FieldType\Image\ImageStorage::deleteFieldData`.
- [x] [CS] Fixed incorrect ioService var case in Image and Binary Storages (670678949e2129bf0196a35786917350ff66f2bb)

TODO:
- [x] Rebase after merging #3057
- [x] Drop TMP commit
- [x] Drop `fix-7.5/ezp-30857-remove-deleted-image-file` branch from upstream repo.
