### PR TITLE
IBX-1281: Fixed Object State Limitation Check

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ObjectStateLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ObjectStateLimitationTest.php
@@ -35,7 +35,7 @@ class ObjectStateLimitationTest extends BaseLimitationTest
     public function testObjectStateLimitationAllow()
     {
         $repository = $this->getRepository();
-        $notLockedState = $this->generateId('objectstate', 2);
+        $notLockedState = $this->generateId('objectstate', 1);
 
         $contentService = $repository->getContentService();
         /* BEGIN: Use Case */
@@ -98,7 +98,7 @@ class ObjectStateLimitationTest extends BaseLimitationTest
     public function testObjectStateLimitationForbid()
     {
         $repository = $this->getRepository();
-        $lockedState = $this->generateId('objectstate', 1);
+        $lockedState = $this->generateId('objectstate', 2);
 
         $contentService = $repository->getContentService();
         /* BEGIN: Use Case */
@@ -166,7 +166,7 @@ class ObjectStateLimitationTest extends BaseLimitationTest
         $objectStateGroup = $this->createObjectStateGroup();
         $objectState = $this->createObjectState($objectStateGroup);
 
-        $lockedState = $this->generateId('objectstate', 1);
+        $lockedState = $this->generateId('objectstate', 2);
         $defaultStateFromAnotherGroup = $this->generateId('objectstate', $objectState->id);
 
         $contentService = $repository->getContentService();
@@ -264,7 +264,7 @@ class ObjectStateLimitationTest extends BaseLimitationTest
         $objectStateGroup = $this->createObjectStateGroup();
         $objectState = $this->createObjectState($objectStateGroup);
 
-        $lockedState = $this->generateId('objectstate', 1);
+        $notLockedState = $this->generateId('objectstate', 1);
         $defaultStateFromAnotherGroup = $this->generateId('objectstate', $objectState->id);
 
         $roleService = $repository->getRoleService();
@@ -272,7 +272,7 @@ class ObjectStateLimitationTest extends BaseLimitationTest
         $roleCreateStruct = $roleService->newRoleCreateStruct($roleName);
         $this->addPolicyToNewRole($roleCreateStruct, 'content', 'read', [
             new ObjectStateLimitation([
-                'limitationValues' => [$lockedState, $defaultStateFromAnotherGroup],
+                'limitationValues' => [$notLockedState, $defaultStateFromAnotherGroup],
             ]),
         ]);
         $roleService->publishRoleDraft(

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -145,11 +145,10 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
                     continue;
                 }
 
-                // default: use object state with lowest priority
-                $defaultStateId = $states[0]->id;
-                $defaultStatePriority = $states[0]->priority;
+                $defaultStateId = null;
+                $defaultStatePriority = -1;
                 foreach ($states as $state) {
-                    if ($state->priority < $defaultStatePriority) {
+                    if ($state->priority > $defaultStatePriority) {
                         $defaultStateId = $state->id;
                         $defaultStatePriority = $state->priority;
                     }

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -147,7 +147,7 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
 
                 // default: use object state with lowest priority
                 $defaultStateId = $states[0]->id;
-                $defaultStatePriority =  $states[0]->priority;
+                $defaultStatePriority = $states[0]->priority;
                 foreach ($states as $state) {
                     if ($state->priority < $defaultStatePriority) {
                         $defaultStateId = $state->id;

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -137,18 +137,19 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
         $objectStateHandler = $this->persistence->objectStateHandler();
         $stateGroups = $objectStateHandler->loadAllGroups();
 
-        // First deal with unpublished content
-        if ($object instanceof ContentCreateStruct || !$object->published) {
+        // First deal with new content
+        if ($object instanceof ContentCreateStruct) {
             foreach ($stateGroups as $stateGroup) {
                 $states = $objectStateHandler->loadObjectStates($stateGroup->id);
                 if (empty($states)) {
                     continue;
                 }
 
-                $defaultStateId = null;
-                $defaultStatePriority = -1;
+                // default: use object state with lowest priority
+                $defaultStateId = $states[0]->id;
+                $defaultStatePriority =  $states[0]->priority;
                 foreach ($states as $state) {
-                    if ($state->priority > $defaultStatePriority) {
+                    if ($state->priority < $defaultStatePriority) {
                         $defaultStateId = $state->id;
                         $defaultStatePriority = $state->priority;
                     }

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -138,6 +138,9 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
         $stateGroups = $objectStateHandler->loadAllGroups();
 
         // First deal with new content
+        // ATM, it seems unclear if $object can ever be a ContentCreateStruct, there are no object state limitation
+        // for content/create, only for content/edit.
+        // Keeping the block here as there are still Unit tests that inject ContentCreateStruct values to this function
         if ($object instanceof ContentCreateStruct) {
             foreach ($stateGroups as $stateGroup) {
                 $states = $objectStateHandler->loadObjectStates($stateGroup->id);

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -148,10 +148,10 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
                     continue;
                 }
 
-                $defaultStateId = null;
-                $defaultStatePriority = -1;
+                $defaultStateId = $states[0]->id;
+                $defaultStatePriority = $states[0]->priority ?? 0;
                 foreach ($states as $state) {
-                    if ($state->priority > $defaultStatePriority) {
+                    if ($state->priority && $state->priority < $defaultStatePriority) {
                         $defaultStateId = $state->id;
                         $defaultStatePriority = $state->priority;
                     }


### PR DESCRIPTION
Fixed Object State Limitation Check for unpublished Content

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1281](https://issues.ibexa.co/browse/IBX-1281)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          |  ?

Content Edit uses wrong Object State when checking Limitation of unpublished Content

The suggested change does 2 things:

1. for Content Objects that have been saved once, but never have been published, Object State limitations are verified based on the Object State that has been saved (and not an assumed default one).
2. If $object is instanceof ContentCreateStruct the Object State with lowest priority is used to verify Object State limitations (and not the one with highest priority). This makes sense as this value is the default when publishing the Object.


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
