### PR TITLE
[Travis] Updated to Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Use trusty for better performance (and avoiding mysql/postgres/solr gone issues on precise and container infra)
-dist: xenial
+dist: focal
 sudo: required
 
 language: php
@@ -63,7 +63,7 @@ before_install:
   - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] || [ "$REST_TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
   # Execute Symfony command if specified
-  - if [ "$SF_CMD" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/console $SF_CMD" ; fi
+  - if [ "$SF_CMD" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "bin/console $SF_CMD" ; fi
   # Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
@@ -76,8 +76,8 @@ install:
 # execute phpunit or behat as the script command
 script:
   - if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 vendor/bin/phpunit -c $TEST_CONFIG ; fi
-  - if [ "$BEHAT_OPTS" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/behat $BEHAT_OPTS" ; fi
-  - if [ "$REST_TEST_CONFIG" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"  ; fi
+  - if [ "$BEHAT_OPTS" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "bin/behat $BEHAT_OPTS" ; fi
+  - if [ "$REST_TEST_CONFIG" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"  ; fi
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-# Use trusty for better performance (and avoiding mysql/postgres/solr gone issues on precise and container infra)
-dist: focal
+#A Use trusty for better performance (and avoiding mysql/postgres/solr gone issues on precise and container infra)
+dist: trusty
 sudo: required
 
 language: php
@@ -14,15 +14,15 @@ cache:
 
 env:
   global:
-    # For functional and acceptance tests
+    #A For functional and acceptance tests
     - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
-    # In order to specify extra flags like ignoring platform reqs, using only stable packages and so on.
+    #A In order to specify extra flags like ignoring platform reqs, using only stable packages and so on.
     - COMPOSER_FLAGS=""
 
 matrix:
   fast_finish: true
   include:
-# 7.1
+#A 7.1
     - php: 7.1
       env: PHP_IMAGE=ezsystems/php:7.1-v1 PHP_IMAGE_DEV=ezsystems/php:7.1-v1-dev REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
     - php: 7.1
@@ -31,10 +31,10 @@ matrix:
       env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml" JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre/"
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
-# Disabled as it currently fails, integration tests are not written for language config awareness in Repo, should probably be opt in by test
-#    - php: 7.1
-#      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" REPOSITORY_SERVICE_ID="ezpublish.siteaccessaware.repository"
-# 7.3
+#A Disabled as it currently fails, integration tests are not written for language config awareness in Repo, should probably be opt in by test
+#A    - php: 7.1
+#A      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" REPOSITORY_SERVICE_ID="ezpublish.siteaccessaware.repository"
+#A 7.3
     - name: Legacy Storage engine tests with MariaDB 10.3
       php: 7.3
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mariadb" DATABASE="mysql://root@localhost/testdb"
@@ -42,42 +42,44 @@ matrix:
         mariadb: 10.3
 
 
-# test only master, stable branches and pull requests
+#A test only master, stable branches and pull requests
 branches:
   only:
     - master
     - /^\d.\d+$/
 
-# setup requirements for running unit/integration/behat tests
+#A setup requirements for running unit/integration/behat tests
 before_install:
-  # Disable memory_limit for composer
+  #A Disable memory_limit for composer
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  # Disable XDebug for all jobs as we don't generate test coverge on travis
+  #A Disable XDebug for all jobs as we don't generate test coverge on travis
   - phpenv config-rm xdebug.ini
-  # make sure we use UTF-8 encoding
+  #A Disable expired certificate
+  - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
+  #A make sure we use UTF-8 encoding
   - echo "default_charset=UTF-8" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  # Install igbinary & lzf PHP extensions if necessary
+  #A Install igbinary & lzf PHP extensions if necessary
   - if [ "$ENABLE_IGBINARY" = true ] ; then pecl install igbinary ; fi
   - if [ "$ENABLE_LZF" = true ] ; then printf "no\n" | pecl install lzf ; fi
-  # Prepare system
+  #A Prepare system
   - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] || [ "$REST_TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
-  # Execute Symfony command if specified
-  - if [ "$SF_CMD" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "bin/console $SF_CMD" ; fi
-  # Detecting timezone issues by testing on random timezone
+  #A Execute Symfony command if specified
+  - if [ "$SF_CMD" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/console $SF_CMD" ; fi
+  #A Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
 
 install:
   - if [ "$TEST_CONFIG" != "" -o "$CHECK_CS" = "1" ] ; then travis_retry composer install --no-progress --no-interaction --prefer-dist $COMPOSER_FLAGS; fi
-  # Setup Solr search if asked for
+  #A Setup Solr search if asked for
   - if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then ./vendor/ezsystems/ezplatform-solr-search-engine/bin/.travis/init_solr.sh; fi
 
-# execute phpunit or behat as the script command
+#A execute phpunit or behat as the script command
 script:
   - if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 vendor/bin/phpunit -c $TEST_CONFIG ; fi
-  - if [ "$BEHAT_OPTS" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "bin/behat $BEHAT_OPTS" ; fi
-  - if [ "$REST_TEST_CONFIG" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"  ; fi
+  - if [ "$BEHAT_OPTS" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/behat $BEHAT_OPTS" ; fi
+  - if [ "$REST_TEST_CONFIG" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"  ; fi
 
 notifications:
   slack:
@@ -87,6 +89,6 @@ notifications:
     on_failure: always
     on_pull_requests: false
 
-# reduce depth (history) of git checkout
+#A reduce depth (history) of git checkout
 git:
   depth: 30

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-#A Use trusty for better performance (and avoiding mysql/postgres/solr gone issues on precise and container infra)
+# Use trusty for better performance (and avoiding mysql/postgres/solr gone issues on precise and container infra)
 dist: trusty
 sudo: required
 
@@ -14,15 +14,15 @@ cache:
 
 env:
   global:
-    #A For functional and acceptance tests
+    # For functional and acceptance tests
     - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
-    #A In order to specify extra flags like ignoring platform reqs, using only stable packages and so on.
+    # In order to specify extra flags like ignoring platform reqs, using only stable packages and so on.
     - COMPOSER_FLAGS=""
 
 matrix:
   fast_finish: true
   include:
-#A 7.1
+# 7.1
     - php: 7.1
       env: PHP_IMAGE=ezsystems/php:7.1-v1 PHP_IMAGE_DEV=ezsystems/php:7.1-v1-dev REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
     - php: 7.1
@@ -31,10 +31,10 @@ matrix:
       env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml" JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre/"
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
-#A Disabled as it currently fails, integration tests are not written for language config awareness in Repo, should probably be opt in by test
-#A    - php: 7.1
-#A      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" REPOSITORY_SERVICE_ID="ezpublish.siteaccessaware.repository"
-#A 7.3
+# Disabled as it currently fails, integration tests are not written for language config awareness in Repo, should probably be opt in by test
+#    - php: 7.1
+#      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" REPOSITORY_SERVICE_ID="ezpublish.siteaccessaware.repository"
+# 7.3
     - name: Legacy Storage engine tests with MariaDB 10.3
       php: 7.3
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mariadb" DATABASE="mysql://root@localhost/testdb"
@@ -42,40 +42,40 @@ matrix:
         mariadb: 10.3
 
 
-#A test only master, stable branches and pull requests
+# test only master, stable branches and pull requests
 branches:
   only:
     - master
     - /^\d.\d+$/
 
-#A setup requirements for running unit/integration/behat tests
+# setup requirements for running unit/integration/behat tests
 before_install:
-  #A Disable memory_limit for composer
+  # Disable memory_limit for composer
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  #A Disable XDebug for all jobs as we don't generate test coverge on travis
+  # Disable XDebug for all jobs as we don't generate test coverge on travis
   - phpenv config-rm xdebug.ini
-  #A Disable expired certificate
+  # Disable expired certificate
   - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
-  #A make sure we use UTF-8 encoding
+  # make sure we use UTF-8 encoding
   - echo "default_charset=UTF-8" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  #A Install igbinary & lzf PHP extensions if necessary
+  # Install igbinary & lzf PHP extensions if necessary
   - if [ "$ENABLE_IGBINARY" = true ] ; then pecl install igbinary ; fi
   - if [ "$ENABLE_LZF" = true ] ; then printf "no\n" | pecl install lzf ; fi
-  #A Prepare system
+  # Prepare system
   - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] || [ "$REST_TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
-  #A Execute Symfony command if specified
+  # Execute Symfony command if specified
   - if [ "$SF_CMD" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/console $SF_CMD" ; fi
-  #A Detecting timezone issues by testing on random timezone
+  # Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
 
 install:
   - if [ "$TEST_CONFIG" != "" -o "$CHECK_CS" = "1" ] ; then travis_retry composer install --no-progress --no-interaction --prefer-dist $COMPOSER_FLAGS; fi
-  #A Setup Solr search if asked for
+  # Setup Solr search if asked for
   - if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then ./vendor/ezsystems/ezplatform-solr-search-engine/bin/.travis/init_solr.sh; fi
 
-#A execute phpunit or behat as the script command
+# execute phpunit or behat as the script command
 script:
   - if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 vendor/bin/phpunit -c $TEST_CONFIG ; fi
   - if [ "$BEHAT_OPTS" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/behat $BEHAT_OPTS" ; fi
@@ -89,6 +89,6 @@ notifications:
     on_failure: always
     on_pull_requests: false
 
-#A reduce depth (history) of git checkout
+# reduce depth (history) of git checkout
 git:
   depth: 30


### PR DESCRIPTION
This PR updates the dist used by Travis to Focal. 

It's related to https://github.com/ezsystems/docker-php/pull/61 - Trusty has OpenSSL 1.0.2, which means that it produces errors when accessing sites using Let's Encrypt certificates. Focal uses the bug-free version (1.1.1).

Focal also has a higher Docker Compose version (1.29.2), which had a change in behaviour compared to the one used on Trusty:
```
Compose supports declaring default environment variables in an environment file named .env placed in the project directory. Docker Compose versions earlier than 1.28, load the .env file from the current working directory, where the command is executed, or from the project directory if this is explicitly set with the --project-directory option. This inconsistency has been addressed starting with +v1.28 by limiting the default .env file path to the project directory. You can use the --env-file commandline option to override the default .env and specify the path to a custom environment file.

The project directory is specified by the order of precedence:

    --project-directory flag
    Folder of the first --file flag
    Current directory
```
[ref](https://docs.docker.com/compose/env-file/)

I'm adding `--env-file=.env` to every docker-compose call to account for that.