### PR TITLE
IBX-984: Replaced hautelook/templated-uri-bundle with Ibexa fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "kriswallsmith/buzz": "^0.17.2",
         "sensio/distribution-bundle": "^5.0.22",
         "nelmio/cors-bundle": "^1.5.0",
-        "hautelook/templated-uri-bundle": "^2.1",
+        "ibexa/templated-uri-bundle": "^2.1",
         "pagerfanta/pagerfanta": "^2.0",
         "ocramius/proxy-manager": "^2.1",
         "doctrine/dbal": "^2.13.0",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-984](https://issues.ibexa.co/browse/IBX-984)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | yes

The `hautelook/templated-uri-bundle` package disappeared from open source ecosystem without any explanation, so we had to fork it and use our own for instead.