### PR TITLE
EZEE-3357: Fixed so that we can get VersionInfo for internal drafts

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -362,7 +362,7 @@ class Mapper
                 $versionInfo->modificationDate = (int)$row['ezcontentobject_version_modified'];
                 $versionInfo->status = (int)$row['ezcontentobject_version_status'];
                 // Versions with VersionInfo::STATUS_INTERNAL_DRAFT might not have a row in ezcontentobject_name
-                $versionInfo->names = isset($nameData[$versionId]) ? $nameData[$versionId] : null;
+                $versionInfo->names = $nameData[$versionId]) ?? [];
                 $versionInfoList[$versionId] = $versionInfo;
                 $versionInfo->languageCodes = $this->extractLanguageCodesFromMask(
                     (int)$row['ezcontentobject_version_language_mask'],

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -361,7 +361,8 @@ class Mapper
                 $versionInfo->creationDate = (int)$row['ezcontentobject_version_created'];
                 $versionInfo->modificationDate = (int)$row['ezcontentobject_version_modified'];
                 $versionInfo->status = (int)$row['ezcontentobject_version_status'];
-                $versionInfo->names = $nameData[$versionId];
+                // Versions with VersionInfo::STATUS_INTERNAL_DRAFT might not have a row in ezcontentobject_name
+                $versionInfo->names = isset($nameData[$versionId]) ? $nameData[$versionId] : null;
                 $versionInfoList[$versionId] = $versionInfo;
                 $versionInfo->languageCodes = $this->extractLanguageCodesFromMask(
                     (int)$row['ezcontentobject_version_language_mask'],


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-3357](https://jira.ez.no/browse/EZEE-3357)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->
During migration from landing page to pagebuilder, I discovered the kernel is not able to create VersionInfo objects for internal drafts without throwing a notice

The corresponding [ezplatform-kernel PR](https://github.com/ezsystems/ezplatform-kernel/pull/134)

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
