### PR TITLE
Fixed setting ParentClass limitation for content/publish

### DIFF
--- a/data/update/mysql/dbupdate-5.4.0-to-6.13.0.sql
+++ b/data/update/mysql/dbupdate-5.4.0-to-6.13.0.sql
@@ -32,7 +32,7 @@ INSERT INTO `ezpolicy_limitation` (`identifier`, `policy_id`)
   FROM `ezpolicy_limitation` AS `l0`
   JOIN `ezpolicy` AS `p0` ON `l0`.`policy_id` = `p0`.`id`
   JOIN `ezpolicy` AS `p1` ON `p0`.`role_id` = `p1`.`role_id` AND `p1`.`module_name` = 'content' AND `p1`.`function_name` = 'publish'
-  WHERE `p0`.`module_name` = 'content' AND `p0`.`function_name` IN ('create', 'edit');
+  WHERE `p0`.`module_name` = 'content' AND `p0`.`function_name` IN ('create', 'edit') AND `l0`.`identifier` NOT IN ('ParentOwner', 'ParentGroup', 'ParentClass', 'ParentDepth');
 
 -- Create content/publish limitation values entries based on existing entries matched by limitation identifier and role
 INSERT INTO `ezpolicy_limitation_value` (`limitation_id`, `value`)


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-XXXX](https://issues.ibexa.co/browse/IBX-XXXX)
| **Type**                                   | feature/bug/improvement
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | yes/no

Current SQl wrongly copies some limitations from content/create to content/publish policy, specifically:
'ParentOwner', 'ParentGroup', 'ParentClass', 'ParentDepth'

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
