### PR TITLE
EZP-32099: Prepared Location API methods to handle Locations without ContentInfo

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -2611,6 +2611,41 @@ class LocationServiceTest extends BaseTest
      * @covers \eZ\Publish\API\Repository\LocationService::moveSubtree
      * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadLocation
      */
+    public function testMoveSubtreeToLocationWithoutContent(): void
+    {
+        $repository = $this->getRepository();
+
+        $rootLocationId = $this->generateId('location', 1);
+        $demoDesignLocationId = $this->generateId('location', 56);
+        $locationService = $repository->getLocationService();
+        $locationToMove = $locationService->loadLocation($demoDesignLocationId);
+        $newParentLocation = $locationService->loadLocation($rootLocationId);
+
+        $locationService->moveSubtree(
+            $locationToMove,
+            $newParentLocation
+        );
+
+        $movedLocation = $locationService->loadLocation($demoDesignLocationId);
+
+        $this->assertPropertiesCorrect(
+            [
+                'hidden' => false,
+                'invisible' => false,
+                'depth' => $newParentLocation->depth + 1,
+                'parentLocationId' => $newParentLocation->id,
+                'pathString' => $newParentLocation->pathString . $this->parseId('location', $movedLocation->id) . '/',
+            ],
+            $movedLocation
+        );
+    }
+
+    /**
+     * Test for the moveSubtree() method.
+     *
+     * @covers \eZ\Publish\API\Repository\LocationService::moveSubtree
+     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadLocation
+     */
     public function testMoveSubtreeThrowsExceptionOnMoveNotIntoContainer(): void
     {
         $repository = $this->getRepository();

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Location;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Location\CreateStruct;
@@ -335,7 +336,7 @@ class Handler implements BaseLocationHandler
 
         // potentially it may occur that the destination Location doesn't have a section (like in Location ID = 1),
         // therefore assigning any or empty section will be invalid here
-        if ($destinationParentSectionId) {
+        if ($destinationParentSectionId !== null) {
             $this->updateSubtreeSectionIfNecessary($copiedSubtreeRootLocation, $destinationParentSectionId);
         }
 
@@ -344,8 +345,12 @@ class Handler implements BaseLocationHandler
 
     /**
      * Retrieves section ID of the location's content.
+     *
+     * @param int $locationId
+     *
+     * @return int|null
      */
-    private function getSectionId(int $locationId): ?int
+    private function getSectionId($locationId)
     {
         $location = $this->load($locationId);
 
@@ -353,7 +358,7 @@ class Handler implements BaseLocationHandler
             $locationContentInfo = $this->contentHandler->loadContentInfo($location->contentId);
 
             return $locationContentInfo->sectionId;
-        } catch (\Throwable $e) {
+        } catch (NotFoundException $e) {
             return null;
         }
     }
@@ -419,7 +424,7 @@ class Handler implements BaseLocationHandler
 
         // potentially it may occur that the destination Location doesn't have a section (like in Location ID = 1),
         // therefore assigning any or empty section will be invalid here
-        if ($destinationParentSectionId) {
+        if ($destinationParentSectionId !== null) {
             $this->updateSubtreeSectionIfNecessary($sourceLocation, $destinationParentSectionId);
         }
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -332,24 +332,30 @@ class Handler implements BaseLocationHandler
         }
 
         $destinationParentSectionId = $this->getSectionId($destinationParentId);
-        $this->updateSubtreeSectionIfNecessary($copiedSubtreeRootLocation, $destinationParentSectionId);
+
+        // potentially it may occur that the destination Location doesn't have a section (like in Location ID = 1),
+        // therefore assigning any or empty section will be invalid here
+        if ($destinationParentSectionId) {
+            $this->updateSubtreeSectionIfNecessary($copiedSubtreeRootLocation, $destinationParentSectionId);
+        }
 
         return $copiedSubtreeRootLocation;
     }
 
     /**
      * Retrieves section ID of the location's content.
-     *
-     * @param int $locationId
-     *
-     * @return int
      */
-    private function getSectionId($locationId)
+    private function getSectionId(int $locationId): ?int
     {
         $location = $this->load($locationId);
-        $locationContentInfo = $this->contentHandler->loadContentInfo($location->contentId);
 
-        return $locationContentInfo->sectionId;
+        try {
+            $locationContentInfo = $this->contentHandler->loadContentInfo($location->contentId);
+
+            return $locationContentInfo->sectionId;
+        } catch (\Throwable $e) {
+            return null;
+        }
     }
 
     /**
@@ -410,7 +416,12 @@ class Handler implements BaseLocationHandler
 
         $sourceLocation = $this->load($sourceId);
         $destinationParentSectionId = $this->getSectionId($destinationParentId);
-        $this->updateSubtreeSectionIfNecessary($sourceLocation, $destinationParentSectionId);
+
+        // potentially it may occur that the destination Location doesn't have a section (like in Location ID = 1),
+        // therefore assigning any or empty section will be invalid here
+        if ($destinationParentSectionId) {
+            $this->updateSubtreeSectionIfNecessary($sourceLocation, $destinationParentSectionId);
+        }
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
@@ -256,7 +256,7 @@ class TreeHandler
             $sectionId = null;
         }
 
-        if ($sectionId) {
+        if ($sectionId !== null) {
             $this->setSectionForSubtree(
                 $locationId,
                 $sectionId

--- a/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
@@ -248,9 +249,18 @@ class TreeHandler
         );
 
         // Update subtree section to the one of the new main location parent location content
-        $this->setSectionForSubtree(
-            $locationId,
-            $this->loadContentInfo($this->loadLocation($parentLocationId)->contentId)->sectionId
-        );
+        $destinationContentId = $this->loadLocation($parentLocationId)->contentId;
+        try {
+            $sectionId = $this->loadContentInfo($destinationContentId)->sectionId;
+        } catch (NotFoundException $e) {
+            $sectionId = null;
+        }
+
+        if ($sectionId) {
+            $this->setSectionForSubtree(
+                $locationId,
+                $sectionId
+            );
+        }
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/TreeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/TreeHandlerTest.php
@@ -331,6 +331,48 @@ class TreeHandlerTest extends TestCase
         $treeHandler->changeMainLocation(12, 34);
     }
 
+    public function testChangeMainLocationToLocationWithoutContentInfo()
+    {
+        $treeHandler = $this->getPartlyMockedTreeHandler(
+            [
+                'loadLocation',
+                'setSectionForSubtree',
+                'loadContentInfo',
+            ]
+        );
+
+        $treeHandler
+            ->expects($this->at(0))
+            ->method('loadLocation')
+            ->with(34)
+            ->will($this->returnValue(new Location(['parentId' => 1])));
+
+        $treeHandler
+            ->expects($this->at(1))
+            ->method('loadContentInfo')
+            ->with('12')
+            ->will($this->returnValue(new ContentInfo(['currentVersionNo' => 1])));
+
+        $treeHandler
+            ->expects($this->at(2))
+            ->method('loadLocation')
+            ->with(1)
+            ->will($this->returnValue(new Location(['contentId' => 84])));
+
+        $treeHandler
+            ->expects($this->at(3))
+            ->method('loadContentInfo')
+            ->with('84')
+            ->will($this->returnValue(new ContentInfo(['sectionId' => 4])));
+
+        $this->getLocationGatewayMock()
+            ->expects($this->once())
+            ->method('changeMainLocation')
+            ->with(12, 34, 1, 1);
+
+        $treeHandler->changeMainLocation(12, 34);
+    }
+
     public function testLoadLocation()
     {
         $treeHandler = $this->getTreeHandler();

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\Repository;
 
+use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\PermissionCriterionResolver;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\Content\Location;
@@ -64,6 +65,9 @@ class LocationService implements LocationServiceInterface
     /** @var \Psr\Log\LoggerInterface */
     private $logger;
 
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    protected $contentTypeService;
+
     /**
      * Setups service with reference to repository object that created it & corresponding handler.
      *
@@ -72,6 +76,7 @@ class LocationService implements LocationServiceInterface
      * @param \eZ\Publish\Core\Repository\Helper\DomainMapper $domainMapper
      * @param \eZ\Publish\Core\Repository\Helper\NameSchemaService $nameSchemaService
      * @param \eZ\Publish\API\Repository\PermissionCriterionResolver $permissionCriterionResolver
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      * @param array $settings
      * @param \Psr\Log\LoggerInterface|null $logger
      */
@@ -81,6 +86,7 @@ class LocationService implements LocationServiceInterface
         Helper\DomainMapper $domainMapper,
         Helper\NameSchemaService $nameSchemaService,
         PermissionCriterionResolver $permissionCriterionResolver,
+        ContentTypeService $contentTypeService,
         array $settings = [],
         LoggerInterface $logger = null
     ) {
@@ -93,6 +99,7 @@ class LocationService implements LocationServiceInterface
             //'defaultSetting' => array(),
         ];
         $this->permissionCriterionResolver = $permissionCriterionResolver;
+        $this->contentTypeService = $contentTypeService;
         $this->logger = null !== $logger ? $logger : new NullLogger();
     }
 
@@ -674,7 +681,7 @@ class LocationService implements LocationServiceInterface
             );
         }
         $contentTypeId = $newParentLocation->contentInfo->contentTypeId;
-        if (!$this->repository->getContentTypeService()->loadContentType($contentTypeId)->isContainer) {
+        if (!$this->contentTypeService->loadContentType($contentTypeId)->isContainer) {
             throw new InvalidArgumentException(
                 '$newParentLocation',
                 'Cannot move Location to a parent that is not a container'

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -673,7 +673,8 @@ class LocationService implements LocationServiceInterface
                 'new parent Location is in a subtree of the given $location'
             );
         }
-        if (!$newParentLocation->getContent()->getContentType()->isContainer) {
+        $contentTypeId = $newParentLocation->contentInfo->contentTypeId;
+        if (!$this->repository->getContentTypeService()->loadContentType($contentTypeId)->isContainer) {
             throw new InvalidArgumentException(
                 '$newParentLocation',
                 'Cannot move Location to a parent that is not a container'

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -532,6 +532,7 @@ class Repository implements RepositoryInterface
             $this->getDomainMapper(),
             $this->getNameSchemaService(),
             $this->getPermissionCriterionResolver(),
+            $this->getContentTypeService(),
             $this->serviceSettings['location'],
             $this->logger
         );


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32099](https://jira.ez.no/browse/EZP-32099)
| **Bug**| yes
| **New feature**    | no
| **Target version** | 7.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

As it is allowed to create Content in Location of ID = 1, one should be able to move, copy or change {{mainLocationId}} to such Location.

There is however a problem with Sections, as Location of ID = 1 doesn't have Content, therefore it doesn't have a Section - **subject for discussion**.

**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
