### PR TITLE
Added missing cast to int of a parent node in UrlAlias Doctrine Gateway

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -1438,7 +1438,7 @@ class DoctrineDatabase extends Gateway
                 $updateQueryBuilder->execute();
             } catch (UniqueConstraintViolationException $e) {
                 // edge case: if such row already exists, there's no way to restore history
-                $this->deleteRow($urlAliasData['parent'], $urlAliasData['text_md5']);
+                $this->deleteRow((int) $urlAliasData['parent'], $urlAliasData['text_md5']);
             }
         }
     }


### PR DESCRIPTION
By default, integers are retrieved from the database as a string, so it is required to cast them to `int` before passing to methods that require the `int` parameter.