### PR TITLE
IBX-111: Injected RequestStack into ExposedRoutesExtractor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "liip/imagine-bundle": "^2.1",
         "oneup/flysystem-bundle": "^3.0",
         "friendsofsymfony/http-cache-bundle": "^1.3.13 | ^2.5.1",
+        "friendsofsymfony/jsrouting-bundle": "^1.6.3",
         "sensio/framework-extra-bundle": "^5.2",
         "jms/translation-bundle": "^1.4",
         "twig/twig": "^2.10",

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/js_routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/js_routing.yml
@@ -4,4 +4,4 @@ services:
         decorates: 'fos_js_routing.extractor'
         arguments:
             - '@ezpublish.js_routing.extractor.inner'
-            - '@=service("request_stack").getMasterRequest()'
+            - '@request_stack'

--- a/eZ/Bundle/EzPublishCoreBundle/Routing/JsRouting/ExposedRoutesExtractor.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/JsRouting/ExposedRoutesExtractor.php
@@ -8,24 +8,26 @@ namespace eZ\Bundle\EzPublishCoreBundle\Routing\JsRouting;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractorInterface;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Decorator of FOSJsRouting routes extractor.
  * Ensures that base URL contains the SiteAccess part when applicable.
+ *
+ * @internal
  */
 class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
 {
-    /** @var ExposedRoutesExtractorInterface */
+    /** @var \FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractorInterface */
     private $innerExtractor;
 
-    /** @var Request */
-    private $masterRequest;
+    /** @var \Symfony\Component\HttpFoundation\RequestStack */
+    private $requestStack;
 
-    public function __construct(ExposedRoutesExtractorInterface $innerExtractor, Request $masterRequest)
+    public function __construct(ExposedRoutesExtractorInterface $innerExtractor, RequestStack $requestStack)
     {
         $this->innerExtractor = $innerExtractor;
-        $this->masterRequest = $masterRequest;
+        $this->requestStack = $requestStack;
     }
 
     public function getRoutes()
@@ -43,7 +45,7 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
     public function getBaseUrl()
     {
         $baseUrl = $this->innerExtractor->getBaseUrl();
-        $siteAccess = $this->masterRequest->attributes->get('siteaccess');
+        $siteAccess = $this->requestStack->getMasterRequest()->attributes->get('siteaccess');
         if ($siteAccess instanceof SiteAccess && $siteAccess->matcher instanceof SiteAccess\URILexer) {
             $baseUrl .= $siteAccess->matcher->analyseLink('');
         }

--- a/eZ/Bundle/EzPublishCoreBundle/Routing/JsRouting/ExposedRoutesExtractor.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/JsRouting/ExposedRoutesExtractor.php
@@ -45,7 +45,12 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
     public function getBaseUrl()
     {
         $baseUrl = $this->innerExtractor->getBaseUrl();
-        $siteAccess = $this->requestStack->getMasterRequest()->attributes->get('siteaccess');
+        $request = $this->requestStack->getMasterRequest();
+        if ($request === null) {
+            return $baseUrl;
+        }
+
+        $siteAccess = $request->attributes->get('siteaccess');
         if ($siteAccess instanceof SiteAccess && $siteAccess->matcher instanceof SiteAccess\URILexer) {
             $baseUrl .= $siteAccess->matcher->analyseLink('');
         }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/JsRouting/ExposedRoutesExtractorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/JsRouting/ExposedRoutesExtractorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Routing\JsRouting;
+
+use eZ\Bundle\EzPublishCoreBundle\Routing\JsRouting\ExposedRoutesExtractor;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractorInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @covers \eZ\Bundle\EzPublishCoreBundle\Routing\JsRouting\ExposedRoutesExtractor
+ *
+ * @internal
+ */
+final class ExposedRoutesExtractorTest extends TestCase
+{
+    private const BASE_URL = '/foo';
+
+    public function getDataForTestGetBaseUrl(): iterable
+    {
+        yield 'CLI' => [
+            // no master request in a stack
+            null,
+            self::BASE_URL,
+        ];
+
+        yield 'No SiteAccess' => [
+            new Request(),
+            self::BASE_URL,
+        ];
+
+        $siteAccess = new SiteAccess(
+            'test',
+            SiteAccess\Matcher\HostText::class,
+            new SiteAccess\Matcher\HostText([])
+        );
+        yield 'SiteAccess w/o URI Lexer matcher' => [
+            new Request([], [], ['siteaccess' => $siteAccess]),
+            self::BASE_URL,
+        ];
+
+        $siteAccess = new SiteAccess(
+            'test',
+            SiteAccess\Matcher\URIText::class,
+            new SiteAccess\Matcher\URIText(['prefix' => 'bar'])
+        );
+        yield 'SiteAccess with URI Lexer matcher' => [
+            new Request([], [], ['siteaccess' => $siteAccess]),
+            self::BASE_URL . '/bar/',
+        ];
+    }
+
+    /**
+     * @dataProvider getDataForTestGetBaseUrl
+     */
+    public function testGetBaseUrl(?Request $masterRequest, string $expectedBaseUrl): void
+    {
+        $innerExtractor = $this->createMock(ExposedRoutesExtractorInterface::class);
+        $requestStack = $this->createMock(RequestStack::class);
+
+        $innerExtractor->method('getBaseUrl')->willReturn(self::BASE_URL);
+        $requestStack->method('getMasterRequest')->willReturn($masterRequest);
+
+        $extractor = new ExposedRoutesExtractor($innerExtractor, $requestStack);
+
+        self::assertSame($expectedBaseUrl, $extractor->getBaseUrl());
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-111](https://jira.ez.no/browse/IBX-111)
| **Type**                                   | bug
| **Target version** | eZ Platform `v2.5`, Ibexa 3.3+
| **BC breaks**                          | no, internal

This PR fixes `ExposedRoutesExtractor` by injecting RequestStack instead of Request, which is [a correct Symfony way](https://symfony.com/doc/3.4/service_container/request.html). As this is FOS extension point, the class was never meant to be consumed or extended, therefore adding missing internal annotation.

### TODO
- [x] Wait for CI

### QA
- [IBX-111](https://jira.ez.no/browse/IBX-111) steps
- Areas affected by JS routing extraction (maybe Fronted Team can help identify those?)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
