### PR TITLE
[Travis] Pinned Composer to version one for CS job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
 # 7.0
     - php: 7.0
-      env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
+      env: COMPOSER_ROOT_VERSION=6.13.x-dev SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
 # 7.1
     - php: 7.1
       env: PHP_IMAGE=ezsystems/php:7.1-v1 BEHAT_OPTS="--profile=core --tags=~@broken" RUN_INSTALL=1 SYMFONY_ENV=behat SYMFONY_DEBUG=1 COMPOSER_MEMORY_LIMIT=-1

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ before_install:
   - if [ "$BEHAT_OPTS" != "" ] ; then ./bin/.travis/enable_swap.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
   - if [ "$REST_TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
+  - if [ "$CHECK_CS" != "" ] ; then travis_retry composer self-update --1 ; fi
   # Execute Symfony command if specified
   - if [ "$SF_CMD" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "app/console $SF_CMD" ; fi
   # Detecting timezone issues by testing on random timezone


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| CI fix
| **New feature**    | no
| **Target version** | 6.13 only
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Failing CS job: https://travis-ci.com/github/ezsystems/ezpublish-kernel/jobs/429324377

This failure is caused by Composer 2(see: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5238)
and the recommened fix should be available in fixer v2.16.7

The version of php-cs-fixer in this package is pinned to `2.15.3`:
https://github.com/ezsystems/ezpublish-kernel/pull/2860

I've tried using 2.16, but the number of changes required to use it is too big to easily switch - I've decided to keep using Composer 1 for this job. There are three options here IHMO:
1) Keep using Composer 1 for CS job
2) Bump CS-Fixer to the latest version and make all the code changes needed
3) Bump CS-Fixer and modify the ruleset until there are no code changes needed

**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
