### PR TITLE
IBX-2291: Refactored `normalize-paths` command

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -142,6 +142,10 @@ EOT
 
         $allVersionsXMLData = $this->imageGateway->getAllVersionsImageXmlForFieldId($fieldId);
         foreach ($allVersionsXMLData as $xmlData) {
+            if (empty($xmlData['data_text'])) {
+                continue;
+            }
+
             $dom = new \DOMDocument();
             $dom->loadXml($xmlData['data_text']);
 

--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -181,6 +181,8 @@ EOT
 
     /**
      * @param resource $inputStream
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     private function updateImagePath(
         int $fieldId,
@@ -225,7 +227,7 @@ EOT
             ]
         );
 
-        // Firstly validate if the same file doesn't exist already in order to not duplicate files
+        // Before creating a new file validate if the same file doesn't exist already in order to not duplicate files
         $newBinaryFile = $this->ioService->loadBinaryFileByUri(\DIRECTORY_SEPARATOR . $newPath);
         if ($newBinaryFile instanceof MissingBinaryFile) {
             $this->ioService->createBinaryFile($binaryCreateStruct);

--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -203,7 +203,7 @@ EOT
         return $imagePathsToNormalize;
     }
 
-    protected function getFinalNormalizedPath(
+    private function getFinalNormalizedPath(
         string $filePath,
         array $imagePathsToNormalize
     ): string {
@@ -221,7 +221,7 @@ EOT
             : $this->filePathNormalizer->normalizePath($filePath);
     }
 
-    protected function getImagePathsToNormalize(SymfonyStyle $io): array
+    private function getImagePathsToNormalize(SymfonyStyle $io): array
     {
         $imagesCount = $this->imageGateway->countDistinctImages();
         $imagePathsToNormalize = [];
@@ -247,7 +247,7 @@ EOT
         return $imagePathsToNormalize;
     }
 
-    protected function normalizeImagePaths(array $imagePathsToNormalize, SymfonyStyle $io): array
+    private function normalizeImagePaths(array $imagePathsToNormalize, SymfonyStyle $io): array
     {
         $oldBinaryFilesToDelete = [];
         foreach ($imagePathsToNormalize as $imagePathToNormalize) {
@@ -275,7 +275,7 @@ EOT
                 $this->connection->commit();
             } catch (BinaryFileNotFoundException $e) {
                 $io->warning(
-                    sprintf('Skipping file %s as it doesn\'t exist physically.', $oldPath)
+                    sprintf('File %s does not exist. Skipping.', $oldPath)
                 );
 
                 $this->connection->rollBack();

--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -147,7 +147,6 @@ EOT
 
             /** @var \DOMElement $imageTag */
             $imageTag = $dom->getElementsByTagName('ezimage')->item(0);
-            $this->imageGateway->updateImagePath($fieldId, $oldPath, $newPath);
             if ($imageTag && $imageTag->getAttribute('filename') === $oldFileName) {
                 $imageTag->setAttribute('filename', $newFilename);
                 $imageTag->setAttribute('basename', $newBaseName);
@@ -159,9 +158,10 @@ EOT
                     (int)$xmlData['version'],
                     $dom->saveXML()
                 );
-                $this->imageGateway->updateImagePath($fieldId, $oldPath, $newPath);
             }
         }
+
+        $this->imageGateway->updateImagePath($fieldId, $oldPath, $newPath);
 
         $newId = str_replace($oldFileName, $newFilename, $oldBinaryFile->id);
         $binaryCreateStruct = new BinaryFileCreateStruct(


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2291](https://issues.ibexa.co/browse/IBX-2291)
| **Type**                                   | bug/improvement
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

The command has been completely refactored in order to improve error handling and others:
- transactions should be single per file change
- handling field attributes that use the same image file
- deleting files at the end

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
