### PR TITLE
IBX-362: Fixed 'user/password' policy check

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1996,15 +1996,13 @@ class UserServiceTest extends BaseTest
         );
         $repository->getPermissionResolver()->setCurrentUserReference($currentUser);
 
-        /* BEGIN: Use Case */
         // Create a new update struct instance
         $userUpdate = $userService->newUserUpdateStruct();
         $userUpdate->password = 'H@xxxiR!_2';
 
         $user = $userService->updateUser($user, $userUpdate);
-        /* END: Use Case */
 
-        $this->assertInstanceOf(User::class, $user);
+        self::assertInstanceOf(User::class, $user);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1977,6 +1977,37 @@ class UserServiceTest extends BaseTest
     }
 
     /**
+     * @covers \eZ\Publish\API\Repository\UserService::updateUser
+     */
+    public function testUpdateUserByUserWithLimitations(): void
+    {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+
+        $user = $this->createTestUserWithPassword('H@xxxiR!_1', $this->createUserContentTypeWithStrongPassword());
+
+        $currentUser = $this->createUserWithPolicies(
+            'user',
+            [
+                ['module' => 'content', 'function' => 'edit'],
+                ['module' => 'user', 'function' => 'password'],
+            ],
+            new SubtreeLimitation(['limitationValues' => ['/1/2']])
+        );
+        $repository->getPermissionResolver()->setCurrentUserReference($currentUser);
+
+        /* BEGIN: Use Case */
+        // Create a new update struct instance
+        $userUpdate = $userService->newUserUpdateStruct();
+        $userUpdate->password = 'H@xxxiR!_2';
+
+        $user = $userService->updateUser($user, $userUpdate);
+        /* END: Use Case */
+
+        $this->assertInstanceOf(User::class, $user);
+    }
+
+    /**
      * Test for the loadUserGroupsOfUser() method.
      *
      * @covers \eZ\Publish\API\Repository\UserService::loadUserGroupsOfUser

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -847,6 +847,7 @@ class UserService implements UserServiceInterface
         }
 
         if (!empty($userUpdateStruct->password) &&
+            !$canEditContent &&
             !$this->permissionResolver->canUser('user', 'password', $loadedUser, [$loadedUser])
         ) {
             throw new UnauthorizedException('user', 'password');

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -847,8 +847,7 @@ class UserService implements UserServiceInterface
         }
 
         if (!empty($userUpdateStruct->password) &&
-            !$canEditContent &&
-            !$this->permissionResolver->canUser('user', 'password', $loadedUser)
+            !$this->permissionResolver->canUser('user', 'password', $loadedUser, [$loadedUser])
         ) {
             throw new UnauthorizedException('user', 'password');
         }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-362](https://jira.ez.no/browse/IBX-362)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Not sure why the `content/edit` policy was required when changing the password, this one has been removed.

Also, this issue is occurring because of Role limitations like the Subtree one. What is happening is that the "User" content is validated against the Subtree limitation (and it fails because of limitation on `Home` content for example) which shouldn't be the case for `user/*` policies as we don't deal with the usual content here. Therefore, the additional target has been added in order to abstain from evaluating this limitation as it doesn't make sense in the case of a user.

**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
