### PR TITLE
IBX-1182: Added cache invalidation to liip:imagine:cache:remove command

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
@@ -129,4 +129,9 @@ class AliasGeneratorDecorator implements VariationHandler, SiteAccessAware
             $this->cacheIdentifierGenerator->generateTag(self::CONTENT_VERSION_TAG, [$contentId, $versionInfo->versionNo]),
         ];
     }
+
+    public function getVariationNameTag(): string
+    {
+        return self::IMAGE_VARIATION_NAME_TAG;
+    }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/IOVariationPurger.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/IOVariationPurger.php
@@ -56,13 +56,13 @@ class IOVariationPurger implements VariationPurger
 
     public function purge(array $aliasNames)
     {
+        $variationNameTag = $this->aliasGeneratorDecorator->getVariationNameTag();
+
         foreach ($aliasNames as $aliasName) {
             $directory = "_aliases/$aliasName";
             $this->io->deleteDirectory($directory);
-            $variationTag = $this->cacheIdentifierGenerator->generateTag(
-                $this->aliasGeneratorDecorator->getVariationNameTag(),
-                [$aliasName]
-            );
+
+            $variationTag = $this->cacheIdentifierGenerator->generateTag($variationNameTag, [$aliasName]);
             $this->cache->invalidateTags([$variationTag]);
 
             if (isset($this->logger)) {

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/IOVariationPurger.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/IOVariationPurger.php
@@ -6,8 +6,11 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
 
+use eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\AliasGeneratorDecorator;
 use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\SPI\Variation\VariationPurger;
+use Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
 /**
  * Purges image variations using the IOService.
@@ -19,12 +22,28 @@ class IOVariationPurger implements VariationPurger
     /** @var \eZ\Publish\Core\IO\IOServiceInterface */
     private $io;
 
+    /** @var \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface */
+    private $cache;
+
+    /** @var \Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface */
+    private $cacheIdentifierGenerator;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\AliasGeneratorDecorator */
+    private $aliasGeneratorDecorator;
+
     /** @var \Psr\Log\LoggerInterface */
     private $logger;
 
-    public function __construct(IOServiceInterface $io)
-    {
+    public function __construct(
+        IOServiceInterface $io,
+        TagAwareAdapterInterface $cache,
+        CacheIdentifierGeneratorInterface $cacheIdentifierGenerator,
+        AliasGeneratorDecorator $aliasGeneratorDecorator
+    ) {
         $this->io = $io;
+        $this->cache = $cache;
+        $this->cacheIdentifierGenerator = $cacheIdentifierGenerator;
+        $this->aliasGeneratorDecorator = $aliasGeneratorDecorator;
     }
 
     /**
@@ -40,6 +59,11 @@ class IOVariationPurger implements VariationPurger
         foreach ($aliasNames as $aliasName) {
             $directory = "_aliases/$aliasName";
             $this->io->deleteDirectory($directory);
+            $variationTag = $this->cacheIdentifierGenerator->generateTag(
+                $this->aliasGeneratorDecorator->getVariationNameTag(),
+                [$aliasName]
+            );
+            $this->cache->invalidateTags([$variationTag]);
 
             if (isset($this->logger)) {
                 $this->logger->info("Purging alias directory $directory");

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -284,6 +284,9 @@ services:
         class: "%ezpublish.image_alias.variation_purger.io.class%"
         arguments:
             - "@ezpublish.fieldType.ezimage.io_service"
+            - "@ezpublish.cache_pool"
+            - '@Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface'
+            - "@ezpublish.image_alias.imagine.cache.alias_generator_decorator"
             - "@ezpublish.image_alias.variation_path_generator.alias_directory"
         calls:
             - [setLogger, ["@?logger"]]

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -283,11 +283,11 @@ services:
     ezpublish.image_alias.variation_purger.io:
         class: "%ezpublish.image_alias.variation_purger.io.class%"
         arguments:
-            - "@ezpublish.fieldType.ezimage.io_service"
-            - "@ezpublish.cache_pool"
+            - '@ezpublish.fieldType.ezimage.io_service'
+            - '@ezpublish.cache_pool'
             - '@Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface'
-            - "@ezpublish.image_alias.imagine.cache.alias_generator_decorator"
-            - "@ezpublish.image_alias.variation_path_generator.alias_directory"
+            - '@ezpublish.image_alias.imagine.cache.alias_generator_decorator'
+            - '@ezpublish.image_alias.variation_path_generator.alias_directory'
         calls:
             - [setLogger, ["@?logger"]]
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/IOVariationPurgerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/IOVariationPurgerTest.php
@@ -6,23 +6,56 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPurger;
 
+use eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\AliasGeneratorDecorator;
 use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\IOVariationPurger;
 use eZ\Publish\Core\IO\IOServiceInterface;
+use Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
 class IOVariationPurgerTest extends TestCase
 {
-    public function testPurgesAliasList()
+    public function testPurgesAliasList(): void
     {
         $ioService = $this->createMock(IOServiceInterface::class);
+        $tagAwareAdapter = $this->createMock(TagAwareAdapterInterface::class);
+        $cacheIdentifierGenerator = $this->createMock(CacheIdentifierGeneratorInterface::class);
+        $aliasGeneratorDecorator = $this->createMock(AliasGeneratorDecorator::class);
+
+        $aliasGeneratorDecorator
+            ->expects(self::once())
+            ->method('getVariationNameTag')
+            ->willReturn('image_variation_name');
         $ioService
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('deleteDirectory')
             ->withConsecutive(
                 ['_aliases/medium'],
                 ['_aliases/large']
             );
-        $purger = new IOVariationPurger($ioService);
+        $cacheIdentifierGenerator
+            ->expects(self::exactly(2))
+            ->method('generateTag')
+            ->withConsecutive(
+                ['image_variation_name', ['medium']],
+                ['image_variation_name', ['large']]
+            )
+            ->willReturnOnConsecutiveCalls('ign-medium', 'ign-large');
+        $tagAwareAdapter
+            ->expects(self::exactly(2))
+            ->method('invalidateTags')
+            ->withConsecutive(
+                [['ign-medium']],
+                [['ign-large']]
+            );
+
+        $purger = new IOVariationPurger(
+            $ioService,
+            $tagAwareAdapter,
+            $cacheIdentifierGenerator,
+            $aliasGeneratorDecorator
+        );
+
         $purger->purge(['medium', 'large']);
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1182](https://issues.ibexa.co/browse/IBX-1182)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
