### PR TITLE
EZP-30746: Keep Content-hidden status when moving subtree

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -3236,30 +3236,17 @@ class LocationServiceTest extends BaseTest
 
         $mediaLocationId = $this->generateId('location', 43);
         $demoDesignLocationId = $this->generateId('location', 56);
-        /* BEGIN: Use Case */
-        // $mediaLocationId is the ID of the "Media" page location in
-        // an eZ Publish demo installation
 
-        // $demoDesignLocationId is the ID of the "Demo Design" page location in an eZ
-        // Publish demo installation
-
-        // Load the location service
         $locationService = $repository->getLocationService();
-
-        // Load the content service
         $contentService = $repository->getContentService();
 
-        // Load location to move
         $locationToMove = $locationService->loadLocation($demoDesignLocationId);
 
-        // Create child below locationToMove
         $subFolderContent = $this->publishContentWithParentLocation('SubFolder', $locationToMove->id);
 
-        // Hide source Content
         $contentService->hideContent($locationToMove->contentInfo);
         $locationToMove = $locationService->loadLocation($demoDesignLocationId);
 
-        // Load new parent location
         $newParentLocation = $locationService->loadLocation($mediaLocationId);
 
         // Move location from "Home" to "Media"
@@ -3268,14 +3255,12 @@ class LocationServiceTest extends BaseTest
             $newParentLocation
         );
 
-        // Load moved location
         $movedLocation = $locationService->loadLocation($demoDesignLocationId);
-        /* END: Use Case */
 
         // Assert Moved Location
         $this->assertPropertiesCorrect(
             [
-                'hidden' => true, // It should be hidden only on object level, not on location level. But impossible to say due to https://github.com/ezsystems/ezpublish-kernel/blob/7.5/eZ/Publish/Core/Repository/Helper/DomainMapper.php#L562
+                'hidden' => true,
                 'invisible' => true,
                 'depth' => $newParentLocation->depth + 1,
                 'parentLocationId' => $newParentLocation->id,
@@ -3284,7 +3269,7 @@ class LocationServiceTest extends BaseTest
             $movedLocation
         );
 
-        $this->assertTrue($movedLocation->getContentInfo()->isHidden);
+        self::assertTrue($movedLocation->getContentInfo()->isHidden);
 
         // Assert child of Moved location
         $childLocation = $locationService->loadLocation($subFolderContent->contentInfo->mainLocationId);

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -3225,7 +3225,7 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
-     * Test that is_visible is set correct for children when moving a content (not the location) which is hidden.
+     * Test that is_visible is set correct for children when moving a content which is hidden (location is not hidden).
      *
      * @covers \eZ\Publish\API\Repository\LocationService::moveSubtree
      * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadLocation

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -3299,7 +3299,7 @@ class LocationServiceTest extends BaseTest
             $childLocation
         );
 
-        $this->assertFalse($childLocation->getContentInfo()->isHidden);
+        self::assertFalse($childLocation->getContentInfo()->isHidden);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -685,11 +685,11 @@ class DoctrineDatabase extends Gateway
                 $expr->or(
                     $expr->eq(
                         't.is_hidden',
-                        $query->createPositionalParameter(1, ParameterType::BOOLEAN)
+                        $query->createPositionalParameter(true, ParameterType::BOOLEAN)
                     ),
                     $expr->eq(
                         'c.is_hidden',
-                        $query->createPositionalParameter(1, ParameterType::BOOLEAN)
+                        $query->createPositionalParameter(true, ParameterType::BOOLEAN)
                     )
                 )
             );

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -410,7 +410,13 @@ class DoctrineDatabase extends Gateway
      * @throws \Doctrine\DBAL\Driver\Exception
      * @throws \Doctrine\DBAL\Exception
      */
-    private function getHiddenNodeIds(int $contentObjectId)
+     /**
+     * @return int[]
+     *
+     * @throws \Doctrine\DBAL\Driver\Exception
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function getHiddenNodeIds(int $contentObjectId): array
     {
         $query = $this->buildHiddenSubtreeQuery();
         $expr = $query->expr();

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -685,7 +685,7 @@ class DoctrineDatabase extends Gateway
                 $expr->or(
                     $expr->eq(
                         't.is_hidden',
-                        $query->createPositionalParameter(true, ParameterType::BOOLEAN)
+                        $query->createPositionalParameter(true, ParameterType::INTEGER)
                     ),
                     $expr->eq(
                         'c.is_hidden',

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -410,7 +410,8 @@ class DoctrineDatabase extends Gateway
      * @throws \Doctrine\DBAL\Driver\Exception
      * @throws \Doctrine\DBAL\Exception
      */
-     /**
+
+    /**
      * @return int[]
      *
      * @throws \Doctrine\DBAL\Driver\Exception
@@ -438,7 +439,7 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Calculates if given node is hidden by location (self or any parent) or on Content level
+     * Calculates if given node is hidden by location (self or any parent) or on Content level.
      *
      * @param string $pathString
      * @param int[] $hiddenNodeIds

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -387,7 +387,7 @@ class DoctrineDatabase extends Gateway
                 // CASE 2: source is only invisible, we will need to re-calculate whole moved tree visibility
                 $query->set(
                     $this->handler->quoteColumn('is_invisible'),
-                    $query->bindValue($this->isHiddenByParent($newPathString, $hiddenNodeIds) ? 1 : 0)
+                    $query->bindValue($this->isHiddenByParentOrSelf($newPathString, $hiddenNodeIds) ? 1 : 0)
                 );
             } else {
                 // CASE 3: keep invisible flags as is (source is either hidden or not hidden/invisible at all)
@@ -425,12 +425,14 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
+     * Calculates if given node is hidden by location (self or any parent) or on Content level
+     *
+     * @param string $pathString
      * @param int[] $hiddenNodeIds
      */
-    private function isHiddenByParent(string $pathString, array $hiddenNodeIds): bool
+    private function isHiddenByParentOrSelf(string $pathString, array $hiddenNodeIds): bool
     {
         $parentNodeIds = array_map('intval', explode('/', trim($pathString, '/')));
-        array_pop($parentNodeIds); // remove self
         foreach ($parentNodeIds as $parentNodeId) {
             if (in_array($parentNodeId, $hiddenNodeIds, true)) {
                 return true;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -410,13 +410,6 @@ class DoctrineDatabase extends Gateway
      * @throws \Doctrine\DBAL\Driver\Exception
      * @throws \Doctrine\DBAL\Exception
      */
-
-    /**
-     * @return int[]
-     *
-     * @throws \Doctrine\DBAL\Driver\Exception
-     * @throws \Doctrine\DBAL\Exception
-     */
     private function getHiddenNodeIds(int $contentObjectId): array
     {
         $query = $this->buildHiddenSubtreeQuery();
@@ -433,7 +426,7 @@ class DoctrineDatabase extends Gateway
             );
         $statement = $query->execute();
 
-        $result = $statement->fetchAll(FetchMode::COLUMN);
+        $result = $statement->fetchFirstColumn();
 
         return array_map('intval', $result);
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
@@ -355,7 +355,6 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
                 ->where($query->expr->in('id', [67, 68, 69, 70, 75, 76, 77, 78, 79, 80, 81])) //,     69, 71, 75, 77, 2]))
                 ->orderBy('id')
         );
-
     }
 
     public function testMoveHiddenSourceChildUpdate()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
@@ -352,7 +352,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
             $query
                 ->select('id', 'is_hidden')
                 ->from('ezcontentobject')
-                ->where($query->expr->in('id', [67, 68, 69, 70, 75, 76, 77, 78, 79, 80, 81])) //,     69, 71, 75, 77, 2]))
+                ->where($query->expr->in('id', [67, 68, 69, 70, 75, 76, 77, 78, 79, 80, 81]))
                 ->orderBy('id')
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
@@ -147,6 +147,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $handler->moveSubtreeNodes(
             [
                 'path_string' => '/1/2/69/',
+                'contentobject_id' => 67,
                 'path_identification_string' => 'products',
                 'is_hidden' => 0,
                 'is_invisible' => 0,
@@ -185,6 +186,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $handler->moveSubtreeNodes(
             [
                 'path_string' => '/1/2/69/',
+                'contentobject_id' => 67,
                 'path_identification_string' => 'products',
                 'is_hidden' => 0,
                 'is_invisible' => 0,
@@ -223,6 +225,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $handler->moveSubtreeNodes(
             [
                 'path_string' => '/1/2/69/',
+                'contentobject_id' => 67,
                 'path_identification_string' => 'products',
                 'is_hidden' => 1,
                 'is_invisible' => 1,
@@ -262,6 +265,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $handler->moveSubtreeNodes(
             [
                 'path_string' => '/1/2/69/',
+                'contentobject_id' => 67,
                 'path_identification_string' => 'products',
                 'is_hidden' => 0,
                 'is_invisible' => 0,

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
@@ -36,7 +36,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
      */
     protected function getContentGateway()
     {
-        $databaseGateway = new \eZ\Publish\Core\Persistence\Legacy\Content\Gateway\DoctrineDatabase(
+        $databaseGateway = new ContentDoctrineDatabase(
             ($dbHandler = $this->getDatabaseHandler()),
             $this->getDatabaseConnection(),
             new ContentDoctrineDatabase\QueryBuilder($dbHandler),

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/_fixtures/full_example_tree.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/_fixtures/full_example_tree.php
@@ -379,6 +379,17 @@ return array(
         array( 'contentobject_id' => 226, 'contentobject_version' => 1, 'from_node_id' => -1, 'id' => 214, 'is_main' => 1, 'op_code' => 3, 'parent_node' => 77, 'parent_remote_id' => '', 'remote_id' => 0, 'sort_field' => 1, 'sort_order' => 1, 'priority' => 0, 'is_hidden' => 0 ),
     ),
     'ezcontentobject' => array(
+        array( 'id' => 67, 'is_hidden' => 0 ),
+        array( 'id' => 68, 'is_hidden' => 0 ),
+        array( 'id' => 69, 'is_hidden' => 0 ),
+        array( 'id' => 70, 'is_hidden' => 0 ),
+        array( 'id' => 75, 'is_hidden' => 0 ),
+        array( 'id' => 76, 'is_hidden' => 0 ),
+        array( 'id' => 77, 'is_hidden' => 0 ),
+        array( 'id' => 78, 'is_hidden' => 0 ),
+        array( 'id' => 79, 'is_hidden' => 0 ),
+        array( 'id' => 80, 'is_hidden' => 0 ),
+        array( 'id' => 81, 'is_hidden' => 0 ),
         array( 'id' => 226, 'status' => 0 ),
     ),
 );


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-30746](https://issues.ibexa.co/browse/EZP-30746)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

`DoctrineDatabase::moveSubtreeNodes` only consider `ezcontentobject_tree.is_hidden` column when checking if nodes are hidden or not.
Since https://github.com/ezsystems/ezpublish-kernel/pull/254], we also needs to check if locations are hidden due to visibility set on the object level (`ezcontentobject.is_hidden` column)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
