### PR TITLE
[POC] IBX-1281: Fixed Object State Limitation for unpublished drafts

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ObjectStateLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ObjectStateLimitationTest.php
@@ -35,7 +35,7 @@ class ObjectStateLimitationTest extends BaseLimitationTest
     public function testObjectStateLimitationAllow()
     {
         $repository = $this->getRepository();
-        $notLockedState = $this->generateId('objectstate', 2);
+        $notLockedState = $this->generateId('objectstate', 1);
 
         $contentService = $repository->getContentService();
         /* BEGIN: Use Case */
@@ -98,7 +98,7 @@ class ObjectStateLimitationTest extends BaseLimitationTest
     public function testObjectStateLimitationForbid()
     {
         $repository = $this->getRepository();
-        $lockedState = $this->generateId('objectstate', 1);
+        $lockedState = $this->generateId('objectstate', 2);
 
         $contentService = $repository->getContentService();
         /* BEGIN: Use Case */
@@ -166,7 +166,7 @@ class ObjectStateLimitationTest extends BaseLimitationTest
         $objectStateGroup = $this->createObjectStateGroup();
         $objectState = $this->createObjectState($objectStateGroup);
 
-        $lockedState = $this->generateId('objectstate', 1);
+        $lockedState = $this->generateId('objectstate', 2);
         $defaultStateFromAnotherGroup = $this->generateId('objectstate', $objectState->id);
 
         $contentService = $repository->getContentService();
@@ -264,7 +264,7 @@ class ObjectStateLimitationTest extends BaseLimitationTest
         $objectStateGroup = $this->createObjectStateGroup();
         $objectState = $this->createObjectState($objectStateGroup);
 
-        $lockedState = $this->generateId('objectstate', 1);
+        $notLockedState = $this->generateId('objectstate', 1);
         $defaultStateFromAnotherGroup = $this->generateId('objectstate', $objectState->id);
 
         $roleService = $repository->getRoleService();
@@ -272,7 +272,7 @@ class ObjectStateLimitationTest extends BaseLimitationTest
         $roleCreateStruct = $roleService->newRoleCreateStruct($roleName);
         $this->addPolicyToNewRole($roleCreateStruct, 'content', 'read', [
             new ObjectStateLimitation([
-                'limitationValues' => [$lockedState, $defaultStateFromAnotherGroup],
+                'limitationValues' => [$notLockedState, $defaultStateFromAnotherGroup],
             ]),
         ]);
         $roleService->publishRoleDraft(

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -15,7 +15,6 @@ use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
-use eZ\Publish\Core\Base\Exceptions\BadStateException;
 use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation as APIObjectStateLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation as APILimitationValue;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -137,42 +137,9 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
         $objectStateHandler = $this->persistence->objectStateHandler();
         $stateGroups = $objectStateHandler->loadAllGroups();
 
-        // First deal with unpublished content
-        if ($object instanceof ContentCreateStruct) {
-            foreach ($stateGroups as $stateGroup) {
-                $states = $objectStateHandler->loadObjectStates($stateGroup->id);
-                if (empty($states)) {
-                    continue;
-                }
-
-                $defaultStateId = null;
-                $defaultStatePriority = -1;
-                foreach ($states as $state) {
-                    if ($state->priority > $defaultStatePriority) {
-                        $defaultStateId = $state->id;
-                        $defaultStatePriority = $state->priority;
-                    }
-                }
-
-                if ($defaultStateId === null) {
-                    throw new BadStateException(
-                        '$defaultStateId',
-                        "Could not find a default state for object state group {$stateGroup->id}"
-                    );
-                }
-
-                foreach ($states as $state) {
-                    // check using loose types as limitation values are strings and id's can be int
-                    if (in_array($state->id, $limitationValues)) {
-                        $objectStateIdsToVerify[] = $defaultStateId;
-                    }
-                }
-            }
-        } else {
-            foreach ($stateGroups as $stateGroup) {
-                if ($this->isStateGroupUsedForLimitation($stateGroup->id, $limitationValues)) {
-                    $objectStateIdsToVerify[] = $objectStateHandler->getContentState($object->id, $stateGroup->id)->id;
-                }
+        foreach ($stateGroups as $stateGroup) {
+            if ($this->isStateGroupUsedForLimitation($stateGroup->id, $limitationValues)) {
+                $objectStateIdsToVerify[] = $objectStateHandler->getContentState($object->id, $stateGroup->id)->id;
             }
         }
 

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -138,7 +138,7 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
         $stateGroups = $objectStateHandler->loadAllGroups();
 
         // First deal with unpublished content
-        if ($object instanceof ContentCreateStruct || !$object->published) {
+        if ($object instanceof ContentCreateStruct) {
             foreach ($stateGroups as $stateGroup) {
                 $states = $objectStateHandler->loadObjectStates($stateGroup->id);
                 if (empty($states)) {

--- a/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
@@ -142,12 +142,6 @@ class ObjectStateLimitationTypeTest extends Base
                 'object' => new ContentInfo(['id' => 0, 'mainLocationId' => 1, 'published' => true]),
                 'expected' => true,
             ],
-            // ContentCreateStruct, with access
-            [
-                'limitation' => new ObjectStateLimitation(['limitationValues' => [1, 3]]),
-                'object' => new ContentCreateStruct(),
-                'expected' => true,
-            ],
         ];
     }
 

--- a/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
@@ -13,7 +13,6 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\Core\Limitation\ObjectStateLimitationType;
-use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\SPI\Persistence\Content\ObjectState;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as SPIHandler;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1281](https://issues.ibexa.co/browse/IBX-1281)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

Reasoning: unpublished and published contents behave exactly the same when it comes to object states. I cannot see why should we bother with priorities in this case.


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
