### PR TITLE
IBX-368: Added image path normalization before storing it into the DB

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -29,6 +29,8 @@ final class NormalizeImagesPathsCommand extends Command
 - Manually clear SPI/HTTP cache after running this command.
 EOT;
 
+    protected static $defaultName = 'ezplatform:images:normalize-paths';
+
     /** @var \eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway */
     private $imageGateway;
 
@@ -55,7 +57,6 @@ EOT;
         $beforeRunningHints = self::BEFORE_RUNNING_HINTS;
 
         $this
-            ->setName('ezplatform:images:normalize-paths')
             ->setDescription('Normalizes stored paths for images.')
             ->setHelp(
                 <<<EOT
@@ -122,7 +123,7 @@ EOT
                     $imagePathToNormalize['oldPath'],
                     $imagePathToNormalize['newPath']
                 );
-                $io->progressAdvance(1);
+                $io->progressAdvance();
             }
             $this->connection->commit();
         } catch (\Exception $e) {

--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Command;
+
+use eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\DoctrineStorage;
+use eZ\Publish\Core\IO\FilePathNormalizerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class NormalizeImagesPathsCommand extends Command
+{
+    const BEFORE_RUNNING_HINTS = <<<EOT
+<error>Before you continue:</error>
+- Make sure to back up your database.
+- Run this command in production environment using <info>--env=prod</info>
+- Manually clear SPI/HTTP cache after running this command.
+EOT;
+
+    /** @var \eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\DoctrineStorage */
+    private $imageGateway;
+
+    /** @var \eZ\Publish\Core\IO\FilePathNormalizerInterface */
+    private $filePathNormalizer;
+
+    public function __construct(
+        DoctrineStorage $imageGateway,
+        FilePathNormalizerInterface $filePathNormalizer
+    ) {
+        parent::__construct();
+
+        $this->imageGateway = $imageGateway;
+        $this->filePathNormalizer = $filePathNormalizer;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('ezplatform:normalize-image-paths')
+            ->setDescription('Normalizes stored paths for images.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Normalize images paths');
+
+        $io->writeln([
+            'Determining the number of images that require path normalization.',
+            'It may take a minute or two...',
+        ]);
+
+        $imagesData = $this->imageGateway->getAllImagesData();
+        $imagePathsToNormalize = [];
+        foreach ($imagesData as $imageData) {
+            $filePath = $imageData['filepath'];
+            $normalizedImagePath = $this->filePathNormalizer->normalizePath($imageData['filepath']);
+            if ($normalizedImagePath !== $filePath) {
+                $imagePathsToNormalize[] = [
+                    'fieldId' => (int) $imageData['contentobject_attribute_id'],
+                    'oldPath' => $filePath,
+                    'newPath' => $normalizedImagePath,
+                ];
+            }
+        }
+
+        $imagePathsToNormalizeCount = \count($imagePathsToNormalize);
+        $io->note(sprintf('Found: %d', $imagePathsToNormalizeCount));
+        if ($imagePathsToNormalizeCount === 0) {
+            $io->success('Nothing to do. Bye!');
+
+            return 0;
+        }
+
+        if (!$io->confirm('Do you want to continue?')) {
+            return 0;
+        }
+
+        $io->writeln('Normalizing images paths. Please wait...');
+        $io->progressStart($imagePathsToNormalizeCount);
+        foreach ($imagePathsToNormalize as $imagePathToNormalize) {
+            $this->updateImagePath(
+                $imagePathToNormalize['fieldId'],
+                $imagePathToNormalize['oldPath'],
+                $imagePathToNormalize['newPath']
+            );
+            $io->progressAdvance(1);
+        }
+        $io->progressFinish();
+        $io->success('Done!');
+
+        return 0;
+    }
+
+    private function updateImagePath(int $fieldId, string $oldPath, string $newPath): void
+    {
+        $oldPathInfo = pathinfo($oldPath);
+        $newPathInfo = pathinfo($newPath);
+        // In Image's XML, basename does not contain a file extension, and the filename does - pathinfo results are exactly the opposite.
+        $oldFileName = $oldPathInfo['basename'];
+        $newFilename = $newPathInfo['basename'];
+        $newBaseName = $newPathInfo['filename'];
+
+        $xmlsData = $this->imageGateway->getAllVersionsImageXmlForFieldId($fieldId);
+        foreach ($xmlsData as $xmlData) {
+            $dom = new \DOMDocument();
+            $dom->loadXml($xmlData['data_text']);
+
+            $ezimageTag = $dom->getElementsByTagName('ezimage')->item(0);
+            $this->imageGateway->updateImagePath($fieldId, $oldPath, $newPath);
+            if ($ezimageTag && $ezimageTag->getAttribute('filename') === $oldFileName) {
+                $ezimageTag->setAttribute('filename', $newFilename);
+                $ezimageTag->setAttribute('basename', $newBaseName);
+                $ezimageTag->setAttribute('dirpath', $newPath);
+                $ezimageTag->setAttribute('url', $newPath);
+
+                $this->imageGateway->updateImageData($fieldId, $xmlData['version'], $dom->saveXML());
+                $this->imageGateway->updateImagePath($fieldId, $oldPath, $newPath);
+            }
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml
@@ -21,3 +21,7 @@ services:
         autoconfigure: true
         arguments:
             $locationHandler: '@ezpublish.spi.persistence.location_handler'
+
+    eZ\Bundle\EzPublishCoreBundle\Command\NormalizeImagesPathsCommand:
+        autowire: true
+        autoconfigure: true

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml
@@ -25,3 +25,5 @@ services:
     eZ\Bundle\EzPublishCoreBundle\Command\NormalizeImagesPathsCommand:
         autowire: true
         autoconfigure: true
+        arguments:
+            $connection: '@ezpublish.persistence.connection'

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -170,6 +170,3 @@ services:
             - "@ezpublish.config.resolver"
         tags:
             - { name: kernel.event_subscriber }
-
-    eZ\Publish\Core\IO\FilePathNormalizer\Flysystem: ~
-    eZ\Publish\Core\IO\FilePathNormalizerInterface: '@eZ\Publish\Core\IO\FilePathNormalizer\Flysystem'

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -170,3 +170,6 @@ services:
             - "@ezpublish.config.resolver"
         tags:
             - { name: kernel.event_subscriber }
+
+    eZ\Publish\Core\IO\FilePathNormalizer\Flysystem: ~
+    eZ\Publish\Core\IO\FilePathNormalizerInterface: '@eZ\Publish\Core\IO\FilePathNormalizer\Flysystem'

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -79,7 +79,7 @@ class ImageStorage extends GatewayBasedStorage
                 ),
                 $field->value->externalData['fileName']
             );
-            $targetPath = $this->filePathNormalizer->normalizePath($targetPath);
+//            $targetPath = $this->filePathNormalizer->normalizePath($targetPath);
 
             if (isset($field->value->externalData['inputUri'])) {
                 $localFilePath = $field->value->externalData['inputUri'];

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -9,9 +9,9 @@ namespace eZ\Publish\Core\FieldType\Image;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Utils\DeprecationWarnerInterface as DeprecationWarner;
 use eZ\Publish\Core\IO\FilePathNormalizerInterface;
-use eZ\Publish\SPI\FieldType\GatewayBasedStorage;
 use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\MetadataHandler;
+use eZ\Publish\SPI\FieldType\GatewayBasedStorage;
 use eZ\Publish\SPI\FieldType\StorageGateway;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
@@ -79,7 +79,7 @@ class ImageStorage extends GatewayBasedStorage
                 ),
                 $field->value->externalData['fileName']
             );
-//            $targetPath = $this->filePathNormalizer->normalizePath($targetPath);
+            $targetPath = $this->filePathNormalizer->normalizePath($targetPath);
 
             if (isset($field->value->externalData['inputUri'])) {
                 $localFilePath = $field->value->externalData['inputUri'];
@@ -97,10 +97,7 @@ class ImageStorage extends GatewayBasedStorage
             } elseif ($this->ioService->exists($targetPath)) {
                 $binaryFile = $this->ioService->loadBinaryFile($targetPath);
             } else {
-                throw new InvalidArgumentException(
-                    'inputUri',
-                    'No source image could be obtained from the given external data'
-                );
+                throw new InvalidArgumentException('inputUri', 'No source image could be obtained from the given external data');
             }
 
             $field->value->externalData['imageId'] = $this->buildImageId($versionInfo, $field);
@@ -183,9 +180,6 @@ class ImageStorage extends GatewayBasedStorage
     }
 
     /**
-     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
-     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
-     *
      * @return string
      */
     private function buildImageId(VersionInfo $versionInfo, Field $field)

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -8,13 +8,13 @@ namespace eZ\Publish\Core\FieldType\Image;
 
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Utils\DeprecationWarnerInterface as DeprecationWarner;
+use eZ\Publish\Core\IO\FilePathNormalizerInterface;
 use eZ\Publish\SPI\FieldType\GatewayBasedStorage;
 use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\MetadataHandler;
 use eZ\Publish\SPI\FieldType\StorageGateway;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
-use League\Flysystem\Util;
 
 /**
  * Converter for Image field type external storage.
@@ -39,13 +39,17 @@ class ImageStorage extends GatewayBasedStorage
     /** @var \eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway */
     protected $gateway;
 
+    /** @var \eZ\Publish\Core\IO\FilePathNormalizerInterface */
+    protected $filePathNormalizer;
+
     public function __construct(
         StorageGateway $gateway,
         IOServiceInterface $ioService,
         PathGenerator $pathGenerator,
         MetadataHandler $imageSizeMetadataHandler,
         DeprecationWarner $deprecationWarner,
-        AliasCleanerInterface $aliasCleaner
+        AliasCleanerInterface $aliasCleaner,
+        FilePathNormalizerInterface $filePathNormalizer
     ) {
         parent::__construct($gateway);
         $this->ioService = $ioService;
@@ -53,6 +57,7 @@ class ImageStorage extends GatewayBasedStorage
         $this->imageSizeMetadataHandler = $imageSizeMetadataHandler;
         $this->deprecationWarner = $deprecationWarner;
         $this->aliasCleaner = $aliasCleaner;
+        $this->filePathNormalizer = $filePathNormalizer;
     }
 
     public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context)
@@ -74,7 +79,7 @@ class ImageStorage extends GatewayBasedStorage
                 ),
                 $field->value->externalData['fileName']
             );
-            $targetPath = Util::normalizePath($targetPath);
+            $targetPath = $this->filePathNormalizer->normalizePath($targetPath);
 
             if (isset($field->value->externalData['inputUri'])) {
                 $localFilePath = $field->value->externalData['inputUri'];

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\IO\MetadataHandler;
 use eZ\Publish\SPI\FieldType\StorageGateway;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+use League\Flysystem\Util;
 
 /**
  * Converter for Image field type external storage.
@@ -73,6 +74,7 @@ class ImageStorage extends GatewayBasedStorage
                 ),
                 $field->value->externalData['fileName']
             );
+            $targetPath = Util::normalizePath($targetPath);
 
             if (isset($field->value->externalData['inputUri'])) {
                 $localFilePath = $field->value->externalData['inputUri'];

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
@@ -63,4 +63,12 @@ abstract class Gateway extends StorageGateway
      * Returns the public uris for the images stored in $xml.
      */
     abstract public function extractFilesFromXml($xml);
+
+    abstract public function getAllVersionsImageXmlForFieldId(int $fieldId): array;
+
+    abstract public function updateImageData(int $fieldId, int $versionNo, string $xml): void;
+
+    abstract public function getImagesData(int $offset, int $limit): array;
+
+    abstract public function updateImagePath(int $fieldId, string $oldPath, string $newPath): void;
 }

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
@@ -8,6 +8,7 @@ namespace eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\ParameterType;
 use DOMDocument;
 use eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;
 use eZ\Publish\Core\IO\UrlRedecoratorInterface;
@@ -156,24 +157,24 @@ class DoctrineStorage extends Gateway
         $selectQuery = $this->connection->createQueryBuilder();
         $selectQuery
             ->select(
-                $this->connection->quoteIdentifier('id'),
-                $this->connection->quoteIdentifier('version'),
-                $this->connection->quoteIdentifier('data_text')
+                'field.id',
+                'field.version',
+                'field.data_text'
             )
-            ->from($this->connection->quoteIdentifier('ezcontentobject_attribute'))
+            ->from($this->connection->quoteIdentifier('ezcontentobject_attribute'), 'field')
             ->where(
                 $selectQuery->expr()->eq(
                     $this->connection->quoteIdentifier('id'),
-                    ':fieldId'
+                    ':field_id'
                 )
             )
-            ->setParameter(':fieldId', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':field_id', $fieldId, PDO::PARAM_INT)
         ;
 
         $statement = $selectQuery->execute();
 
         $fieldLookup = [];
-        foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        foreach ($statement->fetchAllAssociative() as $row) {
             $fieldLookup[$row['id']] = [
                 'version' => $row['version'],
                 'data_text' => $row['data_text'],
@@ -365,10 +366,11 @@ class DoctrineStorage extends Gateway
         $selectQuery = $this->connection->createQueryBuilder();
         $selectQuery
             ->select(
-                $this->connection->quoteIdentifier('contentobject_attribute_id'),
-                $this->connection->quoteIdentifier('filepath')
-            )->from($this->connection->quoteIdentifier(self::IMAGE_FILE_TABLE))
+                'img.contentobject_attribute_id',
+                'img.filepath'
+            )
             ->distinct()
+            ->from($this->connection->quoteIdentifier(self::IMAGE_FILE_TABLE), 'img')
             ->setFirstResult($offset)
             ->setMaxResults($limit);
 
@@ -390,18 +392,18 @@ class DoctrineStorage extends Gateway
             ->where(
                 $expressionBuilder->eq(
                     $this->connection->quoteIdentifier('id'),
-                    ':fieldId'
+                    ':field_id'
                 )
             )
             ->andWhere(
                 $expressionBuilder->eq(
                     $this->connection->quoteIdentifier('version'),
-                    ':versionNo'
+                    ':version_no'
                 )
             )
-            ->setParameter(':fieldId', $fieldId, PDO::PARAM_INT)
-            ->setParameter(':versionNo', $versionNo, PDO::PARAM_INT)
-            ->setParameter(':xml', $xml, PDO::PARAM_STR)
+            ->setParameter(':field_id', $fieldId, ParameterType::INTEGER)
+            ->setParameter(':version_no', $versionNo, ParameterType::INTEGER)
+            ->setParameter(':xml', $xml, ParameterType::STRING)
             ->execute()
         ;
     }
@@ -416,23 +418,23 @@ class DoctrineStorage extends Gateway
             )
             ->set(
                 $this->connection->quoteIdentifier('filepath'),
-                ':newPath'
+                ':new_path'
             )
             ->where(
                 $expressionBuilder->eq(
                     $this->connection->quoteIdentifier('contentobject_attribute_id'),
-                    ':fieldId'
+                    ':field_id'
                 )
             )
             ->andWhere(
                 $expressionBuilder->eq(
                     $this->connection->quoteIdentifier('filepath'),
-                    ':oldPath'
+                    ':old_path'
                 )
             )
-            ->setParameter(':fieldId', $fieldId, PDO::PARAM_INT)
-            ->setParameter(':oldPath', $oldPath, PDO::PARAM_STR)
-            ->setParameter(':newPath', $newPath, PDO::PARAM_STR)
+            ->setParameter(':field_id', $fieldId, ParameterType::INTEGER)
+            ->setParameter(':old_path', $oldPath, ParameterType::STRING)
+            ->setParameter(':new_path', $newPath, ParameterType::STRING)
             ->execute()
         ;
     }

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
@@ -256,9 +256,8 @@ class DoctrineStorage extends Gateway
     {
         $selectQuery = $this->connection->createQueryBuilder();
         $selectQuery
-            ->select($this->connection->getDatabasePlatform()->getCountExpression('contentobject_attribute_id'))
+            ->select($this->connection->getDatabasePlatform()->getCountExpression('DISTINCT(filepath)'))
             ->from($this->connection->quoteIdentifier(self::IMAGE_FILE_TABLE))
-            ->groupBy('contentobject_attribute_id', 'filepath')
         ;
 
         $statement = $selectQuery->execute();

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
@@ -256,12 +256,9 @@ class DoctrineStorage extends Gateway
     {
         $selectQuery = $this->connection->createQueryBuilder();
         $selectQuery
-            ->select(
-                'COUNT(DISTINCT ' . $this->connection->quoteIdentifier('contentobject_attribute_id') .
-                ', ' . $this->connection->quoteIdentifier('filepath') . ')'
-            )
+            ->select($this->connection->getDatabasePlatform()->getCountExpression('contentobject_attribute_id'))
             ->from($this->connection->quoteIdentifier(self::IMAGE_FILE_TABLE))
-            ->distinct()
+            ->groupBy('contentobject_attribute_id', 'filepath')
         ;
 
         $statement = $selectQuery->execute();

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;
 
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\Core\IO\UrlRedecoratorInterface;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
@@ -312,5 +313,37 @@ class LegacyStorage extends Gateway
         }
 
         return null;
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
+     */
+    public function getAllVersionsImageXmlForFieldId(int $fieldId): array
+    {
+        throw new NotImplementedException('getAllVersionsImageXmlForFieldId is not supported with LegacyStorage gateway, inject DoctrineStorage gateway instead to use it');
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
+     */
+    public function updateImageData(int $fieldId, int $versionNo, string $xml): void
+    {
+        throw new NotImplementedException('updateImageData is not supported with LegacyStorage gateway, inject DoctrineStorage gateway instead to use it');
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
+     */
+    public function getImagesData(int $offset, int $limit): array
+    {
+        throw new NotImplementedException('getImagesData is not supported with LegacyStorage gateway, inject DoctrineStorage gateway instead to use it');
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
+     */
+    public function updateImagePath(int $fieldId, string $oldPath, string $newPath): void
+    {
+        throw new NotImplementedException('updateImagePath is not supported with LegacyStorage gateway, inject DoctrineStorage gateway instead to use it');
     }
 }

--- a/eZ/Publish/Core/IO/FilePathNormalizer/Flysystem.php
+++ b/eZ/Publish/Core/IO/FilePathNormalizer/Flysystem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/IO/FilePathNormalizer/Flysystem.php
+++ b/eZ/Publish/Core/IO/FilePathNormalizer/Flysystem.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\IO\FilePathNormalizer;
+
+use eZ\Publish\Core\IO\FilePathNormalizerInterface;
+use League\Flysystem\Util;
+
+class Flysystem implements FilePathNormalizerInterface
+{
+    public function normalizePath(string $filePath): string
+    {
+        return Util::normalizePath($filePath);
+    }
+}

--- a/eZ/Publish/Core/IO/FilePathNormalizer/Flysystem.php
+++ b/eZ/Publish/Core/IO/FilePathNormalizer/Flysystem.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\IO\FilePathNormalizer;
 use eZ\Publish\Core\IO\FilePathNormalizerInterface;
 use League\Flysystem\Util;
 
-class Flysystem implements FilePathNormalizerInterface
+final class Flysystem implements FilePathNormalizerInterface
 {
     public function normalizePath(string $filePath): string
     {

--- a/eZ/Publish/Core/IO/FilePathNormalizerInterface.php
+++ b/eZ/Publish/Core/IO/FilePathNormalizerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\IO;
+
+interface FilePathNormalizerInterface
+{
+    public function normalizePath(string $filePath): string;
+}

--- a/eZ/Publish/Core/IO/FilePathNormalizerInterface.php
+++ b/eZ/Publish/Core/IO/FilePathNormalizerInterface.php
@@ -4,8 +4,13 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\Core\IO;
 
+/**
+ * @internal
+ */
 interface FilePathNormalizerInterface
 {
     public function normalizePath(string $filePath): string;

--- a/eZ/Publish/Core/IO/FilePathNormalizerInterface.php
+++ b/eZ/Publish/Core/IO/FilePathNormalizerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO;

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -27,6 +27,7 @@ services:
             $imageSizeMetadataHandler: '@ezpublish.fieldType.metadataHandler.imagesize'
             $deprecationWarner: '@ezpublish.utils.deprecation_warner'
             $aliasCleaner: '@eZ\Publish\Core\FieldType\Image\AliasCleanerInterface'
+            $filePathNormalizer: '@eZ\Publish\Core\IO\FilePathNormalizerInterface'
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezimage}
 

--- a/eZ/Publish/Core/settings/io.yml
+++ b/eZ/Publish/Core/settings/io.yml
@@ -85,3 +85,6 @@ services:
         arguments:
             - ~
             - "@ezpublish.core.io.image_fieldtype.legacy_url_decorator"
+
+    eZ\Publish\Core\IO\FilePathNormalizer\Flysystem: ~
+    eZ\Publish\Core\IO\FilePathNormalizerInterface: '@eZ\Publish\Core\IO\FilePathNormalizer\Flysystem'

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -44,6 +44,9 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
     /** @var \PHPUnit\Framework\MockObject\MockObject */
     private $aliasCleanerMock;
 
+    /** @var \PHPUnit\Framework\MockObject\MockObject */
+    private $filePathNormalizer;
+
     /**
      * Returns the storage identifier prefix used by the file service.
      *
@@ -94,7 +97,8 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
                 new FieldType\Image\PathGenerator\LegacyPathGenerator(),
                 new IO\MetadataHandler\ImageSize(),
                 $this->getDeprecationWarnerMock(),
-                $this->getAliasCleanerMock()
+                $this->getAliasCleanerMock(),
+                $this->getFilePathNormalizerMock()
             )
         );
     }
@@ -115,6 +119,15 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
         }
 
         return $this->aliasCleanerMock;
+    }
+
+    public function getFilePathNormalizerMock()
+    {
+        if (!isset($this->filePathNormalizer)) {
+            $this->filePathNormalizer = $this->createMock(IO\FilePathNormalizerInterface::class);
+        }
+
+        return $this->filePathNormalizer;
     }
 
     /**

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -125,6 +125,7 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
     {
         if (!isset($this->filePathNormalizer)) {
             $this->filePathNormalizer = $this->createMock(IO\FilePathNormalizerInterface::class);
+            $this->filePathNormalizer->method('normalizePath')->willReturnArgument(0);
         }
 
         return $this->filePathNormalizer;

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -44,7 +44,7 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
     /** @var \PHPUnit\Framework\MockObject\MockObject */
     private $aliasCleanerMock;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject */
+    /** @var \eZ\Publish\Core\IO\FilePathNormalizer\Flysystem */
     private $filePathNormalizer;
 
     /**
@@ -121,7 +121,7 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
         return $this->aliasCleanerMock;
     }
 
-    public function getFilePathNormalizerMock()
+    private function getFilePathNormalizerMock(): IO\FilePathNormalizerInterface
     {
         if (!isset($this->filePathNormalizer)) {
             $this->filePathNormalizer = $this->createMock(IO\FilePathNormalizerInterface::class);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-368](https://jira.ez.no/browse/IBX-368)
| **Bug**| yes
| **Target version** | `7.5+`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

When `Flysystem` stores the image, the path is normalized and (for example) unprintable utf8 characters are dropped. The same transformation is not applied to the path stored in the `ezimagefile` table, which leads to 404 errors.

As the issue did not occur in legacy, an image path normalization command has to be implemented for migrating projects.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Implement an image path normalization command for projects migrating from legacy.
- [x] Ask for Code Review.
