### PR TITLE
EZP-29574: the time life of the token has been adjusted to the same as in the platform

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -2863,7 +2863,7 @@ class UserServiceTest extends BaseTest
 
         $userTokenUpdateStruct = new UserTokenUpdateStruct();
         $userTokenUpdateStruct->hashKey = md5('hash');
-        $userTokenUpdateStruct->time = (new DateTime())->add(new DateInterval('PT10S'));
+        $userTokenUpdateStruct->time = (new DateTime())->add(new DateInterval('PT1H'));
 
         $userService->updateUserToken($user, $userTokenUpdateStruct);
 
@@ -2914,7 +2914,7 @@ class UserServiceTest extends BaseTest
 
         $userTokenUpdateStruct = new UserTokenUpdateStruct();
         $userTokenUpdateStruct->hashKey = md5('my_updated_hash');
-        $userTokenUpdateStruct->time = (new DateTime())->add(new DateInterval('PT10S'));
+        $userTokenUpdateStruct->time = (new DateTime())->add(new DateInterval('PT1H'));
 
         $userService->updateUserToken($user, $userTokenUpdateStruct);
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-29574](https://issues.ibexa.co/browse/EZP-29574)
| **Type**                                   | bug/improvement
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

As there are still sometimes problems with tests and not finding the user when updating the token, the token lifetime has been changed according to the time it is on the platform

ezsettings.default.security.token_interval_spec: PT1H

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
