### PR TITLE
IBX-2382: Changed the order in the command list for Legacy Search

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -874,6 +874,11 @@ class SearchEngineIndexingTest extends BaseTest
             // @todo: Remove as soon as elastic is updated to later version not affected
             ["it's", "it's", [LegacyElasticsearch::class]],
             ['with_underscore', 'with_underscore'],
+            ['MAKİNEİÇ', 'makİneİç'],
+            ['DIŞ', 'diş'],
+            ['TİC', 'tİc'],
+            ['ŞTİ.', 'ştİ'],
+            ['ʻ', 'ʻ'],
         ];
     }
 

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -35,12 +35,6 @@ parameters:
         stopWordThresholdFactor: 0.66
         enableWildcards: true
         commands:
-            - "latin-exta_lowercase"
-            - "latin1_lowercase"
-            - "ascii_lowercase"
-            - "latin_lowercase"
-            - "cyrillic_lowercase"
-            - "greek_lowercase"
             - "ascii_search_cleanup"
             - "cyrillic_diacritical"
             - "cyrillic_search_cleanup"
@@ -65,6 +59,12 @@ parameters:
             - "special_decompose"
             - "specialwords_search_normalize"
             - "tab_search_normalize"
+            - "latin-exta_lowercase"
+            - "latin1_lowercase"
+            - "ascii_lowercase"
+            - "latin_lowercase"
+            - "cyrillic_lowercase"
+            - "greek_lowercase"
 
 services:
     ezpublish.search.legacy.gateway.criterion_handler.base:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2382](https://issues.ibexa.co/browse/IBX-2382)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | yes/no

moved changes from https://github.com/ezsystems/ezplatform-kernel/pull/294, for the changes to come into effect from 2.5

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
