### PR TITLE
IBX-2610: Removed key name to process all version into normalize images paths command

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -197,7 +197,7 @@ EOT
         );
 
         if ($finalNormalizedPath !== $filePath) {
-            $imagePathsToNormalize[$fieldId] = [
+            $imagePathsToNormalize[] = [
                 'fieldId' => $fieldId,
                 'oldPath' => $filePath,
                 'newPath' => $finalNormalizedPath,

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
@@ -175,7 +175,7 @@ class DoctrineStorage extends Gateway
 
         $fieldLookup = [];
         foreach ($statement->fetchAllAssociative() as $row) {
-            $fieldLookup[$row['id']] = [
+            $fieldLookup[] = [
                 'version' => $row['version'],
                 'data_text' => $row['data_text'],
             ];


### PR DESCRIPTION

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2610](https://issues.ibexa.co/browse/IBX-2610)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
