### PR TITLE
fix multi translation for content Object with the same image field

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -47,6 +47,8 @@ EOT;
     /** @var \eZ\Publish\Core\IO\IOServiceInterface */
     private $ioService;
 
+    private $oldFiles = [];
+
     public function __construct(
         ImageStorageGateway $imageGateway,
         FilePathNormalizerInterface $filePathNormalizer,
@@ -136,6 +138,14 @@ EOT
                 $io->progressAdvance();
             }
             $this->connection->commit();
+            /**
+             * Remove old Binary Files
+             */
+            if (count($this->oldFiles)) {
+                foreach ($this->oldFiles as $oldBinaryFile) {
+                    $this->ioService->deleteBinaryFile($oldBinaryFile);
+                }
+            }
         } catch (\Exception $e) {
             $this->connection->rollBack();
         }
@@ -211,7 +221,9 @@ EOT
 
         $newBinaryFile = $this->ioService->createBinaryFile($binaryCreateStruct);
         if ($newBinaryFile instanceof BinaryFile) {
-            $this->ioService->deleteBinaryFile($oldBinaryFile);
+            if (!in_array($oldBinaryFile, $this->oldFiles)) {
+                $this->oldFiles[] = $oldBinaryFile;
+            }
         }
     }
 }

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
@@ -278,7 +278,7 @@ class DoctrineStorage extends Gateway
     {
         $selectQuery = $this->connection->createQueryBuilder();
         $selectQuery
-            ->select($this->connection->getDatabasePlatform()->getCountExpression('DISTINCT(filepath)'))
+            ->select($this->connection->getDatabasePlatform()->getCountExpression('DISTINCT(CONCAT(filepath,contentobject_attribute_id))'))
             ->from($this->connection->quoteIdentifier(self::IMAGE_FILE_TABLE))
         ;
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2291](https://issues.ibexa.co/browse/IBX-2291)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
