### PR TITLE
IBX-2500: Fixed number of iterations in `normalize-paths` command

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -227,10 +227,10 @@ EOT
 
     private function getImagePathsToNormalize(SymfonyStyle $io): array
     {
-        $imagesCount = $this->imageGateway->countDistinctImages();
+        $imagesDataCount = $this->imageGateway->countDistinctImagesData();
         $imagePathsToNormalize = [];
-        $iterations = ceil($imagesCount / self::IMAGE_LIMIT);
-        $io->progressStart($imagesCount);
+        $iterations = ceil($imagesDataCount / self::IMAGE_LIMIT);
+        $io->progressStart($imagesDataCount);
         for ($i = 0; $i < $iterations; ++$i) {
             $imagesData = $this->imageGateway->getImagesData(
                 $i * self::IMAGE_LIMIT,

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
@@ -76,4 +76,6 @@ abstract class Gateway extends StorageGateway
     abstract public function getImagesData(int $offset, int $limit): array;
 
     abstract public function updateImagePath(int $fieldId, string $oldPath, string $newPath): void;
+
+    abstract public function countDistinctImagesData(): int;
 }

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
@@ -274,17 +274,17 @@ class DoctrineStorage extends Gateway
         return (bool)$statement->fetchOne();
     }
 
-    public function countDistinctImages(): int
+    public function countDistinctImagesData(): int
     {
         $selectQuery = $this->connection->createQueryBuilder();
         $selectQuery
-            ->select($this->connection->getDatabasePlatform()->getCountExpression('DISTINCT(filepath)'))
+            ->select($this->connection->getDatabasePlatform()->getCountExpression('id'))
             ->from($this->connection->quoteIdentifier(self::IMAGE_FILE_TABLE))
         ;
 
         $statement = $selectQuery->execute();
 
-        return (int) $statement->fetchColumn();
+        return (int) $statement->fetchOne();
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
@@ -369,4 +369,12 @@ class LegacyStorage extends Gateway
     {
         throw new NotImplementedException('updateImagePath is not supported with LegacyStorage gateway, inject DoctrineStorage gateway instead to use it');
     }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
+     */
+    public function countDistinctImagesData(): int
+    {
+        throw new NotImplementedException('countDistinctImagesData is not supported with LegacyStorage gateway, inject DoctrineStorage gateway instead to use it');
+    }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2500](https://issues.ibexa.co/browse/IBX-2500)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

Previously it could occur, that when having multiple translations and versions, iterations could be finished before the command had processed all images.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
