### PR TITLE
EZP-32361: Fixed Subtree copying when child is invisible

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -2531,6 +2531,8 @@ class LocationServiceTest extends BaseTest
         // Hide child Location
         $locationService->hideLocation($locationService->loadLocation($this->generateId('location', 53)));
 
+        $this->refreshSearch($repository);
+
         $locationToCopy = $locationService->loadLocation($this->generateId('location', 43));
 
         $expected = $this->loadSubtreeProperties($locationToCopy);

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -2521,6 +2521,47 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
+     * @covers \eZ\Publish\API\Repository\LocationService::copySubtree()
+     */
+    public function testCopySubtreeWithInvisibleChild(): void
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        // Hide child Location
+        $locationService->hideLocation($locationService->loadLocation($this->generateId('location', 53)));
+
+        $locationToCopy = $locationService->loadLocation($this->generateId('location', 43));
+
+        $expected = $this->loadSubtreeProperties($locationToCopy);
+
+        $mediaLocationId = $this->generateId('location', 43);
+        $demoDesignLocationId = $this->generateId('location', 56);
+        $locationService = $repository->getLocationService();
+
+        $locationToCopy = $locationService->loadLocation($mediaLocationId);
+
+        $newParentLocation = $locationService->loadLocation($demoDesignLocationId);
+
+        $copiedLocation = $locationService->copySubtree(
+            $locationToCopy,
+            $newParentLocation
+        );
+
+        $this->refreshSearch($repository);
+
+        // Load Subtree properties after copy
+        $actual = $this->loadSubtreeProperties($copiedLocation);
+
+        self::assertEquals(count($expected), count($actual));
+
+        foreach ($actual as $key => $properties) {
+            self::assertEquals($expected[$key]['hidden'], $properties['hidden']);
+            self::assertEquals($expected[$key]['invisible'], $properties['invisible']);
+        }
+    }
+
+    /**
      * Test for the copySubtree() method.
      *
      * @see \eZ\Publish\API\Repository\LocationService::copySubtree()

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -287,7 +287,10 @@ class Handler implements BaseLocationHandler
             $createStruct->contentId = $contentMap[$child['contentobject_id']];
             $parentData = $locationMap[$child['parent_node_id']];
             $createStruct->parentId = $parentData['id'];
-            $createStruct->invisible = $createStruct->hidden || $parentData['hidden'] || $parentData['invisible'];
+            $createStruct->invisible = $createStruct->invisible
+                || $createStruct->hidden
+                || $parentData['hidden']
+                || $parentData['invisible'];
             $pathString = explode('/', $child['path_identification_string']);
             $pathString = end($pathString);
             $createStruct->pathIdentificationString = strlen($pathString) > 0


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32361](https://jira.ez.no/browse/EZP-32361)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**    | no

**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
