### PR TITLE
IBX-1281: Fixed & refactored evaluation of ObjectState Limitations

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\Tests\SetupFactory\Legacy;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\User\UserReference;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\API\Repository\Repository;
@@ -819,5 +820,10 @@ abstract class BaseTest extends TestCase
         );
 
         return $contentTypeService->loadContentTypeByIdentifier($identifier);
+    }
+
+    protected function loginAsUser(UserReference $user): void
+    {
+        $this->getRepository(false)->getPermissionResolver()->setCurrentUserReference($user);
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1281](https://issues.ibexa.co/browse/IBX-1281)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`+
| **BC breaks**                          | no

This PR foremost fixes a logic error when evaluating ObjectStateLimitation.
```php
if ($object instanceof ContentCreateStruct || !$object->published) {
```

becomes
```php
if ($object instanceof ContentCreateStruct) {
```
so not published Content is treated the same as published because currently it is not locked by default.

The PR contains a lot of refactoring to make code more readable, reducing cognitive complexity.

It's unknown what is the use case for handling ContentCreateStruct, but technically API consumer can invoke:
```php
$permissionResolver->canUser('content', 'edit', $contentCreate);
```
so removing it now would make unnecessary BC break, since "access abstain" is not properly handled by PermissionResolver thus resulting in an error being thrown.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
