### PR TITLE
EZP-32401: Fixed handling trashed Content by LocationLimitation

### DIFF
--- a/eZ/Publish/Core/Limitation/LocationLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LocationLimitationType.php
@@ -133,6 +133,8 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
         if ($targets === null) {
             if ($object->published) {
                 $targets = $this->persistence->locationHandler()->loadLocationsByContent($object->id);
+            } elseif ($object->isTrashed()) {
+                $targets = $this->persistence->locationHandler()->loadLocationsByTrashContent($object->id);
             } else {
                 // @todo Need support for draft locations to to work correctly
                 $targets = $this->persistence->locationHandler()->loadParentLocationsForDraftContent($object->id);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32401](https://jira.ez.no/browse/EZP-32401)
| **Bug**| yes
| **New feature**    | no
| **Target version** | 7.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

When Content was trashed and it had reverse relation the Location was not accessible. Therefore additional condition had to be added which exports trashed Location and uses it as a target.

**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
