### PR TITLE
EZP-32321: Added deleteTranslations target to fix 'content/remove' permission check

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
@@ -586,11 +586,9 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
     }
 
     /**
-     * Test for the deleteContent() method.
-     *
-     * @see \eZ\Publish\API\Repository\ContentService::deleteContent()
+     * @covers \eZ\Publish\API\Repository\ContentService::deleteContent()
      */
-    public function testDeleteContentThrowsUnauthorizedExceptionWithLanguageLimitation()
+    public function testDeleteContentThrowsUnauthorizedExceptionWithLanguageLimitation(): void
     {
         $contentVersion2 = $this->createMultipleLanguageContentVersion2();
         $contentInfo = $contentVersion2->contentInfo;
@@ -614,11 +612,9 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
     }
 
     /**
-     * Test for the deleteContent() method.
-     *
-     * @see \eZ\Publish\API\Repository\ContentService::deleteContent()
+     * @covers \eZ\Publish\API\Repository\ContentService::deleteContent()
      */
-    public function testDeleteContentWithLanguageLimitation()
+    public function testDeleteContentWithLanguageLimitation(): void
     {
         $contentVersion2 = $this->createMultipleLanguageContentVersion2();
         $contentInfo = $contentVersion2->contentInfo;

--- a/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
@@ -10,6 +10,7 @@ use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\LocationLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
 
@@ -582,6 +583,60 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
         $this->expectExceptionMessageRegExp('/\'remove\' \'content\'/');
 
         $this->contentService->deleteContent($contentInfo);
+    }
+
+    /**
+     * Test for the deleteContent() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentService::deleteContent()
+     */
+    public function testDeleteContentThrowsUnauthorizedExceptionWithLanguageLimitation()
+    {
+        $contentVersion2 = $this->createMultipleLanguageContentVersion2();
+        $contentInfo = $contentVersion2->contentInfo;
+        $limitations = [
+            new LanguageLimitation(['limitationValues' => ['eng-US']]),
+        ];
+
+        $user = $this->createUserWithPolicies(
+            'user',
+            [
+                ['module' => 'content', 'function' => 'remove', 'limitations' => $limitations],
+            ]
+        );
+
+        $this->permissionResolver->setCurrentUserReference($user);
+
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessageRegExp('/\'remove\' \'content\'/');
+
+        $this->contentService->deleteContent($contentInfo);
+    }
+
+    /**
+     * Test for the deleteContent() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentService::deleteContent()
+     */
+    public function testDeleteContentWithLanguageLimitation()
+    {
+        $contentVersion2 = $this->createMultipleLanguageContentVersion2();
+        $contentInfo = $contentVersion2->contentInfo;
+
+        $limitations = [
+            new LanguageLimitation(['limitationValues' => ['eng-US', 'eng-GB']]),
+        ];
+
+        $user = $this->createUserWithPolicies(
+            'user',
+            [
+                ['module' => 'content', 'function' => 'remove', 'limitations' => $limitations],
+            ]
+        );
+
+        $this->permissionResolver->setCurrentUserReference($user);
+
+        self::assertSame([$contentInfo->mainLocationId], $this->contentService->deleteContent($contentInfo));
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LanguageLimitationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LanguageLimitationIntegrationTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Tests\Limitation\PermissionResolver;
 
 use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation;
+use eZ\Publish\SPI\Limitation\Target;
 
 /**
  * Integration test for chosen use cases of calls to PermissionResolver::canUser.
@@ -159,5 +160,109 @@ class LanguageLimitationIntegrationTest extends BaseLimitationIntegrationTest
         $this->loginAsEditorUserWithLimitations('content', 'publish', $limitations);
 
         $this->assertCanUser($expectedResult, 'content', 'publish', $limitations, $content);
+    }
+
+    /**
+     * Data provider for testCanUserDeleteContent.
+     *
+     * @see testCanUserDeleteContent
+     */
+    public function providerForCanUserDeleteContent(): array
+    {
+        $limitationForGerman = new LanguageLimitation();
+        $limitationForGerman->limitationValues = [self::LANG_GER_DE];
+
+        $limitationForBritishEnglish = new LanguageLimitation();
+        $limitationForBritishEnglish->limitationValues = [self::LANG_ENG_GB];
+
+        $multilingualLimitation = new LanguageLimitation();
+        $multilingualLimitation->limitationValues = [self::LANG_ENG_GB, self::LANG_GER_DE];
+
+        return [
+            [[$limitationForBritishEnglish], false],
+            [[$limitationForGerman], false],
+            // dealing with British and German content, so true only for multilingual Language Limitation
+            [[$multilingualLimitation], true],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForCanUserDeleteContent
+     *
+     * @param array $limitations
+     * @param bool $expectedResult
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testCanUserDeleteContent(array $limitations, bool $expectedResult): void
+    {
+        $content = $this->createFolder(
+            [
+                self::LANG_ENG_GB => 'British Folder',
+                self::LANG_GER_DE => 'German Folder',
+            ],
+            2
+        );
+
+        $this->loginAsEditorUserWithLimitations('content', 'remove', $limitations);
+
+        $target = (new Target\Version())->deleteTranslations($content->getVersionInfo()->languageCodes);
+        $this->assertCanUser($expectedResult, 'content', 'remove', $limitations, $content, [$target]);
+    }
+
+    /**
+     * Data provider for testCanUserDeleteContentTranslation.
+     *
+     * @see testCanUserDeleteContentTranslation
+     */
+    public function providerForCanUserDeleteContentTranslation(): array
+    {
+        $limitationForGerman = new LanguageLimitation();
+        $limitationForGerman->limitationValues = [self::LANG_GER_DE];
+
+        $limitationForBritishEnglish = new LanguageLimitation();
+        $limitationForBritishEnglish->limitationValues = [self::LANG_ENG_GB];
+
+        $multilingualLimitation = new LanguageLimitation();
+        $multilingualLimitation->limitationValues = [self::LANG_ENG_US, self::LANG_GER_DE];
+
+        return [
+            // dealing with British translation, so true for British Language Limitation
+            [[$limitationForBritishEnglish], self::LANG_ENG_GB, true],
+            // dealing with British translation, so false for German Language Limitation
+            [[$limitationForGerman], self::LANG_ENG_GB, false],
+            // dealing with US translation, so true for multilingual(us, ger) Limitation
+            [[$multilingualLimitation], self::LANG_ENG_US, true],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForCanUserDeleteContentTranslation
+     *
+     * @param array $limitations
+     * @param string $translation
+     * @param bool $expectedResult
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testCanUserDeleteContentTranslation(array $limitations, string $translation, bool $expectedResult): void
+    {
+        $content = $this->createFolder(
+            [
+                self::LANG_ENG_GB => 'British Folder',
+                self::LANG_GER_DE => 'German Folder',
+                self::LANG_ENG_US => 'US Folder',
+            ],
+            2
+        );
+
+        $this->loginAsEditorUserWithLimitations('content', 'remove', $limitations);
+
+        $target = (new Target\Builder\VersionBuilder())->translateToAnyLanguageOf([$translation])->build();
+        $this->assertCanUser($expectedResult, 'content', 'remove', $limitations, $content, [$target]);
     }
 }

--- a/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LanguageLimitationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LanguageLimitationIntegrationTest.php
@@ -189,7 +189,7 @@ class LanguageLimitationIntegrationTest extends BaseLimitationIntegrationTest
     /**
      * @dataProvider providerForCanUserDeleteContent
      *
-     * @param array $limitations
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
      * @param bool $expectedResult
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
@@ -217,7 +217,7 @@ class LanguageLimitationIntegrationTest extends BaseLimitationIntegrationTest
      *
      * @see testCanUserDeleteContentTranslation
      */
-    public function providerForCanUserDeleteContentTranslation(): array
+    public function providerForCanUserDeleteContentTranslation(): iterable
     {
         $limitationForGerman = new LanguageLimitation();
         $limitationForGerman->limitationValues = [self::LANG_GER_DE];
@@ -228,20 +228,29 @@ class LanguageLimitationIntegrationTest extends BaseLimitationIntegrationTest
         $multilingualLimitation = new LanguageLimitation();
         $multilingualLimitation->limitationValues = [self::LANG_ENG_US, self::LANG_GER_DE];
 
-        return [
-            // dealing with British translation, so true for British Language Limitation
-            [[$limitationForBritishEnglish], self::LANG_ENG_GB, true],
-            // dealing with British translation, so false for German Language Limitation
-            [[$limitationForGerman], self::LANG_ENG_GB, false],
-            // dealing with US translation, so true for multilingual(us, ger) Limitation
-            [[$multilingualLimitation], self::LANG_ENG_US, true],
+        yield 'Limitation with eng-GB should return true for eng-GB translation' => [
+            [$limitationForBritishEnglish],
+            self::LANG_ENG_GB,
+            true,
+        ];
+
+        yield 'Limitation with ger-de should return false for eng-GB translation' => [
+            [$limitationForGerman],
+            self::LANG_ENG_GB,
+            false,
+        ];
+
+        yield 'Limitation with neg-US and ger-de should return true for eng-US translation' => [
+            [$multilingualLimitation],
+            self::LANG_ENG_US,
+            true,
         ];
     }
 
     /**
      * @dataProvider providerForCanUserDeleteContentTranslation
      *
-     * @param array $limitations
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
      * @param string $translation
      * @param bool $expectedResult
      *

--- a/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
@@ -387,11 +387,9 @@ class LocationServiceAuthorizationTest extends BaseTest
     }
 
     /**
-     * Test for the deleteLocation() method.
-     *
-     * @see \eZ\Publish\API\Repository\LocationService::deleteLocation()
+     * @covers \eZ\Publish\API\Repository\LocationService::deleteLocation()
      */
-    public function testDeleteLocationThrowsUnauthorizedExceptionWithLanguageLimitation()
+    public function testDeleteLocationThrowsUnauthorizedExceptionWithLanguageLimitation(): void
     {
         $repository = $this->getRepository();
         $mediaLocationId = $this->generateId('location', 43);

--- a/eZ/Publish/API/Repository/Tests/TrashServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceAuthorizationTest.php
@@ -82,11 +82,8 @@ class TrashServiceAuthorizationTest extends BaseTrashServiceTest
      *
      * @covers \eZ\Publish\API\Repository\TrashService::trash
      */
-    public function testTrashThrowsUnauthorizedExceptionWithLanguageLimitation()
+    public function testTrashThrowsUnauthorizedExceptionWithLanguageLimitation(): void
     {
-        $this->expectException(UnauthorizedException::class);
-        $this->expectExceptionMessage('User does not have access to \'remove\' \'content\'');
-
         $repository = $this->getRepository();
         $trashService = $repository->getTrashService();
         $locationService = $repository->getLocationService();
@@ -108,6 +105,10 @@ class TrashServiceAuthorizationTest extends BaseTrashServiceTest
         );
 
         $repository->getPermissionResolver()->setCurrentUserReference($user);
+
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage('User does not have access to \'remove\' \'content\'');
+
         $trashService->trash($mediaLocation);
     }
 

--- a/eZ/Publish/Core/Limitation/LanguageLimitation/ContentDeleteEvaluator.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitation/ContentDeleteEvaluator.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Limitation\LanguageLimitation;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\Core\Limitation\LanguageLimitationType;
+use eZ\Publish\SPI\Limitation\Target;
+
+/**
+ * @internal for internal use by LanguageLimitation
+ */
+final class ContentDeleteEvaluator implements VersionTargetEvaluator
+{
+    public function accept(Target\Version $targetVersion): bool
+    {
+        return !empty($targetVersion->getTranslationsToDelete());
+    }
+
+    /**
+     * Allow access if all of the given language codes for content matches limitation values.
+     */
+    public function evaluate(Target\Version $targetVersion, Limitation $limitationValue): ?bool
+    {
+        $diff = array_diff(
+            $targetVersion->getTranslationsToDelete(),
+            $limitationValue->limitationValues
+        );
+        $accessVote = empty($diff)
+            ? LanguageLimitationType::ACCESS_GRANTED
+            : LanguageLimitationType::ACCESS_DENIED;
+
+        return $accessVote;
+    }
+}

--- a/eZ/Publish/Core/Limitation/Tests/LangugeLimitation/ContentDeleteEvaluatorTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/LangugeLimitation/ContentDeleteEvaluatorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Limitation\Tests\LanguageLimitation;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\Core\Limitation\LanguageLimitation\ContentDeleteEvaluator;
+use eZ\Publish\SPI\Limitation\Target;
+use PHPUnit\Framework\TestCase;
+
+final class ContentDeleteEvaluatorTest extends TestCase
+{
+    /**
+     * @dataProvider dataProviderForAccept
+     */
+    public function testAccept(Target\Version $targetVersion, bool $expected): void
+    {
+        self::assertSame(
+            $expected,
+            (new ContentDeleteEvaluator())->accept($targetVersion)
+        );
+    }
+
+    public function dataProviderForAccept(): iterable
+    {
+        yield [
+            $this->getTergetVersion(['eng-GB', 'ger-DE']),
+            true,
+        ];
+
+        yield [
+            $this->getTergetVersion([]),
+            false,
+        ];
+
+        yield [
+            new Target\Version(),
+            false,
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForEvaluate
+     */
+    public function testEvaluate(Target\Version $targetVersion, Limitation $limitationValue, bool $expected): void
+    {
+        self::assertSame(
+            $expected,
+            (new ContentDeleteEvaluator())->evaluate($targetVersion, $limitationValue)
+        );
+    }
+
+    public function dataProviderForEvaluate(): iterable
+    {
+        yield 'same_values' => [
+            $this->getTergetVersion(['eng-GB', 'ger-DE']),
+            $this->getLanguageLimitation(['eng-GB', 'ger-DE']),
+            true,
+        ];
+
+        yield 'missing_fr_limitation' => [
+            $this->getTergetVersion(['eng-GB', 'ger-DE', 'fre-FR']),
+            $this->getLanguageLimitation(['eng-GB', 'ger-DE']),
+            false,
+        ];
+
+        yield 'extra_fr_limitation' => [
+            $this->getTergetVersion(['eng-GB', 'ger-DE']),
+            $this->getLanguageLimitation(['eng-GB', 'ger-DE', 'fre-FR']),
+            true,
+        ];
+
+        yield 'separable_values' => [
+            $this->getTergetVersion(['eng-GB']),
+            $this->getLanguageLimitation(['fre-FR']),
+            false,
+        ];
+    }
+
+    private function getTergetVersion(array $languageCodes): Target\Version
+    {
+        return (new Target\Version())->deleteTranslations($languageCodes);
+    }
+
+    private function getLanguageLimitation(array $languageCodes): Limitation\LanguageLimitation
+    {
+        return new Limitation\LanguageLimitation(['limitationValues' => $languageCodes]);
+    }
+}

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1040,8 +1040,14 @@ class ContentService implements ContentServiceInterface
     public function deleteContent(ContentInfo $contentInfo)
     {
         $contentInfo = $this->internalLoadContentInfo($contentInfo->id);
+        $versionInfo = $this->persistenceHandler->contentHandler()->loadVersionInfo(
+            $contentInfo->id,
+            $contentInfo->currentVersionNo
+        );
+        $translations = $versionInfo->languageCodes;
+        $target = (new Target\Version())->deleteTranslations($translations);
 
-        if (!$this->repository->canUser('content', 'remove', $contentInfo)) {
+        if (!$this->repository->canUser('content', 'remove', $contentInfo, [$target])) {
             throw new UnauthorizedException('content', 'remove', ['contentId' => $contentInfo->id]);
         }
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -734,8 +734,26 @@ class ContentTest extends BaseServiceMockTest
 
         $contentInfo->expects($this->any())
             ->method('__get')
-            ->with('id')
-            ->will($this->returnValue(42));
+            ->willReturnMap(
+                [
+                    ['id', 42],
+                    ['currentVersionNo', 7],
+                ]
+            );
+
+        $persistenceHandlerMock = $this->getPersistenceMockHandler('Handler');
+        /** @var \PHPUnit\Framework\MockObject\MockObject $contentHandler */
+        $contentHandler = $this->getPersistenceMock()->contentHandler();
+
+        $contentHandler
+            ->expects($this->once())
+            ->method('loadVersionInfo')
+            ->with(
+                $this->equalTo(42),
+                $this->equalTo(7)
+            )->will(
+                $this->returnValue(new SPIVersionInfo())
+            );
 
         $contentService->expects($this->once())
             ->method('internalLoadContentInfo')
@@ -782,8 +800,26 @@ class ContentTest extends BaseServiceMockTest
 
         $contentInfo->expects($this->any())
             ->method('__get')
-            ->with('id')
-            ->will($this->returnValue(42));
+            ->willReturnMap(
+                [
+                    ['id', 42],
+                    ['currentVersionNo', 7],
+                ]
+            );
+
+        $persistenceHandlerMock = $this->getPersistenceMockHandler('Handler');
+        /** @var \PHPUnit\Framework\MockObject\MockObject $contentHandler */
+        $contentHandler = $this->getPersistenceMock()->contentHandler();
+
+        $contentHandler
+            ->expects($this->once())
+            ->method('loadVersionInfo')
+            ->with(
+                $this->equalTo(42),
+                $this->equalTo(7)
+            )->will(
+                $this->returnValue(new SPIVersionInfo())
+            );
 
         $repository->expects($this->once())->method('beginTransaction');
 
@@ -840,8 +876,26 @@ class ContentTest extends BaseServiceMockTest
 
         $contentInfo->expects($this->any())
             ->method('__get')
-            ->with('id')
-            ->will($this->returnValue(42));
+            ->willReturnMap(
+                [
+                    ['id', 42],
+                    ['currentVersionNo', 7],
+                ]
+            );
+
+        $persistenceHandlerMock = $this->getPersistenceMockHandler('Handler');
+        /** @var \PHPUnit\Framework\MockObject\MockObject $contentHandler */
+        $contentHandler = $this->getPersistenceMock()->contentHandler();
+
+        $contentHandler
+            ->expects($this->once())
+            ->method('loadVersionInfo')
+            ->with(
+                $this->equalTo(42),
+                $this->equalTo(7)
+            )->will(
+                $this->returnValue(new SPIVersionInfo())
+            );
 
         $repository->expects($this->once())->method('beginTransaction');
 

--- a/eZ/Publish/SPI/Limitation/Target/Version.php
+++ b/eZ/Publish/SPI/Limitation/Target/Version.php
@@ -68,4 +68,29 @@ final class Version extends ValueObject implements Target
      * @var int|null
      */
     protected $newStatus;
+
+    /**
+     * List of language codes of translations to delete. All must match Limitation values.
+     *
+     * @var string[]
+     */
+    private $translationsToDelete = [];
+
+    /**
+     * @param string[] $translationsToDelete List of language codes of translations to delete
+     */
+    public function deleteTranslations(array $translationsToDelete): self
+    {
+        $this->translationsToDelete = $translationsToDelete;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getTranslationsToDelete(): array
+    {
+        return $this->translationsToDelete;
+    }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32321](https://jira.ez.no/browse/EZP-32321)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Related PR**      | https://github.com/ezsystems/ezplatform-admin-ui/pull/1703
| **Tests pass**     | yes
| **Doc needed**     | yes

A bug occurs how long a policy `content/remove` has a language limitation. If 'initialLanguageCode' of content is the same as one of the allowed languages then the user can delete content. Because initial language code is set when content is edited in given language behavior is nondeterministic. To eliminate this bug additional "target" should be passed as an argument when the permission check I performed. After this change, if the user has `content/remove` policy with language limitations then he has to have access to all languages of content.

#### Documentation
After this change, if the user has `content/remove` policy with language limitations then he has to have access to all languages of content.
Below is an example of how a permission check could be achieved
```
$translations = $location->getContent()->getVersionInfo()->languageCodes;
$target = (new Target\Version())->deleteTranslations($translations);
$permissionResolver->canUser(
    'content', 'remove', $location->getContentInfo(), [$location, $target]
);
```

#### QA
- moving content to trash
- removing location
- removing content from trash

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
