### PR TITLE
IBX-1237: Removed duplicated content tag

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
@@ -126,7 +126,6 @@ class AliasGeneratorDecorator implements VariationHandler, SiteAccessAware
             $this->cacheIdentifierGenerator->generateTag(self::IMAGE_VARIATION_CONTENT_TAG, [$contentId]),
             $this->cacheIdentifierGenerator->generateTag(self::IMAGE_VARIATION_FIELD_TAG, [$field->id]),
             $this->cacheIdentifierGenerator->generateTag(self::CONTENT_TAG, [$contentId]),
-            $this->cacheIdentifierGenerator->generateTag(self::CONTENT_TAG, [$contentId]),
             $this->cacheIdentifierGenerator->generateTag(self::CONTENT_VERSION_TAG, [$contentId, $versionInfo->versionNo]),
         ];
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1237](https://issues.ibexa.co/browse/IBX-1237)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

The duplicated tag was wrongly introduced in https://github.com/ezsystems/ezpublish-kernel/pull/3114/files#diff-4e4afd929b7d374bdbb6ca18617eeb1482d209f7eb9493b20b6adafe112f1ea0R129.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
