### PR TITLE
EZP-32308: Fixed evaluating permissions on non prepared targets

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LocationLimitationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LocationLimitationIntegrationTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace eZ\Publish\API\Repository\Tests\Limitation\PermissionResolver;
 
-use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 use eZ\Publish\API\Repository\Values\User\Limitation\LocationLimitation;
 use eZ\Publish\SPI\Limitation\Target\Version;
 

--- a/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LocationLimitationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LocationLimitationIntegrationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Limitation\PermissionResolver;
+
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
+use eZ\Publish\API\Repository\Values\User\Limitation\LocationLimitation;
+use eZ\Publish\SPI\Limitation\Target\Version;
+
+class LocationLimitationIntegrationTest extends BaseLimitationIntegrationTest
+{
+    private const LOCATION_ID = 2;
+
+    public function providerForCanUserEditOrPublishContent(): array
+    {
+        $limitationRoot = new LocationLimitation();
+        $limitationRoot->limitationValues = [self::LOCATION_ID];
+
+        return [
+            [[$limitationRoot], true],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForCanUserEditOrPublishContent
+     *
+     * @param array $limitations
+     * @param bool $expectedResult
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testCanUserEditContent(array $limitations, bool $expectedResult): void
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $location = $locationService->loadLocation(2);
+
+        $this->loginAsEditorUserWithLimitations('content', 'edit', $limitations);
+
+        $this->assertCanUser(
+            $expectedResult,
+            'content',
+            'edit',
+            $limitations,
+            $location->contentInfo,
+            [$location]
+        );
+
+        $this->assertCanUser(
+            $expectedResult,
+            'content',
+            'edit',
+            $limitations,
+            $location->contentInfo,
+            [$location, new Version(['allLanguageCodesList' => 'eng-GB'])]
+        );
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
+++ b/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
@@ -1258,17 +1258,16 @@ class PermissionResolverTest extends BaseTest
                     'module' => $module,
                     'function' => $function,
                     'limitations' => [
-                        new Limitation\LocationLimitation(['limitationValues' => [$location->id]])
-                    ]
+                        new Limitation\LocationLimitation(['limitationValues' => [$location->id]]),
+                    ],
                 ],
                 [
                     'module' => $module,
                     'function' => $function,
                     'limitations' => [
-                        new Limitation\LanguageLimitation(['limitationValues' => ['eng-GB']])
-                    ]
+                        new Limitation\LanguageLimitation(['limitationValues' => ['eng-GB']]),
+                    ],
                 ],
-
             ]
         );
         $user = $this->createUser('user', 'John', 'Doe', $userService->loadUserGroup(4));
@@ -1300,7 +1299,7 @@ class PermissionResolverTest extends BaseTest
                 $location->contentInfo,
                 [
                     (new VersionBuilder())->translateToAnyLanguageOf(['eng-GB'])->build(),
-                    $location
+                    $location,
                 ],
                 [Limitation::LANGUAGE]
             )

--- a/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
+++ b/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\SPI\Limitation\Target\Builder\VersionBuilder;
 use function array_filter;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
@@ -1235,6 +1236,74 @@ class PermissionResolverTest extends BaseTest
         self::assertEquals(
             $expected,
             $permissionResolver->lookupLimitations($module, $function, $this->getContentCreateStruct($repository), [])
+        );
+    }
+
+    public function testLookupLimitationsWithMixedTargets(): void
+    {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+        $permissionResolver = $repository->getPermissionResolver();
+        $roleService = $repository->getRoleService();
+        $locationService = $repository->getLocationService();
+
+        $location = $locationService->loadLocation(2);
+        $module = 'content';
+        $function = 'edit';
+
+        $role = $this->createRoleWithPolicies(
+            'role_' . __FUNCTION__,
+            [
+                [
+                    'module' => $module,
+                    'function' => $function,
+                    'limitations' => [
+                        new Limitation\LocationLimitation(['limitationValues' => [$location->id]])
+                    ]
+                ],
+                [
+                    'module' => $module,
+                    'function' => $function,
+                    'limitations' => [
+                        new Limitation\LanguageLimitation(['limitationValues' => ['eng-GB']])
+                    ]
+                ],
+
+            ]
+        );
+        $user = $this->createUser('user', 'John', 'Doe', $userService->loadUserGroup(4));
+        $roleService->assignRoleToUser($role, $user);
+        $permissionResolver->setCurrentUserReference($user);
+
+        $expected = new LookupLimitationResult(
+            true,
+            [],
+            [
+                new LookupPolicyLimitations(
+                    $role->getPolicies()[0],
+                    []
+                ),
+                new LookupPolicyLimitations(
+                    $role->getPolicies()[1],
+                    [
+                        new Limitation\LanguageLimitation(['limitationValues' => ['eng-GB']]),
+                    ]
+                ),
+            ]
+        );
+
+        self::assertEquals(
+            $expected,
+            $permissionResolver->lookupLimitations(
+                $module,
+                $function,
+                $location->contentInfo,
+                [
+                    (new VersionBuilder())->translateToAnyLanguageOf(['eng-GB'])->build(),
+                    $location
+                ],
+                [Limitation::LANGUAGE]
+            )
         );
     }
 

--- a/eZ/Publish/Core/Limitation/LocationLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LocationLimitationType.php
@@ -138,22 +138,19 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
                 $targets = $this->persistence->locationHandler()->loadParentLocationsForDraftContent($object->id);
             }
         }
-        /** @var \eZ\Publish\API\Repository\Values\Content\Location[]|\eZ\Publish\SPI\Persistence\Content\Location[] $targets */
-        $targets = array_filter($targets, function ($target) {
-            return $target instanceof Location || $target instanceof SPILocation;
-        });
-
-        if (empty($targets)) {
-            throw new InvalidArgumentException('$targets', 'Must contain at least one Location object');
-        }
 
         foreach ($targets as $target) {
+            if (!$target instanceof Location && !$target instanceof SPILocation) {
+                throw new InvalidArgumentException('$targets', 'Must contain objects of type: Location');
+            }
+
+            // Single match is sufficient
             if (in_array($target->id, $value->limitationValues)) {
-                return self::ACCESS_GRANTED;
+                return true;
             }
         }
 
-        return self::ACCESS_DENIED;
+        return false;
     }
 
     /**

--- a/eZ/Publish/Core/Limitation/LocationLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LocationLimitationType.php
@@ -138,19 +138,22 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
                 $targets = $this->persistence->locationHandler()->loadParentLocationsForDraftContent($object->id);
             }
         }
+        /** @var \eZ\Publish\API\Repository\Values\Content\Location[]|\eZ\Publish\SPI\Persistence\Content\Location[] $targets */
+        $targets = array_filter($targets, function ($target) {
+            return $target instanceof Location || $target instanceof SPILocation;
+        });
+
+        if (empty($targets)) {
+            throw new InvalidArgumentException('$targets', 'Must contain at least one Location object');
+        }
 
         foreach ($targets as $target) {
-            if (!$target instanceof Location && !$target instanceof SPILocation) {
-                throw new InvalidArgumentException('$targets', 'Must contain objects of type: Location');
-            }
-
-            // Single match is sufficient
             if (in_array($target->id, $value->limitationValues)) {
-                return true;
+                return self::ACCESS_GRANTED;
             }
         }
 
-        return false;
+        return self::ACCESS_DENIED;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -339,7 +339,12 @@ class PermissionResolver implements PermissionResolverInterface
         ?array $targets
     ): bool {
         $type = $this->limitationService->getLimitationType($limitation->getIdentifier());
-        $accessVote = $type->evaluate($limitation, $currentUserReference, $object, $targets);
+        $accessVote = $type->evaluate(
+            $limitation,
+            $currentUserReference,
+            $object,
+            $this->prepareTargetsForType($targets, $type)
+        );
 
         return $accessVote === LimitationType::ACCESS_GRANTED;
     }
@@ -366,7 +371,12 @@ class PermissionResolver implements PermissionResolverInterface
         }
 
         $type = $this->limitationService->getLimitationType($limitation->getIdentifier());
-        $accessVote = $type->evaluate($limitation, $currentUserReference, $object, $targets);
+        $accessVote = $type->evaluate(
+            $limitation,
+            $currentUserReference,
+            $object,
+            $this->prepareTargetsForType($targets, $type)
+        );
 
         return $accessVote === LimitationType::ACCESS_DENIED;
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32308](https://jira.ez.no/browse/EZP-32308)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Instead of requiring that all `targets` must be instance of `Location`, at least one valid is needed.

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
