### PR TITLE
IBX-2098: Handled missing files in 'images:normalize-paths' command

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -15,7 +15,6 @@ use eZ\Publish\Core\IO\FilePathNormalizerInterface;
 use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\IO\Values\BinaryFileCreateStruct;
-use eZ\Publish\Core\IO\Values\MissingBinaryFile;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -191,7 +191,6 @@ EOT
      * @param resource $inputStream
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue
      */
     private function moveFile(
         string $oldFileName,

--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -158,12 +158,6 @@ EOT
 
         // Checking if a file exists physically
         $oldBinaryFile = $this->ioService->loadBinaryFileByUri(\DIRECTORY_SEPARATOR . $oldPath);
-        if ($oldBinaryFile instanceof MissingBinaryFile) {
-            $io->warning(sprintf('Skipping file %s as it doesn\'t exists physically.', $oldPath));
-
-            return;
-        }
-
         try {
             $inputStream = $this->ioService->getFileInputStream($oldBinaryFile);
         } catch (BinaryFileNotFoundException $e) {
@@ -194,6 +188,12 @@ EOT
         $this->moveFile($oldFileName, $newFilename, $oldBinaryFile, $inputStream);
     }
 
+    /**
+     * @param resource $inputStream
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue
+     */
     private function moveFile(
         string $oldFileName,
         string $newFileName,

--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\IO\FilePathNormalizerInterface;
 use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\IO\Values\BinaryFileCreateStruct;
+use eZ\Publish\Core\IO\Values\MissingBinaryFile;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -178,6 +179,10 @@ EOT
     private function moveFile(string $oldFileName, string $newFileName, string $oldPath): void
     {
         $oldBinaryFile = $this->ioService->loadBinaryFileByUri(\DIRECTORY_SEPARATOR . $oldPath);
+        if ($oldBinaryFile instanceof MissingBinaryFile) {
+            return;
+        }
+
         $newId = str_replace($oldFileName, $newFileName, $oldBinaryFile->id);
         $inputStream = $this->ioService->getFileInputStream($oldBinaryFile);
 
@@ -191,7 +196,6 @@ EOT
         );
 
         $newBinaryFile = $this->ioService->createBinaryFile($binaryCreateStruct);
-
         if ($newBinaryFile instanceof BinaryFile) {
             $this->ioService->deleteBinaryFile($oldBinaryFile);
         }

--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -132,7 +132,7 @@ EOT
                     $imagePathToNormalize['fieldId'],
                     $imagePathToNormalize['oldPath'],
                     $imagePathToNormalize['newPath'],
-                    $io,
+                    $io
                 );
                 $io->progressAdvance();
             }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2098](https://issues.ibexa.co/browse/IBX-2098)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

Minor update to handle missing files when running the mentioned command and provide console output on missing files.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
