### PR TITLE
EZP-31930: Cleaned up output of commands displaying progress bar

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -173,12 +173,7 @@ EOT
             $output->writeln('Re-indexing started for search engine: ' . $this->searchIndexer->getName());
             $output->writeln('');
 
-            $return = $this->indexIncrementally($input, $output, $iterationCount, $commit);
-
-            $output->writeln('');
-            $output->writeln('Finished re-indexing');
-
-            return $return;
+            return $this->indexIncrementally($input, $output, $iterationCount, $commit);
         }
 
         return 0;
@@ -257,6 +252,11 @@ EOT
         }
 
         $progress->finish();
+        $output->writeln('');
+        $output->writeln('Finished re-indexing');
+        $output->writeln('');
+        // clear leftover progress bar parts
+        $progress->clear();
 
         return 0;
     }

--- a/eZ/Bundle/PlatformInstallerBundle/src/Installer/CoreInstaller.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Installer/CoreInstaller.php
@@ -80,8 +80,10 @@ class CoreInstaller extends DbBasedInstaller implements Installer
         }
 
         $progressBar->finish();
-        // go to the next line after ProgressBar::finish
-        $this->output->writeln('');
+        // go to the next line after ProgressBar::finish and add one more extra blank line for readability
+        $this->output->writeln(PHP_EOL);
+        // clear any leftover progress bar parts in the output buffer
+        $progressBar->clear();
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31930](https://jira.ez.no/browse/EZP-31930)
| **Required by** | ezsystems/ezplatform#597
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`, `ezplatform-kernel:1.1`, `ezplatform-kernel:master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

### TL;DR;
Cleaned up output showing a progress bar for the following commands:
* ezplatform:install
* ezplatform:reindex

to resolve issues discovered in ezsystems/ezplatform#597

### Summary

This is an attempt to further cleanup output of commands used by `composer ezplatform-install` with ANSI mode. While ANSI solves most important issues, sometimes ProgressBar gets randomly repeated after a command finishes execution and next output appears (either terminal prompt or from chained next command), as can be seen https://github.com/ezsystems/ezplatform/pull/597#issuecomment-702037803

The issues occurring are not deterministic and the fix is a result of trial & error approach.

### Known issues

Sometimes the progress bar of `ezplatform:reindex` either disappears or shows 0%. Seems it's a random race issue due to small volume of data and the operation being too quick for terminal buffer to adjust.

**TODO**:
- [x] Fix a bug.
- ~Implement tests.~ // covered implicitly by every behat scenario
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.