### PR TITLE
IBX-154: Allowed to define if the alternative text for image field is required (2.5)

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
@@ -114,6 +114,12 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
                     'default' => false,
                 ],
             ],
+            'AlternativeTextValidator' => [
+                'required' => [
+                    'type' => 'bool',
+                    'default' => false,
+                ],
+            ],
         ];
     }
 
@@ -127,6 +133,9 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
         return [
             'FileSizeValidator' => [
                 'maxFileSize' => 2 * 1024 * 1024, // 2 MB
+            ],
+            'AlternativeTextValidator' => [
+                'required' => true,
             ],
         ];
     }

--- a/eZ/Publish/Core/FieldType/Image/Type.php
+++ b/eZ/Publish/Core/FieldType/Image/Type.php
@@ -29,6 +29,12 @@ class Type extends FieldType
                 'default' => null,
             ],
         ],
+        'AlternativeTextValidator' => [
+            'required' => [
+                'type' => 'bool',
+                'default' => false,
+            ],
+        ],
     ];
 
     /** @var \eZ\Publish\Core\FieldType\Validator[] */
@@ -189,6 +195,16 @@ class Type extends FieldType
                         );
                     }
                     break;
+                case 'AlternativeTextValidator':
+                    if ($parameters['required'] && $fieldValue->isAlternativeTextEmpty()) {
+                        $errors[] = new ValidationError(
+                            'Alternative text is required.',
+                            null,
+                            [],
+                            'alternativeText'
+                        );
+                    }
+                    break;
             }
         }
 
@@ -231,6 +247,19 @@ class Type extends FieldType
                                 '%type%' => 'integer',
                             ],
                             "[$validatorIdentifier][maxFileSize]"
+                        );
+                    }
+                    break;
+                case 'AlternativeTextValidator':
+                    if (!array_key_exists('required', $parameters)) {
+                        $validationErrors[] = new ValidationError(
+                            'Validator %validator% expects parameter %parameter% to be set.',
+                            null,
+                            [
+                                '%validator%' => $validatorIdentifier,
+                                '%parameter%' => 'required',
+                            ],
+                            "[$validatorIdentifier]"
                         );
                     }
                     break;

--- a/eZ/Publish/Core/FieldType/Image/Value.php
+++ b/eZ/Publish/Core/FieldType/Image/Value.php
@@ -110,6 +110,11 @@ class Value extends BaseValue
         }
     }
 
+    public function isAlternativeTextEmpty(): bool
+    {
+        return $this->alternativeText === null || trim($this->alternativeText) === '';
+    }
+
     /**
      * Creates a value only from a file path.
      *

--- a/eZ/Publish/Core/FieldType/Tests/ImageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageTest.php
@@ -116,6 +116,12 @@ class ImageTest extends FieldTypeTest
                     'default' => null,
                 ],
             ],
+            'AlternativeTextValidator' => [
+                'required' => [
+                    'type' => 'bool',
+                    'default' => false,
+                ],
+            ],
         ];
     }
 
@@ -650,8 +656,7 @@ class ImageTest extends FieldTypeTest
     public function provideInvalidDataForValidate()
     {
         return [
-            // File is too large
-            [
+            'file is too large' => [
                 [
                     'validatorConfiguration' => [
                         'FileSizeValidator' => [
@@ -679,9 +684,7 @@ class ImageTest extends FieldTypeTest
                     ),
                 ],
             ],
-
-            // file is not an image file
-            [
+            'file is not an image file' => [
                 [
                     'validatorConfiguration' => [
                         'FileSizeValidator' => [
@@ -710,9 +713,7 @@ class ImageTest extends FieldTypeTest
                     ),
                 ],
             ],
-
-            // file is too large and invalid
-            [
+            'file is too large and invalid' => [
                 [
                     'validatorConfiguration' => [
                         'FileSizeValidator' => [
@@ -747,9 +748,7 @@ class ImageTest extends FieldTypeTest
                     ),
                 ],
             ],
-
-            // file is an image file but filename ends with .php
-            [
+            'file is an image file but filename ends with .php' => [
                 [
                     'validatorConfiguration' => [
                         'FileSizeValidator' => [
@@ -778,9 +777,7 @@ class ImageTest extends FieldTypeTest
                     ),
                 ],
             ],
-
-            // file is an image file but filename ends with .PHP (upper case)
-            [
+            'file is an image file but filename ends with .PHP (upper case)' => [
                 [
                     'validatorConfiguration' => [
                         'FileSizeValidator' => [
@@ -806,6 +803,52 @@ class ImageTest extends FieldTypeTest
                     ),
                     new ValidationError(
                         'A valid image file is required.', null, [], 'id'
+                    ),
+                ],
+            ],
+            'alternative text is null' => [
+                [
+                    'validatorConfiguration' => [
+                        'AlternativeTextValidator' => [
+                            'required' => true,
+                        ],
+                    ],
+                ],
+                new ImageValue(
+                    [
+                        'id' => $this->getImageInputPath(),
+                        'fileName' => basename($this->getImageInputPath()),
+                        'fileSize' => filesize($this->getImageInputPath()),
+                        'alternativeText' => null,
+                        'uri' => '',
+                    ]
+                ),
+                [
+                    new ValidationError(
+                        'Alternative text is required.', null, [], 'alternativeText'
+                    ),
+                ],
+            ],
+            'alternative text is empty string' => [
+                [
+                    'validatorConfiguration' => [
+                        'AlternativeTextValidator' => [
+                            'required' => true,
+                        ],
+                    ],
+                ],
+                new ImageValue(
+                    [
+                        'id' => $this->getImageInputPath(),
+                        'fileName' => basename($this->getImageInputPath()),
+                        'fileSize' => filesize($this->getImageInputPath()),
+                        'alternativeText' => '',
+                        'uri' => '',
+                    ]
+                ),
+                [
+                    new ValidationError(
+                        'Alternative text is required.', null, [], 'alternativeText'
                     ),
                 ],
             ],

--- a/eZ/Publish/Core/Persistence/Tests/FieldValue/Converter/ImageConverterTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/FieldValue/Converter/ImageConverterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.

--- a/eZ/Publish/Core/Persistence/Tests/FieldValue/Converter/ImageConverterTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/FieldValue/Converter/ImageConverterTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Tests\FieldValue\Converter;
+
+use eZ\Publish\Core\IO\IOServiceInterface;
+use eZ\Publish\Core\IO\UrlRedecoratorInterface;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use PHPUnit\Framework\TestCase;
+
+final class ImageConverterTest extends TestCase
+{
+    /** @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageConverter */
+    private $imageConverter;
+
+    /** @var \eZ\Publish\Core\IO\UrlRedecoratorInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $urlRedecorator;
+
+    /** @var \eZ\Publish\Core\IO\IOServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $ioService;
+
+    protected function setUp(): void
+    {
+        $this->ioService = $this->createMock(IOServiceInterface::class);
+        $this->urlRedecorator = $this->createMock(UrlRedecoratorInterface::class);
+
+        $this->imageConverter = new ImageConverter(
+            $this->ioService,
+            $this->urlRedecorator
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderForTestToStorageFieldDefinition
+     */
+    public function testToStorageFieldDefinition(
+        FieldDefinition $fieldDefinition,
+        StorageFieldDefinition $expectedStorageDef
+    ): void {
+        $storageFieldDefinition = new StorageFieldDefinition();
+
+        $this->imageConverter->toStorageFieldDefinition($fieldDefinition, $storageFieldDefinition);
+
+        self::assertEquals(
+            $expectedStorageDef,
+            $storageFieldDefinition
+        );
+    }
+
+    public function dataProviderForTestToStorageFieldDefinition(): iterable
+    {
+        yield [
+            new FieldDefinition([
+                'fieldTypeConstraints' => new FieldTypeConstraints([
+                    'validators' => [],
+                ]),
+            ]),
+            new StorageFieldDefinition([
+                'dataInt1' => 0,
+                'dataInt2' => 0,
+            ]),
+        ];
+
+        yield [
+            new FieldDefinition([
+                'fieldTypeConstraints' => new FieldTypeConstraints([
+                    'validators' => [
+                        'FileSizeValidator' => [
+                            'maxFileSize' => 1024,
+                        ],
+                    ],
+                ]),
+            ]),
+            new StorageFieldDefinition([
+                'dataInt1' => 1024,
+                'dataInt2' => 0,
+            ]),
+        ];
+
+        yield [
+            new FieldDefinition([
+                'fieldTypeConstraints' => new FieldTypeConstraints([
+                    'validators' => [
+                        'AlternativeTextValidator' => [
+                            'required' => true,
+                        ],
+                    ],
+                ]),
+            ]),
+            new StorageFieldDefinition([
+                'dataInt1' => 0,
+                'dataInt2' => 1,
+            ]),
+        ];
+
+        yield [
+            new FieldDefinition([
+                'fieldTypeConstraints' => new FieldTypeConstraints([
+                    'validators' => [
+                        'AlternativeTextValidator' => [
+                            'required' => false,
+                        ],
+                    ],
+                ]),
+            ]),
+            new StorageFieldDefinition([
+                'dataInt1' => 0,
+                'dataInt2' => 0,
+            ]),
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTestToFieldDefinition
+     */
+    public function testToFieldDefinition(
+        StorageFieldDefinition $storageDef,
+        FieldDefinition $expectedFieldDefinition
+    ): void {
+        $fieldDefinition = new FieldDefinition();
+
+        $this->imageConverter->toFieldDefinition($storageDef, $fieldDefinition);
+
+        self::assertEquals(
+            $expectedFieldDefinition,
+            $fieldDefinition
+        );
+    }
+
+    public function dataProviderForTestToFieldDefinition(): iterable
+    {
+        yield [
+            new StorageFieldDefinition([
+                'dataInt1' => 0,
+                'dataInt2' => 0,
+            ]),
+            new FieldDefinition([
+                'fieldTypeConstraints' => new FieldTypeConstraints([
+                    'validators' => [
+                        'FileSizeValidator' => [
+                            'maxFileSize' => null,
+                        ],
+                        'AlternativeTextValidator' => [
+                            'required' => false,
+                        ],
+                    ],
+                ]),
+            ]),
+        ];
+
+        yield [
+            new StorageFieldDefinition([
+                'dataInt1' => 1024,
+                'dataInt2' => 1,
+            ]),
+            new FieldDefinition([
+                'fieldTypeConstraints' => new FieldTypeConstraints([
+                    'validators' => [
+                        'FileSizeValidator' => [
+                            'maxFileSize' => 1024,
+                        ],
+                        'AlternativeTextValidator' => [
+                            'required' => true,
+                        ],
+                    ],
+                ]),
+            ]),
+        ];
+    }
+}

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -145,6 +145,9 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
                     'FileSizeValidator' => [
                         'maxFileSize' => 2 * 1024 * 1024, // 2 MB
                     ],
+                    'AlternativeTextValidator' => [
+                        'required' => true,
+                    ],
                 ],
             ]
         );
@@ -170,6 +173,9 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
                         'validators' => [
                             'FileSizeValidator' => [
                                 'maxFileSize' => 2 * 1024 * 1024, // 2 MB
+                            ],
+                            'AlternativeTextValidator' => [
+                                'required' => true,
                             ],
                         ],
                     ]


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-154](https://jira.ez.no/browse/IBX-154)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

https://github.com/ezsystems/ezplatform-kernel/pull/194 rebased to 2.5

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
