### PR TITLE
IBX-374: Fixed retrieving factory names in LazyDoctrineRepositoriesPass

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/LazyDoctrineRepositoriesPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/LazyDoctrineRepositoriesPass.php
@@ -11,6 +11,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 final class LazyDoctrineRepositoriesPass implements CompilerPassInterface
 {

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/LazyDoctrineRepositoriesPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/LazyDoctrineRepositoriesPass.php
@@ -23,6 +23,10 @@ final class LazyDoctrineRepositoriesPass implements CompilerPassInterface
             }
 
             $factory = $definition->getFactory();
+            if (!is_string($factory[0]) && !$factory[0] instanceof Reference) {
+                continue;
+            }
+
             $factoryServiceId = (string) $factory[0];
 
             if ($factoryServiceId !== 'ibexa.doctrine.orm.entity_manager') {

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/LazyDoctrineRepositoriesPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/LazyDoctrineRepositoriesPassTest.php
@@ -39,7 +39,12 @@ class LazyDoctrineRepositoriesPassTest extends AbstractCompilerPassTestCase
         $myServiceWithFactory->setFactory([new Reference('my_factory'), 'getService']);
         $myServiceWithFactory->setLazy(true);
 
+        $myOtherServiceWithFactory = new Definition();
+        $myOtherServiceWithFactory->setFactory([new Definition('\My\Class'), 'getService']);
+        $myOtherServiceWithFactory->setLazy(true);
+
         $this->setDefinition('my_service', $myServiceWithFactory);
+        $this->setDefinition('my_other_service', $myOtherServiceWithFactory);
         $this->setDefinition('my_entity_manager', $myServiceWithEntityManagerFactory);
         $this->setDefinition('my_lazy_entity_manager', $myLazyServiceWithEntityManagerFactory);
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-374](https://jira.ez.no/browse/IBX-374)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.5` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

###Note to QA:

You can't really test this from user perspective. I recommend doing sanities around installation process and container building (via cache:clear).

I remember issue mentioned by Edi to be reproducible on 3.2 or 3.3 as this fix was already implemented there. We can try reverting it for 3.2 and 3.3 so we can find out what was exactly causing this issue to replicate the same setup on 2.5.

If you want to test it really deeply I think you can go over whole Entity Manager testing procedure.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
