### PR TITLE
Fix fatal error in DownloadController

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -63,7 +63,7 @@ class DownloadController extends Controller
     protected function findFieldInContent(int $fieldId, Content $content): Field
     {
         foreach ($content->getFields() as $field) {
-            if ($field->getId() === $fieldId) {
+            if ($field->id === $fieldId) {
                 return $field;
             }
         }


### PR DESCRIPTION
Regression from IBEXA-SA-2023-005

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7021](https://issues.ibexa.co/browse/IBX-7021)
| **Type**                                   | bug
| **Target eZ Platform version** | `v2.5`
| **BC breaks**                          | no

Fatal error "undefined method getId" on download. Regression from IBEXA-SA-2023-005:
https://developers.ibexa.co/security-advisories/ibexa-sa-2023-005-vulnerabilities-in-solr-search-and-file-downloads

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
