### PR TITLE
EZP-31891: Use specified templates for embedded image and asset FT

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/asset_image.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/asset_image.html.twig
@@ -2,6 +2,7 @@
 
 {% if image_field_identifier is not null %}
     {{ ez_render_field(content, image_field_identifier, {
+        template: '@EzPublishCore/content_fields.html.twig',
         parameters: parameters
     }) }}
 {% endif %}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed_image.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed_image.html.twig
@@ -5,6 +5,7 @@
         content,
         image_field_identifier,
         {
+            template: '@EzPublishCore/content_fields.html.twig',
             parameters:
             {
                 alias: objectParameters.size|default('original'),


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31891](https://jira.ez.no/browse/EZP-31891)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Introduced by:
https://github.com/ezsystems/ezplatform-admin-ui/pull/1457

As those views are configurable by semantic/parameters this seems to be safe solution in terms of possible overrides.
**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
