### PR TITLE
IBX-6185: Added more PHP file types to default upload blocklist

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -106,6 +106,9 @@ parameters:
     ezsettings.default.io.file_storage.file_type_blacklist:
         - php
         - php3
+        - php4
+        - php5
+        - phps
         - phar
         - phpt
         - pht


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6185](https://issues.ibexa.co/browse/IBX-6185)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

The file upload blocklist includes file types that are not allowed to be uploaded.
https://github.com/ibexa/core/blob/main/src/bundle/Core/Resources/config/default_settings.yml#L111

Some variants of PHP file types are not included by default, we should add them:
php4, php5, phps

Doc PR for the security checklist: https://github.com/ezsystems/developer-documentation/pull/2059

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] ~Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).~
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
