### PR TITLE
EZP-31837: Creating an additional Content Location does not repect Content visibility

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -133,11 +133,11 @@ class LocationServiceTest extends BaseTest
     /**
      * Test for the createLocation() method.
      *
-     * @see \eZ\Publish\API\Repository\LocationService::createLocation()
+     * @covers \eZ\Publish\API\Repository\LocationService::createLocation
      * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testCreateLocation
      * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testHideContent
      */
-    public function testCreateLocationChecksContentVisibility()
+    public function testCreateLocationChecksContentVisibility(): void
     {
         $repository = $this->getRepository();
 
@@ -166,12 +166,9 @@ class LocationServiceTest extends BaseTest
         );
         /* END: Use Case */
 
-        $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\Location',
-            $location
-        );
+        self::assertInstanceOf(Location::class, $location);
 
-        $this->assertTrue($location->invisible);
+        self::assertTrue($location->invisible);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -131,6 +131,50 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
+     * Test for the createLocation() method.
+     *
+     * @see \eZ\Publish\API\Repository\LocationService::createLocation()
+     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testCreateLocation
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testHideContent
+     */
+    public function testCreateLocationChecksContentVisibility()
+    {
+        $repository = $this->getRepository();
+
+        $contentId = $this->generateId('object', 41);
+        $parentLocationId = $this->generateId('location', 5);
+        /* BEGIN: Use Case */
+        // $contentId is the ID of an existing content object
+        // $parentLocationId is the ID of an existing location
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+
+        // ContentInfo for "How to use eZ Publish"
+        $contentInfo = $contentService->loadContentInfo($contentId);
+        $contentService->hideContent($contentInfo);
+
+        $locationCreate = $locationService->newLocationCreateStruct($parentLocationId);
+        $locationCreate->priority = 23;
+        $locationCreate->hidden = false;
+        $locationCreate->remoteId = 'sindelfingen';
+        $locationCreate->sortField = Location::SORT_FIELD_NODE_ID;
+        $locationCreate->sortOrder = Location::SORT_ORDER_DESC;
+
+        $location = $locationService->createLocation(
+            $contentInfo,
+            $locationCreate
+        );
+        /* END: Use Case */
+
+        $this->assertInstanceOf(
+            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\Location',
+            $location
+        );
+
+        $this->assertTrue($location->invisible);
+    }
+
+    /**
      * Test for the createLocation() method with utilizing default ContentType sorting options.
      *
      * @covers \eZ\Publish\API\Repository\LocationService::createLocation

--- a/eZ/Publish/API/Repository/Values/Content/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Location.php
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
  * @property-read mixed $id the id of the location
  * @property-read int $priority Position of the Location among its siblings when sorted using priority
  * @property-read bool $hidden Indicates that the Location entity is hidden (explicitly or hidden by content).
- * @property-read bool $invisible  Indicates that the Location is implicitly marked as hidden by a parent location
+ * @property-read bool $invisible Indicates that the Location is not visible, being either marked as hidden itself, or implicitly hidden by its Content or an ancestor Location
  * @property-read bool $explicitlyHidden Indicates that the Location entity has been explicitly marked as hidden.
  * @property-read string $remoteId a global unique id of the content object
  * @property-read mixed $parentLocationId the id of the parent location
@@ -119,8 +119,8 @@ abstract class Location extends ValueObject
     protected $hidden;
 
     /**
-     * Indicates that the Location is implicitly marked as hidden by a parent
-     * location.
+     * Indicates that the Location is not visible, being either marked as hidden itself,
+     * or implicitly hidden by its Content or an ancestor Location.
      *
      * @var bool
      */

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -879,7 +879,8 @@ class ContentService implements ContentServiceInterface
                 $mainLocation,
                 // For Content draft contentId and contentVersionNo are set in ContentHandler upon draft creation
                 null,
-                null
+                null,
+                false
             );
 
             // First Location in the list will be created as main Location

--- a/eZ/Publish/Core/Repository/Helper/DomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/DomainMapper.php
@@ -683,6 +683,7 @@ class DomainMapper
      * @param mixed $mainLocation
      * @param mixed $contentId
      * @param mixed $contentVersionNo
+     * @param bool $isContentHidden
      *
      * @return \eZ\Publish\SPI\Persistence\Content\Location\CreateStruct
      */
@@ -691,7 +692,8 @@ class DomainMapper
         APILocation $parentLocation,
         $mainLocation,
         $contentId,
-        $contentVersionNo
+        $contentVersionNo,
+        bool $isContentHidden
     ) {
         if (!$this->isValidLocationPriority($locationCreateStruct->priority)) {
             throw new InvalidArgumentValue('priority', $locationCreateStruct->priority, 'LocationCreateStruct');
@@ -733,10 +735,10 @@ class DomainMapper
                 'priority' => $locationCreateStruct->priority,
                 'hidden' => $locationCreateStruct->hidden,
                 // If we declare the new Location as hidden, it is automatically invisible
-                // Otherwise it picks up visibility from parent Location
+                // Otherwise it picks up visibility from parent Location and Content
                 // Note: There is no need to check for hidden status of parent, as hidden Location
                 // is always invisible as well
-                'invisible' => ($locationCreateStruct->hidden === true || $parentLocation->invisible),
+                'invisible' => ($locationCreateStruct->hidden === true || $parentLocation->invisible || $isContentHidden),
                 'remoteId' => $remoteId,
                 'contentId' => $contentId,
                 'contentVersion' => $contentVersionNo,

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -468,7 +468,8 @@ class LocationService implements LocationServiceInterface
             $parentLocation,
             $contentInfo->mainLocationId ?? true,
             $contentInfo->id,
-            $contentInfo->currentVersionNo
+            $contentInfo->currentVersionNo,
+            $contentInfo->isHidden
         );
 
         $this->repository->beginTransaction();

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -2510,7 +2510,8 @@ class ContentTest extends BaseServiceMockTest
                 $this->equalTo($parentLocation),
                 $this->equalTo(true),
                 $this->equalTo(null),
-                $this->equalTo(null)
+                $this->equalTo(null),
+                $this->equalTo(false)
             )->will($this->returnValue($spiLocationCreateStruct));
 
         $domainMapperMock->expects($this->at(2))
@@ -2520,7 +2521,8 @@ class ContentTest extends BaseServiceMockTest
                 $this->equalTo($parentLocation),
                 $this->equalTo(false),
                 $this->equalTo(null),
-                $this->equalTo(null)
+                $this->equalTo(null),
+                $this->equalTo(false)
             )->will($this->returnValue($spiLocationCreateStruct));
 
         $spiContentCreateStruct = new SPIContentCreateStruct(
@@ -2689,7 +2691,8 @@ class ContentTest extends BaseServiceMockTest
                 $this->equalTo($parentLocation),
                 $this->equalTo(true),
                 $this->equalTo(null),
-                $this->equalTo(null)
+                $this->equalTo(null),
+                $this->equalTo(false)
             )->will($this->returnValue($spiLocationCreateStruct));
 
         $mockedService->createContent(


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31837](https://jira.ez.no/browse/EZP-31837)
| **Type**                                   | bug
| **Target eZ Platform version** | `v7.5`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
