### PR TITLE
IBX-1314: Fixed StreamFileListener using encoded uri for images

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/EventListener/StreamFileListener.php
+++ b/eZ/Bundle/EzPublishIOBundle/EventListener/StreamFileListener.php
@@ -51,10 +51,11 @@ class StreamFileListener implements EventSubscriberInterface
 
         $request = $event->getRequest();
         $urlPrefix = $this->configResolver->getParameter('io.url_prefix');
+        $pathInfo = $request->getPathInfo();
         if (strpos($urlPrefix, '://') !== false) {
-            $uri = $request->getSchemeAndHttpHost() . $request->getPathInfo();
+            $uri = $request->getSchemeAndHttpHost() . $pathInfo;
         } else {
-            $uri = $request->getPathInfo();
+            $uri = $pathInfo;
         }
 
         if (!$this->isIoUri($uri, $urlPrefix)) {

--- a/eZ/Bundle/EzPublishIOBundle/EventListener/StreamFileListener.php
+++ b/eZ/Bundle/EzPublishIOBundle/EventListener/StreamFileListener.php
@@ -54,7 +54,7 @@ class StreamFileListener implements EventSubscriberInterface
         if (strpos($urlPrefix, '://') !== false) {
             $uri = $request->getSchemeAndHttpHost() . $request->getPathInfo();
         } else {
-            $uri = $request->attributes->get('semanticPathinfo');
+            $uri = $request->getPathInfo();
         }
 
         if (!$this->isIoUri($uri, $urlPrefix)) {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1314](https://issues.ibexa.co/browse/IBX-1314)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`, `v3.3`
| **BC breaks**                          | no

During checks which determine if a file exists `semanticPathinfo` is used, which is generated with `rawurldecode`. This results in filenames like `some%25special+chars.jpg` being wrongly converted to `some%special+chars.jpg`. After that, the wrong filename is searched, thus a 404 exception is thrown.

This PR replaces 
```
$uri = $request->attributes->get('semanticPathinfo');
```
with
```
$uri = $request->getPathInfo();
```
to avoid this.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
