### PR TITLE
[CI] Pinned lzf to version 1.6.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ before_install:
   - echo "default_charset=UTF-8" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   # Install igbinary & lzf PHP extensions if necessary
   - if [ "$REDIS_ENABLE_IGBINARY" = true ] ; then pecl install igbinary ; fi
-  - if [ "$REDIS_ENABLE_LZF" = true ] ; then printf "no\n" | pecl install lzf ; fi
+  - if [ "$REDIS_ENABLE_LZF" = true ] ; then printf "no\n" | pecl install lzf-1.6.8 ; fi
   # Prepare system
   - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] ; then ./bin/.travis/enable_swap.sh ; fi


### PR DESCRIPTION
Example failure: https://app.travis-ci.com/github/ezsystems/ezpublish-kernel/jobs/554256695
```
$ if [ "$REDIS_ENABLE_LZF" = true ] ; then printf "no\n" | pecl install lzf ; fi
WARNING: channel "pecl.php.net" has updated its protocols, use "pecl channel-update pecl.php.net" to update
pecl/LZF requires PHP (version >= 7.2.0), installed version is 7.1.11
No valid packages found
install failed
```

The 1.7.0 release of lzf (released yesterday - https://pecl.php.net/package/lzf) drops support for PHP versions lower than 7.2:
https://pecl.php.net/package-changelog.php?package=lzf

Pinning to the oldest version supporting PHP 7.1 should allow us to continue running these tests.