### PR TITLE
IBX-571: Added missing key in ContentTypeHandler

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -56,6 +56,7 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
         };
         $this->getTypeKeys = function (Type $type, int $status = Type::STATUS_DEFINED) {
             return [
+                'ez-content-type-' . $type->id,
                 'ez-content-type-' . $type->id . '-' . $status,
                 'ez-content-type-' . $this->escapeForCacheKey($type->identifier) . '-by-identifier',
                 'ez-content-type-' . $this->escapeForCacheKey($type->remoteId) . '-by-remote',


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-571](https://issues.ibexa.co/browse/IBX-571)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     |no

`ContentTypeHandler` was missing a single key (`ez-content-type-<id>`) which resulted in multiple calls to the SPI cache.