### PR TITLE
IBX-569: Changed ObjectStateHandler to extend AbstractInMemoryPersistenceHandler

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
@@ -6,13 +6,15 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache;
 
+use eZ\Publish\SPI\Persistence\Content\ObjectState;
+use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as ObjectStateHandlerInterface;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\InputStruct;
 
 /**
  * @see \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler
  */
-class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerInterface
+class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements ObjectStateHandlerInterface
 {
     /**
      * {@inheritdoc}
@@ -32,19 +34,19 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
      */
     public function loadGroup($groupId)
     {
-        $cacheItem = $this->cache->getItem('ez-state-group-' . $groupId);
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
-
-        $this->logger->logCall(__METHOD__, ['groupId' => $groupId]);
-        $group = $this->persistenceHandler->objectStateHandler()->loadGroup($groupId);
-
-        $cacheItem->set($group);
-        $cacheItem->tag(['state-group-' . $group->id]);
-        $this->cache->save($cacheItem);
-
-        return $group;
+        return $this->getCacheValue(
+            (int) $groupId,
+            'ez-state-group-',
+            function (int $groupId) {
+                return $this->persistenceHandler->objectStateHandler()->loadGroup($groupId);
+            },
+            static function () use ($groupId) {
+                return ['state-group-' . (int) $groupId];
+            },
+            static function () use ($groupId) {
+                return ['ez-state-group-' . (int) $groupId];
+            }
+        );
     }
 
     /**
@@ -52,19 +54,22 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
      */
     public function loadGroupByIdentifier($identifier)
     {
-        $cacheItem = $this->cache->getItem('ez-state-group-' . $this->escapeForCacheKey($identifier) . '-by-identifier');
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
+        $identifier = $this->escapeForCacheKey($identifier);
 
-        $this->logger->logCall(__METHOD__, ['groupId' => $identifier]);
-        $group = $this->persistenceHandler->objectStateHandler()->loadGroupByIdentifier($identifier);
-
-        $cacheItem->set($group);
-        $cacheItem->tag(['state-group-' . $group->id]);
-        $this->cache->save($cacheItem);
-
-        return $group;
+        return $this->getCacheValue(
+            $identifier,
+            'ez-state-group-',
+            function ($identifier) {
+                return $this->persistenceHandler->objectStateHandler()->loadGroupByIdentifier($identifier);
+            },
+            static function (Group $group) {
+                return ['state-group-' . $group->id];
+            },
+            static function () use ($identifier) {
+                return ['ez-state-group-' . $identifier . '-by-identifier'];
+            },
+            '-by-identifier'
+        );
     }
 
     /**
@@ -72,23 +77,26 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
      */
     public function loadAllGroups($offset = 0, $limit = -1)
     {
-        $cacheItem = $this->cache->getItem('ez-state-group-all');
-        if ($cacheItem->isHit()) {
-            return array_slice($cacheItem->get(), $offset, $limit > -1 ? $limit : null);
-        }
+        $stateGroups = $this->getCacheValue(
+            '',
+            'ez-state-group-all',
+            function () {
+                return $this->persistenceHandler->objectStateHandler()->loadAllGroups(0, -1);
+            },
+            static function (array $stateGroups) {
+                $cacheTags = [];
+                foreach ($stateGroups as $group) {
+                    $cacheTags[] = 'state-group-' . $group->id;
+                }
 
-        $this->logger->logCall(__METHOD__, ['offset' => $offset, 'limit' => $limit]);
-        $stateGroups = $this->persistenceHandler->objectStateHandler()->loadAllGroups(0, -1);
+                return $cacheTags;
+            },
+            static function () {
+                return ['ez-state-group-all'];
+            }
+        );
 
-        $cacheItem->set($stateGroups);
-        $cacheTags = [];
-        foreach ($stateGroups as $group) {
-            $cacheTags[] = 'state-group-' . $group->id;
-        }
-        $cacheItem->tag($cacheTags);
-        $this->cache->save($cacheItem);
-
-        return array_slice($stateGroups, $offset, $limit > -1 ? $limit : null);
+        return \array_slice($stateGroups, $offset, $limit > -1 ? $limit : null);
     }
 
     /**
@@ -96,21 +104,25 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
      */
     public function loadObjectStates($groupId)
     {
-        $cacheItem = $this->cache->getItem('ez-state-list-by-group-' . $groupId);
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
+        $objectStates = $this->getCacheValue(
+            $groupId,
+            'ez-state-list-by-group-',
+            function ($groupId) {
+                return $this->persistenceHandler->objectStateHandler()->loadObjectStates($groupId);
+            },
+            static function (array $objectStates) use ($groupId) {
+                $cacheTags = [];
+                $cacheTags[] = 'state-group-' . (int) $groupId;
+                foreach ($objectStates as $state) {
+                    $cacheTags[] = 'state-' . $state->id;
+                }
 
-        $this->logger->logCall(__METHOD__, ['groupId' => $groupId]);
-        $objectStates = $this->persistenceHandler->objectStateHandler()->loadObjectStates($groupId);
-
-        $cacheItem->set($objectStates);
-        $cacheTags = ['state-group-' . $groupId];
-        foreach ($objectStates as $state) {
-            $cacheTags[] = 'state-' . $state->id;
-        }
-        $cacheItem->tag($cacheTags);
-        $this->cache->save($cacheItem);
+                return $cacheTags;
+            },
+            static function () use ($groupId) {
+                return ['ez-state-list-by-group-' . (int) $groupId];
+            }
+        );
 
         return $objectStates;
     }
@@ -159,17 +171,19 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
      */
     public function load($stateId)
     {
-        $cacheItem = $this->cache->getItem('ez-state-' . $stateId);
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
-
-        $this->logger->logCall(__METHOD__, ['stateId' => $stateId]);
-        $objectState = $this->persistenceHandler->objectStateHandler()->load($stateId);
-
-        $cacheItem->set($objectState);
-        $cacheItem->tag(['state-' . $objectState->id, 'state-group-' . $objectState->groupId]);
-        $this->cache->save($cacheItem);
+        $objectState = $this->getCacheValue(
+            (int) $stateId,
+            'ez-state-',
+            function ($stateId) {
+                return $this->persistenceHandler->objectStateHandler()->load((int) $stateId);
+            },
+            static function (ObjectState $objectState) {
+                return ['state-' . $objectState->id, 'state-group-' . $objectState->groupId];
+            },
+            static function () use ($stateId) {
+                return ['ez-state-' . (int) $stateId];
+            }
+        );
 
         return $objectState;
     }
@@ -179,19 +193,22 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
      */
     public function loadByIdentifier($identifier, $groupId)
     {
-        $cacheItem = $this->cache->getItem('ez-state-identifier-' . $this->escapeForCacheKey($identifier) . '-by-group-' . $groupId);
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
+        $identifier = $this->escapeForCacheKey($identifier);
 
-        $this->logger->logCall(__METHOD__, ['identifier' => $identifier, 'groupId' => $groupId]);
-        $objectState = $this->persistenceHandler->objectStateHandler()->loadByIdentifier($identifier, $groupId);
-
-        $cacheItem->set($objectState);
-        $cacheItem->tag(['state-' . $objectState->id, 'state-group-' . $objectState->groupId]);
-        $this->cache->save($cacheItem);
-
-        return $objectState;
+        return $this->getCacheValue(
+            $identifier,
+            'ez-state-identifier-',
+            function ($identifier) use ($groupId) {
+                return $this->persistenceHandler->objectStateHandler()->loadByIdentifier($identifier, (int) $groupId);
+            },
+            static function (ObjectState $objectState) {
+                return ['state-' . $objectState->id, 'state-group-' . $objectState->groupId];
+            },
+            static function () use ($identifier, $groupId) {
+                return ['ez-state-identifier-' . $identifier . '-by-group-' . (int) $groupId];
+            },
+            '-by-group-' . (int) $groupId
+        );
     }
 
     /**
@@ -251,19 +268,20 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
      */
     public function getContentState($contentId, $stateGroupId)
     {
-        $cacheItem = $this->cache->getItem('ez-state-by-group-' . $stateGroupId . '-on-content-' . $contentId);
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
-
-        $this->logger->logCall(__METHOD__, ['contentId' => $contentId, 'stateGroupId' => $stateGroupId]);
-        $contentState = $this->persistenceHandler->objectStateHandler()->getContentState($contentId, $stateGroupId);
-
-        $cacheItem->set($contentState);
-        $cacheItem->tag(['state-' . $contentState->id, 'content-' . $contentId]);
-        $this->cache->save($cacheItem);
-
-        return $contentState;
+        return $this->getCacheValue(
+            (int) $stateGroupId,
+            'ez-state-by-group-',
+            function ($stateGroupId) use ($contentId) {
+                return $this->persistenceHandler->objectStateHandler()->getContentState((int) $contentId, (int) $stateGroupId);
+            },
+            static function (ObjectState $contentState) use ($contentId) {
+                return ['state-' . $contentState->id, 'content-' . (int) $contentId];
+            },
+            static function () use ($contentId, $stateGroupId) {
+                return ['ez-state-by-group-' . (int) $stateGroupId . '-on-content-' . (int) $contentId];
+            },
+            '-on-content-' . $contentId
+        );
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
@@ -96,7 +96,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             }
         );
 
-        return \array_slice((array) $stateGroups, $offset, $limit > -1 ? $limit : null);
+        return \array_slice($stateGroups, $offset, $limit > -1 ? $limit : null);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
@@ -38,6 +38,8 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             (int) $groupId,
             'ez-state-group-',
             function (int $groupId) {
+                $this->logger->logCall(__METHOD__, ['groupId' => (int) $groupId]);
+
                 return $this->persistenceHandler->objectStateHandler()->loadGroup($groupId);
             },
             static function () use ($groupId) {
@@ -60,6 +62,8 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             $identifier,
             'ez-state-group-',
             function ($identifier) {
+                $this->logger->logCall(__METHOD__, ['groupId' => $identifier]);
+
                 return $this->persistenceHandler->objectStateHandler()->loadGroupByIdentifier($identifier);
             },
             static function (Group $group) {
@@ -80,7 +84,9 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
         $stateGroups = $this->getCacheValue(
             '',
             'ez-state-group-all',
-            function () {
+            function () use ($offset, $limit) {
+                $this->logger->logCall(__METHOD__, ['offset' => (int) $offset, 'limit' => (int) $limit]);
+
                 return $this->persistenceHandler->objectStateHandler()->loadAllGroups(0, -1);
             },
             static function (array $stateGroups) {
@@ -108,6 +114,8 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             $groupId,
             'ez-state-list-by-group-',
             function ($groupId) {
+                $this->logger->logCall(__METHOD__, ['groupId' => (int) $groupId]);
+
                 return $this->persistenceHandler->objectStateHandler()->loadObjectStates($groupId);
             },
             static function (array $objectStates) use ($groupId) {
@@ -175,6 +183,8 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             (int) $stateId,
             'ez-state-',
             function ($stateId) {
+                $this->logger->logCall(__METHOD__, ['stateId' => (int) $stateId]);
+
                 return $this->persistenceHandler->objectStateHandler()->load((int) $stateId);
             },
             static function (ObjectState $objectState) {
@@ -199,6 +209,8 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             $identifier,
             'ez-state-identifier-',
             function ($identifier) use ($groupId) {
+                $this->logger->logCall(__METHOD__, ['identifier' => $identifier, 'groupId' => (int) $groupId]);
+
                 return $this->persistenceHandler->objectStateHandler()->loadByIdentifier($identifier, (int) $groupId);
             },
             static function (ObjectState $objectState) {
@@ -272,6 +284,8 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             (int) $stateGroupId,
             'ez-state-by-group-',
             function ($stateGroupId) use ($contentId) {
+                $this->logger->logCall(__METHOD__, ['contentId' => (int) $contentId, 'stateGroupId' => (int) $stateGroupId]);
+
                 return $this->persistenceHandler->objectStateHandler()->getContentState((int) $contentId, (int) $stateGroupId);
             },
             static function (ObjectState $contentState) use ($contentId) {

--- a/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
@@ -102,7 +102,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             }
         );
 
-        return \array_slice($stateGroups, $offset, $limit > -1 ? $limit : null);
+        return \array_slice((array) $stateGroups, $offset, $limit > -1 ? $limit : null);
     }
 
     /**
@@ -110,7 +110,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
      */
     public function loadObjectStates($groupId)
     {
-        $objectStates = $this->getCacheValue(
+        return $this->getCacheValue(
             $groupId,
             'ez-state-list-by-group-',
             function (int $groupId): array {
@@ -131,8 +131,6 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
                 return ['ez-state-list-by-group-' . (int) $groupId];
             }
         );
-
-        return $objectStates;
     }
 
     /**
@@ -284,7 +282,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             function (int $stateGroupId) use ($contentId): ObjectState {
                 $this->logger->logCall(__METHOD__, ['contentId' => (int) $contentId, 'stateGroupId' => $stateGroupId]);
 
-                return $this->persistenceHandler->objectStateHandler()->getContentState((int) $contentId, (int) $stateGroupId);
+                return $this->persistenceHandler->objectStateHandler()->getContentState((int) $contentId, $stateGroupId);
             },
             static function (ObjectState $contentState) use ($contentId): array {
                 return ['state-' . $contentState->id, 'content-' . (int) $contentId];

--- a/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
@@ -37,12 +37,12 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
         return $this->getCacheValue(
             (int) $groupId,
             'ez-state-group-',
-            function (int $groupId) {
+            function (int $groupId): Group {
                 $this->logger->logCall(__METHOD__, ['groupId' => (int) $groupId]);
 
                 return $this->persistenceHandler->objectStateHandler()->loadGroup($groupId);
             },
-            static function () use ($groupId) {
+            static function () use ($groupId): array {
                 return ['state-group-' . (int) $groupId];
             },
             static function () use ($groupId) {
@@ -61,15 +61,15 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
         return $this->getCacheValue(
             $identifier,
             'ez-state-group-',
-            function ($identifier) {
+            function (string $identifier): Group {
                 $this->logger->logCall(__METHOD__, ['groupId' => $identifier]);
 
                 return $this->persistenceHandler->objectStateHandler()->loadGroupByIdentifier($identifier);
             },
-            static function (Group $group) {
+            static function (Group $group): array {
                 return ['state-group-' . $group->id];
             },
-            static function () use ($identifier) {
+            static function () use ($identifier): array {
                 return ['ez-state-group-' . $identifier . '-by-identifier'];
             },
             '-by-identifier'
@@ -84,12 +84,12 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
         $stateGroups = $this->getCacheValue(
             '',
             'ez-state-group-all',
-            function () use ($offset, $limit) {
+            function () use ($offset, $limit): array {
                 $this->logger->logCall(__METHOD__, ['offset' => (int) $offset, 'limit' => (int) $limit]);
 
                 return $this->persistenceHandler->objectStateHandler()->loadAllGroups(0, -1);
             },
-            static function (array $stateGroups) {
+            static function (array $stateGroups): array {
                 $cacheTags = [];
                 foreach ($stateGroups as $group) {
                     $cacheTags[] = 'state-group-' . $group->id;
@@ -97,7 +97,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
 
                 return $cacheTags;
             },
-            static function () {
+            static function (): array {
                 return ['ez-state-group-all'];
             }
         );
@@ -113,12 +113,12 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
         $objectStates = $this->getCacheValue(
             $groupId,
             'ez-state-list-by-group-',
-            function ($groupId) {
+            function (int $groupId): array {
                 $this->logger->logCall(__METHOD__, ['groupId' => (int) $groupId]);
 
                 return $this->persistenceHandler->objectStateHandler()->loadObjectStates($groupId);
             },
-            static function (array $objectStates) use ($groupId) {
+            static function (array $objectStates) use ($groupId): array {
                 $cacheTags = [];
                 $cacheTags[] = 'state-group-' . (int) $groupId;
                 foreach ($objectStates as $state) {
@@ -127,7 +127,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
 
                 return $cacheTags;
             },
-            static function () use ($groupId) {
+            static function () use ($groupId): array {
                 return ['ez-state-list-by-group-' . (int) $groupId];
             }
         );
@@ -179,23 +179,21 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
      */
     public function load($stateId)
     {
-        $objectState = $this->getCacheValue(
+        return $this->getCacheValue(
             (int) $stateId,
             'ez-state-',
-            function ($stateId) {
-                $this->logger->logCall(__METHOD__, ['stateId' => (int) $stateId]);
+            function (int $stateId): ObjectState {
+                $this->logger->logCall(__METHOD__, ['stateId' => $stateId]);
 
-                return $this->persistenceHandler->objectStateHandler()->load((int) $stateId);
+                return $this->persistenceHandler->objectStateHandler()->load($stateId);
             },
-            static function (ObjectState $objectState) {
+            static function (ObjectState $objectState): array {
                 return ['state-' . $objectState->id, 'state-group-' . $objectState->groupId];
             },
-            static function () use ($stateId) {
+            static function () use ($stateId): array {
                 return ['ez-state-' . (int) $stateId];
             }
         );
-
-        return $objectState;
     }
 
     /**
@@ -208,15 +206,15 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
         return $this->getCacheValue(
             $identifier,
             'ez-state-identifier-',
-            function ($identifier) use ($groupId) {
+            function (string $identifier) use ($groupId): ObjectState {
                 $this->logger->logCall(__METHOD__, ['identifier' => $identifier, 'groupId' => (int) $groupId]);
 
                 return $this->persistenceHandler->objectStateHandler()->loadByIdentifier($identifier, (int) $groupId);
             },
-            static function (ObjectState $objectState) {
+            static function (ObjectState $objectState): array {
                 return ['state-' . $objectState->id, 'state-group-' . $objectState->groupId];
             },
-            static function () use ($identifier, $groupId) {
+            static function () use ($identifier, $groupId): array {
                 return ['ez-state-identifier-' . $identifier . '-by-group-' . (int) $groupId];
             },
             '-by-group-' . (int) $groupId
@@ -283,15 +281,15 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
         return $this->getCacheValue(
             (int) $stateGroupId,
             'ez-state-by-group-',
-            function ($stateGroupId) use ($contentId) {
-                $this->logger->logCall(__METHOD__, ['contentId' => (int) $contentId, 'stateGroupId' => (int) $stateGroupId]);
+            function (int $stateGroupId) use ($contentId): ObjectState {
+                $this->logger->logCall(__METHOD__, ['contentId' => (int) $contentId, 'stateGroupId' => $stateGroupId]);
 
                 return $this->persistenceHandler->objectStateHandler()->getContentState((int) $contentId, (int) $stateGroupId);
             },
-            static function (ObjectState $contentState) use ($contentId) {
+            static function (ObjectState $contentState) use ($contentId): array {
                 return ['state-' . $contentState->id, 'content-' . (int) $contentId];
             },
-            static function () use ($contentId, $stateGroupId) {
+            static function () use ($contentId, $stateGroupId): array {
                 return ['ez-state-by-group-' . (int) $stateGroupId . '-on-content-' . (int) $contentId];
             },
             '-on-content-' . $contentId

--- a/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
@@ -70,7 +70,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
                 return ['state-group-' . $group->id];
             },
             static function () use ($identifier): array {
-                return ['ez-state-group-' . $identifier . '-by-identifier'];
+                return ['' . $identifier . '-by-identifier'];
             },
             '-by-identifier'
         );
@@ -81,24 +81,18 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
      */
     public function loadAllGroups($offset = 0, $limit = -1)
     {
-        $stateGroups = $this->getCacheValue(
-            '',
+        $stateGroups = $this->getListCacheValue(
             'ez-state-group-all',
             function () use ($offset, $limit): array {
                 $this->logger->logCall(__METHOD__, ['offset' => (int) $offset, 'limit' => (int) $limit]);
 
                 return $this->persistenceHandler->objectStateHandler()->loadAllGroups(0, -1);
             },
-            static function (array $stateGroups): array {
-                $cacheTags = [];
-                foreach ($stateGroups as $group) {
-                    $cacheTags[] = 'state-group-' . $group->id;
-                }
-
-                return $cacheTags;
+            static function (Group $group): array {
+                return ['state-group-' . $group->id];
             },
-            static function (): array {
-                return ['ez-state-group-all'];
+            static function (Group $group): array {
+                return ['ez-state-group-' . $group->id, 'ez-state-group-' . $group->id . '-by-identifier'];
             }
         );
 

--- a/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
@@ -56,7 +56,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
      */
     public function loadGroupByIdentifier($identifier)
     {
-        $identifier = $this->escapeForCacheKey($identifier);
+        $escapedIdentifier = $this->escapeForCacheKey($identifier);
 
         return $this->getCacheValue(
             $identifier,
@@ -69,8 +69,8 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             static function (Group $group): array {
                 return ['state-group-' . $group->id];
             },
-            static function () use ($identifier): array {
-                return ['' . $identifier . '-by-identifier'];
+            static function (Group $group) use ($escapedIdentifier): array {
+                return ['ez-state-group-' . $escapedIdentifier . '-by-identifier', 'ez-state-group-' . $group->id];
             },
             '-by-identifier'
         );
@@ -193,7 +193,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
      */
     public function loadByIdentifier($identifier, $groupId)
     {
-        $identifier = $this->escapeForCacheKey($identifier);
+        $escapedIdentifier = $this->escapeForCacheKey($identifier);
 
         return $this->getCacheValue(
             $identifier,
@@ -206,8 +206,8 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             static function (ObjectState $objectState): array {
                 return ['state-' . $objectState->id, 'state-group-' . $objectState->groupId];
             },
-            static function () use ($identifier, $groupId): array {
-                return ['ez-state-identifier-' . $identifier . '-by-group-' . (int) $groupId];
+            static function () use ($escapedIdentifier, $groupId): array {
+                return ['ez-state-identifier-' . $escapedIdentifier . '-by-group-' . (int) $groupId];
             },
             '-by-group-' . (int) $groupId
         );

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
@@ -77,7 +77,7 @@ abstract class AbstractBaseHandlerTest extends TestCase
             new CacheTransactionHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),
             new CacheTrashHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
             new CacheUrlAliasHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),
-            new CacheObjectStateHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
+            new CacheObjectStateHandler($this->cacheMock, $this->loggerMock, $this->inMemoryMock, $this->persistenceHandlerMock),
             new CacheUrlHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
             new CacheBookmarkHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),
             new CacheNotificationHandler($this->cacheMock, $this->persistenceHandlerMock, $this->loggerMock),

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -114,6 +114,10 @@ services:
         arguments: # Overload argument to use content in-memory service
             index_2: '@ezpublish.spi.persistence.cache.inmemory.content'
 
+    ezpublish.spi.persistence.cache.objectStateHandler:
+        class: "%ezpublish.spi.persistence.cache.objectStateHandler.class%"
+        parent: ezpublish.spi.persistence.cache.abstractInMemoryPersistenceHandler
+
     ezpublish.spi.persistence.cache.contentLanguageHandler:
         class: "%ezpublish.spi.persistence.cache.contentLanguageHandler.class%"
         parent: ezpublish.spi.persistence.cache.abstractInMemoryPersistenceHandler
@@ -139,10 +143,6 @@ services:
         parent: ezpublish.spi.persistence.cache.abstractInMemoryPersistenceHandler
         arguments: # Overload argument to use content in-memory service
           index_2: '@ezpublish.spi.persistence.cache.inmemory.content'
-
-    ezpublish.spi.persistence.cache.objectStateHandler:
-        class: "%ezpublish.spi.persistence.cache.objectStateHandler.class%"
-        parent: ezpublish.spi.persistence.cache.abstractHandler
 
     ezpublish.spi.persistence.cache.urlHandler:
         class: "%ezpublish.spi.persistence.cache.urlHandler.class%"


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-569](https://issues.ibexa.co/browse/IBX-569)
| **Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | no

This PR rewrites `ObjectStateHandler ` to take advantage of the `InMemory` cache.