### PR TITLE
EZP-31779: Missing language filtering in LocationSearch breaking paging

### DIFF
--- a/eZ/Publish/Core/Pagination/Pagerfanta/LocationSearchHitAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/LocationSearchHitAdapter.php
@@ -49,7 +49,7 @@ class LocationSearchHitAdapter implements AdapterInterface
         $countQuery = clone $this->query;
         $countQuery->limit = 0;
 
-        return $this->nbResults = $this->searchService->findLocations($countQuery)->totalCount;
+        return $this->nbResults = $this->searchService->findLocations($countQuery, $this->languageFilter)->totalCount;
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31779](https://jira.ez.no/browse/EZP-31779)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`
| **BC breaks**      | no
| **Tests pass**     | ??
| **Doc needed**     | no


**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
