### PR TITLE
Fixed code style failure after php-cs-fixer update `2.19.2`

### DIFF
--- a/eZ/Publish/Core/REST/Server/Controller/Location.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Location.php
@@ -217,7 +217,7 @@ class Location extends RestController
      *
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\BadRequestException if the Destination header cannot be parsed as location or trash
      *
-     * @return \eZ\Publish\Core\REST\Server\Values\ResourceCreated | \eZ\Publish\Core\REST\Server\Values\NoContent
+     * @return \eZ\Publish\Core\REST\Server\Values\ResourceCreated|\eZ\Publish\Core\REST\Server\Values\NoContent
      */
     public function moveSubtree($locationPath, Request $request)
     {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

Fixes one of the phpdoc declarations that started to become marked as an issue after one of the php-cs-fixer updates.

#### Checklist:
- [x] Provided PR description.
- [x] ~Tested the solution manually.~
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
