### PR TITLE
IBX-85: Fixed Content cache containing invalid "uri" for file field types

### DIFF
--- a/eZ/Publish/Core/FieldType/BinaryBase/Type.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/Type.php
@@ -22,7 +22,7 @@ use eZ\Publish\Core\FieldType\Value as BaseValue;
 abstract class Type extends FieldType
 {
     /**
-     * @see eZ\Publish\Core\FieldType::$validatorConfigurationSchema
+     * @see \eZ\Publish\Core\FieldType\FieldType::$validatorConfigurationSchema
      */
     protected $validatorConfigurationSchema = [
         'FileSizeValidator' => [
@@ -62,7 +62,7 @@ abstract class Type extends FieldType
         if (isset($this->routeAwarePathGenerator, $inputValue['route'])) {
             $inputValue['uri'] = $this->routeAwarePathGenerator->generate(
                 $inputValue['route'],
-                $inputValue['route_parameters'] ?? null
+                $inputValue['route_parameters'] ?? []
             );
 
             unset($inputValue['route'], $inputValue['route_parameters']);

--- a/eZ/Publish/Core/FieldType/BinaryBase/Type.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/Type.php
@@ -42,13 +42,9 @@ abstract class Type extends FieldType
     /**
      * @param \eZ\Publish\Core\FieldType\Validator[] $validators
      */
-    public function __construct(array $validators)
+    public function __construct(array $validators, ?RouteAwarePathGenerator $routeAwarePathGenerator = null)
     {
         $this->validators = $validators;
-    }
-
-    public function setRouteAwarePathGenerator(?RouteAwarePathGenerator $routeAwarePathGenerator): void
-    {
         $this->routeAwarePathGenerator = $routeAwarePathGenerator;
     }
 

--- a/eZ/Publish/Core/FieldType/BinaryFile/Type.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/Type.php
@@ -44,10 +44,12 @@ class Type extends BinaryBaseType
      *
      * @param array $inputValue
      *
-     * @return Value
+     * @return \eZ\Publish\Core\FieldType\BinaryFile\Value
      */
     protected function createValue(array $inputValue)
     {
+        $inputValue = $this->regenerateUri($inputValue);
+
         return new Value($inputValue);
     }
 

--- a/eZ/Publish/Core/FieldType/Media/Type.php
+++ b/eZ/Publish/Core/FieldType/Media/Type.php
@@ -120,10 +120,12 @@ class Type extends BaseType
      *
      * @param array $inputValue
      *
-     * @return Value
+     * @return \eZ\Publish\Core\FieldType\Media\Value
      */
     protected function createValue(array $inputValue)
     {
+        $inputValue = $this->regenerateUri($inputValue);
+
         return new Value($inputValue);
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/FieldTypeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FieldTypeTest.php
@@ -685,7 +685,7 @@ abstract class FieldTypeTest extends TestCase
     }
 
     /**
-     * @param mixed $inputValue
+     * @param mixed $inputHash
      * @param array $expectedResult
      *
      * @dataProvider provideInputForFromHash

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/BinaryBase/ContentDownloadUrlGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/BinaryBase/ContentDownloadUrlGenerator.php
@@ -7,14 +7,18 @@
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\BinaryBase;
 
 use eZ\Publish\SPI\FieldType\BinaryBase\PathGenerator;
+use eZ\Publish\SPI\FieldType\BinaryBase\RouteAwarePathGenerator;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use Symfony\Component\Routing\RouterInterface;
 
-class ContentDownloadUrlGenerator extends PathGenerator
+class ContentDownloadUrlGenerator extends PathGenerator implements RouteAwarePathGenerator
 {
     /** @var \Symfony\Component\Routing\RouterInterface */
     private $router;
+
+    /** @var string */
+    private $route = 'ez_content_download_field_id';
 
     public function __construct(RouterInterface $router)
     {
@@ -23,13 +27,25 @@ class ContentDownloadUrlGenerator extends PathGenerator
 
     public function getStoragePathForField(Field $field, VersionInfo $versionInfo)
     {
-        return $this->router->generate(
-            'ez_content_download_field_id',
-            [
-                'contentId' => $versionInfo->contentInfo->id,
-                'fieldId' => $field->id,
-                'version' => $versionInfo->versionNo,
-            ]
-        );
+        return $this->generate($this->route, $this->getParameters($field, $versionInfo));
+    }
+
+    public function generate(string $route, ?array $parameters = []): string
+    {
+        return $this->router->generate($route, $parameters ?? []);
+    }
+
+    public function getRoute(Field $field, VersionInfo $versionInfo): string
+    {
+        return $this->route;
+    }
+
+    public function getParameters(Field $field, VersionInfo $versionInfo): array
+    {
+        return [
+            'contentId' => $versionInfo->contentInfo->id,
+            'fieldId' => $field->id,
+            'version' => $versionInfo->versionNo,
+        ];
     }
 }

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -292,6 +292,8 @@ services:
         class: "%ezpublish.fieldType.ezbinaryfile.class%"
         arguments:
             - ['@ezpublish.fieldType.validator.black_list']
+        calls:
+            - [setRouteAwarePathGenerator, ["@?ezpublish.fieldType.ezbinarybase.download_url_generator"]]
         parent: ezpublish.fieldType
         tags:
             - {name: ezpublish.fieldType, alias: ezbinaryfile}

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -292,7 +292,7 @@ services:
         class: "%ezpublish.fieldType.ezbinaryfile.class%"
         arguments:
             - ['@ezpublish.fieldType.validator.black_list']
-            - "@ezpublish.fieldType.ezbinarybase.download_url_generator"
+            - "@?ezpublish.fieldType.ezbinarybase.download_url_generator"
         parent: ezpublish.fieldType
         tags:
             - {name: ezpublish.fieldType, alias: ezbinaryfile}

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -292,7 +292,7 @@ services:
         class: "%ezpublish.fieldType.ezbinaryfile.class%"
         arguments:
             - ['@ezpublish.fieldType.validator.black_list']
-            - "@?ezpublish.fieldType.ezbinarybase.download_url_generator"
+            - "@ezpublish.fieldType.ezbinarybase.download_url_generator"
         parent: ezpublish.fieldType
         tags:
             - {name: ezpublish.fieldType, alias: ezbinaryfile}

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -292,8 +292,7 @@ services:
         class: "%ezpublish.fieldType.ezbinaryfile.class%"
         arguments:
             - ['@ezpublish.fieldType.validator.black_list']
-        calls:
-            - [setRouteAwarePathGenerator, ["@?ezpublish.fieldType.ezbinarybase.download_url_generator"]]
+            - "@?ezpublish.fieldType.ezbinarybase.download_url_generator"
         parent: ezpublish.fieldType
         tags:
             - {name: ezpublish.fieldType, alias: ezbinaryfile}

--- a/eZ/Publish/SPI/FieldType/BinaryBase/PathGenerator.php
+++ b/eZ/Publish/SPI/FieldType/BinaryBase/PathGenerator.php
@@ -9,6 +9,9 @@ namespace eZ\Publish\SPI\FieldType\BinaryBase;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 
+/**
+ * @deprecated use \eZ\Publish\SPI\FieldType\BinaryBase\PathGeneratorInterface instead.
+ */
 abstract class PathGenerator implements PathGeneratorInterface
 {
     abstract public function getStoragePathForField(Field $field, VersionInfo $versionInfo);

--- a/eZ/Publish/SPI/FieldType/BinaryBase/PathGenerator.php
+++ b/eZ/Publish/SPI/FieldType/BinaryBase/PathGenerator.php
@@ -9,7 +9,7 @@ namespace eZ\Publish\SPI\FieldType\BinaryBase;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 
-abstract class PathGenerator
+abstract class PathGenerator implements PathGeneratorInterface
 {
     abstract public function getStoragePathForField(Field $field, VersionInfo $versionInfo);
 }

--- a/eZ/Publish/SPI/FieldType/BinaryBase/PathGeneratorInterface.php
+++ b/eZ/Publish/SPI/FieldType/BinaryBase/PathGeneratorInterface.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace eZ\Publish\SPI\FieldType\BinaryBase;

--- a/eZ/Publish/SPI/FieldType/BinaryBase/PathGeneratorInterface.php
+++ b/eZ/Publish/SPI/FieldType/BinaryBase/PathGeneratorInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\FieldType\BinaryBase;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+
+interface PathGeneratorInterface
+{
+    public function getStoragePathForField(Field $field, VersionInfo $versionInfo);
+}

--- a/eZ/Publish/SPI/FieldType/BinaryBase/RouteAwarePathGenerator.php
+++ b/eZ/Publish/SPI/FieldType/BinaryBase/RouteAwarePathGenerator.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace eZ\Publish\SPI\FieldType\BinaryBase;

--- a/eZ/Publish/SPI/FieldType/BinaryBase/RouteAwarePathGenerator.php
+++ b/eZ/Publish/SPI/FieldType/BinaryBase/RouteAwarePathGenerator.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\FieldType\BinaryBase;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+
+/**
+ * A variant of PathGenerator that uses Symfony routes for generating URIs.
+ */
+interface RouteAwarePathGenerator extends PathGeneratorInterface
+{
+    public function getRoute(Field $field, VersionInfo $versionInfo): string;
+
+    public function getParameters(Field $field, VersionInfo $versionInfo): array;
+
+    public function generate(string $route, array $parameters = []): string;
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-85](https://issues.ibexa.co/browse/IBX-85)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This fixes the issue of Content sharing field with Site-Access aware/reliant external data.

The root of the issue is that "uri" for `BinaryFileField` is calculated right after it is acquired from the database, in SPI persistence layer. This causes cache to contain this calculated "uri" value in all SiteAccess' that share the same cache key.

Solution involves:
1. Extending the `eZ\Publish\Core\MVC\Symfony\FieldType\BinaryBase\ContentDownloadUrlGenerator` with additional methods that would allow recovering of the route and parameters used for the "uri" calculation. A new `eZ\Publish\SPI\FieldType\BinaryBase\RouteAwarePathGenerator` is introduced to mark their presence.
2. Making `eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage::getFieldData`, which is called internally by `eZ\Publish\Core\Persistence\Legacy\Content\Handler::load`, add "route" and "route_parameters" to external data (if `RouteAwarePathGenerator` is used). They are stored into cache alongside the calculated "uri" for BC compatibility.
3. Have classes descending from `eZ\Publish\Core\FieldType\BinaryBase\Type` use newly introduced `regenerateUri` method that recalculates the "uri" from cached "route" and "route_parameters", if they are present.

## How to reproduce the issue
1. Add a new Media File
![image](https://user-images.githubusercontent.com/3183926/113995663-bcf95b80-9856-11eb-8401-cb34d75a551a.png)

2. Either manually clear cache and visit admin file content page, or trigger any admin edit actions that result in cache being regenerated.

3. Observe the URI generated for `content.fields` in template.
(`vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/themes/admin/content/location_view.html.twig`)
![image](https://user-images.githubusercontent.com/3183926/114001879-a6560300-985c-11eb-89cd-c2d8260eb2d3.png)
![image](https://user-images.githubusercontent.com/3183926/114000359-385d0c00-985b-11eb-9e84-3c08eb599bef.png)

4. Visit the content location. Observe that the URL in template for `content.fields` is the same as the one visible in admin. That's the bug. (`eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/full.html.twig`)
![image](https://user-images.githubusercontent.com/3183926/114001990-bff74a80-985c-11eb-920c-dd505a550df5.png)
![image](https://user-images.githubusercontent.com/3183926/114000478-54f94400-985b-11eb-9771-a26d2aff2d19.png)

## Note
Our content field templates do regenerate the URI during rendering (`eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig`).
![image](https://user-images.githubusercontent.com/3183926/114001706-76a6fb00-985c-11eb-974e-36815d9dffb7.png)

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
