### PR TITLE
EZP-32308: Fixed failing tests due to pgsql randomness in returned results

### DIFF
--- a/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
+++ b/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
@@ -1274,36 +1274,39 @@ class PermissionResolverTest extends BaseTest
         $roleService->assignRoleToUser($role, $user);
         $permissionResolver->setCurrentUserReference($user);
 
-        $expected = new LookupLimitationResult(
-            true,
-            [],
+        $actual = $permissionResolver->lookupLimitations(
+            $module,
+            $function,
+            $location->contentInfo,
             [
+                (new VersionBuilder())->translateToAnyLanguageOf(['eng-GB'])->build(),
+                $location,
+            ],
+            [Limitation::LANGUAGE]
+        );
+
+        self::assertTrue($actual->hasAccess);
+        self::assertEmpty($actual->roleLimitations);
+        self::assertCount(2, $actual->lookupPolicyLimitations);
+
+        self::assertTrue(
+            in_array(
                 new LookupPolicyLimitations(
                     $role->getPolicies()[0],
                     []
                 ),
+                $actual->lookupPolicyLimitations
+        ));
+        self::assertTrue(
+            in_array(
                 new LookupPolicyLimitations(
                     $role->getPolicies()[1],
                     [
                         new Limitation\LanguageLimitation(['limitationValues' => ['eng-GB']]),
                     ]
                 ),
-            ]
-        );
-
-        self::assertEquals(
-            $expected,
-            $permissionResolver->lookupLimitations(
-                $module,
-                $function,
-                $location->contentInfo,
-                [
-                    (new VersionBuilder())->translateToAnyLanguageOf(['eng-GB'])->build(),
-                    $location,
-                ],
-                [Limitation::LANGUAGE]
-            )
-        );
+                $actual->lookupPolicyLimitations
+            ));
     }
 
     /**


### PR DESCRIPTION
As returned `LookupPolicyLimitations` are in random order on pgsql, there was a need to readjust tests assertions.