### PR TITLE
EZP-31110: Fixed URLAlias utilizing `tree_root.location_id` and `place at site root` options

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Routing/UrlAliasRouter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/UrlAliasRouter.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Routing;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter as BaseUrlAliasRouter;
 use Symfony\Component\HttpFoundation\Request;
@@ -56,6 +57,12 @@ class UrlAliasRouter extends BaseUrlAliasRouter
             return parent::getUrlAlias($pathinfo);
         }
 
-        return $this->urlAliasService->lookup($pathPrefix . $pathinfo);
+        try {
+            return $this->urlAliasService->lookup($pathPrefix . $pathinfo);
+        } catch (NotFoundException $e) {
+            // It may occur that requested URL is placed at site root, therefore we won't need $pathPrefix prepend.
+            // As of now there is no other way to check whether URLAlias is placed in site root.
+            return $this->urlAliasService->lookup($pathinfo);
+        }
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Routing/UrlAliasRouter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/UrlAliasRouter.php
@@ -6,7 +6,6 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Routing;
 
-use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter as BaseUrlAliasRouter;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,29 +39,25 @@ class UrlAliasRouter extends BaseUrlAliasRouter
      * Will return the right UrlAlias in regards to configured root location.
      *
      * @param string $pathinfo
+     * @param bool $isPlacedOnSiteRoot
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the path does not exist or is not valid for the given language
      *
      * @return \eZ\Publish\API\Repository\Values\Content\URLAlias
      */
-    protected function getUrlAlias($pathinfo)
+    protected function getUrlAlias($pathinfo, $isPlacedOnSiteRoot = false)
     {
         $pathPrefix = $this->generator->getPathPrefixByRootLocationId($this->rootLocationId);
 
         if (
             $this->rootLocationId === null ||
             $this->generator->isUriPrefixExcluded($pathinfo) ||
-            $pathPrefix === '/'
+            $pathPrefix === '/' ||
+            $isPlacedOnSiteRoot
         ) {
             return parent::getUrlAlias($pathinfo);
         }
 
-        try {
-            return $this->urlAliasService->lookup($pathPrefix . $pathinfo);
-        } catch (NotFoundException $e) {
-            // It may occur that requested URL is placed at site root, therefore we won't need $pathPrefix prepend.
-            // As of now there is no other way to check whether URLAlias is placed in site root.
-            return $this->urlAliasService->lookup($pathinfo);
-        }
+        return $this->urlAliasService->lookup($pathPrefix . $pathinfo);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Routing/UrlAliasRouter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/UrlAliasRouter.php
@@ -34,30 +34,4 @@ class UrlAliasRouter extends BaseUrlAliasRouter
 
         return parent::matchRequest($request);
     }
-
-    /**
-     * Will return the right UrlAlias in regards to configured root location.
-     *
-     * @param string $pathinfo
-     * @param bool $isPlacedOnSiteRoot
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the path does not exist or is not valid for the given language
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\URLAlias
-     */
-    protected function getUrlAlias($pathinfo, $isPlacedOnSiteRoot = false)
-    {
-        $pathPrefix = $this->generator->getPathPrefixByRootLocationId($this->rootLocationId);
-
-        if (
-            $this->rootLocationId === null ||
-            $this->generator->isUriPrefixExcluded($pathinfo) ||
-            $pathPrefix === '/' ||
-            $isPlacedOnSiteRoot
-        ) {
-            return parent::getUrlAlias($pathinfo);
-        }
-
-        return $this->urlAliasService->lookup($pathPrefix . $pathinfo);
-    }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasRouterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasRouterTest.php
@@ -465,7 +465,7 @@ class UrlAliasRouterTest extends TestCase
         $pathInfo = '/foo/bar';
         $request = $this->getRequestByPathInfo($pathInfo);
         $this->urlAliasService
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('lookup')
             ->with($pathInfo)
             ->will($this->throwException(new NotFoundException('URLAlias', $pathInfo)));

--- a/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -263,15 +263,22 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
     /**
      * Returns the UrlAlias object to use, starting from the request.
      *
-     * @param $pathinfo
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the path does not exist or is not valid for the given language
-     *
-     * @return URLAlias
      */
-    protected function getUrlAlias($pathinfo)
+    protected function getUrlAlias(string $pathinfo, bool $isPlacedOnSiteRoot = false): URLAlias
     {
-        return $this->urlAliasService->lookup($pathinfo);
+        $pathPrefix = $this->generator->getPathPrefixByRootLocationId($this->rootLocationId);
+
+        if (
+            $this->rootLocationId === null ||
+            $this->generator->isUriPrefixExcluded($pathinfo) ||
+            $pathPrefix === '/' ||
+            $isPlacedOnSiteRoot
+        ) {
+            return $this->urlAliasService->lookup($pathinfo);
+        }
+
+        return $this->urlAliasService->lookup($pathPrefix . $pathinfo);
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -141,7 +141,7 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
                             // Specify not to prepend siteaccess while redirecting when applicable since it would be already present (see UrlAliasGenerator::doGenerate())
                             'prependSiteaccessOnRedirect' => false,
                         ];
-                    } elseif ($this->needsCaseRedirect($urlAlias, $requestedPath, $pathPrefix)) {
+                    } elseif ($this->needsCaseRedirect($urlAlias, $requestedPath)) {
                         $params += [
                             'semanticPathinfo' => $this->removePathPrefix($urlAlias->path, $pathPrefix),
                             'needsRedirect' => true,
@@ -165,7 +165,7 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
                             'semanticPathinfo' => '/' . trim($urlAlias->destination, '/'),
                             'needsRedirect' => true,
                         ];
-                    } elseif ($this->needsCaseRedirect($urlAlias, $requestedPath, $pathPrefix)) {
+                    } elseif ($this->needsCaseRedirect($urlAlias, $requestedPath)) {
                         // Handle case-correction redirect
                         $params += [
                             'semanticPathinfo' => $this->removePathPrefix($urlAlias->path, $pathPrefix),
@@ -182,7 +182,7 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
 
                 case URLAlias::VIRTUAL:
                     // Handle case-correction redirect
-                    if ($this->needsCaseRedirect($urlAlias, $requestedPath, $pathPrefix)) {
+                    if ($this->needsCaseRedirect($urlAlias, $requestedPath)) {
                         $params += [
                             'semanticPathinfo' => $this->removePathPrefix($urlAlias->path, $pathPrefix),
                             'needsRedirect' => true,
@@ -235,20 +235,14 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
      *
      * @return bool
      */
-    protected function needsCaseRedirect(URLAlias $loadedUrlAlias, $requestedPath, $pathPrefix)
+    protected function needsCaseRedirect(URLAlias $loadedUrlAlias, $requestedPath)
     {
         // If requested path is excluded from tree root jail, compare it to loaded UrlAlias directly.
         if ($this->generator->isUriPrefixExcluded($requestedPath)) {
             return strcmp($loadedUrlAlias->path, $requestedPath) !== 0;
         }
 
-        // Compare loaded UrlAlias with requested path, prefixed with configured path prefix.
-        return
-            strcmp(
-                $loadedUrlAlias->path,
-                $pathPrefix . ($pathPrefix === '/' ? trim($requestedPath, '/') : rtrim($requestedPath, '/'))
-            ) !== 0
-        ;
+        return false;
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31110](https://jira.ez.no/browse/EZP-31110)
| **Bug**| yes
| **New feature**    | no
| **Target version** | 7.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Using `place at site root` option in case of using `tree_root.location_id` would never match any URLAlias because of `$pathPrefix` being included into search when `tree_root.location_id` is used. Therefore, additional `try` has been added to  account for URLAlias which might be placed at the site root.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
