### PR TITLE
IBX-148: Fixed deleting orphaned Relations when removing a Field

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -1997,6 +1997,60 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
     }
 
     /**
+     * Test for the removeFieldDefinition() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentTypeService::removeFieldDefinition()
+     */
+    public function testRemoveFieldDefinitionRemovesOrphanedRelations(): void
+    {
+        $repository = $this->getRepository();
+
+        $contentTypeService = $repository->getContentTypeService();
+        $contentService = $repository->getContentService();
+
+        $relationFieldCreate = $contentTypeService->newFieldDefinitionCreateStruct(
+            'relation',
+            'ezobjectrelation'
+        );
+        $relationFieldCreate->names = ['eng-US' => 'Relation'];
+        $relationFieldCreate->descriptions = ['eng-US' => 'Relation to any Content'];
+        $relationFieldCreate->fieldGroup = 'blog-content';
+        $relationFieldCreate->position = 3;
+        $relationFieldCreate->isTranslatable = false;
+        $relationFieldCreate->isRequired = false;
+        $relationFieldCreate->isInfoCollector = false;
+        $relationFieldCreate->validatorConfiguration = [];
+        $relationFieldCreate->isSearchable = false;
+
+        // Create ContentType
+        $contentTypeDraft = $this->createContentTypeDraft([$relationFieldCreate]);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+        $publishedType = $contentTypeService->loadContentType($contentTypeDraft->id);
+
+        // Create Content with Relation
+        $contentDraft = $this->createContentDraft();
+        $publishedVersion = $contentService->publishVersion($contentDraft->versionInfo);
+
+        $newDraft = $contentService->createContentDraft($publishedVersion->contentInfo);
+        $updateStruct = $contentService->newContentUpdateStruct();
+        $updateStruct->setField('relation', 14, 'eng-US');
+        $contentDraft = $contentService->updateContent($newDraft->versionInfo, $updateStruct);
+        $publishedContent = $contentService->publishVersion($contentDraft->versionInfo);
+
+        // Remove field definition from ContentType
+        $contentTypeDraft = $contentTypeService->createContentTypeDraft($publishedType);
+        $relationField = $contentTypeDraft->getFieldDefinition('relation');
+        $contentTypeService->removeFieldDefinition($contentTypeDraft, $relationField);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+
+        // Load Content
+        $content = $contentService->loadContent($publishedContent->contentInfo->id);
+        $relationsCount = count($contentService->loadRelations($content->versionInfo));
+
+        $this->assertEquals(0, $relationsCount);
+    }
+
+    /**
      * Test for the addFieldDefinition() method.
      *
      * @see \eZ\Publish\API\Repository\ContentTypeService::addFieldDefinition()

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
 use eZ\Publish\API\Repository\Values\Translation\Message;
 use Exception;
 use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
@@ -1997,9 +1998,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
     }
 
     /**
-     * Test for the removeFieldDefinition() method.
-     *
-     * @see \eZ\Publish\API\Repository\ContentTypeService::removeFieldDefinition()
+     * @covers \eZ\Publish\API\Repository\ContentTypeService::removeFieldDefinition()
      */
     public function testRemoveFieldDefinitionRemovesOrphanedRelations(): void
     {
@@ -2008,22 +2007,8 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $contentTypeService = $repository->getContentTypeService();
         $contentService = $repository->getContentService();
 
-        $relationFieldCreate = $contentTypeService->newFieldDefinitionCreateStruct(
-            'relation',
-            'ezobjectrelation'
-        );
-        $relationFieldCreate->names = ['eng-US' => 'Relation'];
-        $relationFieldCreate->descriptions = ['eng-US' => 'Relation to any Content'];
-        $relationFieldCreate->fieldGroup = 'blog-content';
-        $relationFieldCreate->position = 3;
-        $relationFieldCreate->isTranslatable = false;
-        $relationFieldCreate->isRequired = false;
-        $relationFieldCreate->isInfoCollector = false;
-        $relationFieldCreate->validatorConfiguration = [];
-        $relationFieldCreate->isSearchable = false;
-
         // Create ContentType
-        $contentTypeDraft = $this->createContentTypeDraft([$relationFieldCreate]);
+        $contentTypeDraft = $this->createContentTypeDraft([$this->getRelationFieldDefinition()]);
         $contentTypeService->publishContentTypeDraft($contentTypeDraft);
         $publishedType = $contentTypeService->loadContentType($contentTypeDraft->id);
 
@@ -2045,9 +2030,31 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
 
         // Load Content
         $content = $contentService->loadContent($publishedContent->contentInfo->id);
-        $relationsCount = count($contentService->loadRelations($content->versionInfo));
 
-        $this->assertEquals(0, $relationsCount);
+        $this->assertCount(0, $contentService->loadRelations($content->versionInfo));
+    }
+
+    private function getRelationFieldDefinition(): FieldDefinitionCreateStruct
+    {
+        $repository = $this->getRepository();
+
+        $contentTypeService = $repository->getContentTypeService();
+
+        $relationFieldCreate = $contentTypeService->newFieldDefinitionCreateStruct(
+            'relation',
+            'ezobjectrelation'
+        );
+        $relationFieldCreate->names = ['eng-US' => 'Relation'];
+        $relationFieldCreate->descriptions = ['eng-US' => 'Relation to any Content'];
+        $relationFieldCreate->fieldGroup = 'blog-content';
+        $relationFieldCreate->position = 3;
+        $relationFieldCreate->isTranslatable = false;
+        $relationFieldCreate->isRequired = false;
+        $relationFieldCreate->isInfoCollector = false;
+        $relationFieldCreate->validatorConfiguration = [];
+        $relationFieldCreate->isSearchable = false;
+
+        return $relationFieldCreate;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -339,7 +339,7 @@ abstract class Gateway
     /**
      * Removes orphaned relations resulting from deleted relation fieldtype.
      */
-    abstract public function removeRelationsViaFieldDefinitionId(int $fieldDefinitionId);
+    abstract public function removeRelationsByFieldDefinitionId(int $fieldDefinitionId);
 
     /**
      * Deletes the field with the given $fieldId.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -337,6 +337,11 @@ abstract class Gateway
     abstract public function removeReverseFieldRelations($contentId);
 
     /**
+     * Removes orphaned relations resulting from deleted relation fieldtype.
+     */
+    abstract public function removeRelationsViaFieldDefinitionId(int $fieldDefinitionId);
+
+    /**
      * Deletes the field with the given $fieldId.
      *
      * @param int $fieldId

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -1525,6 +1525,20 @@ HEREDOC;
         }
     }
 
+    public function removeRelationsViaFieldDefinitionId(int $fieldDefinitionId)
+    {
+        $query = $this->dbHandler->createDeleteQuery();
+        $query->deleteFrom($this->dbHandler->quoteTable('ezcontentobject_link'))
+            ->where(
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn('contentclassattribute_id'),
+                    $query->bindValue($fieldDefinitionId, null, \PDO::PARAM_INT)
+                )
+            );
+
+        $query->prepare()->execute();
+    }
+
     /**
      * Updates field value of RelationList field type identified by given $row data,
      * removing relations toward given $contentId.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -1525,7 +1525,7 @@ HEREDOC;
         }
     }
 
-    public function removeRelationsViaFieldDefinitionId(int $fieldDefinitionId)
+    public function removeRelationsByFieldDefinitionId(int $fieldDefinitionId)
     {
         $query = $this->dbHandler->createDeleteQuery();
         $query->deleteFrom($this->dbHandler->quoteTable('ezcontentobject_link'))

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -516,10 +516,10 @@ class ExceptionConversion extends Gateway
         }
     }
 
-    public function removeRelationsViaFieldDefinitionId(int $fieldDefinitionId)
+    public function removeRelationsByFieldDefinitionId(int $fieldDefinitionId)
     {
         try {
-            return $this->innerGateway->removeRelationsViaFieldDefinitionId($fieldDefinitionId);
+            return $this->innerGateway->removeRelationsByFieldDefinitionId($fieldDefinitionId);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -516,6 +516,15 @@ class ExceptionConversion extends Gateway
         }
     }
 
+    public function removeRelationsViaFieldDefinitionId(int $fieldDefinitionId)
+    {
+        try {
+            return $this->innerGateway->removeRelationsViaFieldDefinitionId($fieldDefinitionId);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
+        }
+    }
+
     /**
      * Deletes the field with the given $fieldId.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/RemoveField.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/RemoveField.php
@@ -95,18 +95,11 @@ class RemoveField extends Action
         }
 
         // Delete from relations storage
-        if ($this->isRelationFieldType($this->fieldDefinition)) {
-            $this->contentGateway->removeRelationsByFieldDefinitionId($this->fieldDefinition->id);
-        }
+        $this->contentGateway->removeRelationsByFieldDefinitionId($this->fieldDefinition->id);
+
         // Delete from internal storage -- field is always deleted from _all_ versions
         foreach (array_keys($fieldIdSet) as $fieldId) {
             $this->contentGateway->deleteField($fieldId);
         }
-    }
-
-    private function isRelationFieldType(FieldDefinition $fieldDefinition): bool
-    {
-        return $fieldDefinition->fieldType === 'ezobjectrelation'
-            || $fieldDefinition->fieldType === 'ezobjectrelationlist';
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/RemoveField.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/RemoveField.php
@@ -96,10 +96,10 @@ class RemoveField extends Action
 
         // Delete from relations storage
         if (
-            $this->fieldDefinition->fieldType === 'ezobjectrelationlist'
+            $this->fieldDefinition->fieldType === 'ezobjectrelation'
             || $this->fieldDefinition->fieldType === 'ezobjectrelationlist'
         ) {
-            $this->contentGateway->removeRelationsViaFieldDefinitionId($this->fieldDefinition->id);
+            $this->contentGateway->removeRelationsByFieldDefinitionId($this->fieldDefinition->id);
         }
         // Delete from internal storage -- field is always deleted from _all_ versions
         foreach (array_keys($fieldIdSet) as $fieldId) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/RemoveField.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/RemoveField.php
@@ -95,15 +95,18 @@ class RemoveField extends Action
         }
 
         // Delete from relations storage
-        if (
-            $this->fieldDefinition->fieldType === 'ezobjectrelation'
-            || $this->fieldDefinition->fieldType === 'ezobjectrelationlist'
-        ) {
+        if ($this->isRelationFieldType($this->fieldDefinition)) {
             $this->contentGateway->removeRelationsByFieldDefinitionId($this->fieldDefinition->id);
         }
         // Delete from internal storage -- field is always deleted from _all_ versions
         foreach (array_keys($fieldIdSet) as $fieldId) {
             $this->contentGateway->deleteField($fieldId);
         }
+    }
+
+    private function isRelationFieldType(FieldDefinition $fieldDefinition): bool
+    {
+        return $fieldDefinition->fieldType === 'ezobjectrelation'
+            || $fieldDefinition->fieldType === 'ezobjectrelationlist';
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/RemoveField.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/RemoveField.php
@@ -94,6 +94,13 @@ class RemoveField extends Action
             );
         }
 
+        // Delete from relations storage
+        if (
+            $this->fieldDefinition->fieldType === 'ezobjectrelationlist'
+            || $this->fieldDefinition->fieldType === 'ezobjectrelationlist'
+        ) {
+            $this->contentGateway->removeRelationsViaFieldDefinitionId($this->fieldDefinition->id);
+        }
         // Delete from internal storage -- field is always deleted from _all_ versions
         foreach (array_keys($fieldIdSet) as $fieldId) {
             $this->contentGateway->deleteField($fieldId);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/RemoveFieldTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/RemoveFieldTest.php
@@ -232,12 +232,12 @@ class RemoveFieldTest extends TestCase
             ->will($this->returnValue([$content2]));
 
         $this->getContentGatewayMock()
-            ->expects($this->at(4))
+            ->expects($this->at(5))
             ->method('deleteField')
             ->with($this->equalTo('3-cro-HR'));
 
         $this->getContentGatewayMock()
-            ->expects($this->at(5))
+            ->expects($this->at(6))
             ->method('deleteField')
             ->with($this->equalTo('3-hun-HU'));
 
@@ -258,6 +258,11 @@ class RemoveFieldTest extends TestCase
                 $content2->versionInfo,
                 $this->equalTo(['3-cro-HR', '3-hun-HU'])
             );
+
+        $this->getContentGatewayMock()
+            ->expects($this->at(4))
+            ->method('removeRelationsByFieldDefinitionId')
+            ->with($this->equalTo(42));
 
         $action->apply($contentId);
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-148](https://jira.ez.no/browse/IBX-148)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Additional method has been added to `Content\Gateway` which deletes orphaned Relations resulting of an `ezobjectrelation` and `ezobjectrelationlist` fieldtypes deletion.

**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
