### PR TITLE
IBX-143: Refactored reindexing command to be DBAL 2.13-compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "hautelook/templated-uri-bundle": "^2.1",
         "pagerfanta/pagerfanta": "^2.0",
         "ocramius/proxy-manager": "^2.1",
+        "doctrine/dbal": "^2.13.0",
         "doctrine/orm": "^2.7",
         "doctrine/doctrine-bundle": "~1.6",
         "liip/imagine-bundle": "^2.1",

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -48,6 +48,7 @@ class ReindexCommand extends ContainerAwareCommand
 
     /** @var \eZ\Publish\SPI\Search\Content\IndexerGateway */
     private $gateway;
+
     /** @var \eZ\Publish\SPI\Persistence\Content\Location\Handler */
     private $locationHandler;
 

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -209,18 +209,18 @@ EOT
         }
 
         if ($since = $input->getOption('since')) {
-            $stmt = $this->gateway->getStatementContentSince(new DateTime($since));
-            $count = (int)$this->gateway->getStatementContentSince(new DateTime($since), true)->fetchColumn();
+            $count = $this->gateway->countContentSince(new DateTime($since));
+            $generator = $this->gateway->getContentSince(new DateTime($since), $iterationCount);
             $purge = false;
         } elseif ($locationId = (int) $input->getOption('subtree')) {
             /** @var \eZ\Publish\SPI\Persistence\Content\Location\Handler */
             $location = $this->locationHandler->load($locationId);
-            $stmt = $this->gateway->getStatementSubtree($location->pathString);
-            $count = (int) $this->gateway->getStatementSubtree($location->pathString, true)->fetchColumn();
+            $count = $this->gateway->countContentInSubtree($location->pathString);
+            $generator = $this->gateway->getContentInSubtree($location->pathString, $iterationCount);
             $purge = false;
         } else {
-            $stmt = $this->gateway->getStatementContentAll();
-            $count = (int) $this->gateway->getStatementContentAll(true)->fetchColumn();
+            $count = $this->gateway->countAllContent();
+            $generator = $this->gateway->getAllContent($iterationCount);
             $purge = !$input->getOption('no-purge');
         }
 
@@ -252,7 +252,6 @@ EOT
         $progress = new ProgressBar($output);
         $progress->start($iterations);
 
-        $generator = $this->gateway->fetchIteration($stmt, $iterationCount);
         if ($processCount > 1) {
             $this->runParallelProcess(
                 $progress,

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -7,10 +7,11 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Command;
 
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\Core\Search\Common\Indexer;
 use eZ\Publish\Core\Search\Common\IncrementalIndexer;
-use Doctrine\DBAL\Driver\Statement;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
+use eZ\Publish\SPI\Search\Content\IndexerGateway;
+use Generator;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,15 +22,11 @@ use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
 use RuntimeException;
 use DateTime;
-use PDO;
 
 class ReindexCommand extends ContainerAwareCommand
 {
     /** @var \eZ\Publish\Core\Search\Common\Indexer|\eZ\Publish\Core\Search\Common\IncrementalIndexer */
     private $searchIndexer;
-
-    /** @var \Doctrine\DBAL\Connection */
-    private $connection;
 
     /** @var string */
     private $phpPath;
@@ -49,6 +46,19 @@ class ReindexCommand extends ContainerAwareCommand
     /** @var string */
     private $projectDir;
 
+    /** @var \eZ\Publish\SPI\Search\Content\IndexerGateway */
+    private $gateway;
+    /** @var \eZ\Publish\SPI\Persistence\Content\Location\Handler */
+    private $locationHandler;
+
+    public function __construct(IndexerGateway $gateway, LocationHandler $locationHandler)
+    {
+        $this->gateway = $gateway;
+        $this->locationHandler = $locationHandler;
+
+        parent::__construct();
+    }
+
     /**
      * Initialize objects required by {@see execute()}.
      *
@@ -59,7 +69,6 @@ class ReindexCommand extends ContainerAwareCommand
     {
         parent::initialize($input, $output);
         $this->searchIndexer = $this->getContainer()->get('ezpublish.spi.search.indexer');
-        $this->connection = $this->getContainer()->get('ezpublish.api.storage_engine.legacy.connection');
         $this->logger = $this->getContainer()->get('logger');
         $this->env = $this->getContainer()->getParameter('kernel.environment');
         $this->isDebug = $this->getContainer()->getParameter('kernel.debug');
@@ -200,16 +209,18 @@ EOT
         }
 
         if ($since = $input->getOption('since')) {
-            $stmt = $this->getStatementContentSince(new DateTime($since));
-            $count = (int)$this->getStatementContentSince(new DateTime($since), true)->fetchColumn();
+            $stmt = $this->gateway->getStatementContentSince(new DateTime($since));
+            $count = (int)$this->gateway->getStatementContentSince(new DateTime($since), true)->fetchColumn();
             $purge = false;
         } elseif ($locationId = (int) $input->getOption('subtree')) {
-            $stmt = $this->getStatementSubtree($locationId);
-            $count = (int) $this->getStatementSubtree($locationId, true)->fetchColumn();
+            /** @var \eZ\Publish\SPI\Persistence\Content\Location\Handler */
+            $location = $this->locationHandler->load($locationId);
+            $stmt = $this->gateway->getStatementSubtree($location->pathString);
+            $count = (int) $this->gateway->getStatementSubtree($location->pathString, true)->fetchColumn();
             $purge = false;
         } else {
-            $stmt = $this->getStatementContentAll();
-            $count = (int) $this->getStatementContentAll(true)->fetchColumn();
+            $stmt = $this->gateway->getStatementContentAll();
+            $count = (int) $this->gateway->getStatementContentAll(true)->fetchColumn();
             $purge = !$input->getOption('no-purge');
         }
 
@@ -241,11 +252,17 @@ EOT
         $progress = new ProgressBar($output);
         $progress->start($iterations);
 
+        $generator = $this->gateway->fetchIteration($stmt, $iterationCount);
         if ($processCount > 1) {
-            $this->runParallelProcess($progress, $stmt, (int) $processCount, (int) $iterationCount, $commit);
+            $this->runParallelProcess(
+                $progress,
+                $generator,
+                (int)$processCount,
+                $commit
+            );
         } else {
             // if we only have one process, or less iterations to warrant running several, we index it all inline
-            foreach ($this->fetchIteration($stmt, $iterationCount) as $contentIds) {
+            foreach ($generator as $contentIds) {
                 $this->searchIndexer->updateSearchIndex($contentIds, $commit);
                 $progress->advance(1);
             }
@@ -266,14 +283,12 @@ EOT
      */
     private function runParallelProcess(
         ProgressBar $progress,
-        Statement $stmt,
+        Generator $generator,
         int $processCount,
-        int $iterationCount,
         bool $commit
     ): void {
         /** @var \Symfony\Component\Process\Process[]|null[] */
         $processes = array_fill(0, $processCount, null);
-        $generator = $this->fetchIteration($stmt, $iterationCount);
         do {
             /** @var \Symfony\Component\Process\Process $process */
             foreach ($processes as $key => $process) {
@@ -310,90 +325,6 @@ EOT
                 sleep(1);
             }
         } while (!empty($processes));
-    }
-
-    /**
-     * @param DateTime $since
-     * @param bool $count
-     *
-     * @return \Doctrine\DBAL\Driver\Statement
-     */
-    private function getStatementContentSince(DateTime $since, $count = false)
-    {
-        $q = $this->connection->createQueryBuilder()
-            ->select($count ? 'count(c.id)' : 'c.id')
-            ->from('ezcontentobject', 'c')
-            ->where('c.status = :status')->andWhere('c.modified >= :since')
-            ->orderBy('c.modified')
-            ->setParameter('status', ContentInfo::STATUS_PUBLISHED, PDO::PARAM_INT)
-            ->setParameter('since', $since->getTimestamp(), PDO::PARAM_INT);
-
-        return $q->execute();
-    }
-
-    /**
-     * @param mixed $locationId
-     * @param bool $count
-     *
-     * @return \Doctrine\DBAL\Driver\Statement
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     */
-    private function getStatementSubtree($locationId, $count = false)
-    {
-        /** @var \eZ\Publish\SPI\Persistence\Content\Location\Handler */
-        $locationHandler = $this->getContainer()->get('ezpublish.spi.persistence.location_handler');
-        $location = $locationHandler->load($locationId);
-        $q = $this->connection->createQueryBuilder()
-            ->select($count ? 'count(DISTINCT c.id)' : 'DISTINCT c.id')
-            ->from('ezcontentobject', 'c')
-            ->innerJoin('c', 'ezcontentobject_tree', 't', 't.contentobject_id = c.id')
-            ->where('c.status = :status')
-            ->andWhere('t.path_string LIKE :path')
-            ->setParameter('status', ContentInfo::STATUS_PUBLISHED, PDO::PARAM_INT)
-            ->setParameter('path', $location->pathString . '%', PDO::PARAM_STR);
-
-        return $q->execute();
-    }
-
-    /**
-     * @param bool $count
-     *
-     * @return \Doctrine\DBAL\Driver\Statement
-     */
-    private function getStatementContentAll($count = false)
-    {
-        $q = $this->connection->createQueryBuilder()
-            ->select($count ? 'count(c.id)' : 'c.id')
-            ->from('ezcontentobject', 'c')
-            ->where('c.status = :status')
-            ->setParameter('status', ContentInfo::STATUS_PUBLISHED, PDO::PARAM_INT);
-
-        return $q->execute();
-    }
-
-    /**
-     * @param \Doctrine\DBAL\Driver\Statement $stmt
-     * @param int $iterationCount
-     *
-     * @return \Generator Return an array of arrays, each array contains content id's of $iterationCount.
-     */
-    private function fetchIteration(Statement $stmt, $iterationCount)
-    {
-        do {
-            $contentIds = [];
-            for ($i = 0; $i < $iterationCount; ++$i) {
-                if ($contentId = $stmt->fetch(PDO::FETCH_COLUMN)) {
-                    $contentIds[] = $contentId;
-                } elseif (empty($contentIds)) {
-                    return;
-                } else {
-                    break;
-                }
-            }
-
-            yield $contentIds;
-        } while (!empty($contentId));
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml
@@ -15,3 +15,9 @@ services:
             - "@ezpublish.siteaccess"
         tags:
             - { name: console.command }
+
+    eZ\Bundle\EzPublishCoreBundle\Command\ReindexCommand:
+        autowire: true
+        autoconfigure: true
+        arguments:
+            $locationHandler: '@ezpublish.spi.persistence.location_handler'

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -98,3 +98,6 @@ services:
             - '@ezpublish.spi.search'
         tags:
             - { name: kernel.event_subscriber }
+
+    eZ\Publish\SPI\Search\Content\IndexerGateway:
+        alias: eZ\Publish\Core\Search\Legacy\Content\IndexerGateway

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -622,7 +622,7 @@ abstract class BaseTest extends TestCase
      *
      * @throws \ErrorException
      */
-    protected function getRawDatabaseConnection()
+    protected function getRawDatabaseConnection(): Connection
     {
         $connection = $this
             ->getSetupFactory()

--- a/eZ/Publish/Core/Search/Legacy/Content/IndexerGateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/IndexerGateway.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Search\Legacy\Content;
 
-use DateTime;
+use DateTimeInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\ParameterType;
@@ -29,7 +29,7 @@ final class IndexerGateway implements SPIIndexerGateway
         $this->connection = $connection;
     }
 
-    public function getStatementContentSince(DateTime $since, bool $count = false): ResultStatement
+    public function getStatementContentSince(DateTimeInterface $since, bool $count = false): ResultStatement
     {
         $q = $this->connection->createQueryBuilder()
             ->select($count ? 'count(c.id)' : 'c.id')

--- a/eZ/Publish/Core/Search/Legacy/Content/IndexerGateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/IndexerGateway.php
@@ -127,12 +127,12 @@ final class IndexerGateway implements SPIIndexerGateway
         return $query;
     }
 
-    private function fetchIteration(ResultStatement $stmt, int $iterationCount): Generator
+    private function fetchIteration(ResultStatement $statement, int $iterationCount): Generator
     {
         do {
             $contentIds = [];
             for ($i = 0; $i < $iterationCount; ++$i) {
-                if ($contentId = $stmt->fetchOne()) {
+                if ($contentId = $statement->fetchOne()) {
                     $contentIds[] = $contentId;
                 } elseif (empty($contentIds)) {
                     return;

--- a/eZ/Publish/Core/Search/Legacy/Content/IndexerGateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/IndexerGateway.php
@@ -33,6 +33,7 @@ final class IndexerGateway implements SPIIndexerGateway
     public function getContentSince(DateTimeInterface $since, int $iterationCount): Generator
     {
         $query = $this->buildQueryForContentSince($since);
+        $query->orderBy('c.modified');
 
         yield from $this->fetchIteration($query->execute(), $iterationCount);
     }
@@ -84,7 +85,6 @@ final class IndexerGateway implements SPIIndexerGateway
             ->select('c.id')
             ->from('ezcontentobject', 'c')
             ->where('c.status = :status')->andWhere('c.modified >= :since')
-            ->orderBy('c.modified')
             ->setParameter('status', ContentInfo::STATUS_PUBLISHED, ParameterType::INTEGER)
             ->setParameter('since', $since->getTimestamp(), ParameterType::INTEGER);
     }

--- a/eZ/Publish/Core/Search/Legacy/Content/IndexerGateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/IndexerGateway.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Search\Legacy\Content;
+
+use DateTime;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\ResultStatement;
+use Doctrine\DBAL\ParameterType;
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\SPI\Search\Content\IndexerGateway as SPIIndexerGateway;
+use Generator;
+
+/**
+ * @internal
+ */
+final class IndexerGateway implements SPIIndexerGateway
+{
+    /** @var \Doctrine\DBAL\Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function getStatementContentSince(DateTime $since, bool $count = false): ResultStatement
+    {
+        $q = $this->connection->createQueryBuilder()
+            ->select($count ? 'count(c.id)' : 'c.id')
+            ->from('ezcontentobject', 'c')
+            ->where('c.status = :status')->andWhere('c.modified >= :since')
+            ->orderBy('c.modified')
+            ->setParameter('status', ContentInfo::STATUS_PUBLISHED, ParameterType::INTEGER)
+            ->setParameter('since', $since->getTimestamp(), ParameterType::INTEGER);
+
+        return $q->execute();
+    }
+
+    public function getStatementSubtree(string $locationPath, bool $count = false): ResultStatement
+    {
+        $q = $this->connection->createQueryBuilder()
+            ->select($count ? 'count(DISTINCT c.id)' : 'DISTINCT c.id')
+            ->from('ezcontentobject', 'c')
+            ->innerJoin('c', 'ezcontentobject_tree', 't', 't.contentobject_id = c.id')
+            ->where('c.status = :status')
+            ->andWhere('t.path_string LIKE :path')
+            ->setParameter('status', ContentInfo::STATUS_PUBLISHED, ParameterType::INTEGER)
+            ->setParameter('path', $locationPath . '%', ParameterType::STRING);
+
+        return $q->execute();
+    }
+
+    public function getStatementContentAll(bool $count = false): ResultStatement
+    {
+        $q = $this->connection->createQueryBuilder()
+            ->select($count ? 'count(c.id)' : 'c.id')
+            ->from('ezcontentobject', 'c')
+            ->where('c.status = :status')
+            ->setParameter('status', ContentInfo::STATUS_PUBLISHED, ParameterType::INTEGER);
+
+        return $q->execute();
+    }
+
+    public function fetchIteration(ResultStatement $stmt, int $iterationCount): Generator
+    {
+        do {
+            $contentIds = [];
+            for ($i = 0; $i < $iterationCount; ++$i) {
+                if ($contentId = $stmt->fetchOne()) {
+                    $contentIds[] = $contentId;
+                } elseif (empty($contentIds)) {
+                    return;
+                } else {
+                    break;
+                }
+            }
+
+            yield $contentIds;
+        } while (!empty($contentId));
+    }
+}

--- a/eZ/Publish/Core/settings/search_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy.yml
@@ -104,3 +104,7 @@ services:
         tags:
             - {name: ezpublish.searchEngineIndexer, alias: legacy}
         lazy: true
+
+    eZ\Publish\Core\Search\Legacy\Content\IndexerGateway:
+        arguments:
+            $connection: '@ezpublish.persistence.connection'

--- a/eZ/Publish/SPI/Search/Content/IndexerGateway.php
+++ b/eZ/Publish/SPI/Search/Content/IndexerGateway.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Search\Content;
+
+use DateTime;
+use Doctrine\DBAL\Driver\ResultStatement;
+use Generator;
+
+/**
+ * @internal
+ */
+interface IndexerGateway
+{
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function getStatementContentSince(DateTime $since, bool $count = false): ResultStatement;
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function getStatementSubtree(string $locationPath, bool $count = false): ResultStatement;
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function getStatementContentAll(bool $count = false): ResultStatement;
+
+    /**
+     * @return \Generator a list of Content IDs for each iteration
+     */
+    public function fetchIteration(ResultStatement $stmt, int $iterationCount): Generator;
+}

--- a/eZ/Publish/SPI/Search/Content/IndexerGateway.php
+++ b/eZ/Publish/SPI/Search/Content/IndexerGateway.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace eZ\Publish\SPI\Search\Content;
 
-use DateTime;
+use DateTimeInterface;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Generator;
 
@@ -20,7 +20,7 @@ interface IndexerGateway
     /**
      * @throws \Doctrine\DBAL\Exception
      */
-    public function getStatementContentSince(DateTime $since, bool $count = false): ResultStatement;
+    public function getStatementContentSince(DateTimeInterface $since, bool $count = false): ResultStatement;
 
     /**
      * @throws \Doctrine\DBAL\Exception

--- a/eZ/Publish/SPI/Search/Content/IndexerGateway.php
+++ b/eZ/Publish/SPI/Search/Content/IndexerGateway.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace eZ\Publish\SPI\Search\Content;
 
 use DateTimeInterface;
-use Doctrine\DBAL\Driver\ResultStatement;
 use Generator;
 
 /**
@@ -19,21 +18,37 @@ interface IndexerGateway
 {
     /**
      * @throws \Doctrine\DBAL\Exception
+     *
+     * @return \Generator list of Content IDs for each iteration
      */
-    public function getStatementContentSince(DateTimeInterface $since, bool $count = false): ResultStatement;
+    public function getContentSince(DateTimeInterface $since, int $iterationCount): Generator;
 
     /**
      * @throws \Doctrine\DBAL\Exception
      */
-    public function getStatementSubtree(string $locationPath, bool $count = false): ResultStatement;
+    public function countContentSince(DateTimeInterface $since): int;
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     *
+     * @return \Generator list of Content IDs for each iteration
+     */
+    public function getContentInSubtree(string $locationPath, int $iterationCount): Generator;
 
     /**
      * @throws \Doctrine\DBAL\Exception
      */
-    public function getStatementContentAll(bool $count = false): ResultStatement;
+    public function countContentInSubtree(string $locationPath): int;
 
     /**
-     * @return \Generator a list of Content IDs for each iteration
+     * @throws \Doctrine\DBAL\Exception
+     *
+     * @return \Generator list of Content IDs for each iteration
      */
-    public function fetchIteration(ResultStatement $stmt, int $iterationCount): Generator;
+    public function getAllContent(int $iterationCount): Generator;
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function countAllContent(): int;
 }

--- a/eZ/Publish/SPI/Tests/BaseGatewayTest.php
+++ b/eZ/Publish/SPI/Tests/BaseGatewayTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Tests;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Tests\SetupFactory\Legacy;
+
+abstract class BaseGatewayTest extends BaseTest
+{
+    /** @var \eZ\Publish\API\Repository\Repository */
+    protected $repository;
+
+    protected function setUp(): void
+    {
+        $this->repository = (new Legacy())->getRepository(true);
+    }
+}

--- a/eZ/Publish/SPI/Tests/Search/Content/IndexerGatewayTest.php
+++ b/eZ/Publish/SPI/Tests/Search/Content/IndexerGatewayTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Tests\Search\Content;
+
+use DateTimeImmutable;
+use eZ\Publish\Core\Search\Legacy\Content\IndexerGateway;
+use eZ\Publish\SPI\Tests\BaseGatewayTest;
+
+/**
+ * @internal
+ *
+ * @covers \eZ\Publish\Core\Search\Legacy\Content\IndexerGateway
+ */
+final class IndexerGatewayTest extends BaseGatewayTest
+{
+    /** @var \eZ\Publish\Core\Search\Legacy\Content\IndexerGateway */
+    private $gateway;
+
+    /**
+     * @throws \ErrorException
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->gateway = new IndexerGateway($this->getRawDatabaseConnection());
+    }
+
+    public function getDataForContentSince(): iterable
+    {
+        yield '1999-01-01' => [
+            new DateTimeImmutable('1999-01-01'),
+            9,
+            2,
+        ];
+
+        yield 'now' => [
+            new DateTimeImmutable('now'),
+            0,
+            2,
+        ];
+    }
+
+    public function getDataForContentInSubtree(): iterable
+    {
+        yield '/1/5/' => [
+            '/1/5/',
+            8,
+            1,
+        ];
+
+        yield '/999/888/' => [
+            '/999/888/',
+            0,
+            1,
+        ];
+    }
+
+    /**
+     * @dataProvider getDataForContentSince
+     *
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function testGetContentSince(
+        DateTimeImmutable $since,
+        int $expectedCount,
+        int $iterationCount
+    ): void {
+        self::assertCount($expectedCount, iterator_to_array($this->gateway->getContentSince($since, $iterationCount)));
+    }
+
+    /**
+     * @dataProvider getDataForContentSince
+     *
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function testCountContentSince(
+        DateTimeImmutable $since,
+        int $expectedCount,
+        int $iterationCount
+    ): void {
+        self::assertSame(
+            $expectedCount * $iterationCount,
+            $this->gateway->countContentSince($since)
+        );
+    }
+
+    /**
+     * @dataProvider getDataForContentInSubtree
+     *
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function testGetContentInSubtree(
+        string $subtreePath,
+        int $expectedCount,
+        int $iterationCount
+    ): void {
+        self::assertCount(
+            $expectedCount,
+            iterator_to_array($this->gateway->getContentInSubtree($subtreePath, $iterationCount))
+        );
+    }
+
+    /**
+     * @dataProvider getDataForContentInSubtree
+     *
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function testCountContentInSubtree(
+        string $subtreePath,
+        int $expectedCount,
+        int $iterationCount
+    ): void {
+        self::assertSame(
+            $expectedCount * $iterationCount,
+            $this->gateway->countContentInSubtree($subtreePath)
+        );
+    }
+
+    public function testCountAllContent(): void
+    {
+        self::assertCount(9, iterator_to_array($this->gateway->getAllContent(2)));
+    }
+
+    public function testGetAllContent(): void
+    {
+        self::assertSame(18, $this->gateway->countAllContent());
+    }
+}

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -69,6 +69,9 @@
         <testsuite name="eZ\Publish\Core\FieldType\Tests\Integration">
             <directory>eZ/Publish/Core/FieldType/Tests/Integration</directory>
         </testsuite>
+        <testsuite name="gateway-integration">
+            <file>eZ/Publish/SPI/Tests/Search/Content/IndexerGatewayTest.php</file>
+        </testsuite>
     </testsuites>
     <filter>
         <whitelist>


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-143](https://issues.ibexa.co/browse/IBX-143)
| **Type**                                   | improvement
| **Target Ibexa version** | `v2.5`, `v3.2`, `v3.3`
| **BC breaks**                          | no

Since eZ Platform 2.5 [requires Doctrine Bundle ^1.9](https://github.com/ezsystems/ezplatform/blob/v2.5.13/composer.json#L28) which requires `doctrine/dbal:^2.5.12`, it's safe to force `doctrine/dbal:^2.13`, which introduces some changes ResultStatement-related class structure.

This PR besides fixing the issue at hand, refactors the code to be more future-proof and adds test coverage to prevent further regressions.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
