### PR TITLE
EZP-31768: Fixed cache invalidation during url alias reassignment

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -29,7 +29,7 @@ class UrlAliasHandlerTest extends AbstractInMemoryCacheHandlerTest
         // string $method, array $arguments, array? $tags, array? $key, mixed? $returnValue
         return [
             ['publishUrlAliasForLocation', [44, 2, 'name', 'eng-GB', true, false], ['urlAlias-location-44', 'urlAlias-location-path-44', 'urlAlias-notFound']],
-            ['createCustomUrlAlias', [44, '1/2/44', true, null, false], ['urlAlias-location-44', 'urlAlias-location-path-44', 'urlAlias-notFound']],
+            ['createCustomUrlAlias', [44, '1/2/44', true, null, false], ['urlAlias-location-44', 'urlAlias-location-path-44', 'urlAlias-notFound', 'urlAlias-5'], null, new UrlAlias(['id' => 5])],
             ['createGlobalUrlAlias', ['something', '1/2/44', true, null, false], ['urlAlias-notFound']],
             ['createGlobalUrlAlias', ['something', '1/2/44', true, 'eng-GB', false], ['urlAlias-notFound']],
             ['listGlobalURLAliases', ['eng-GB', 10, 50]],

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -83,7 +83,7 @@ class UrlAliasHandler extends AbstractInMemoryPersistenceHandler implements UrlA
             'urlAlias-location-' . $locationId,
             'urlAlias-location-path-' . $locationId,
             'urlAlias-notFound',
-            'urlAlias-' . $urlAlias->id
+            'urlAlias-' . $urlAlias->id,
         ]);
 
         return $urlAlias;

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -83,11 +83,8 @@ class UrlAliasHandler extends AbstractInMemoryPersistenceHandler implements UrlA
             'urlAlias-location-' . $locationId,
             'urlAlias-location-path-' . $locationId,
             'urlAlias-notFound',
+            'urlAlias-' . $urlAlias->id
         ]);
-
-        if ($urlAlias instanceof UrlAlias) {
-            $this->cache->invalidateTags(['urlAlias-' . $urlAlias->id]);
-        }
 
         return $urlAlias;
     }

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -83,8 +83,11 @@ class UrlAliasHandler extends AbstractInMemoryPersistenceHandler implements UrlA
             'urlAlias-location-' . $locationId,
             'urlAlias-location-path-' . $locationId,
             'urlAlias-notFound',
-            'urlAlias-' . $urlAlias->id,
         ]);
+
+        if ($urlAlias instanceof UrlAlias) {
+            $this->cache->invalidateTags(['urlAlias-' . $urlAlias->id]);
+        }
 
         return $urlAlias;
     }

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -79,7 +79,12 @@ class UrlAliasHandler extends AbstractInMemoryPersistenceHandler implements UrlA
             $alwaysAvailable
         );
 
-        $this->cache->invalidateTags(['urlAlias-location-' . $locationId, 'urlAlias-location-path-' . $locationId, 'urlAlias-notFound']);
+        $this->cache->invalidateTags([
+            'urlAlias-location-' . $locationId,
+            'urlAlias-location-path-' . $locationId,
+            'urlAlias-notFound',
+            'urlAlias-' . $urlAlias->id,
+        ]);
 
         return $urlAlias;
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31768](https://jira.ez.no/browse/EZP-31768)
| **Bug**| yes
| **New feature**    | no
| **Target version** | 7.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

During reassigning of the URL Alias belonging to a different Content cached alias would still point to that previous Content.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
