### PR TITLE
IBX-5236: Added version parameter validation in DownloadController

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -42,12 +42,19 @@ class DownloadController extends Controller
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
      * @return \eZ\Bundle\EzPublishIOBundle\BinaryStreamResponse
-     * @return \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function downloadBinaryFileAction($contentId, $fieldIdentifier, $filename, Request $request)
     {
         if ($request->query->has('version')) {
-            $content = $this->contentService->loadContent($contentId, null, $request->query->get('version'));
+            $version = (int) $request->query->get('version');
+            if ($version <= 0) {
+                throw new NotFoundException('File', $filename);
+            }
+            $content = $this->contentService->loadContent($contentId, null, $version);
         } else {
             $content = $this->contentService->loadContent($contentId);
         }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5236](https://issues.ibexa.co/browse/IBX-5236)
| **see also**                          | [IBX-3110](https://issues.ibexa.co/browse/IBX-3110)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

This was fixed before in v3.3: https://github.com/ezsystems/ezplatform-kernel/pull/319
but could use a fix in v2.5 too. Note v2.5 is EOM, but not EOL. This is not a security issue, so should normally not be released for v2.5, but could we do it anyway for best practice reasons? TBD.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
