### PR TITLE
IBX-784: Provided PHP8 compatibility for Selection FieldType

### DIFF
--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -234,7 +234,7 @@ class Type extends FieldType
                 return array_keys($languageOptionIndexes);
             }, $fieldSettings['multilingualOptions']);
 
-            $possibleOptionIndexes = call_user_func_array('array_merge', $possibleOptionIndexesByLanguage);
+            $possibleOptionIndexes = call_user_func_array('array_merge', array_values($possibleOptionIndexesByLanguage));
 
             foreach ($fieldValue->selection as $optionIndex) {
                 if (!in_array($optionIndex, $possibleOptionIndexes)) {

--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -234,7 +234,7 @@ class Type extends FieldType
                 return array_keys($languageOptionIndexes);
             }, $fieldSettings['multilingualOptions']);
 
-            $possibleOptionIndexes = call_user_func_array('array_merge', array_values($possibleOptionIndexesByLanguage));
+            $possibleOptionIndexes = array_merge(...array_values($possibleOptionIndexesByLanguage));
 
             foreach ($fieldValue->selection as $optionIndex) {
                 if (!in_array($optionIndex, $possibleOptionIndexes)) {

--- a/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
@@ -600,7 +600,7 @@ class SelectionTest extends FieldTypeTest
                         'selection'
                     ),
                 ],
-            ]
+            ],
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
@@ -446,6 +446,31 @@ class SelectionTest extends FieldTypeTest
                 ],
                 new SelectionValue(),
             ],
+            [
+                [
+                    'fieldSettings' => [
+                        'isMultiple' => false,
+                        'options' => [0 => 1, 1 => 2],
+                        'multilingualOptions' => [
+                            'en_GB' => [0 => 1, 1 => 2],
+                            'de_DE' => [0 => 1, 1 => 2],
+                        ],
+                    ],
+                ],
+                new SelectionValue([1]),
+            ],
+            [
+                'fieldSettings' => [
+                    'isMultiple' => false,
+                    'options' => [0 => 1, 1 => 2],
+                    'multilingualOptions' => [
+                        'en_GB' => [0 => 1, 1 => 2],
+                        'de_DE' => [0 => 1],
+                    ],
+                ],
+            ],
+            new SelectionValue([1]),
+
         ];
     }
 
@@ -552,6 +577,29 @@ class SelectionTest extends FieldTypeTest
                     ),
                 ],
             ],
+            [
+                [
+                    'fieldSettings' => [
+                        'isMultiple' => false,
+                        'options' => [0 => 1, 1 => 2],
+                        'multilingualOptions' => [
+                            'en_GB' => [0 => 1, 1 => 2],
+                            'de_DE' => [0 => 1],
+                        ],
+                    ],
+                ],
+                new SelectionValue([3]),
+                [
+                    new ValidationError(
+                        'Option with index %index% does not exist in the field definition.',
+                        null,
+                        [
+                            '%index%' => 3,
+                        ],
+                        'selection'
+                    ),
+                ],
+            ]
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
@@ -460,17 +460,18 @@ class SelectionTest extends FieldTypeTest
                 new SelectionValue([1]),
             ],
             [
-                'fieldSettings' => [
-                    'isMultiple' => false,
-                    'options' => [0 => 1, 1 => 2],
-                    'multilingualOptions' => [
-                        'en_GB' => [0 => 1, 1 => 2],
-                        'de_DE' => [0 => 1],
+                [
+                    'fieldSettings' => [
+                        'isMultiple' => false,
+                        'options' => [0 => 1, 1 => 2],
+                        'multilingualOptions' => [
+                            'en_GB' => [0 => 1, 1 => 2],
+                            'de_DE' => [0 => 1],
+                        ],
                     ],
                 ],
+                new SelectionValue([1]),
             ],
-            new SelectionValue([1]),
-
         ];
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/IBX-784
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

It seems that there is some unintended BC break in php8 related to https://wiki.php.net/rfc/named_params.

QA:
Changes were made around multilingual selection options, so that is the part thats need to be tested if we push this thru QA.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
