### PR TITLE
Fixed EZP-32302: Kosovo and South Sudan are missing in the Country FieldType

### DIFF
--- a/doc/specifications/rest/xsd/ISOCountryCodeType-V2006.xsd
+++ b/doc/specifications/rest/xsd/ISOCountryCodeType-V2006.xsd
@@ -462,6 +462,11 @@
           <xsd:documentation>SOUTH GEORGIA AND THE SOUTH SANDWICH ISLANDS</xsd:documentation>
         </xsd:annotation>
       </xsd:enumeration>
+      <xsd:enumeration value="SS">
+        <xsd:annotation>
+          <xsd:documentation>SOUTH SUDAN, REPUBLIC OF</xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
       <xsd:enumeration value="GT">
         <xsd:annotation>
           <xsd:documentation>GUATEMALA</xsd:documentation>
@@ -622,6 +627,11 @@
           <xsd:documentation>KOREA, REPUBLIC OF</xsd:documentation>
         </xsd:annotation>
       </xsd:enumeration>
+      <xsd:enumeration value="XK">
+        <xsd:annotation>
+          <xsd:documentation>KOSOVO</xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
       <xsd:enumeration value="KW">
         <xsd:annotation>
           <xsd:documentation>KUWAIT</xsd:documentation>
@@ -729,7 +739,7 @@
       </xsd:enumeration>
       <xsd:enumeration value="MK">
         <xsd:annotation>
-          <xsd:documentation>MACEDONIA, THE FORMER YUGOSLAV REPUBLIC OF</xsd:documentation>
+          <xsd:documentation>NORTH MACEDONIA, REPUBLIC OF</xsd:documentation>
         </xsd:annotation>
       </xsd:enumeration>
       <xsd:enumeration value="ML">

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -141,6 +141,7 @@ parameters:
         KI: {Name: "Kiribati", Alpha2: "KI", Alpha3: "KIR", IDC: "686"}
         KP: {Name: "Korea, Democratic People's Republic of", Alpha2: "KP", Alpha3: "PRK", IDC: "850"}
         KR: {Name: "Korea, Republic of", Alpha2: "KR", Alpha3: "KOR", IDC: "82"}
+        XK: {Name: "Kosovo", Alpha2: "XK", Alpha3: "XXK", IDC: "383"}
         KW: {Name: "Kuwait", Alpha2: "KW", Alpha3: "KWT", IDC: "965"}
         KG: {Name: "Kyrgyzstan", Alpha2: "KG", Alpha3: "KGZ", IDC: "996"}
         LA: {Name: "Lao People's Democratic Republic", Alpha2: "LA", Alpha3: "LAO", IDC: "856"}
@@ -153,7 +154,6 @@ parameters:
         LT: {Name: "Lithuania", Alpha2: "LT", Alpha3: "LTU", IDC: "370"}
         LU: {Name: "Luxembourg", Alpha2: "LU", Alpha3: "LUX", IDC: "352"}
         MO: {Name: "Macau", Alpha2: "MO", Alpha3: "MAC", IDC: "853"}
-        MK: {Name: "Macedonia, The Former Yugoslav Republic of", Alpha2: "MK", Alpha3: "MKD", IDC: "389"}
         MG: {Name: "Madagascar", Alpha2: "MG", Alpha3: "MDG", IDC: "261"}
         MW: {Name: "Malawi", Alpha2: "MW", Alpha3: "MWI", IDC: "265"}
         MY: {Name: "Malaysia", Alpha2: "MY", Alpha3: "MYS", IDC: "60"}
@@ -188,6 +188,7 @@ parameters:
         NU: {Name: "Niue", Alpha2: "NU", Alpha3: "NIU", IDC: "683"}
         NF: {Name: "Norfolk Island", Alpha2: "NF", Alpha3: "NFK", IDC: "6723"}
         MP: {Name: "Northern Mariana Islands", Alpha2: "MP", Alpha3: "MNP", IDC: "1670"}
+        MK: {Name: "North Macedonia, Republic of", Alpha2: "MK", Alpha3: "MKD", IDC: "389"}
         NO: {Name: "Norway", Alpha2: "NO", Alpha3: "NOR", IDC: "47"}
         OM: {Name: "Oman", Alpha2: "OM", Alpha3: "OMN", IDC: "968"}
         PK: {Name: "Pakistan", Alpha2: "PK", Alpha3: "PAK", IDC: "92"}
@@ -229,6 +230,7 @@ parameters:
         SO: {Name: "Somalia", Alpha2: "SO", Alpha3: "SOM", IDC: "252"}
         ZA: {Name: "South Africa", Alpha2: "ZA", Alpha3: "ZAF", IDC: "27"}
         GS: {Name: "South Georgia and The South Sandwich Islands", Alpha2: "GS", Alpha3: "SGS", IDC: "500"}
+        SS: {Name: "South Sudan, Republic of", Alpha2: "SS", Alpha3: "SSD", IDC: "211"}
         ES: {Name: "Spain", Alpha2: "ES", Alpha3: "ESP", IDC: "34"}
         LK: {Name: "Sri Lanka", Alpha2: "LK", Alpha3: "LKA", IDC: "94"}
         SD: {Name: "Sudan", Alpha2: "SD", Alpha3: "SDN", IDC: "249"}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32302](https://jira.ez.no/browse/EZP-32302)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Excerpt from JIRA:
>The customer observed that Kosovo is missing on Country FieldType. We should also add South Sudan and update Macedonia.

PR for 3.x will be prepared separately.

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
