### PR TITLE
IBX-85: Fixed missing service injection in Media\Type

### DIFF
--- a/eZ/Publish/Core/FieldType/BinaryBase/Type.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/Type.php
@@ -64,9 +64,9 @@ abstract class Type extends FieldType
                 $inputValue['route'],
                 $inputValue['route_parameters'] ?? []
             );
-
-            unset($inputValue['route'], $inputValue['route_parameters']);
         }
+
+        unset($inputValue['route'], $inputValue['route_parameters']);
 
         return $inputValue;
     }

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -372,6 +372,7 @@ services:
         class: "%ezpublish.fieldType.ezmedia.class%"
         arguments:
             - ['@ezpublish.fieldType.validator.black_list']
+            - "@?ezpublish.fieldType.ezbinarybase.download_url_generator"
         parent: ezpublish.fieldType
         tags:
             - {name: ezpublish.fieldType, alias: ezmedia}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-85](https://issues.ibexa.co/browse/IBX-85)
| **Bug/Improvement**| bug
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Fixes issue introduced in #3096.

This fixes an issue with Media type fields that tried to instantiate `Value` using `$hash` still containing the `route` and `route_parameters` fields.

Since `BinaryValue` does not contain `route` & `route_parameters`, this results in an exception.

Therefore:
1. Missing service responsible for regenerating `uri` has been added.
2. `route` & `route_parameters` coming from persistence are always removed.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
