### PR TITLE
EZP-31039: Skip requirement of sort params when updating Location via REST

### DIFF
--- a/eZ/Publish/Core/REST/Server/Input/Parser/LocationUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/LocationUpdate.php
@@ -9,7 +9,6 @@ namespace eZ\Publish\Core\REST\Server\Input\Parser;
 use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
-use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\REST\Server\Values\RestLocationUpdateStruct;
 

--- a/eZ/Publish/Core/REST/Server/Input/Parser/LocationUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/LocationUpdate.php
@@ -69,17 +69,13 @@ class LocationUpdate extends BaseParser
             $hidden = $this->parserTools->parseBooleanValue($data['hidden']);
         }
 
-        if (!array_key_exists('sortField', $data)) {
-            throw new Exceptions\Parser("Missing 'sortField' element for LocationUpdate.");
+        if (array_key_exists('sortField', $data)) {
+            $locationUpdateStruct->sortField = $this->parserTools->parseDefaultSortField($data['sortField']);
         }
 
-        $locationUpdateStruct->sortField = $this->parserTools->parseDefaultSortField($data['sortField']);
-
-        if (!array_key_exists('sortOrder', $data)) {
-            throw new Exceptions\Parser("Missing 'sortOrder' element for LocationUpdate.");
+        if (array_key_exists('sortOrder', $data)) {
+            $locationUpdateStruct->sortOrder = $this->parserTools->parseDefaultSortOrder($data['sortOrder']);
         }
-
-        $locationUpdateStruct->sortOrder = $this->parserTools->parseDefaultSortOrder($data['sortOrder']);
 
         return new RestLocationUpdateStruct($locationUpdateStruct, $hidden);
     }

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/LocationUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/LocationUpdateTest.php
@@ -75,7 +75,7 @@ class LocationUpdateTest extends BaseTest
     /**
      * Test LocationUpdate parser with missing sort field.
      */
-    public function testParseExceptionOnMissingSortField()
+    public function testParseWithMissingSortField()
     {
         $inputArray = [
             'priority' => 0,
@@ -104,7 +104,7 @@ class LocationUpdateTest extends BaseTest
     /**
      * Test LocationUpdate parser with missing sort order.
      */
-    public function testParseExceptionOnMissingSortOrder()
+    public function testParseWithMissingSortOrder()
     {
         $inputArray = [
             'priority' => 0,

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/LocationUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/LocationUpdateTest.php
@@ -73,10 +73,7 @@ class LocationUpdateTest extends BaseTest
     }
 
     /**
-     * Test LocationUpdate parser throwing exception on missing sort field.
-     *
-     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
-     * @expectedExceptionMessage Missing 'sortField' element for LocationUpdate.
+     * Test LocationUpdate parser with missing sort field.
      */
     public function testParseExceptionOnMissingSortField()
     {
@@ -87,14 +84,26 @@ class LocationUpdateTest extends BaseTest
         ];
 
         $locationUpdate = $this->getParser();
-        $locationUpdate->parse($inputArray, $this->getParsingDispatcherMock());
+        $result = $locationUpdate->parse($inputArray, $this->getParsingDispatcherMock());
+
+        $this->assertInstanceOf(
+            RestLocationUpdateStruct::class,
+            $result
+        );
+
+        $this->assertInstanceOf(
+            LocationUpdateStruct::class,
+            $result->locationUpdateStruct
+        );
+
+        $this->assertEquals(
+            null,
+            $result->locationUpdateStruct->sortField
+        );
     }
 
     /**
-     * Test LocationUpdate parser throwing exception on missing sort order.
-     *
-     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
-     * @expectedExceptionMessage Missing 'sortOrder' element for LocationUpdate.
+     * Test LocationUpdate parser with missing sort order.
      */
     public function testParseExceptionOnMissingSortOrder()
     {
@@ -105,7 +114,22 @@ class LocationUpdateTest extends BaseTest
         ];
 
         $locationUpdate = $this->getParser();
-        $locationUpdate->parse($inputArray, $this->getParsingDispatcherMock());
+        $result = $locationUpdate->parse($inputArray, $this->getParsingDispatcherMock());
+
+        $this->assertInstanceOf(
+            RestLocationUpdateStruct::class,
+            $result
+        );
+
+        $this->assertInstanceOf(
+            LocationUpdateStruct::class,
+            $result->locationUpdateStruct
+        );
+
+        $this->assertEquals(
+            null,
+            $result->locationUpdateStruct->sortOrder
+        );
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/LocationUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/LocationUpdateTest.php
@@ -96,8 +96,7 @@ class LocationUpdateTest extends BaseTest
             $result->locationUpdateStruct
         );
 
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $result->locationUpdateStruct->sortField
         );
     }
@@ -126,8 +125,7 @@ class LocationUpdateTest extends BaseTest
             $result->locationUpdateStruct
         );
 
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $result->locationUpdateStruct->sortOrder
         );
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31039](https://jira.ez.no/browse/EZP-31039)
| **Improvement**| yes
| **New feature**    | no
| **Target version** | 7.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

`updateLocation` API method doesn't require the existence of sort params in `LocationUpdateStruct` (it will use params already stored in the Location itself), we can remove them when parsing REST data.

Related PR: https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/287

**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
